### PR TITLE
fix bug 763616 - Adding article searching and removing redirects

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1034,7 +1034,9 @@ def autosuggest_documents(request):
     # TODO: isolate to just approved docs?
     docs = (Document.objects.filter(title__icontains=partial_title,
                                     is_template=0,
-                                    locale=request.locale))
+                                    locale=request.locale).
+                             exclude(title__iregex=r'Redirect [0-9]+$').
+                             order_by('title'))
 
     docs_list = []
     for d in docs:


### PR DESCRIPTION
FYI -- I tried using "\d" instead of "[0-9]" but, for some reason, it wasn't properly matching.
