### PR TITLE
Bug 677695 and bug 677696 - Strip out redundant / non-functioning toolbar buttons

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -1,3 +1,24 @@
 CKEDITOR.editorConfig = function(config) {
+
+    config.extraPlugins = 'autogrow,definitionlist,mdn-buttons';
+
+    config.toolbar_MDN = [
+        ['Source','-','mdnSave','mdnNewPage','mdnPreview'],
+        ['Cut','Copy','Paste','PasteText','PasteFromWord','-','Print', 'SpellChecker', 'Scayt'],
+        ['Undo','Redo','-','Find','Replace','-','SelectAll','RemoveFormat'],
+        ['Bold','Italic','Underline','Strike','-','Subscript','Superscript'],
+        ['NumberedList','BulletedList','DefinitionList','DefinitionTerm','DefinitionDescription','-','Outdent','Indent','Blockquote','CreateDiv'],
+        ['JustifyLeft','JustifyCenter','JustifyRight','JustifyBlock'],
+        ['BidiLtr', 'BidiRtl' ],
+        ['Link','Unlink','Anchor'],
+        ['Image','Table','HorizontalRule','SpecialChar','Iframe'],
+        ['h1Button', 'h2Button', 'h3Button', 'preButton', 'codeButton', '-', 'Styles'],
+        ['TextColor','BGColor'],
+        ['Maximize', 'ShowBlocks','-','About']
+    ];
+    config.skin = 'kuma';
+    config.startupFocus = true;
+    config.toolbar = 'MDN';
+
     {{ editor_config|safe }}
 };

--- a/apps/wiki/templates/wiki/includes/page_buttons.html
+++ b/apps/wiki/templates/wiki/includes/page_buttons.html
@@ -4,7 +4,10 @@
 {% else %}
     {% set discard_href = url('wiki.new_document') %}
 {% endif %}
-<ul id="page-buttons">
+<ul id="page-buttons" 
+    data-new-page-href="{{ url('wiki.new_document') }}"
+    data-new-page-label="{{ _('New Page') }}"
+    data-new-page-msg="{{ _('Discard changes and create a new document?') }}">
   {% if document %}
     <li>
       <iframe id="save-and-edit-target" name="save-and-edit-target"></iframe>

--- a/media/ckeditor/plugins/mdn-buttons/plugin.js
+++ b/media/ckeditor/plugins/mdn-buttons/plugin.js
@@ -4,6 +4,7 @@
 CKEDITOR.config.mdnButtons_tags = ['pre', 'code', 'h1', 'h2', 'h3'];
 
 (function(){
+    
     // make a generic command object that wraps text in <tag>
     var tagCommand = function(tag) {
         var command = {
@@ -17,8 +18,10 @@ CKEDITOR.config.mdnButtons_tags = ['pre', 'code', 'h1', 'h2', 'h3'];
         };
         return command;
     };
+    
     CKEDITOR.plugins.add("mdn-buttons", {
         init: function(editor) {
+
             var tags = CKEDITOR.config.mdnButtons_tags;
             var pluginName = "mdn-buttons";
             // addCommand and addButton for each tag in the list
@@ -33,6 +36,59 @@ CKEDITOR.config.mdnButtons_tags = ['pre', 'code', 'h1', 'h2', 'h3'];
                     className: 'mdn-buttons-button ' + tag,
                 });
             }
+
+            // Use the save-and-edit if available, fall back to save
+            var save_btn = $('#btn-save-and-edit');
+            if (save_btn.length < 1) {
+                save_btn = $('#btn-save');
+            }
+
+            // Define the command and button for "Save"
+            editor.addCommand(pluginName + '-save', {
+                exec: function (editor, data) {
+                    editor.updateElement();
+                    save_btn.click();
+                }
+            });
+            editor.ui.addButton('mdnSave', {
+                label: save_btn.text(),
+                className: 'cke_button_save',
+                command: pluginName + '-save'
+            });
+
+            // Some localized strings are stashed on #page-buttons...
+            var pb = $('#page-buttons');
+
+            // Define command and button for "New Page"
+            editor.addCommand(pluginName + '-newpage', {
+                exec: function (editor, data) {
+                    var msg = pb.attr('data-new-page-msg'),
+                        href = pb.attr('data-new-page-href');
+                    if (window.confirm(msg)) {
+                        window.location.href = href;
+                    }
+                }
+            });
+            editor.ui.addButton('mdnNewPage', {
+                label: pb.attr('data-new-page-label'),
+                className: 'cke_button_newpage',
+                command: pluginName + '-newpage'
+            });
+
+            // Define command and button for "Preview"
+            editor.addCommand(pluginName + '-preview', {
+                exec: function (editor, data) {
+                    editor.updateElement();
+                    $('#btn-preview').click();
+                }
+            });
+            editor.ui.addButton('mdnPreview', {
+                label: $('#btn-preview').text(),
+                className: 'cke_button_preview',
+                command: pluginName + '-preview'
+            });
+
         }
     });
+
 })();


### PR DESCRIPTION
Knocked my head against CKEditor docs for a long while to find that repurposing toolbar buttons is almost impossible short of writing new CKEditor plugins to replace the features.

Rather than do that, this patch takes the easy way out and strips out buttons from the toolbar that already exist elsewhere on the page. In the case of the "Templates" button, that one doesn't actually have any use on Kuma (yet?)
