### PR TITLE
Tweaked Installation Instructions. Added a Step and Made it Look Better

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -120,6 +120,7 @@ Once you've set up the database, you can generate the schema with Django's
 ``syncdb`` command::
 
     ./manage.py syncdb
+    ./manage.py migrate
 
 This will generate an empty database, which will get you started!
 


### PR DESCRIPTION
Last night ran into an issue where a table didn't exist and to correct it I needed to run `./manage.py migrate` as per groovecoder's instructions. So I added that to instructions.

Also the formatting from yesterdays edits got messed up, probably my fault somewhere, so I fixed those so they look good again.
