### PR TITLE
Setup Instructions Were a Bit Off

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -57,6 +57,7 @@ Grab the source from Github using::
 
     git clone git://github.com/mozilla/kuma.git
     cd kuma
+    git submodule update --init --recursive
 
 Installing the Packages
 =======================
@@ -79,14 +80,6 @@ All of the pure-Python requirements are available in a git repository, known as
 a vendor library. This allows them to be available on the Python path without
 needing to be installed in the system, allowing multiple versions for multiple
 projects simultaneously.
-
-To get the vendor library, just::
-
-    git clone --recursive git://github.com/mozilla/kuma-lib.git vendor
-
-This will clone the repository and all its submodules into a directory called
-``vendor``.
-
 
 Configuration
 =============


### PR DESCRIPTION
Not sure what changed where, when, or for what, but running:

```
git submodule update --init
```

Does bad things later on down the road when you are trying to setup kuma and cannot run:

```
git clone --recursive git://github.com/mozilla/kuma-lib.git vendor
```

When you run both the submodule update and the clone it conflicts on the clone since vendor is already full. So when you move on and get down to `./manage.py syncdb` you will end up with the bug [689001](https://bugzilla.mozilla.org/show_bug.cgi?id=689001). As a fix it was a matter of removing the submodule update line and it all works out well. The alternative fix is to remove the vendor folder before you do a the clone of kuma-lib repository.

The other issue was not being able to see images or render-css, but by adding a couple of extra lines to the `settings_local.py` file it no longer requires the compressed files and works well locally.
