### PR TITLE
Updates to go-tmux.sh in vagrant VM

### DIFF
--- a/puppet/files/etc/motd
+++ b/puppet/files/etc/motd
@@ -3,6 +3,9 @@ Welcome to Kuma (developer-dev.mozilla.org)
 To update this dev environment:
     sudo puppet apply /vagrant/puppet/manifests/dev-vagrant.pp
 
+To launch or reattach to a Tmux session running everything:
+    ~/bin/go-tmux.sh
+
 To start the Django app:
     ./manage.py runserver --forked 0.0.0.0:8000
 

--- a/puppet/files/home/vagrant/bin/go-tmux.sh
+++ b/puppet/files/home/vagrant/bin/go-tmux.sh
@@ -10,7 +10,7 @@ fi
 
 tmux new-session -d -s $SESSION
 
-tmux split-window -t $SESSION:0 -v -p 50 './manage.py runserver; /bin/bash'
+tmux split-window -t $SESSION:0 -v -p 50 './manage.py runserver 0.0.0.0:8000; /bin/bash'
 tmux swap-pane    -t $SESSION:0 -U
 tmux split-window -t $SESSION:0 -v -p 50 'node kumascript/run.js; /bin/bash'
 tmux select-pane  -t $SESSION:0.2


### PR DESCRIPTION
- Mention go-tmux.sh in /etc/motd on login
- Start Django runserver on all net interfaces, so it can be accessed on
  port 8000 from the host.
