### PR TITLE
Reset retained DB queries between documents to flatten memory usage

### DIFF
--- a/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
+++ b/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
@@ -30,6 +30,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.management.base import (BaseCommand, NoArgsCommand,
                                          CommandError)
+import django.db
 from django.db import connections, connection, transaction, IntegrityError
 from django.utils import encoding, hashcompat
 
@@ -134,6 +135,11 @@ class Command(BaseCommand):
                 if self.update_document(r):
                     # Something was actually updated and not skipped
                     ct += 1
+                
+                # Clear query cache after each document. Lots of queries are
+                # bound to happen, there.
+                django.db.reset_queries()
+
                 if ct >= self.options['limit']:
                     log.info("Reached limit of %s documents migrated" %
                              self.options['limit'])
@@ -196,6 +202,9 @@ class Command(BaseCommand):
             ct += 1
             if 0 == (ct % 10):
                 log.debug("\t%s deleted" % ct)
+                # Clear query cache after each document. Lots of queries are
+                # bound to happen, there.
+                django.db.reset_queries()
 
     def index_migrated_docs(self):
         """Build an index of Kuma docs already migrated, mapping Mindtouch page

--- a/scripts/migrate_all.sh
+++ b/scripts/migrate_all.sh
@@ -1,15 +1,5 @@
 #!/bin/bash
 # 
-# HACK: Run the migration command on chunks until it runs out.
+# Migrate all pages
 #
-# Since the migration process eats up memory without end, run migration on
-# limited chunks in a loop. If a migration run comes up with a non-zero
-# exit status, then presumably there's nothing left to migrate and so the loop
-# can stop.
-#
-while [ 1 ]; do
-    ./manage.py migrate_to_kuma_wiki --all --limit=200
-    if [ $? -ne 0 ]; then
-        break
-    fi
-done
+./manage.py migrate_to_kuma_wiki --all


### PR DESCRIPTION
Before this change, the migration command would steadily consume memory until the system killed it. Now, I've been able to run it for 30 min on my VM without memory consumption rising above 505MB. No need for hacks that run the script on a chunk of documents and then restarts it to reclaim memory.
