### PR TITLE
bug 754534: Simplify wiki URLs

### DIFF
--- a/apps/devmo/helpers.py
+++ b/apps/devmo/helpers.py
@@ -77,14 +77,18 @@ def devmo_url(context, path):
         Look for a wiki page in the current locale first,
         then default to given path
     """
+    if not settings.DEKIWIKI_ENDPOINT:
+        # HACK: If MindTouch is unavailable, skip the rest of this and lean on
+        # locale processing redirects to resolve things. Might be interesting
+        # to resolve some of the redirects first, and come up with the ultimate
+        # real URL. See bug 759356 for followup.
+        path = path.replace('/en', '')
+        return '/%s/docs%s' % (context['request'].locale, path)
+
     # HACK: If DEKIWIKI_MOCK is True, just skip hitting the API. This can speed
     # up a lot of tests without adding decorators, and should never be true in
     # production.
     if getattr(settings, 'DEKIWIKI_MOCK', False):
-        return path
-
-    if not settings.DEKIWIKI_ENDPOINT:
-        # If MindTouch is unavailable, skip the rest of this
         return path
 
     current_locale = context['request'].locale

--- a/apps/devmo/tests/test_misc.py
+++ b/apps/devmo/tests/test_misc.py
@@ -115,7 +115,7 @@ class TestDevMoHelpers(test_utils.TestCase):
 
     @attr('current')
     @mock.patch('devmo.helpers.check_devmo_local_page')
-    def test_devmo_url_midtouch_disabled(self, mock_check_devmo_local_page):
+    def test_devmo_url_mindtouch_disabled(self, mock_check_devmo_local_page):
         _old = settings.DEKIWIKI_ENDPOINT
         settings.DEKIWIKI_ENDPOINT = False
 
@@ -132,11 +132,8 @@ class TestDevMoHelpers(test_utils.TestCase):
         req = test_utils.RequestFactory().get('/')
         context = {'request': req}
 
-        # NOTE: This is undesirable behavior, but expected. Since devmo_url can
-        # no longer consult MindTouch, it will punt and claim that /en/HTML is
-        # the proper path to the de locale page. See also, bug 759356
         req.locale = 'de'
-        eq_(devmo_url(context, localized_page), '/en/HTML')
+        eq_(devmo_url(context, localized_page), '/de/docs/HTML')
 
         ok_(not trap['was_called'])
         settings.DEKIWIKI_ENDPOINT = _old

--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -33,7 +33,10 @@
         {% if documents.object_list %}
           <ul class="documents cols-3">
             {% for doc in documents.object_list %}
-              <li><a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a></li>
+              <li>
+                <a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a> ({{ doc.locale }})<br/>
+                <small>{{ doc.get_absolute_url() }}</small>
+              </li>
             {% endfor %}
           </ul>
           {{ documents|paginator }}

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -998,21 +998,21 @@ class TranslateTests(TestCaseBase):
     def test_translate_GET_logged_out(self):
         """Try to create a translation while logged out."""
         self.client.logout()
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         eq_(302, response.status_code)
-        expected_url = '%s?next=%s' % (reverse('users.login', locale='en-US'),
+        expected_url = '%s?next=%s' % (reverse('users.login', locale='es'),
                                        translate_uri)
         ok_(expected_url in response['Location'])
 
     def test_translate_GET_with_perm(self):
         """HTTP GET to translate URL renders the form."""
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         eq_(200, response.status_code)
@@ -1025,18 +1025,18 @@ class TranslateTests(TestCaseBase):
         """HTTP GET to translate URL returns 400 when not localizable."""
         self.d.is_localizable = False
         self.d.save()
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         eq_(400, response.status_code)
 
     def test_invalid_document_form(self):
         """Make sure we handle invalid document form without a 500."""
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         data = _translation_data()
         data['slug'] = ''  # Invalid slug
@@ -1046,9 +1046,9 @@ class TranslateTests(TestCaseBase):
     def test_invalid_revision_form(self):
         """When creating a new translation, an invalid revision form shouldn't
         result in a new Document being created."""
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         data = _translation_data()
         data['content'] = ''  # Content is required
@@ -1064,9 +1064,9 @@ class TranslateTests(TestCaseBase):
         """Create the first translation of a doc to new locale."""
         get_current.return_value.domain = 'testserver'
 
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         data = _translation_data()
         response = self.client.post(translate_uri, data)
@@ -1110,9 +1110,9 @@ class TranslateTests(TestCaseBase):
         rev_enUS.save()
 
         # Verify the form renders with correct content
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         doc = pq(response.content)
@@ -1124,7 +1124,7 @@ class TranslateTests(TestCaseBase):
         data['content'] = 'loremo ipsumo doloro sito ameto nuevo'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/docs/es/un-test-articulo',
+        eq_('http://testserver/es/docs/un-test-articulo',
             response['location'])
         doc = Document.objects.get(slug=data['slug'])
         rev = doc.revisions.filter(content=data['content'])[0]
@@ -1149,9 +1149,9 @@ class TranslateTests(TestCaseBase):
         """Submitting the document form should update document. No new
         revisions should be created."""
         rev_es = self._create_and_approve_first_translation()
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         data = _translation_data()
         new_title = 'Un nuevo titulo'
@@ -1159,7 +1159,7 @@ class TranslateTests(TestCaseBase):
         data['form'] = 'doc'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/docs/es/un-test-articulo$edit'
+        eq_('http://testserver/es/docs/un-test-articulo$edit'
             '?opendescription=1',
             response['location'])
         revisions = rev_es.document.revisions.all()
@@ -1171,9 +1171,9 @@ class TranslateTests(TestCaseBase):
         """Submitting the revision form should create a new revision.
         And since Kuma docs default to approved, should update doc too."""
         rev_es = self._create_and_approve_first_translation()
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         data = _translation_data()
         new_title = 'Un nuevo titulo'
@@ -1181,7 +1181,7 @@ class TranslateTests(TestCaseBase):
         data['form'] = 'rev'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/docs/es/un-test-articulo',
+        eq_('http://testserver/es/docs/un-test-articulo',
             response['location'])
         revisions = rev_es.document.revisions.all()
         eq_(2, revisions.count())  # New revision is created
@@ -1192,9 +1192,9 @@ class TranslateTests(TestCaseBase):
         """If there are existing but unapproved translations, prefill
         content with latest."""
         self.test_first_translation_to_locale()
-        translate_path = 'es/' + self.d.slug
+        translate_path = self.d.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         doc = pq(response.content)
@@ -1213,9 +1213,9 @@ class TranslateTests(TestCaseBase):
         d = Document.objects.get(pk=base_rev.document.id)
         eq_(r, base_rev.document.current_revision)
 
-        translate_path = 'es/' + d.slug
+        translate_path = d.slug
         uri = urllib.quote(reverse('wiki.new_revision_based_on',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path,
                                                    base_rev.id]))
         response = self.client.get(uri)
@@ -1229,9 +1229,9 @@ class TranslateTests(TestCaseBase):
         en_revision = revision(is_approved=False, save=True, reviewer=user,
                                reviewed=datetime.now())
 
-        translate_path = 'es/' + en_revision.document.slug
+        translate_path = en_revision.document.slug
         translate_uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale='es',
                                              args=[translate_path]))
         response = self.client.get(translate_uri)
         doc = pq(response.content)
@@ -1246,9 +1246,9 @@ def _test_form_maintains_based_on_rev(client, doc, view, post_data,
     form was first loaded, even if other revisions have been approved in the
     meantime."""
     if trans_lang:
