### PR TITLE
Bug 715723 - Make the BrowserID verification form exempt from CSRF protection

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -12,6 +12,8 @@ from django.contrib.sites.models import Site
 from django.http import HttpResponseRedirect, Http404
 from django.views.decorators.http import (require_http_methods, require_GET,
                                           require_POST)
+from django.views.decorators.csrf import csrf_exempt
+
 from django.shortcuts import get_object_or_404
 from django.utils.http import base36_to_int
 
@@ -76,6 +78,7 @@ def set_browserid_explained(response):
     return response
 
 
+@csrf_exempt
 @ssl_required
 @require_POST
 def browserid_verify(request):


### PR DESCRIPTION
Quick 2-line change to make the browserid verification form exempt from CSRF enforcement. Still thinking about tests, but might not need any. 

Can't quite figure out how to stop the CSRF token from being added to the form, since I think some middleware is doing that. And, I think the middleware is configured by the whole request and not by individual form.

Either way, this change should enable browserid forms posted from the Deki skin to be accepted
