### PR TITLE
Fixing up padding within the message blocks

### DIFF
--- a/media/css/wiki-edcontent.css
+++ b/media/css/wiki-edcontent.css
@@ -92,7 +92,8 @@ table.mainpage-table td { padding: 0 10px 10px 10px; vertical-align: top; }
 .wrong-inline { border: 1px solid #ac6262; padding: 0 3px 0 3px; background: #fbeded; color: #6d675f; }
 .wrong-source-code { color: #8a4e4e; }
 .right-source-code { color: #537d46; }
-div.bug, div.warning { margin: 0 0 1.5em; border: 2px solid #ac6262; padding: 0 10px; background: #fbeded; color: #6d675f; }
+div.bug, div.warning { margin: 0 0 1.5em; border: 2px solid #ac6262; padding: 10px; background: #fbeded; color: #6d675f; }
+  div.bug *:last-child, div.warning *:last-child { padding: 0; margin: 0; }
 .originaldocinfo { margin: 15px 0; border: 1px solid #e9e9e9; padding: 10px 10px 0; background: #f3f3f3; font-size: 80%; font-family: Verdana, Tahoma, sans-serif; }
 .originaldocinfo h2 { font-size: 120%; }
 .licenseblock { border: 1px dashed #ccc; padding: 0 10px; background: #f1f1f1; font-size: 80%; font-family: Verdana, Tahoma, sans-serif; }

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -465,7 +465,8 @@ table.mainpage-table td { padding: 0 10px 10px 10px; vertical-align: top; }
 .wrong-inline { border: 1px solid #ac6262; padding: 0 3px 0 3px; background: #fbeded; color: #6d675f; }
 .article .wrong-source-code { color: #8a4e4e; }
 .article .right-source-code { color: #537d46; }
-div.bug, div.warning { margin: 0 0 1.5em; border: 2px solid #ac6262; padding: 0 10px; background: #fbeded; color: #6d675f; }
+div.bug, div.warning { margin: 0 0 1.5em; border: 2px solid #ac6262; padding: 10px; background: #fbeded; color: #6d675f; }
+  div.bug *:last-child, div.warning *:last-child { padding: 0; margin: 0; }
 .originaldocinfo { margin: 15px 0; border: 1px solid #e9e9e9; padding: 10px 10px 0; background: #f3f3f3; font-size: 80%; font-family: Verdana, Tahoma, sans-serif; }
 .originaldocinfo h2 { font-size: 120%; }
 .licenseblock { border: 1px dashed #ccc; padding: 0 10px; background: #f1f1f1; font-size: 80%; font-family: Verdana, Tahoma, sans-serif; }


### PR DESCRIPTION
This has been bugging me.  Our error message blocks have the text pushed to the top of the block, with the inner P elements padding forcing a gap below.  Making them prettier.
