### PR TITLE
fix bug 760595: Cannot edit new localized page

### DIFF
--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -62,7 +62,7 @@
             </li>
           {% endif %}
           {% if user.is_authenticated() %}
-            <li><a href="{{ url('wiki.new_revision_based_on', document.slug, revision.id) }}">{{ _('Edit article based on this revision') }}</a></li>
+            <li><a href="{{ url('wiki.new_revision_based_on', document.full_path, revision.id) }}">{{ _('Edit article based on this revision') }}</a></li>
           {% endif %}
         </ul>
       </div>

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -44,6 +44,8 @@ document_patterns = patterns('wiki.views',
         name='wiki.review_revision'),
     url(r'^\$compare$', 'compare_revisions', name='wiki.compare_revisions'),
     url(r'^\$translate$', 'translate', name='wiki.translate'),
+    url(r'^\$translate/(?P<revision_id>\d+)$', 'translate',
+        name='wiki.translate'),
     url(r'^\$locales$', 'select_locale', name='wiki.select_locale'),
     url(r'^\$json$', 'json_view', name='wiki.json_slug'),
 

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -714,7 +714,11 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
     # If this document has a parent, then the edit is handled by the
     # translate view. Pass it on.
     if doc.parent:
-        return translate(request, doc.parent.slug, doc.locale, revision_id)
+        kw = {"document_path": doc.full_path}
+        if revision_id:
+            kw['revision_id'] = revision_id
+        url = reverse('wiki.translate', kwargs=kw)
+        return HttpResponseRedirect(url)
     if revision_id:
         rev = get_object_or_404(Revision, pk=revision_id, document=doc)
     else:


### PR DESCRIPTION
I couldn't edit a localized page after creating it. This seems to fix the issue.
