### PR TITLE
Parent doc ui bug 753584

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -27,7 +27,7 @@
         <ul id="page-tools" class="sub-menu">
           <li class="page-print"> <a href="#" onclick="return window.print();"  title="{{ _('Print page') }}">{{ _('Print page') }}</a></li>
           {% if not document.is_template %}
-            <li><a href="{{ url('wiki.new_document')+'?slug='+document.slug+'/' }}">{{ _('New sub-page') }}</a></li>
+            <li><a href="{{ url('wiki.new_document') }}?parent={{ document.id }}">{{ _('New sub-page') }}</a></li>
           {% endif %}
         </ul>
       </li>

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -104,6 +104,9 @@
             <ul class="metadata">
                 <li><label>{{_('Title:')}}</label> {{ revision_form.title | safe }}</li>
                 <li><label>{{_('Slug:')}}</label> {{ revision_form.slug | safe }}</li>
+                {% if parent_slug %}
+                  <li><label>{{_('Parent:')}}</label> <span class="metadataDisplay">{{ parent_slug }}</span></li>
+                {% endif %}
                 {% if not document.is_template %}
                   <li><label><abbr title="{{_('Generate table of contents')}}">{{_('TOC:')}}</abbr></label>
                     {{ revision_form.show_toc | safe }}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -24,8 +24,8 @@
         <ul class="metadata">
           <li><label>{{_('Title:')}}</label> {{ document_form.title | safe }}</li>
           <li><label>{{_('Slug:')}}</label> {{ document_form.slug | safe }}</li>
-          {% if not is_template %}
-            <li><label>{{_('Parent:')}}</label> {{ document_form.parent_topic | safe }}</li>
+          {% if parent_slug and not is_template %}
+            <li><label>{{_('Parent:')}}</label> <span class="metadataDisplay">{{ parent_slug }}</span></li>
           {% endif %}
           <li><label>{{_('Tags:')}}</label> {{ revision_form.tags | safe }}</li>
           {% if not is_template %}
@@ -34,6 +34,8 @@
             </li>
           {% endif %}
         </ul>
+        <input type="hidden" name="parent_topic" value="{{ parent_id | safe }}" />
+        <div class="hidden" id="parentSlugPrefix">{{ parent_slug | safe }}</div>
 
         {% include 'wiki/includes/page_buttons.html' %}
 

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -61,13 +61,24 @@
               <li>
                 <dl class="approved">
                   <dt>{{ _('Slug:') }}</dt>
-                  <dd>{{ parent.slug }}</dd>
+                  <dd>{{ specific_slug }}</dd>
                 </dl>
                 <dl class="localized">
                   <dt><label for="{{ document_form.slug.auto_id }}" title="{{ document_form.slug.help_text }}">{{ _('Slug in {locale}:')|f(locale=language) }}</label></dt>
                   <dd>{{ document_form.slug|safe }}</dd>
                 </dl>
               </li>
+              {% if parent_slug %}
+              <li>
+                <dl class="approved">
+                  <dt>{{ _('Parent:') }}</dt>
+                  <dd>{{ parent_slug }}</dd>
+                </dl>
+                <dl class="localized">
+                  &nbsp;
+                </dl>
+              </li>
+              {% endif %}
             </ul>
       </details>
     {% endif %}

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -498,7 +498,7 @@ class NewRevisionTests(TestCaseBase):
         response = self.client.post(
             reverse('wiki.edit_document', args=[self.d.full_path]),
             {'summary': 'A brief summary', 'content': 'The article content',
-             'keywords': 'keyword1 keyword2',
+             'keywords': 'keyword1 keyword2', 'slug': '',
              'based_on': self.d.current_revision.id, 'form': 'rev'})
         ok_(response.status_code in (200, 302))
         eq_(2, self.d.revisions.count())
