### PR TITLE
Bug 738256: Correct labeling of username field

### DIFF
--- a/apps/users/templates/users/browserid_register.html
+++ b/apps/users/templates/users/browserid_register.html
@@ -21,7 +21,7 @@
           <h2>{{ _('New MDN Members') }}</h2>
           <p>{% trans %}
             We couldn't find an MDN profile for your BrowserID. If you're new here, 
-            you can pick a display name now and complete your registration.
+            you can pick an MDN username now and complete your registration.
           {% endtrans %}</p>
           <p>{% trans %}
             You can access everything on the MDN website even without an account, 
@@ -35,7 +35,7 @@
           <fieldset>
             <ul>
               <li>
-                <label for="id_username">{{ _('Display name') }}</label>
+                <label for="id_username">{{ _('Username') }}</label>
                 {{ register_form.username|safe }}
               </li>
               <li class="submit">


### PR DESCRIPTION
It's a username field and has the same restrictions as a Django username, so let's call it that to avoid confusing people :)
