### PR TITLE
IRC nickname in profile

### DIFF
--- a/apps/devmo/templates/devmo/profile.html
+++ b/apps/devmo/templates/devmo/profile.html
@@ -29,11 +29,12 @@
       <div class="main">
         <h1 class="page-title"><span class="nickname">{{ profile.user.username }}</span> {% if profile.fullname %}<b>(<span class="fn">{{ profile.fullname }}</span>)</b>{% endif %}</h1>
   
-      {% if profile.title or profile.organization or profile.location %}
+      {% if profile.title or profile.organization or profile.location or profile.irc_nickname %}
       <ul class="info">
         {% if profile.title %}<li class="title">{{ profile.title }}</li>{% endif %}
         {% if profile.organization %}<li class="org">{{ profile.organization }}</li>{% endif %}
         {% if profile.location %}<li class="loc">{{ profile.location }}</li>{% endif %}
+	{% if profile.irc_nickname %}<li class="irc">IRC: {{ profile.irc_nickname }}</li>{% endif %}
       </ul>
       {% endif %}
   
@@ -83,7 +84,6 @@
                 <li class="{{site_name}}"><a href="{{href}}" rel="me external" class="url">{{site_meta['label']}}</a></li>
             {% endif %}
           {% endfor %}
-	  {% if profile.irc_nickname %}<li class="irc">IRC: {{ profile.irc_nickname }}</li>{% endif %}
           <li class="docs"><a href="/User:{{profile.user.username}}" rel="me">{{_("Docs user page")}}</a></li>
         </ul>
       </div>


### PR DESCRIPTION
This moves the IRC nickname field into a block of the profile template that always shows, rather than one that only shows when we have all the card info.
