### PR TITLE
679193 duplicate tags

### DIFF
--- a/apps/taggit_extras/managers.py
+++ b/apps/taggit_extras/managers.py
@@ -57,7 +57,18 @@ class _NamespacedTaggableManager(_TaggableManager):
         if namespace is not None:
             # Namespace requested, so generate filtered set
             # TODO: Do this in the DB query? Might not be worth it.
-            return [t for t in tags if t.name.startswith(namespace)]
+            #
+            # TODO: this is a minimal band-aid fix applied for bug
+            # 679193; rather than properly solve duplicated tags and
+            # case-sensitivity, we just filter out the duplicates
+            # here.
+            seen = []
+            results = []
+            for t in tags:
+                if t.name.startswith(namespace) and t.name.lower() not in seen:
+                    seen.append(t.name.lower())
+                    results.append(t)
+            return results
 
         # No namespace requested, so collate into namespaces
         ns_tags = {}


### PR DESCRIPTION
This is, so far as I can tell, the minimal "band-aid" fix to deal with the case-sensitivity problems. Of course, down the line we'll want to solve it for real, but until then this just figures out which tags are identical except for case and does a bit of filtering to weed out the duplicates.
