### PR TITLE
Bug 715923 profile feed errors

### DIFF
--- a/apps/devmo/models.py
+++ b/apps/devmo/models.py
@@ -248,21 +248,26 @@ class UserDocsActivityFeed(object):
         # If there's no feed data in the object, try getting it.
         if not self._items:
 
-            # Try getting the parsed feed data from cache
-            url = self.feed_url_for_user()
-            cache_key = '%s:%s' % (
-                USER_DOCS_ACTIVITY_FEED_CACHE_PREFIX,
-                hashlib.md5(url).hexdigest())
-            items = cache.get(cache_key)
+            try:
+                # Try getting the parsed feed data from cache
+                url = self.feed_url_for_user()
+                cache_key = '%s:%s' % (
+                    USER_DOCS_ACTIVITY_FEED_CACHE_PREFIX,
+                    hashlib.md5(url).hexdigest())
+                items = cache.get(cache_key)
 
-            # If no cached feed data, try fetching & parsing it.
-            if not items:
-                data = self.fetch_user_feed()
-                parser = UserDocsActivityFeedParser(base_url=self.base_url)
-                parser.parseString(data)
-                items = parser.items
-                cache.set(cache_key, items,
-                          USER_DOCS_ACTIVITY_FEED_CACHE_TIMEOUT)
+                # If no cached feed data, try fetching & parsing it.
+                if not items:
+                    data = self.fetch_user_feed()
+                    parser = UserDocsActivityFeedParser(base_url=self.base_url)
+                    parser.parseString(data)
+                    items = parser.items
+                    cache.set(cache_key, items,
+                              USER_DOCS_ACTIVITY_FEED_CACHE_TIMEOUT)
+
+            except Exception, e:
+                # On error, items isn't just empty, it's False
+                items = False
 
             # We've got feed data now.
             self._items = items

--- a/apps/devmo/templates/devmo/profile.html
+++ b/apps/devmo/templates/devmo/profile.html
@@ -113,7 +113,10 @@
         </section>
     {% endif %}
  
-    {% if docs_feed_items | length > 0 %}
+    {# TODO: Maybe show a more explicit temporary-failure messge when
+             docs_feed_items is False, rather than just hiding the section? 
+             This will be reimplemented for Kuma, anyway, though. #}
+    {% if docs_feed_items and docs_feed_items | length > 0 %}
         <section id="docs-activity" class="profile-section">
           <header>
             <h2>{{_("Recent Docs Activity")}}</h2>

--- a/apps/devmo/tests/test_models.py
+++ b/apps/devmo/tests/test_models.py
@@ -177,6 +177,20 @@ class TestUserProfile(test_utils.TestCase):
                 eq_(item.rc_moved_to_title, item.current_title)
 
     @attr('docs_activity')
+    @attr('bug715923')
+    @patch('devmo.models.UserDocsActivityFeed.fetch_user_feed')
+    def test_bug715923_feed_parsing_errors(self, fetch_user_feed):
+        fetch_user_feed.return_value = """
+            THIS IS NOT EVEN XML, SO BROKEN
+        """
+        try:
+            feed = UserDocsActivityFeed(username="Sheppy")
+            items = feed.items
+            eq_(False, items,
+                "On error, items should be False")
+        except Exception, e:
+            ok_(False, "There should be no exception %s" % e)
+
     def test_irc_nickname(self):
         """We've added IRC nickname as a profile field. Make sure it shows up."""
         user = User.objects.get(username='testuser')

--- a/apps/devmo/views.py
+++ b/apps/devmo/views.py
@@ -60,8 +60,9 @@ def profile_view(request, username):
     demos_paginator = Paginator(demos, DEMOS_PAGE_SIZE, True)
     demos_page = demos_paginator.page(page_number)
 
-    docs_feed_items = (UserDocsActivityFeed(user.username)
-                       .items[:DOCS_ACTIVITY_MAX_ITEMS])
+    docs_feed_items = UserDocsActivityFeed(user.username).items
+    if docs_feed_items is not False:
+        docs_feed_items = docs_feed_items[:DOCS_ACTIVITY_MAX_ITEMS]
 
     return jingo.render(request, 'devmo/profile.html', dict(
         profile=profile, demos=demos, demos_paginator=demos_paginator,


### PR DESCRIPTION
Traps any parsing errors resulting from a failed request for a MindTouch activity feed, and just hides the feed displayed on user profile.

Could be possible to display a message about the temporary failure, rather than hide the section altogether, but not sure it's worth it since these errors should be transient and the feature will be rewritten entirely for Kuma.
