### PR TITLE
bug 671886: clean up and migrate templates

### DIFF
--- a/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
+++ b/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
@@ -67,7 +67,8 @@ MT_NAMESPACES = (
 MT_NS_NAME_TO_ID = dict(MT_NAMESPACES)
 MT_NS_ID_TO_NAME = dict((x[1], x[0]) for x in MT_NAMESPACES)
 MT_MIGRATED_NS_IDS = (MT_NS_NAME_TO_ID[x] for x in (
-    '', 'Talk:', 'User:', 'User_talk:', 'Project:', 'Project_talk:'
+    '', 'Talk:', 'User:', 'User_talk:', 'Project:', 'Project_talk:',
+    'Template:', 'Template_talk:',
 ))
 
 # NOTE: These are MD5 hashes of garbage User page content. The criteria is that
@@ -143,6 +144,8 @@ class Command(BaseCommand):
                     help="Migrate # of documents with syntax blocks"),
         make_option('--withscripts', dest="withscripts", type="int", default=0,
                     help="Migrate # of documents that use scripts"),
+        make_option('--withtemplates', dest="withtemplates", type="int", default=0,
+                    help="Migrate # of template documents"),
         make_option('--syntax-metrics', action="store_true",
                     dest="syntax_metrics", default=False,
                     help="Measure syntax highlighter usage, skip migration"),
@@ -474,6 +477,18 @@ class Command(BaseCommand):
                     LIMIT %s
                 """ % (ns_list, '%s'), self.options['withscripts']))
 
+            if self.options['withtemplates'] > 0:
+                log.info("Gathering %s templates" %
+                         self.options['withtemplates'])
+                iters.append(self._query("""
+                    SELECT *
+                    FROM pages
+                    WHERE page_namespace=%s
+                    ORDER BY page_timestamp DESC
+                    LIMIT %s
+                """, MT_NS_NAME_TO_ID['Template:'],
+                     self.options['withtemplates']))
+
         return itertools.chain(*iters)
 
     @transaction.commit_on_success
@@ -510,6 +525,12 @@ class Command(BaseCommand):
                 log.debug("\t%s/%s (%s) matched User: content exclusion list" %
                           (locale, slug, r['page_display_name']))
                 return False
+
+        # Skip migrating Template:MindTouch/* templates
+        if slug.startswith('Template:MindTouch'):
+            log.debug("\t%s/%s (%s) skipped, was a MindTouch default template" %
+                      (locale, slug, r['page_display_name']))
+            return False
 
         # Check to see if this page's content is too long, skip if so.
         if len(r['page_text']) > self.options['maxlength']:
@@ -596,7 +617,7 @@ class Command(BaseCommand):
                 significance=SIGNIFICANCES[0][0],
                 summary='',
                 keywords='',
-                content=self.convert_page_text(r['old_text']),
+                content=self.convert_page_text(r_page, r['old_text']),
                 comment=r['old_comment'],
                 created=ts,
                 creator_id=self.get_django_user_id_for_deki_id(r['old_user']),
@@ -657,7 +678,7 @@ class Command(BaseCommand):
         rev.slug = doc.slug
         rev.title = doc.title
         rev.tags = tags
-        rev.content = self.convert_page_text(r['page_text'])
+        rev.content = self.convert_page_text(r, r['page_text'])
 
         # HACK: Some comments end up being too long, but just truncate.
         rev.comment = r['page_comment'][:255]
@@ -666,20 +687,31 @@ class Command(BaseCommand):
         rev.save()
         rev.make_current()
 
+        # If this is a template, set it as in need of template review
+        if doc.slug.startswith('Template:'):
+            rev.review_tags.set('template') 
+
         if created:
             log.info("\t\tCurrent revision created. (ID=%s)" % rev.pk)
         else:
             log.info("\t\tCurrent revision updated. (ID=%s)" % rev.pk)
 
-    def convert_page_text(self, pt):
+    def convert_page_text(self, r, pt):
         """Given a page row from MindTouch, do whatever needs doing to convert
         the page content for Kuma."""
 
+        # If this is a redirect, just convert the redirect.
         if pt.startswith('#REDIRECT'):
-            pt = self.convert_redirect(pt)
+            return self.convert_redirect(pt)
 
+        # If this is a template, just do template conversion
+        ns_name = MT_NS_ID_TO_NAME.get(r['page_namespace'], '')
+        if ns_name == 'Template:':
+            return self.convert_dekiscript_template(pt)
+
+        # Otherwise, run through the rest of the conversions.
         pt = self.convert_code_blocks(pt)
-        pt = self.convert_dekiscript_template_calls(pt)
+        pt = self.convert_dekiscript_calls(pt)
         # TODO: bug 710726 - Convert intra-wiki links?
 
         return pt
@@ -699,9 +731,47 @@ class Command(BaseCommand):
         pt = ContentSectionTool(pt).filter(CodeSyntaxFilter).serialize()
         return pt
 
-    def convert_dekiscript_template_calls(self, pt):
+    def convert_dekiscript_calls(self, pt):
         return (wiki.content.parse(pt).filter(DekiscriptMacroFilter)
                     .serialize())
+
+    def convert_dekiscript_template(self, pt):
+        """Do what we can to convert DekiScript templates into EJS templates.
+
+        This is an incomplete process, but it tries to take care off as much as
+        it can so that human intervention is minimized."""
+
+        # Many templates start with this prefix, which corresponds to {% in EJS
+        pre = '<pre class="script">'
+        if pt.startswith(pre):
+            pt = "{%%\n%s" % pt[len(pre):]
+
+        # Many templates end with this postfix, which corresponds to %} in EJS
+        post = '</pre>'
+        if pt.endswith(post):
+            pt = "%s\n%%}" % pt[:0-len(post)]
+
+        # Template source is usually HTML encoded inside the <pre>
+        pt = (pt.replace('&amp;', '&')
+                .replace('&lt;', '<')
+                .replace('&gt;', '>')
+                .replace('&quot;', '"'))
+
+        # String concatenation is '..' in DS, '+' in EJS
+        pt = pt.replace('..', '+')
+
+        # ?? in DS is pretty much || in EJS
+        pt = pt.replace('??', '||')
+
+        # No need for DS 'let' in EJS
+        pt = pt.replace('let ', '')
+
+        # This is a common sequence at the start of many templates. It clobbers
+        # the url API, and needs correcting.
+        pt = (pt.replace('var uri =', 'var u =')
+                .replace('uri.path[', 'u.path['))
+
+        return pt
 
     def get_tags_for_page(self, r):
         """For a given page row, get the list of tags from MindTouch and build

