### PR TITLE
Bug 719945 demo submit browserid

### DIFF
--- a/apps/demos/templates/demos/submit_noauth.html
+++ b/apps/demos/templates/demos/submit_noauth.html
@@ -1,9 +1,15 @@
 {% extends "demos/base.html" %}
 
+{% set use_browserid = LANG|lower in config.BROWSERID_LOCALES.split(' ') %}
+
 {% set obj = submission %}
 {% set submit_url=url('demos_submit') %}
-{% set signup_url=url('users.register') | e %}
 {% set login_url='%s?next=%s' % (url('users.login'), submit_url) %}
+{% if use_browserid %}
+    {% set signup_url=login_url %}
+{% else %}
+    {% set signup_url=url('users.register') | e %}
+{% endif %}
 
 {% block pageid %}demos-submit{% endblock %}
 {% block bodyclass %}section-demos plain{% endblock %}
@@ -63,7 +69,9 @@
     {% endtrans %}
     
     <p class="choices">
+        {% if not use_browserid %}
         <a href="{{signup_url}}" class="button positive">{{_('Create an Account')}}</a> 
+        {% endif %}
         <a href="{{login_url}}" class="button">{{_('Log In to Account')}}</a>
     </p>
 

--- a/apps/users/templates/users/browserid_login_form.html
+++ b/apps/users/templates/users/browserid_login_form.html
@@ -1,0 +1,11 @@
+{% from "layout/errorlist.html" import errorlist %}
+<form class="browserid boxed" action="{{url('users.browserid_verify')}}" method="POST">
+  <input type="hidden" name="next" value="{{ next_url }}" />
+  {{ errorlist(form) }}
+  <p>{% trans browserid_href='https://browserid.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
+  MDN has switched to <a href="{{ browserid_href }}" rel="external">BrowserID</a>, 
+  a safe and simple way to sign in with just your e-mail address. <a href="{{ why_browserid }}" rel="external">Learn more about it.</a>
+  {% endtrans %}</p> 
+  {{ browserid_form }}
+  <a href="https://browserid.org/" target="_blank" class="browserid-signin" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a>
+</form>

--- a/apps/users/templates/users/login.html
+++ b/apps/users/templates/users/login.html
@@ -12,16 +12,7 @@
         <article id="login" class="main">
         {% if use_browserid %}
             <h1>{{ _('Sign In with BrowserID') }}</h1> 
-            <form class="browserid boxed" action="{{url('users.browserid_verify')}}" method="POST">
-              <input type="hidden" name="next" value="{{ next_url }}" />
-              {{ errorlist(form) }}
-              <p>{% trans browserid_href='https://browserid.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
-              MDN has switched to <a href="{{ browserid_href }}" rel="external">BrowserID</a>, 
-              a safe and simple way to sign in with just your e-mail address. <a href="{{ why_browserid }}" rel="external">Learn more about it.</a>
-              {% endtrans %}</p> 
-              {{ browserid_form }}
-              <a href="https://browserid.org/" target="_blank" class="browserid-signin" title="{{_('Sign in with BrowserID')}}">{{ _('Sign in') }}</a>
-            </form>
+            {% include "users/browserid_login_form.html" %}
         {% else %}
             <h1>{{ _('Log In') }}</h1>
             {% include "users/login_form.html" %}

--- a/apps/users/templates/users/register.html
+++ b/apps/users/templates/users/register.html
@@ -3,12 +3,17 @@
 {% from "layout/errorlist.html" import errorlist %}
 {% set title = _('Register') %}
 {% set classes = 'register' %}
+{% set use_browserid = LANG|lower in config.BROWSERID_LOCALES.split(' ') %}
 
 {% block content %}
 <section id="content">
   <div class="wrap">
     <div id="content-main" class="full">
       <article id="register" class="main">
+        {% if use_browserid %}
+            <h1>{{ _('Sign In with BrowserID') }}</h1> 
+            {% include "users/browserid_login_form.html" %}
+        {% else %}
         <h1>{{ _('Register') }}</h1>
         <p>{% trans %}
           You can access everything on the MDN website even without an account, but 
@@ -26,6 +31,7 @@
             <li class="submit"><button type="submit">{{ _('Register') }}</button></li>
           </ul>
         </form>
+        {% endif %}
       </article>
     </div>
    </div>


### PR DESCRIPTION
- Remove "create account" button on demo submit non-auth'd when
  browserid is available.
- Link "MDN Account" to login when browserid is available.
- Embed browserid login form on registration page for legacy links
