### PR TITLE
Hide the BrowserID button with CSS until the JS is ready

### DIFF
--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -312,6 +312,11 @@ a.browserid-signin:link, a.browserid-signin:visited { padding: 1px 10px 1px 28px
 a.browserid-signin:hover, a.browserid-signin:focus, a.browserid-link:active { background-color: #666; }
 
 #user-signin a.browserid-signin { position: relative; z-index: 100; }
+
+/* Hide the BrowserID sign in button until the JS behind it is ready */
+#user-signin .browserid-signin { display: none; }
+.hasJS #user-signin .browserid-signin { display: inline; }
+
 #browserid-info { position: absolute; z-index: 99; left: -999em; top: 0; margin-top: 25px; 
   width: 300px; 
   color: #ccc; 

--- a/templates/includes/login.html
+++ b/templates/includes/login.html
@@ -20,7 +20,7 @@
               {% if request.COOKIES.get('browserid_explained', 0) == '1' %}
                 {% set toggle = '' %}
               {% endif %}
-              <a href="https://browserid.org/" target="_blank" class="browserid-signin {{ toggle }}" aria-haspopup="true" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a> 
+              <a href="#" target="_blank" class="browserid-signin {{ toggle }}" aria-haspopup="true" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a> 
               {% if toggle %}
               <div id="browserid-info" class="sub-menu" aria-hidden="true" aria-labelledby="user-signin">
               {% trans browserid_href='https://browserid.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
@@ -30,7 +30,7 @@
                 <p><strong>Returning members:</strong> sign in with BrowserID and you'll be connected to your MDN profile (all your information is still here).</p>
                 <p><strong>New members:</strong> sign in with BrowserID first, then you'll be able to set up your new MDN profile.</p>
               {% endtrans %}
-                <p><a href="https://browserid.org/" target="_blank" class="browserid-signin" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a></p>
+                <p><a href="#" target="_blank" class="browserid-signin" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a></p>
               </div>
               {% endif %}
           </form>


### PR DESCRIPTION
If a user clicks on "Sign In" before the BrowserID JS has initialized,
they get sent to browserid.org in a new tab/window. That's confusing.
