### PR TITLE
Fix Bug 740065 remove duplicate constance config keys and add unique con...

### DIFF
--- a/migrations/13-constance-unique-key.sql
+++ b/migrations/13-constance-unique-key.sql
@@ -1,0 +1,16 @@
+--
+-- django-constance uses manager.get(key=) but doesn't specify unique=True on the
+-- key field. This migration fixes any duplicates and adds the unique constraint
+
+CREATE TEMPORARY TABLE dup_constance_config_keys
+    SELECT `key`, `value`
+    FROM constance_config
+    GROUP BY `key`
+    HAVING count(`key`) > 1;
+
+DELETE FROM constance_config
+    WHERE `key` IN
+        (SELECT `key` FROM dup_constance_config_keys);
+
+ALTER TABLE constance_config
+    ADD UNIQUE constance_config_key_unique(`key`(100));


### PR DESCRIPTION
I had to 

```
INSERT INTO constance_config (`key`, `value`) values ('DEMOS_DEVDERBY_CHALLENGE_CHOICE_TAGS', 'some other value');
```

to replicate the kuma-stage behavior. Then I ran this schematic migration and it fixed the issue.

I also submitted a [pull request](https://github.com/jezdez/django-constance/pull/1) to jezdez to fix the underlying issue in django-constance
