### PR TITLE
Fix Bug 735888 fill parent_id using MindTouch wiki.languages

### DIFF
--- a/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
+++ b/apps/dekicompat/management/commands/migrate_to_kuma_wiki.py
@@ -154,9 +154,6 @@ class Command(BaseCommand):
         make_option('--syntax-metrics', action="store_true",
                     dest="syntax_metrics", default=False,
                     help="Measure syntax highlighter usage, skip migration"),
-        make_option('--language-rels', action="store_true",
-                    dest="language_rels", default=False,
-                    help="Build page languages tree, skip migration"),
 
         make_option('--limit', dest="limit", type="int", default=99999,
                     help="Stop after a migrating a number of documents"),
@@ -200,10 +197,10 @@ class Command(BaseCommand):
             self.handle_template_metrics(rows)
         elif options['syntax_metrics']:
             self.handle_syntax_metrics(rows)
-        elif options['language_rels']:
-            self.make_languages_relationships(rows)
         else:
             self.handle_migration(rows)
+            rows = self.gather_pages()
+            self.make_languages_relationships(rows)
 
     def init(self, options):
         """Set up connections and options"""


### PR DESCRIPTION
New options on the migration script:

--withlanguages=NN 
migrates NN pages that have {{ wiki.languages ... }} in the content. An easy way to grab a bunch of pages that actually have source/translation relationships

--language-rels
makes kuma parent/child relationships for pages specified in the migrate options

e.g.,

migrate_to_kuma_wiki --wipe --withlanguages=5 --language-rels
wipes all pages, migrates 5 pages with translations, migrates the translations, and creates the parent/child relationship for the $translate page to work

migrate_to_kuma_wiki --wipe --viewed=50 --language-rels
wipes all pages, migrates 50 most-viewed pages, migrates their translations (if any), and creates the parent/child relationship for the $translate page to work
