### PR TITLE
fix bug 763655 - removing duplicate jQuery inclusion that broke 'SAKE'

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -663,7 +663,6 @@ MINIFY_BUNDLES = {
             'syntaxhighlighter/scripts/shBrushPlain.js',
             'js/wiki.js',
             'js/main.js',
-            'js/jquery-1.4.2.min.js',
             'js/libs/jqueryui.min.js',
             'js/jquery-ui-customizations.js',
             'js/libs/tag-it.js',


### PR DESCRIPTION
Le _sigh_.  Duplicate jQuery inclusion broke the "Save and Keep Editing" functionality.  Of course.
