### PR TITLE
bug fix 762554 - Isolating document lookups only the current locale

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -999,7 +999,9 @@ def autosuggest_documents(request):
     partial_title = request.GET.get('term', '')
 
     # TODO: isolate to just approved docs?
-    docs = Document.objects.filter(title__icontains=partial_title).filter(is_template=0)
+    docs = (Document.objects.filter(title__icontains=partial_title,
+                                    is_template=0,
+                                    locale=request.locale))
 
     docs_list = []
     for d in docs:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=762554