--- a/apps/wiki/admin.py
+++ b/apps/wiki/admin.py
@@ -4,16 +4,28 @@ from wiki.models import Document, Revision, EditorToolbar
 
 
 class DocumentAdmin(admin.ModelAdmin):
-    exclude = ('tags',)
-    list_display = ('id', 'locale', 'slug', 'title', 'category',
-                    'is_localizable')
+    fields = ('title', 'slug', 'locale', 'parent', 'category')
+    list_display = ('id', 'locale', 'slug', 'title', 'is_localizable',
+                    'modified', 'parent_document_link',
+                    'current_revision_link', 'related_revisions_link',)
     list_display_links = ('id', 'slug',)
     list_filter = ('is_template', 'is_localizable', 'category', 'locale')
     raw_id_fields = ('parent',)
     readonly_fields = ('id', 'current_revision')
-    search_fields = ('title',)
+    search_fields = ('title', 'slug', 'html')
+
+
+class RevisionAdmin(admin.ModelAdmin):
+    fields = ('title', 'slug', 'summary', 'content', 'keywords', 'tags',
+              'reviewed', 'comment', 'is_approved')
+    list_display = ('id', 'slug', 'title', 'is_approved', 'created',
+                    'creator',)
+    list_display_links = ('id', 'slug')
+    list_filter = ('is_approved', )
+    ordering = ('-created',)
+    search_fields = ('title', 'slug', 'summary', 'content', 'tags')
 
 
 admin.site.register(Document, DocumentAdmin)
-admin.site.register(Revision, admin.ModelAdmin)
+admin.site.register(Revision, RevisionAdmin)
 admin.site.register(EditorToolbar, admin.ModelAdmin)

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1,3 +1,4 @@
+import logging
 from collections import namedtuple
 from datetime import datetime
 from itertools import chain
@@ -137,7 +138,9 @@ REDIRECT_SLUG = _lazy(u'%(old)s-redirect-%(number)i')
 REVIEW_FLAG_TAGS = (
     ('technical', _('Technical - code samples, APIs, or technologies')),
     ('editorial', _('Editorial - prose, grammar, or content')),
+    ('template',  _('Template - KumaScript code')),
 )
