### PR TITLE
Fix Bug 665701 Include processed template output in Kuma preview

### DIFF
--- a/apps/wiki/templates/wiki/preview.html
+++ b/apps/wiki/templates/wiki/preview.html
@@ -1,4 +1,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
+{% if kumascript_errors %}
+  {% include 'wiki/includes/kumascript_errors.html' %}
+{% endif %}
 <div id="doc-content">
   {{ content|safe }}
 </div>

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -711,7 +711,7 @@
             $.ajax({
                 url: $(this).attr('data-preview-url'),
                 type: 'POST',
-                data: $('#id_content').serialize(),
+                data: $('#id_content').val(CKEDITOR.instances['id_content'].getData()).serialize(),
                 dataType: 'html',
                 success: function(html) {
                     var $preview = $('#preview');


### PR DESCRIPTION
fix preview changes button - get latest content from ckeditor

_perform_kumascript_post and refactoring kumascript logic up into functions

send X-FireLogger to kumascript; include errors display in preview
