### PR TITLE
700673 actioncounterunique

### DIFF
--- a/apps/actioncounters/migrations/0002_unique_hash_index.py
+++ b/apps/actioncounters/migrations/0002_unique_hash_index.py
@@ -12,7 +12,7 @@ class Migration(SchemaMigration):
         db.delete_column('actioncounters_actioncounterunique', 'session_key')
 
         # Adding field 'ActionCounterUnique.unique_hash'
-        db.add_column('actioncounters_actioncounterunique', 'unique_hash', self.gf('django.db.models.fields.CharField')(blank=True, max_length=32, null=True, db_index=True), keep_default=False)
+        db.add_column('actioncounters_actioncounterunique', 'unique_hash', self.gf('django.db.models.fields.CharField')(blank=True, max_length=32, unique=True, null=True, db_index=True), keep_default=False)
 
 
     def backwards(self, orm):

--- a/migrations/10-unique-hash-indexes.sql
+++ b/migrations/10-unique-hash-indexes.sql
@@ -1,0 +1,19 @@
+--
+-- The unique constraint got left out of an earlier actioncounters migration,
+-- so this schematic migration forcibly cleans up the few duplicates and adds
+-- the unique constraint.
+--
+-- There should only be about 50 duplicates in 180000 or so production records.
+--
+CREATE TEMPORARY TABLE dup_actioncounter_hashes
+    SELECT unique_hash
+    FROM actioncounters_actioncounterunique
+    GROUP BY unique_hash 
+    HAVING count(unique_hash) > 1;
+
+DELETE FROM actioncounters_actioncounterunique 
+    WHERE unique_hash IN
+        (SELECT unique_hash FROM dup_actioncounter_hashes);
+
+ALTER TABLE actioncounters_actioncounterunique 
+    ADD UNIQUE actioncounters_actioncounterunique_unique (unique_hash);


### PR DESCRIPTION
Looks like `unique=true` was left out of the previous South migration for actioncounters. This commit adds it.

However, that doesn't help the current situation. Doesn't seem like South has an easy way to add a new unique constraint, and especially not where there are already duplicates in the table.

So, there's also a schematic migration which deletes the duplicate rows and then adds the unique index to the table.

I have one concern about this, and it's that the schematic migration may fail on a new install where the new South migration is run and the unique index gets correctly added. I'm not sure how to address that, or if it's a big deal.
