### PR TITLE
Add go-tmux.sh command to vagrant to launch django, node, and a shell

### DIFF
--- a/puppet/files/home/vagrant/bin/go-tmux.sh
+++ b/puppet/files/home/vagrant/bin/go-tmux.sh
@@ -1,0 +1,18 @@
+SESSION=$USER
+
+tmux has-session -t $SESSION
+if [ $? -eq 0 ]; then
+    echo "Session $SESSION already exists. Attaching."
+    sleep 1
+    tmux attach -t $SESSION
+    exit 0;
+fi
+
+tmux new-session -d -s $SESSION
+
+tmux split-window -t $SESSION:0 -v -p 50 './manage.py runserver; /bin/bash'
+tmux swap-pane    -t $SESSION:0 -U
+tmux split-window -t $SESSION:0 -v -p 50 'node kumascript/run.js; /bin/bash'
+tmux select-pane  -t $SESSION:0.2
+ 
+tmux attach -t $SESSION

--- a/puppet/manifests/classes/dev-hacks.pp
+++ b/puppet/manifests/classes/dev-hacks.pp
@@ -119,6 +119,12 @@ class dev_hacks_post {
         "/home/vagrant/.bash_profile":
             source => "$PROJ_DIR/puppet/files/home/vagrant/bash_profile",
             owner => "vagrant", group => "vagrant", mode => 0664;
+        "/home/vagrant/bin":
+            ensure => directory,
+            owner => "vagrant", group => "vagrant", mode => 0777;
+        "/home/vagrant/bin/go-tmux.sh":
+            source => "$PROJ_DIR/puppet/files/home/vagrant/bin/go-tmux.sh",
+            owner => "vagrant", group => "vagrant", mode => 0777;
     }
     
     case $operatingsystem {


### PR DESCRIPTION
Others might find this handy: Makes a `go-tmux.sh` script available. So, `vagrant ssh` from the host, then `go-tmux.sh` in the VM, and you get all the current services fired up or you get re-attached to an already-running session.
