### PR TITLE
Whitelist nobr and dfn tags for wiki content

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -39,6 +39,7 @@ ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'div', 'span', 'p', 'br', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
     'pre', 'code',
     'dl', 'dt', 'dd', 'small', 'sup', 'u',
+    'nobr', 'dfn', 'caption',
     'img',
     'input',
     'table', 'tbody', 'thead', 'tr', 'th', 'td',


### PR DESCRIPTION
This is probably going to be one of a series of commits to whitelist additional HTML tags for Bleached wiki content. These two in particular are used in a number of pages
