### PR TITLE
Fix Bug 742451 bad characters in referer

### DIFF
--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -610,8 +610,10 @@ def _clean_next_url(request):
         url = request.POST.get('next')
     elif 'next' in request.GET:
         url = request.GET.get('next')
+    elif 'HTTP_REFERER' in request.META:
+        url = request.META.get('HTTP_REFERER').decode('latin1', 'ignore')
     else:
-        url = request.META.get('HTTP_REFERER')
+        url = None
 
     if url:
         parsed_url = urlparse.urlparse(url)


### PR DESCRIPTION
Since this was hard/impossible to reproduce via the GUI, I just reproduce it with curl. (See the test code for the headers to send.)