+REVIEW_FLAG_TAGS_DEFAULT = ['technical', 'editorial']
 
 # TODO: This is info derived from urls.py, but unsure how to DRY it
 RESERVED_SLUGS = (
@@ -410,7 +413,7 @@ class Document(NotificationsMixin, ModelBase):
             return unique_attr()
 
     def save(self, *args, **kwargs):
-        self.is_template = self.title.startswith(TEMPLATE_TITLE_PREFIX)
+        self.is_template = self.slug.startswith(TEMPLATE_TITLE_PREFIX)
 
         try:
             # Check if the slug would collide with an existing doc
@@ -697,6 +700,39 @@ class Document(NotificationsMixin, ModelBase):
         from wiki.events import EditDocumentEvent
         return EditDocumentEvent.is_notifying(user, self)
 
+    def related_revisions_link(self):
+        """HTML link to related revisions for admin change list"""
+        link = '%s?%s' % (
+            reverse('admin:wiki_revision_changelist', args=[]),
+            'document__exact=%s' % (self.id)
+        )
+        count = self.revisions.count()
+        what = (count == 1) and 'revision' or 'revisons'
+        return '<a href="%s">%s %s</a>' % (link, count, what)
+
+    related_revisions_link.allow_tags = True
+    related_revisions_link.short_description = "All Revisions"
+        
+    def current_revision_link(self):
+        """HTML link to the current revision for the admin change list"""
+        if not self.current_revision:
+            return "None"
+        rev = self.current_revision
+        rev_url = reverse('admin:wiki_revision_change', args=[rev.id])
+        return '<a href="%s">Revision #%s</a>' % (rev_url, rev.id)
+
+    current_revision_link.allow_tags = True
+    current_revision_link.short_description = "Current Revision"
+        
+    def parent_document_link(self):
+        """HTML link to the parent document for admin change list"""
+        if not self.parent:
+            return "None"
+        url = reverse('admin:wiki_document_change', args=[self.parent.id])
+        return '<a href="%s">Document #%s</a>' % (url, self.parent.id)
+
+    parent_document_link.allow_tags = True
+    parent_document_link.short_description = "Parent Document"
 
 class ReviewTag(TagBase):
     """A tag indicating review status, mainly for revisions"""
@@ -828,7 +864,7 @@ class Revision(ModelBase):
                                    'to a revision of the default-'
                                    'language document.')
 
-        if self.content:
+        if self.content and not self.document.is_template:
             self.content = (wiki.content
                             .parse(self.content)
                             .injectSectionIDs()
@@ -874,6 +910,8 @@ class Revision(ModelBase):
 
     @property
     def content_cleaned(self):
+        if self.document.is_template:
+            return self.content
         return bleach.clean(
             self.content, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS,
             strip_comments=False

--- a/apps/wiki/templates/wiki/list_documents_for_review.html
+++ b/apps/wiki/templates/wiki/list_documents_for_review.html
@@ -20,19 +20,21 @@
 <section id="content">
   <div class="wrap">
     <div id="content-main" class="full">
-  <article id="document-list" class="main">
-    <h1>{{ title }}</h1>
-    {% if documents.object_list %}
-      <ul class="documents">
-        {% for doc in documents.object_list %}
-          <li><a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a></li>
-        {% endfor %}
-      </ul>
-      {{ documents|paginator }}
-    {% else %}
-      <p>{{ _('There are no articles.') }}</p>
-    {% endif %}
-  </article>
+
+      <div id="document-list" class="boxed">
+        <h1>{{ title }}</h1>
+        {% if documents.object_list %}
+          <ul class="documents cols-3">
+            {% for doc in documents.object_list %}
+              <li><a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a></li>
+            {% endfor %}
+          </ul>
+          {{ documents|paginator }}
+        {% else %}
+          <p>{{ _('There are no articles.') }}</p>
+        {% endif %}
+      </div>
+
     </div>
    </div>
 </section>

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -40,12 +40,12 @@ class DocumentTests(TestCase):
 
         assert not d.is_template
 
-        d.title = 'Template:test'
+        d.slug = 'Template:test'
         d.save()
 
         assert d.is_template
 
-        d.title = 'Back to document'
+        d.slug = 'Back-to-document'
         d.save()
 
         assert not d.is_template


### PR DESCRIPTION
- Defer bleach sanitation of template content all the way until the
  kumascript service response
- --withtemplates option to select templates for migration
- Migrate documents in Template: namespace, with some content tweaking
  to ease transition to KumaScript
- Add "template" review tag to mark templates in need of review
- Tweaks to review list page to use tag list styles
- Index Template: in slug as is_template, rather than title
- Skip Template:MindTouch/\* in migration, since they're out-of-box
  templates and not really used
- Tweaks to wiki admin to allow easier navigation between documents and
  related revisions
- More fields included in admin search
