### PR TITLE
fix bug 710724, bug 717445: Migrate locales, separate UI and doc locale

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -62,8 +62,8 @@ class ContentSectionTool(object):
         self.stream = SectionIDFilter(self.stream)
         return self
 
-    def injectSectionEditingLinks(self, slug, locale):
-        self.stream = SectionEditLinkFilter(self.stream, slug, locale)
+    def injectSectionEditingLinks(self, full_path, locale):
+        self.stream = SectionEditLinkFilter(self.stream, full_path, locale)
         return self
 
     def extractSection(self, id):
@@ -120,9 +120,9 @@ class SectionIDFilter(html5lib_Filter):
 class SectionEditLinkFilter(html5lib_Filter):
     """Filter which injects editing links for sections with IDs"""
 
-    def __init__(self, source, slug, locale):
+    def __init__(self, source, full_path, locale):
         html5lib_Filter.__init__(self, source)
-        self.slug = slug
+        self.full_path = full_path
         self.locale = locale
 
     def __iter__(self):
@@ -145,13 +145,13 @@ class SectionEditLinkFilter(html5lib_Filter):
                              'data-section-id': id,
                              'data-section-src-url': '%s?%s' % (
                                  reverse('wiki.document',
-                                         args=[self.slug],
+                                         args=[self.full_path],
                                          locale=self.locale),
                                  urlencode({'section': id, 'raw': 'true'})
                               ),
                               'href': '%s?%s' % (
                                  reverse('wiki.edit_document',
-                                         args=[self.slug],
+                                         args=[self.full_path],
                                          locale=self.locale),
                                  urlencode({'section': id,
                                             'edit_links': 'true'})

--- a/apps/wiki/events.py
+++ b/apps/wiki/events.py
@@ -44,8 +44,8 @@ class EditDocumentEvent(InstanceEvent):
 
     def _mails(self, users_and_watches):
         document = self.revision.document
-        log.debug('Sending edited notification email for document (id=%s)' %
-                  document.id)
+        # log.debug('Sending edited notification email for document (id=%s)' %
+        #           document.id)
         subject = _('{title} was edited by {creator}')
         url = reverse('wiki.document_revisions', locale=document.locale,
                       args=[document.slug])
@@ -80,8 +80,8 @@ class ReviewableRevisionInLocaleEvent(_RevisionInLocaleEvent):
     def _mails(self, users_and_watches):
         revision = self.revision
         document = revision.document
-        log.debug('Sending ready for review email for revision (id=%s)' %
-                  revision.id)
+        # log.debug('Sending ready for review email for revision (id=%s)' %
+        #           revision.id)
         subject = _('{title} is ready for review ({creator})')
         url = reverse('wiki.review_revision', locale=document.locale,
                       args=[document.slug, revision.id])

--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -26,11 +26,11 @@ log = logging.getLogger('k.task')
 def send_reviewed_notification(revision, document, message):
     """Send notification of review to the revision creator."""
     if revision.reviewer == revision.creator:
-        log.debug('Revision (id=%s) reviewed by creator, skipping email' % \
-                  revision.id)
+        # log.debug('Revision (id=%s) reviewed by creator, skipping email' % \
+        #           revision.id)
         return
 
-    log.debug('Sending reviewed email for revision (id=%s)' % revision.id)
+    # log.debug('Sending reviewed email for revision (id=%s)' % revision.id)
     if revision.is_approved:
         subject = _('Your revision has been approved: {title}')
     else:

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -8,12 +8,12 @@
 {% block bodyclass %}document{% endblock %}
 {% if document.parent %}
   {# If there is a parent doc, use it's URL for switching locales. #}
-  {% set localizable_url = url('wiki.document', document.parent.slug, locale=settings.WIKI_DEFAULT_LANGUAGE) %}
+  {% set localizable_url = document.parent.get_absolute_url(settings.WIKI_DEFAULT_LANGUAGE) %}
 {% endif %}
 
 {% block extrahead %}
   <link rel="alternate" type="application/json" 
-    href="{{ url('wiki.json_slug', document.slug) }}">
+    href="{{ url('wiki.json_slug', document.full_path) }}">
 {% endblock %}
 
 {% block content %}
@@ -29,12 +29,12 @@
             <h1 class="page-title">{{ document.title }}</h1>
         </div>
         <ul id="page-buttons">
-            <li class="page-history"><a href="{{ url('wiki.document_revisions', document.slug) }}">{{_('History')}}</a></li>
+            <li class="page-history"><a href="{{ url('wiki.document_revisions', document.full_path) }}">{{_('History')}}</a></li>
             {% if request.user.is_authenticated() %}
-              <li class="page-watch"><a href="{{ url('wiki.document_watch', document.slug) }}">{{_('Watch')}}</a></li>
+              <li class="page-watch"><a href="{{ url('wiki.document_watch', document.full_path) }}">{{_('Watch')}}</a></li>
             {% endif %}
             {% if document.allows_editing_by(request.user) %}
-              <li class="page-edit"><a href="{{ url('wiki.edit_document', document.slug) }}">{{_('Edit')}}</a></li>
+              <li class="page-edit"><a href="{{ url('wiki.edit_document', document.full_path) }}">{{_('Edit')}}</a></li>
             {% endif %}
         </ul>
        </header>
@@ -119,18 +119,21 @@
       {% endif %}
     </div>
     <section class="page-meta">
+      {% set tags = document.tags.all() %}
+      {% if tags | length %}
       <section id="page-tags">
         <h2>{{ _('Tags') }}</h2>
         <div id="deki-page-tags">
           <ul class="tags">
             <li>
-              {% for tag in document.tags.all() %}
+              {% for tag in tags %}
                 <a class="text" href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a>
               {% endfor %}
             </li>
           </ul>
         </div>
       </section>
+      {% endif %}
       <section id="doc-contributors">
         {% trans contributors=user_list(contributors) %}
           Contributors to this page: {{ contributors }}
@@ -138,7 +141,7 @@
       </section>
     </section>
   </article>
-  <form id="wiki-page-edit" class="editing" method="post" action="{{ url('wiki.edit_document', document_slug=document.slug) }}">
+  <form id="wiki-page-edit" class="editing" method="post" action="{{ url('wiki.edit_document', document_path=document.full_path) }}">
       <input type="hidden" name="form" id="form" value="rev" />
       <input type="hidden" name="content" id="content" value="" />
   </form>
@@ -172,12 +175,12 @@
   {% if user.is_authenticated() and document %}
     <div id="doc-watch">
       {% if document.is_watched_by(user) %}
-        <form action="{{ url('wiki.document_unwatch', document.slug) }}" method="post">
+        <form action="{{ url('wiki.document_unwatch', document.full_path) }}" method="post">
           {{ csrf() }}
           <input type="submit" class="link-btn" value="{{ _('Turn off emails.') }}" />
         </form>
       {% else %}
-        <form action="{{ url('wiki.document_watch', document.slug) }}" method="post">
+        <form action="{{ url('wiki.document_watch', document.full_path) }}" method="post">
           {{ csrf() }}
           <input type="submit" class="link-btn" value="{{ _('Get emailed when this article changes.') }}" />
         </form>

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -39,7 +39,7 @@
               </div>
               <div>
                 <h3>
-                    <a href="{{ url('wiki.revision', current_revision.document.slug, current_revision.id) }}">
+                    <a href="{{ url('wiki.revision', current_revision.document.full_path, current_revision.id) }}">
                       {{ _('Current Revision:')|f(num=current_revision.id) }}
                     </a>
                 </h3>

--- a/apps/wiki/templates/wiki/includes/page_buttons.html
+++ b/apps/wiki/templates/wiki/includes/page_buttons.html
@@ -1,6 +1,6 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% if document %}
-    {% set discard_href = url('wiki.document', document.slug) %}
+    {% set discard_href = url('wiki.document', document.full_path) %}
 {% else %}
     {% set discard_href = url('wiki.new_document') %}
 {% endif %}

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -97,7 +97,9 @@ def doc_rev(content=''):
 def new_document_data(tags=None):
     return {
         'title': 'A Test Article',
+        'locale': 'en-US',
         'slug': 'a-test-article',
+        'full_path': 'en-US/a-test-article',
         'tags': ', '.join(tags or []),
         'firefox_versions': [1, 2],
         'operating_systems': [1, 3],

--- a/apps/wiki/tests/test_forms.py
+++ b/apps/wiki/tests/test_forms.py
@@ -47,7 +47,6 @@ class FormSectionEditingTests(TestCase):
         eq_(normalize_html(expected), 
             normalize_html(rev_form.initial['content']))
 
-    @attr('current')
     def test_form_save_section(self):
         d, r = doc_rev("""
             <h1 id="s1">Head 1</h1>

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -104,5 +104,5 @@ urlpatterns += patterns('wiki.views',
 
     url(r'^/tag/(?P<tag>[^/]+)$', 'list_documents', name='wiki.tag'),
 
-    (r'^/(?P<document_slug>[^\$]+)', include(document_patterns)),
+    (r'^/(?P<document_path>[^\$]+)', include(document_patterns)),
 )

--- a/scripts/migrate_recent.sh
+++ b/scripts/migrate_recent.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # Script for staging server migration cron job
 # Migrate the 25 most recently modified MindTouch pages 
-#
-# python26 manage.py migrate_to_kuma_wiki --recent=25
+
+python26 manage.py migrate_to_kuma_wiki --recent=25

--- a/settings.py
+++ b/settings.py
@@ -100,8 +100,10 @@ SUMO_LANGUAGES = (
 #LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in SUMO_LANGUAGES])
 
 # Accepted locales
-MDN_LANGUAGES = ('en-US', 'de', 'el', 'es', 'fr', 'fy-NL', 'ga-IE', 'hr', 'hu', 'id',
-                 'ja', 'ko', 'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'sq', 'th', 'zh-CN', 'zh-TW')
+MDN_LANGUAGES = ('en-US', 'ar', 'de', 'it', 'el', 'es', 'fa', 'fi', 'fr', 'cs',
+                 'ca', 'fy-NL', 'ga-IE', 'he', 'hr', 'hu', 'id', 'ja', 'ka',
+                 'ko', 'nl', 'pl', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sq', 'th',
+                 'tr', 'vi', 'zh-CN', 'zh-TW')
 RTL_LANGUAGES = None # ('ar', 'fa', 'fa-IR', 'he')
 
 DEV_POOTLE_PRODUCT_DETAILS_MAP = {
@@ -162,6 +164,68 @@ def lazy_language_deki_map():
     return lang_deki_map
 
 LANGUAGE_DEKI_MAP = lazy(lazy_language_deki_map, dict)()
+
+# List of MindTouch locales mapped to Kuma locales.
+# 
+# Language in MindTouch pages are first determined from the locale in the page
+# title, with a fallback to the language in the page record.
+#
+# So, first MindTouch locales were inventoried like so:
+#
+#     mysql --skip-column-names -uroot wikidb -B \
+#           -e 'select page_title from pages  where page_namespace=0' \
+#           > page-titles.txt
+#
+#     grep '/' page-titles.txt | cut -d'/' -f1 | sort -f | uniq -ci | sort -rn
+#
+# Then, the database languages were inventoried like so:
+#
+#     select page_language, count(page_id) as ct 
+#     from pages group by page_language order by ct desc;
+#
+# Also worth noting, these are locales configured in the prod Control Panel:
+#
+# en,ar,ca,cs,de,el,es,fa,fi,fr,he,hr,hu,it,ja,
+# ka,ko,nl,pl,pt,ro,ru,th,tr,uk,vi,zh-cn,zh-tw
+# 
+# The Kuma side was picked from elements of the MDN_LANGUAGES list in
+# settings.py, and a few were added to match MindTouch locales.
+#
+# Most of these end up being direct mappings, but it's instructive to go
+# through the mapping exercise.
+
+MT_TO_KUMA_LOCALE_MAP = {
+    "en"    : "en-US",
+    "ja"    : "ja",
+    "pl"    : "pl",
+    "fr"    : "fr",
+    "es"    : "es",
+    ""      : "en-US",
+    "cn"    : "zh-CN",
+    "zh_cn" : "zh-CN",
+    "zh-cn" : "zh-CN",
+    "zh_tw" : "zh-TW",
+    "zh-tw" : "zh-TW",
+    "ko"    : "ko",
+    "pt"    : "pt-PT",
+    "de"    : "de",
+    "it"    : "it",
+    "ca"    : "ca",
+    "cs"    : "cs",
+    "ru"    : "ru",
+    "nl"    : "nl",
+    "hu"    : "hu",
+    "he"    : "he",
+    "el"    : "el",
+    "fi"    : "fi",
+    "tr"    : "tr",
+    "vi"    : "vi",
+    "ro"    : "ro",
+    "ar"    : "ar",
+    "th"    : "th",
+    "fa"    : "fa",
+    "ka"    : "ka",
+}
 
 TEXT_DOMAIN = 'messages'
 


### PR DESCRIPTION
- Migration translates locale from MindTouch page title and page locale
  to Kuma locale
- Changed URL structure for Kuma doc pages to include both UI and
  Document locales.
- Attempting smart redirects for docs from old-style MindTouch locales
  to new Kuma locales.
- Updates to tests to reflect new Kuma doc URL structure
- Migration --nonen option to migrate pages in locales other than en-US
- Migration --failfast option to die on errors, or just continue
- Assembled mapping from known MindTouch locales to Kuma locales
- Commented out some annoying debug log messages
- Re-enabled migration cron script
