### PR TITLE
Properly include page title while using base.html for MDN

### DIFF
--- a/apps/wiki/templates/wiki/compare_revisions.html
+++ b/apps/wiki/templates/wiki/compare_revisions.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Compare Revisions | {document}')|f(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),
                  (None, _('Compare Revisions'))] %}

--- a/apps/wiki/templates/wiki/confirm_revision_delete.html
+++ b/apps/wiki/templates/wiki/confirm_revision_delete.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Delete Revision | {document}')|f(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),
                  (None, _('Delete Revision'))] %}

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -3,6 +3,7 @@
 {% from "wiki/includes/sidebar_modules.html" import document_tabs, document_notifications %}
 {# L10n: {t} is the title of the document. {c} is the category. #}
 {% set title = _('{t} | {c}')|f(t=document.title, c=document.get_category_display()) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set classes = 'document' %}
 {% block bodyclass %}document{% endblock %}
 {% if document.parent %}

--- a/apps/wiki/templates/wiki/document_revisions.html
+++ b/apps/wiki/templates/wiki/document_revisions.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Revision History | {document}')|fe(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),
                  (None, _('History'))] %}

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -3,6 +3,7 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Edit Article | {document}')|f(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),

--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -7,6 +7,7 @@
 {% else %}
   {% set title = _('All Articles') %}
 {% endif %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block extrahead %}

--- a/apps/wiki/templates/wiki/list_documents_for_review.html
+++ b/apps/wiki/templates/wiki/list_documents_for_review.html
@@ -13,6 +13,7 @@
 {% else %}
   {% set title = _('All Articles in Need of Review') %}
 {% endif %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block content %}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -3,6 +3,7 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Create a New Article | Knowledge Base') %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(None, _('New Article'))] %}
 {% set classes = 'new' %}

--- a/apps/wiki/templates/wiki/review_revision.html
+++ b/apps/wiki/templates/wiki/review_revision.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Review Revision {id} | {document}')|f(document=document.title, id=revision.id) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title), (None, 'Review Revision')] %}
 {% set classes = 'review' %}

--- a/apps/wiki/templates/wiki/review_translation.html
+++ b/apps/wiki/templates/wiki/review_translation.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Review Translation {id} | {document}')|f(document=document.parent.title, id=revision.id) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title), (None, 'Review Translation')] %}
 {% set classes = 'review' %}

--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -3,6 +3,7 @@
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {# L10n: {n} is the revision number, {t} is the title of the document. {c} is the category. #}
 {% set title = _('Revision {n} | {t} | {c}')|f(n=revision.id, t=document.title, c=document.get_category_display()) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set meta = [('robots', 'noindex, nofollow')] %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),

--- a/apps/wiki/templates/wiki/select_locale.html
+++ b/apps/wiki/templates/wiki/select_locale.html
@@ -2,6 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% set title = _('Select language | {document}')|f(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
                  (document.get_absolute_url(), document.title),
                  (None, _('Select language'))] %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -4,6 +4,7 @@
 {% from "wiki/includes/sidebar_modules.html" import document_tabs %}
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Translate Article | {document}')|f(document=parent.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(url('wiki.category', parent.category), parent.get_category_display()),
                  (parent.get_absolute_url(), parent.title),
                  (None, _('Translate Article'))] %}


### PR DESCRIPTION
There's no bug for this, but I discovered that the page titles on wiki templates weren't being properly passed up to the MDN base template
