### PR TITLE
Demo launch js cleanup

### DIFF
--- a/apps/demos/templates/demos/detail.html
+++ b/apps/demos/templates/demos/detail.html
@@ -323,44 +323,50 @@
 
     </script>
 
+
     <script type="text/javascript">      
-      $("#share-opts").ready(function(){
-      	$("#share-opts").addClass("js").hide();
-      	
-      	$("#sharetoggle").click(function() {
-          $("#share-opts").fadeIn(100);
+
+      $(document).ready(function() {
+        var $shareOpts = $("#share-opts"),
+          $shareToggle = $("#sharetoggle");
+
+        $shareOpts.addClass("js").hide();
+
+        $shareToggle.click(function() {
+          $shareOpts.fadeIn(100);
           return false;
-      	});
-      	
-        $("#share-opts").hover(
+        });
+        
+        $shareOpts.hover(
           function() {
             $(this).show();
           },
           function() {
             $(this).fadeOut(100);
-            $("#sharetoggle").blur();
+            $shareToggle.blur();
           }
         );
         
-        $("#shorturl").focus(function() {
-          $(this).select().addClass("focus");
-        });
-        $("#shorturl").click(function() {
-          $(this).select().addClass("focus");
-        });
-        $("#shorturl").blur(function() {
-          $(this).removeClass("focus");
-        });
+        $("#shorturl")
+          .focus(function() {
+            $(this).select().addClass("focus");
+          })
+          .click(function() {
+            $(this).select().addClass("focus");
+          })
+          .blur(function() {
+            $(this).removeClass("focus");
+          });
 
-        $('#share-opts li a').click(function () {
+        $shareOpts.find('li a').click(function () {
             var link = $(this);
             window.open(link.attr('href'), 'sharer', 
                 'toolbar=0, status=0, resizable=1, width=626, height=436');
             return false;
         });
-      
+
       });
-      </script>
+    </script>
        <script type="text/javascript" src="{{MEDIA_URL}}js/mdn/carousel.js"></script>
 
         <script type="text/javascript">

--- a/apps/demos/templates/demos/launch.html
+++ b/apps/demos/templates/demos/launch.html
@@ -76,48 +76,54 @@
       <p id="close"><a href="{{ submission.demo_package.url.replace('.zip', '/index.html') }}" title="{{_('Remove this toolbar')}}">{{_('Remove toolbar')}}</a></p>
     
     <script type="text/javascript">
-    $("#share-opts").ready(function(){
-    	$("#share-opts").addClass("js").hide();
-    	
-    	$("#sharetoggle").click(function() {
-        $("#share-opts").fadeIn(100);
+
+    $(document).ready(function() {
+
+      var $shareOpts = $("#share-opts"),
+          $shareToggle = $("#sharetoggle");
+
+      // Hide the "share" dropdown options
+      $shareOpts.addClass("js").hide();
+
+      // Toggle the dropdown when the button is clicked
+      $shareToggle.click(function() {
+        $shareOpts.fadeIn(100);
         return false;
-    	});
-    	
-      $("#share-opts").hover(
+      });
+
+      $shareOpts.hover(
         function() {
           $(this).show();
         },
         function() {
           $(this).fadeOut(100);
-          $("#sharetoggle").blur();
+          $shareToggle.blur();
         }
       );
-    	
-      $(document).bind('click', function(e) {
-        var $clicked = $(e.target);
-        if (! $clicked.parents().hasClass("share"))
-          $("#share-opts").hide();
-      });
-      
-      $("a, input, textarea, button").bind('focus', function(e) {
-        var $focused = $(e.target);
-        if (! $focused.parents().hasClass("share"))
-          $("#share-opts").hide();
-      });
-      
-      $("#shorturl").focus(function() {
-        $(this).select().addClass("focus");
-      });
-      $("#shorturl").click(function() {
-        $(this).select().addClass("focus");
-      });
-      $("#shorturl").blur(function() {
-        $(this).removeClass("focus");
-      });
-    
-    });
 
+      $(document).bind("click", function(e) {
+        if (! $(e.target).parents().hasClass("share"))
+          $shareOpts.hide();
+      });
+      
+      $("a, input, textarea, button").bind("focus", function(e) {
+        if (! $(e.target).parents().hasClass("share"))
+          $shareOpts.hide();
+      });
+      
+      $("#shorturl")
+        .focus(function() {
+          $(this).select().addClass("focus");
+        })
+        .click(function() {
+          $(this).select().addClass("focus");
+        })
+        .blur(function() {
+          $(this).removeClass("focus");
+        });
+
+
+    });
     </script>
     
   </header>


### PR DESCRIPTION
Just a bit of JS cleanup on the demo and launch pages;  shouldn't be re-querying node collections that we've already got.
