### PR TITLE
fix bug 760587: l10n save redirects to saved page

### DIFF
--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -1124,7 +1124,7 @@ class TranslateTests(TestCaseBase):
         data['content'] = 'loremo ipsumo doloro sito ameto nuevo'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/docs/es/un-test-articulo$history',
+        eq_('http://testserver/en-US/docs/es/un-test-articulo',
             response['location'])
         doc = Document.objects.get(slug=data['slug'])
         rev = doc.revisions.filter(content=data['content'])[0]
@@ -1181,7 +1181,7 @@ class TranslateTests(TestCaseBase):
         data['form'] = 'rev'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/docs/es/un-test-articulo$history',
+        eq_('http://testserver/en-US/docs/es/un-test-articulo',
             response['location'])
         revisions = rev_es.document.revisions.all()
         eq_(2, revisions.count())  # New revision is created

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1169,7 +1169,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
             rev_form.instance.document = doc  # for rev_form.clean()
             if rev_form.is_valid() and not doc_form_invalid:
                 _save_rev_and_notify(rev_form, request.user, doc)
-                url = reverse('wiki.document_revisions',
+                url = reverse('wiki.document',
                               args=[doc.full_path])
                 return HttpResponseRedirect(url)
 


### PR DESCRIPTION
Small tweak: When a translation is saved, redirect to the saved document view rather than its history view.
