### PR TITLE
Bug 730994 migrate macros

### DIFF
--- a/apps/users/helpers.py
+++ b/apps/users/helpers.py
@@ -10,7 +10,10 @@ from sumo.urlresolvers import reverse
 @register.function
 def profile_url(user):
     """Return a URL to the user's profile."""
-    return reverse('devmo_profile_view', args=[user.username])
+    try:
+        return reverse('devmo_profile_view', args=[user.username])
+    except Exception, e:
+        return user.username
 
 
 @register.function

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -43,8 +43,9 @@
             <ul>
               {% for error in kumascript_errors %}
                 <li class="error error-{{ error.level }}">
-                  <span class="level">{{ error.level }}</span>
+                  {# <span class="level">{{ error.level }}</span> #}
                   {% if error.args %}<span class="type">{{ error.args[0] }}</span>{% endif %}
+                  &#8212;
                   <span class="message">{{ error.message }}</span>
                 </li>
               {% endfor %}


### PR DESCRIPTION
This adds code to the migration script to convert DekiScript calls in content into KumaScript macros. This should let us move on to converting templates, but not need to edit pages that use templates much

There are a lot of variations to be found in how DekiScript is used in content, but I think my analysis found them all and this normalizes them into a common KumaScript macro style
