### PR TITLE
*some* fixes for migrations for fresh vagrant boxes

### DIFF
--- a/apps/wiki/migrations/0014_add_show_toc_field.py
+++ b/apps/wiki/migrations/0014_add_show_toc_field.py
@@ -9,7 +9,7 @@ class Migration(SchemaMigration):
     def forwards(self, orm):
         
         # Adding field 'Revision.show_toc'
-        db.add_column('wiki_revision', 'show_toc', self.gf('django.db.models.fields.BooleanField')(default=True), keep_default=False)
+        db.add_column('wiki_revision', 'show_toc', self.gf('django.db.models.fields.BooleanField')(default=True), keep_default=True)
 
 
     def backwards(self, orm):

--- a/migrations/11-drop-old-wiki-tables.sql
+++ b/migrations/11-drop-old-wiki-tables.sql
@@ -5,6 +5,7 @@
 SET FOREIGN_KEY_CHECKS=0;
 DROP TABLE IF EXISTS
     wiki_document,
+    wiki_documenttag,
     wiki_editortoolbar,
     wiki_firefoxversion,
     wiki_helpfulvote,
@@ -12,7 +13,8 @@ DROP TABLE IF EXISTS
     wiki_relateddocument,
     wiki_reviewtag,
     wiki_reviewtaggedrevision,
-    wiki_revision;
+    wiki_revision,
+    wiki_taggeddocument;
 
 DELETE FROM south_migrationhistory 
     WHERE app_name="wiki";

--- a/migrations/12-add-soapbox.sql
+++ b/migrations/12-add-soapbox.sql
@@ -1,4 +1,6 @@
 BEGIN;
+DROP TABLE IF EXISTS `soapbox_message`;
+
 CREATE TABLE `soapbox_message` (
     `id` integer AUTO_INCREMENT NOT NULL PRIMARY KEY,
     `message` longtext NOT NULL,

--- a/migrations/14-unique-hash-indexes.sql
+++ b/migrations/14-unique-hash-indexes.sql
@@ -15,5 +15,8 @@ DELETE FROM actioncounters_actioncounterunique
     WHERE unique_hash IN
         (SELECT unique_hash FROM dup_actioncounter_hashes);
 
+DROP INDEX actioncounters_actioncounterunique_unique
+    ON actioncounters_actioncounterunique;
+
 ALTER TABLE actioncounters_actioncounterunique 
     ADD UNIQUE actioncounters_actioncounterunique_unique (unique_hash);

--- a/puppet/files/tmp/postimport.sql
+++ b/puppet/files/tmp/postimport.sql
@@ -5,6 +5,7 @@ SET FOREIGN_KEY_CHECKS = 0;
 DROP TABLE IF EXISTS `devmo_event` CASCADE;
 DROP TABLE IF EXISTS `devmo_calendar` CASCADE;
 DROP TABLE IF EXISTS `wiki_document` CASCADE;
+DROP TABLE IF EXISTS `wiki_documenttag` CASCADE;
 DROP TABLE IF EXISTS `wiki_revision` CASCADE;
 DROP TABLE IF EXISTS `wiki_firefoxversion` CASCADE; 
 DROP TABLE IF EXISTS `wiki_operatingsystem` CASCADE;
@@ -13,6 +14,7 @@ DROP TABLE IF EXISTS `wiki_relateddocument` CASCADE;
 DROP TABLE IF EXISTS `wiki_editortoolbar` CASCADE;
 DROP TABLE IF EXISTS `wiki_reviewtaggedrevision` CASCADE;
 DROP TABLE IF EXISTS `wiki_reviewtag` CASCADE;
+DROP TABLE IF EXISTS `wiki_taggeddocument` CASCADE;
 
 -- Change site to developer-dev
 UPDATE django_site set domain = 'developer-dev.mozilla.org', name = 'developer-dev.mozilla.org';

--- a/puppet/manifests/dev-vagrant.pp
+++ b/puppet/manifests/dev-vagrant.pp
@@ -34,7 +34,7 @@ class dev {
         apache:    stage => basics;
         mysql:     stage => basics;
         memcache:  stage => basics;
-        sphinx:    stage => basics;
+#        sphinx:    stage => basics;
 
         python: stage => langs;
         php:    stage => langs;


### PR DESCRIPTION
This doesn't fix everything, but it improves things so it only takes a few commands to prep a fresh vagrant box to run the migrate_to_kuma_wiki command. I filed https://bugzilla.mozilla.org/show_bug.cgi?id=748806 for the rest.