-        translate_path = trans_lang + '/' + doc.slug
+        translate_path = doc.slug
         uri = urllib.quote(reverse('wiki.translate',
-                                             locale='en-US',
+                                             locale=trans_lang,
                                              args=[translate_path]))
     else:
         uri = reverse(view, locale=locale, args=[doc.full_path])

--- a/configs/htaccess-with-mindtouch
+++ b/configs/htaccess-with-mindtouch
@@ -1,0 +1,124 @@
+# Note this file should be symlinked from the dekiwiki root
+# Example: ln -s /home/foo/mdn/configs/htaccess /var/www/dekiwiki/.htaccess
+#
+# Make sure AllowOverride has FileInfo
+ReWriteEngine On
+RewriteBase /
+
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?mwc/?)$      /apps [NC,PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/?)?)$           /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?addons/?)$   /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?demos.*)$    /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?docs.*)$     /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?users.*/?)$   /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?mobile/?)$   /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?mozilla/?)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?search/?)$   /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?web/?)$      /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?apps.*)$      /mwsgi/$1 [NC,PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?learn.*)$    /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?promote.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?events.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?profiles?.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?discussions.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?forum-archive.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|ga-IE|hr|hu|id|it|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?jsi18n.*)$  /mwsgi/$1 [PT,L]
+RewriteRule ^(admin(/.*)?)$                                                                 /mwsgi/$1 [PT,L]
+
+
+# For debug_toolbar, mainly on dev VMs
+RewriteRule ^(((en-US|de|el|es|fr|fy-NL|ga|hr|hu|id|ja|ko|nl|pl|pt-BR|pt-PT|ro|ru|sl|sq|th|x-testing|zh-TW|zh-CN)/)?__debug__(/.*)?)$ /mwsgi/$1 [PT,L]
+
+   RewriteCond %{REQUEST_URI} ^/Special:UserPreferences$ [NC]
+   RewriteRule (.*) /profile/edit/ [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/Special:Userlogin$ [NC]
+   RewriteRule (.*) /users/login? [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/index.php$ [NC]
+   RewriteCond %{QUERY_STRING} title=Special:Userlogin [NC]
+   RewriteCond %{QUERY_STRING} returntotitle=(.*)&? [NC]
+   RewriteRule (.*) /users/login?next=/%1 [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/index.php$ [NC]
+   RewriteCond %{QUERY_STRING} title=Special:Userlogin [NC]
+   RewriteRule (.*) /users/login? [L,R]
+
+   # PeteE: redirect feeds to a feeds disabled page
+   RewriteCond %{REQUEST_URI} ^/Special:Article$ [NC]
+   RewriteCond %{QUERY_STRING} type=feed [NC]
+   RewriteRule (.*) /deki/feeds_disabled.php? [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/index.php$ [NC]
+   RewriteCond %{QUERY_STRING} title=Special:Article [NC]
+   RewriteCond %{QUERY_STRING} type=feed [NC]
+   RewriteRule (.*) /deki/feeds_disabled.php? [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/Special:Watchlist$ [NC]
+   RewriteCond %{QUERY_STRING} type=feed [NC]
+   RewriteRule (.*) /deki/feeds_disabled.php? [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/index.php$ [NC]
+   RewriteCond %{QUERY_STRING} title=Special:Watchlist [NC]
+   RewriteCond %{QUERY_STRING} type=feed [NC]
+   RewriteRule (.*) /deki/feeds_disabled.php? [L,R]
+
+   RewriteCond %{REQUEST_URI} ^/@api/deki/pages/[0-9]+/feed(/)?$ [NC,OR]
+   RewriteCond %{REQUEST_URI} ^/@api/deki/pages/[0-9]+/feed/new(/)?$ [NC,OR]
+   RewriteCond %{REQUEST_URI} ^/@api/deki/users/[0-9]+/feed(/)?$ [NC,OR]
+   RewriteCond %{REQUEST_URI} ^/@api/deki/users/[0-9]+/feed/new(/)?$ [NC,OR]
+   RewriteCond %{REQUEST_URI} ^/@api/deki/users/[0-9]+/favorites/feed(/)?$ [NC]
+   RewriteRule (.*) /deki/feeds_disabled.php? [L,R]
+   # END FEEDS DISABLED
+
+	RewriteRule ^patches(.*) data/www/patches$1 [L]
+	RewriteRule ^presentations(.*) data/www/presentations$1 [L]
+	RewriteRule ^samples(.*) data/www/samples$1 [L]
+	RewriteRule ^diagrams(.*) data/www/diagrams$1 [L]
+	RewriteRule ^devnews(.*) data/www/devnews$1 [L]
+	RewriteRule ^web-tech(.*) data/www/web-tech$1 [L]
+	RewriteRule ^css(.*) data/www/css$1 [L]
+
+    RewriteRule ^En/JavaScript/Reference/Objects/Array$ en/JavaScript/Reference/Global_Objects/Array [R=301,L,NC]
+    RewriteRule ^En/JavaScript/Reference/Objects$ en/JavaScript/Reference/Global_Objects/Object [R=301,L,NC]
+
+    RewriteRule ^En/Core_JavaScript_1\.5_Reference/Objects/(.*) en/JavaScript/Reference/Global_Objects/$1 [R=301,L,NC]
+    RewriteRule ^En/Core_JavaScript_1\.5_Reference/(.*) en/JavaScript/Reference/$1 [R=301,L,NC]
+	RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
+	RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]
+	RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
+
+       RewriteCond %{REQUEST_URI} ^/$
+       RewriteRule ^$ En [L,NE,R]
+
+	RewriteCond %{REQUEST_URI} ^/@gui/[^.]+$
+	RewriteRule ^@gui/(.*)$ proxy.php?path=$1 [L,QSA,NE]
+
+	### Begin MDC rewrite rules ###
+	RewriteCond %{REQUEST_URI} ^/(.*)$
+	RewriteRule ^([a-z]{2}|[a-z_]{5})/docs/(.*):(.*)$ $2:$3/$1 [L,QSA,NE,NC,R]
+
+	RewriteCond %{REQUEST_URI} ^/(.*)$
+	RewriteRule ^([a-z]{2}|[a-z_]{5})/docs/(.*)$ $1/$2 [L,QSA,NE,NC,R]
+
+	RewriteCond %{REQUEST_URI} ^/(.*)$
+	RewriteRule ^docs/(.*):(.*)$ $1:$2/En [L,QSA,NE,NC,R]
+
+	RewriteCond %{REQUEST_URI} ^/(.*)$
+	RewriteRule ^docs/(.*)$ En/$1 [L,QSA,NE,NC,R]
+	### End MDC rewrite rules ###
+
+	RewriteCond %{REQUEST_URI} !/(@api|editor|skins|config|deki|media|admin-media)/
+	RewriteCond %{REQUEST_URI} !/forums
+	RewriteCond %{REQUEST_URI} !/(redirect|texvc|Version).php
+	RewriteCond %{REQUEST_URI} !/error/(40(1|3|4)|500).html
+	RewriteCond %{REQUEST_URI} !/favicon.ico
+	RewriteCond %{REQUEST_URI} !/robots.txt
+	RewriteCond %{REQUEST_URI} !/block_862be.html
+	RewriteCond %{REQUEST_URI} !/block_f90c2.html
+	RewriteCond %{QUERY_STRING} ^$ [OR] %{REQUEST_URI} ^/Special:Search
+	RewriteRule ^(.*)$ index.php?mt=1&title=$1 [L,QSA,NE,E=CORS:True]
+
+    Header set Access-Control-Allow-Origin "*" env=CORS
+    Header set Access-Control-Allow-Methods "GET" env=CORS
+    Header set Access-Control-Allow-Credentials "false" env=CORS

--- a/configs/htaccess-without-mindtouch
+++ b/configs/htaccess-without-mindtouch
@@ -1,0 +1,49 @@
+# Note this file should be symlinked from the web root
+# Example: ln -s /home/foo/mdn/configs/htaccess /var/www/dekiwiki/.htaccess
+#
+# Make sure AllowOverride has FileInfo
+ReWriteEngine On
+RewriteBase /
+
+# Links to FTP'ed code samples and examples
+RewriteRule ^patches(.*) data/www/patches$1 [L]
+RewriteRule ^presentations(.*) data/www/presentations$1 [L]
+RewriteRule ^samples(.*) data/www/samples$1 [L]
+RewriteRule ^diagrams(.*) data/www/diagrams$1 [L]
+RewriteRule ^devnews(.*) data/www/devnews$1 [L]
+RewriteRule ^web-tech(.*) data/www/web-tech$1 [L]
+RewriteRule ^css(.*) data/www/css$1 [L]
+
+# Some blanket section moves / renames
+RewriteRule ^En/JavaScript/Reference/Objects/Array$ en-US/docs/JavaScript/Reference/Global_Objects/Array [R=301,L,NC]
+RewriteRule ^En/JavaScript/Reference/Objects$ en-US/docs/JavaScript/Reference/Global_Objects/Object [R=301,L,NC]
+RewriteRule ^En/Core_JavaScript_1\.5_Reference/Objects/(.*) en-US/docs/JavaScript/Reference/Global_Objects/$1 [R=301,L,NC]
+RewriteRule ^En/Core_JavaScript_1\.5_Reference/(.*) en-US/docs/JavaScript/Reference/$1 [R=301,L,NC]
+
+# Off-site redirects
+RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
+RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]
+RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
+
+# HACK: Django will eventually redirect the user to the right spot, but skip a
+# couple of redirects for these known legacy locales
+RewriteRule ^en/(.*)$     /mwsgi/en-US/$1 [L,QSA,NE,NC,E=CORS:True]
+RewriteRule ^cn/(.*)$     /mwsgi/zh-CN/$1 [L,QSA,NE,NC,E=CORS:True]
+RewriteRule ^zh_cn/(.*)$  /mwsgi/zh-CN/$1 [L,QSA,NE,NC,E=CORS:True]
+RewriteRule ^zh_tw/(.*)$  /mwsgi/zh-TW/$1 [L,QSA,NE,NC,E=CORS:True]
+
+# These are some known static files
+RewriteCond %{REQUEST_URI} !/forums
+RewriteCond %{REQUEST_URI} !/favicon.ico
+# TODO: Should Django handle robots.txt?
+RewriteCond %{REQUEST_URI} !/robots.txt
+RewriteCond %{REQUEST_URI} !/block_862be.html
+RewriteCond %{REQUEST_URI} !/block_f90c2.html
+
+# Everything else passes through the Django handler
+RewriteRule ^(.*)$ /mwsgi/$1 [L,QSA,NE,E=CORS:True]
+
+# Allow wide-open CORS on the site.
+Header set Access-Control-Allow-Origin "*" env=CORS
+Header set Access-Control-Allow-Methods "GET" env=CORS
+Header set Access-Control-Allow-Credentials "false" env=CORS

--- a/urls.py
+++ b/urls.py
@@ -56,7 +56,7 @@ urlpatterns = patterns('',
         {'document_root': settings.HUMANSTXT_ROOT, 'path': 'humans.txt'}),
 
     # Legacy MindTouch redirects.
-    #(r'^(?P<path>.*)$', 'wiki.views.mindtouch_to_kuma_redirect'),
+    (r'^(?P<path>.*)$', 'wiki.views.mindtouch_to_kuma_redirect'),
 )
 
 # Handle 404 and 500 errors


### PR DESCRIPTION
- Rework locale_and_slug_from_path to support redirects where
  legacy-MindTouch or modern-Kuma locales appear as first path segment,
  but otherwise use request-detected or default locale
- Widespread test tweaks to account for URL change
- Uncomment URL route to enable mindtouch_to_kuma_redirect - no need to
  leave it commented out, since Apache won't send traffic to it until
  configs/htaccess is changed to exclude MindTouch anyway
- Sample config/htaccess files both with and without MindTouch enabled
- Tweak to mindtouch_to_kuma_redirect and mindtouch_namespace_redirect
  to account for new URL structure
- Tweak to devmo_url() helper to rewrite old /en links to point to new
  Kuma URLs with current detected locale
- Template tweak to include document locale and path in documents list
- Unicode fixes and refactorings for document Last-Modified cache keys
