### PR TITLE
fix bug 762073 - Removing 'anchor' tab from WYSIWYG Link Dialog

### DIFF
--- a/media/ckeditor/plugins/mdn-link/dialogs/link.js
+++ b/media/ckeditor/plugins/mdn-link/dialogs/link.js
@@ -779,7 +779,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 						}
 					}
 				]
-			},
+			},/*
 			{
 				id : 'target',
 				label : linkLang.target,
@@ -999,7 +999,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 						]
 					}
 				]
-			},
+			},*/
 			{
 				id: autoCompletePaneId,
 				label: gettext("Search"),


### PR DESCRIPTION
Simple request from Sheppy