@@ -574,7 +574,7 @@ class NewRevisionTests(TestCaseBase):
         editing."""
         _test_form_maintains_based_on_rev(
             self.client, self.d, 'wiki.edit_document',
-            {'summary': 'Windy', 'content': 'gerbils', 'form': 'rev'},
+            {'summary': 'Windy', 'content': 'gerbils', 'form': 'rev', 'slug': ''},
             locale='en-US')
 
 

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -1140,6 +1140,7 @@ class SectionEditingResourceTests(TestCaseBase):
         response = client.post('%s?section=s2&raw=true' %
                                reverse('wiki.edit_document', args=[d.full_path]),
                                {"form": "rev",
+                               'slug': '',
                                 "content": replace},
                                follow=True)
         eq_(normalize_html(expected), 
@@ -1204,7 +1205,8 @@ class SectionEditingResourceTests(TestCaseBase):
         """
         data = {
             'form': 'rev',
-            'content': rev.content
+            'content': rev.content,
+            'slug': ''
         }
 
         # Edit #1 starts...
@@ -1304,6 +1306,7 @@ class SectionEditingResourceTests(TestCaseBase):
         data.update({
             'form': 'rev',
             'content': replace_2,
+            'slug': '',
             'current_rev': rev_id2
         })
         resp = client.post('%s?section=s2&raw=true' %

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -185,6 +185,7 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 .editing ul.metadata li label { display: block; float: left; line-height: 2.5em; text-align: right; width: 10ex; font-weight: bold; padding-right: 0.25em; color: #888; }
 .editing ul.metadata li input, .editing ul.metadata li input#id_title { font-size: 1em; padding: 6px 8px; margin: 2px 0px; width: 70%; }
 .editing ul.metadata li input[type="checkbox"] { width: auto; margin-left: 6px; }
+.editing ul.metadata li .metadataDisplay { display:inline-block; padding: 7px 0 0 3px; }
 
 .editing .title { float: left; width: 55%; }
 .editing .title h1 { display: inline-block; width: auto; float: none; color: #888; }

--- a/media/js/libs/django/prepopulate.js
+++ b/media/js/libs/django/prepopulate.js
@@ -16,16 +16,16 @@
             maxLength - maximum length of the URLify'd string
         */
         return this.each(function() {
-            var field = $(this);
+            var $field = $(this);
 
-            field.data("_changed", false);
-            field.change(function() {
-                field.data("_changed", true);
+            $field.data("_changed", false);
+            $field.change(function() {
+                $field.data("_changed", true);
             });
 
             var populate = function () {
                 // Bail if the fields value has changed
-                if (field.data("_changed") == true) return;
+                if ($field.data("_changed") == true) return;
 
                 var values = [], field_val, field_val_raw;
                 dependencies.each(function() {
@@ -37,8 +37,7 @@
                 s = values.join(" ");
                 
                 // Remove anything from the slug that could cause big problems
-                s = s.replace(/[\?\&\#\*\$ +?]/g, "_");
-                
+                s = s.replace(/[\?\&\#\*\$\/ +?]/g, "_");
 
                 // "$" is used for verb delimiter in URLs
                 s = s.replace(/\$/g, ""); 
@@ -49,9 +48,9 @@
                 // trim to first num_chars chars
                 s = s.substring(0, maxLength);
 
-                field.val(s);
+                $field.val(s);
             };
-
+            
             dependencies.keyup(populate).change(populate).focus(populate);
         });
     };


### PR DESCRIPTION
This changeset allows users to add and edit child documents.  The parent document id is passed via the "New sub-page link".  The slug INPUT field is restricted to only individual child page's slug, not the parent chain slug, to prevent the user from reparenting their document via the slug.  If the document is a child, regardless of being new or an edit, the "long" slug is built in an automated fashion.
# Why I've PR'd
1.  I'm not a python expert, so you'll have comments about how I've written the python pieces;  I welcome the ideas
2.  There may be something in the document flow (i.e. revision flow vs. edit flow, etc) that I'm missing
3.  The translation page does nto do the slug splitting yet.
4.  The _big_ issue is that while the "parent_topic_id" stays correct through slug changes, if a parent document's _individual slug_ (without the hierarchy, i.e. "parent") changes, child documents which include that parent's previous slug value don't change ("parent/child" -> "parent_new_slug/child" doesn't happen for children)

Any ideas, guidance, etc. would be very, very much appreciated.
