### PR TITLE
Bug 745902

### DIFF
--- a/apps/demos/tests/test_models.py
+++ b/apps/demos/tests/test_models.py
@@ -28,6 +28,8 @@ from django.contrib.auth.models import User
 
 from django.core.files.base import ContentFile
 
+from django.template.defaultfilters import slugify
+
 from nose.tools import assert_equal, with_setup, assert_false, eq_, ok_
 from nose.plugins.attrib import attr
 
@@ -40,7 +42,7 @@ from demos.forms import SubmissionEditForm, SubmissionNewForm
 
 def save_valid_submission(title='hello world'):
     testuser = User.objects.get(username='testuser')
-    s = Submission(title=title, slug='hello-world',
+    s = Submission(title=title, slug=slugify(title),
         description='This is a hello world demo',
         creator=testuser)
     fout = StringIO()


### PR DESCRIPTION
This fixes the too-long URL by truncating the slug when it's generated in Submission.save(), rather than throwing a too-long slug at the DB and letting it truncate there (possibly resulting in us using a Python-level slug that doesn't match what ended up in the DB). Also makes the max_length on the slug's field explicit; 50 is the Django default if not specified for a SlugField, but it's nice to see it in the code so that we don't make incorrect assumptions about what can go in there.
