### PR TITLE
679193 duplicate tags

### DIFF
--- a/apps/devmo/views.py
+++ b/apps/devmo/views.py
@@ -114,7 +114,7 @@ def profile_edit(request, username):
 
             # Update tags from form fields
             for field, tag_ns in field_to_tag_ns:
-                tags = parse_tags(form.cleaned_data.get(field, ''))
+                tags = [t.lower() for t in parse_tags(form.cleaned_data.get(field, ''))]
                 profile_new.tags.set_ns(tag_ns, *tags)
 
             # Change the email address, if necessary.

--- a/apps/taggit_extras/managers.py
+++ b/apps/taggit_extras/managers.py
@@ -58,10 +58,15 @@ class _NamespacedTaggableManager(_TaggableManager):
             # Namespace requested, so generate filtered set
             # TODO: Do this in the DB query? Might not be worth it.
             #
-            # TODO: this is a minimal band-aid fix applied for bug
-            # 679193; rather than properly solve duplicated tags and
-            # case-sensitivity, we just filter out the duplicates
-            # here.
+            # On databases with case-insensitive collation, we can end
+            # up with duplicate tags (the same tag, differing only by
+            # case, like 'javascript' and 'JavaScript') in some
+            # cases. The most common instance of this is user profile
+            # tags, which are coerced to lowercase on save to avoid
+            # the problem, but because there are a large number of
+            # these duplicates already existing, we do a quick filter
+            # here to ensure we don't return a bunch of dupes that
+            # differ only by case.
             seen = []
             results = []
             for t in tags:


### PR DESCRIPTION
Bug 679193: Regardless of whether we ever work out a migration for killing the existing dupes, we need this to avoid creating new ones.
