### PR TITLE
fix bug 764426 - Prevent slashes in slugs from form

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -382,3 +382,16 @@ class ReviewForm(forms.Form):
                     label=_lazy(u'Significance:'),
                     choices=SIGNIFICANCES, initial=SIGNIFICANCES[0][0],
                     required=False, widget=forms.RadioSelect())
+
+
+class RevisionValidationForm(RevisionForm):
+    """Created primarily to disallow slashes in slugs during validation"""
+
+    #def __init__(self, *args, **kwargs):
+    #    return super(RevisionValidationForm, self).__init__(self, *args, **kwargs)
+
+    def clean_slug(self):
+        # "/" disallowed in form input
+        if '/' in self.cleaned_data['slug']:
+            raise forms.ValidationError(SLUG_INVALID)
+        return super(RevisionValidationForm, self).clean_slug()

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -781,13 +781,11 @@ class DocumentEditingTests(TestCaseBase):
                 reverse('wiki.document', args=[data['slug']],
                                          locale='en-US'))
 
-        # Slashes should be fine
+        # Slashes should not be acceptable via form input
         data['title'] = 'valid with slash'
         data['slug'] = 'va/lid'
         response = client.post(reverse('wiki.new_document'), data)
-        self.assertRedirects(response,
-                reverse('wiki.document', args=[data['slug']],
-                                         locale='en-US'))
+        self.assertContains(response, 'The slug provided is not valid.')
 
         # Dollar sign is reserved for verbs
         data['title'] = 'invalid with dollars'
@@ -832,6 +830,86 @@ class DocumentEditingTests(TestCaseBase):
             data['slug'] = term
             response = client.post(reverse('wiki.new_document'), data)
             self.assertContains(response, 'The slug provided is not valid.')
+
+    def test_parent_child_slug_built_properly(self):
+        """Slugs and their parents are properly rebuilt during each edit"""
+
+        client = LocalizingClient()
+        client.login(username='admin', password='testpass')
+
+        # Create the parent document
+        parent_slug = 'parentDoc'
+        parent_doc = document(title='Parent Doc', slug=parent_slug, is_localizable=True)
+        parent_doc.save()
+        r = revision(document=parent_doc)
+        r.save()
+
+        # Create the new document test data
+        data = new_document_data()
+        data['title'] = 'Child Doc'
+        data['slug'] = 'childDoc'
+        data['content'] = 'I am a bunch of content'
+        data['is_localizable'] = True
+
+        # Validate that a child slug is built properly
+        response = client.post(reverse('wiki.new_document') + '?parent=' + str(parent_doc.id), data)
+        eq_(302, response.status_code)
+        child_doc = parent_doc.children.all()[0]
+        ok_(parent_doc.children.count() == 1)
+        eq_(child_doc.slug, 'parentDoc/childDoc')
+
+        # Now validate that the slug stays correct when an edit is done and the slug isn't touched
+        data['form'] = 'rev'
+        edit_url = reverse('wiki.edit_document',
+                                   locale=settings.WIKI_DEFAULT_LANGUAGE,
+                                   args=[child_doc.full_path])
+        response = client.post(edit_url, data)
+        self.assertRedirects(response, '/' + settings.WIKI_DEFAULT_LANGUAGE + '/docs/' + parent_slug + '/' + data['slug'])
+        child_doc = parent_doc.children.all()[0]
+        eq_(child_doc.slug, parent_slug + '/' + data['slug'])
+
+
+        # Validate that the slug stays correct when an edit is done and the slug *is* touched
+        data['slug'] = 'childDocUpdated'
+        response = client.post(edit_url, data)
+        self.assertRedirects(response, '/' + settings.WIKI_DEFAULT_LANGUAGE + '/docs/' + parent_slug + '/' + data['slug'])
+        child_doc = parent_doc.children.all()[0]
+        eq_(child_doc.slug, parent_slug + '/' + data['slug'])
+            
+        # Validate that the slug is correctly built when translated
+        child_doc = parent_doc.children.all()[0]
+        child_doc.is_localizable = True
+        child_doc.save()
+        data['slug'] = 'ChildSluggo'
+        data['form'] = 'both'
+        translate_url = reverse('wiki.document', locale=settings.WIKI_DEFAULT_LANGUAGE, args=[child_doc.slug]) + '$translate?tolocale=es'
+        response = client.post(translate_url, data)
+        self.assertRedirects(response, '/es/docs/' + parent_slug + '/' + data['slug'])
+
+        # Validate that the grandchild slug is properly created
+        grandchild_data = new_document_data()
+        grandchild_data['title'] = 'Grandchild Doc'
+        grandchild_data['slug'] = 'grandchildDoc'
+        grandchild_data['contnet'] = 'This is the document'
+        grandchild_data['is_localizable'] = True
+        response = client.post(reverse('wiki.new_document') + '?parent=' + str(child_doc.id), grandchild_data)
+        eq_(302, response.status_code)
+        grandchild_doc = child_doc.children.all()[0]
+        eq_(grandchild_doc.slug, child_doc.slug + '/' + grandchild_data['slug'])
+
+        # Validate that the grandchild slug is correct after edit
+        child_doc = parent_doc.children.all()[0]
+        grandchild_data['form'] = 'rev'
+        edit_url = reverse('wiki.edit_document',
+                                   locale=settings.WIKI_DEFAULT_LANGUAGE,
+                                   args=[grandchild_doc.full_path])
+        grandchild_data['slug'] = 'grandchildDocUpdated'
+        response = client.post(edit_url, grandchild_data)
+        self.assertRedirects(response, '/' + settings.WIKI_DEFAULT_LANGUAGE + '/docs/' + child_doc.slug + '/' + grandchild_data['slug'])
+        grandchild_doc = child_doc.children.all()[0]
+        eq_(grandchild_doc.slug, child_doc.slug + '/' + grandchild_data['slug'])
+
+
 
     def test_localized_based_on(self):
         """Editing a localized article 'based on' an older revision of the

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -50,7 +50,7 @@ from wiki import (DOCUMENTS_PER_PAGE, TEMPLATE_TITLE_PREFIX,
 from wiki.decorators import check_readonly
 from wiki.events import (EditDocumentEvent, ReviewableRevisionInLocaleEvent,
                          ApproveRevisionInLocaleEvent)
-from wiki.forms import DocumentForm, RevisionForm, ReviewForm
+from wiki.forms import DocumentForm, RevisionForm, ReviewForm, RevisionValidationForm
 from wiki.models import (Document, Revision, HelpfulVote, EditorToolbar,
                          DocumentTag, ReviewTag,
                          CATEGORIES,
@@ -690,7 +690,7 @@ def new_document(request):
             parent_slug = parent_doc.slug
             parent_path = request.build_absolute_uri(parent_doc.get_absolute_url())
         except Document.DoesNotExist:
-            parent_slug = ''
+            logging.debug('Cannot find parent')
 
     if request.method == 'GET':
 
@@ -727,15 +727,20 @@ def new_document(request):
 
     post_data = request.POST.copy()
     post_data.update({'locale': request.locale})
-
-    # Prefix this new doc's slug with the parent document's slug.
     if parent_slug:
-        post_data.update({'slug': parent_slug + '/' + post_data['slug']})
+        post_data.update({'parent_topic': initial_parent_id})
 
     doc_form = DocumentForm(post_data)
-    rev_form = RevisionForm(post_data)
+    rev_form = RevisionValidationForm(post_data)
 
     if doc_form.is_valid() and rev_form.is_valid():
+        
+        rev_form = RevisionForm(post_data)
+        
+        # Prefix this new doc's slug with the parent document's slug.
+        if parent_slug:
+            post_data.update({'slug': parent_slug + '/' + post_data['slug']})
+
         slug = doc_form.cleaned_data['slug']
         if not Document.objects.allows_add_by(request.user, slug):
             raise PermissionDenied
@@ -752,7 +757,9 @@ def new_document(request):
     return jingo.render(request, 'wiki/new_document.html',
                         {'is_template': is_template,
                          'document_form': doc_form,
-                         'revision_form': rev_form})
+                         'revision_form': rev_form,
+                         'parent_slug': parent_slug,
+                         'parent_path': parent_path})
 
 
 @waffle_flag('kumawiki')
@@ -779,12 +786,12 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
                                                              '-id')[0]
 
     # Keep hold of the full post slug
-    full_slug = rev.slug
+    full_slug = document_slug
     slug_split = full_slug.split('/')
     # Update the slug, removing the parent path, and
     # *only* using the last piece.
     # This is only for the edit form.
-    rev.slug = slug_split[-1]
+    doc.slug = rev.slug = slug_split[-1]
     # Keep a parent slug
     # Create the slug prefix from the parent string
     slug_split.pop()
@@ -821,13 +828,14 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
             if doc.allows_editing_by(user):
                 post_data = request.POST.copy()
 
-                if 'slug' in post_data:  # if a section edit
-                    slug_split.append(post_data['slug'])
-                    post_data['slug'] = '/'.join(slug_split)
-
                 post_data.update({'locale': document_locale})
                 doc_form = DocumentForm(post_data, instance=doc)
                 if doc_form.is_valid():
+
+                    if 'slug' in post_data:  # if must be here for section edits
+                        slug_split.append(post_data['slug'])
+                        post_data['slug'] = '/'.join(slug_split)
+
                     # Get the possibly new slug for the imminent redirection:
                     doc = doc_form.save(None)
                     _invalidate_kumascript_cache(doc)
@@ -860,11 +868,8 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
             else:
 
                 post_data = request.POST.copy()
-                if 'slug' in post_data:
-                    slug_split.append(post_data['slug'])
-                    post_data['slug'] = '/'.join(slug_split)
 
-                rev_form = RevisionForm(post_data,
+                rev_form = RevisionValidationForm(post_data,
                                         is_iframe_target=is_iframe_target,
                                         section_id=section_id)
                 rev_form.instance.document = doc  # for rev_form.clean()
@@ -881,7 +886,7 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
                 curr_rev = doc.current_revision
 
                 if not rev_form.is_valid():
-
+                    
                     # Was there a mid-air collision?
                     if 'current_rev' in rev_form._errors:
                         # Jump out to a function to escape indentation hell
@@ -891,6 +896,18 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
                                 rev, doc)
 
                 else:
+                    
+                    if 'slug' in post_data:
+                        slug_split.append(post_data['slug'])
+                        post_data['slug'] = '/'.join(slug_split)
+
+                    # We know now that the form is valid (i.e. slug doesn't have a "/")
+                    # Now we can make it a true revision form
+                    rev_form = RevisionForm(post_data,
+                                            is_iframe_target=is_iframe_target,
+                                            section_id=section_id)
+                    rev_form.instance.document = doc  # for rev_form.clean()
+                    
                     _save_rev_and_notify(rev_form, user, doc)
 
                     if is_iframe_target:
@@ -1279,12 +1296,13 @@ def translate(request, document_slug, document_locale, revision_id=None):
             doc_form.instance.locale = document_locale
             doc_form.instance.parent = parent_doc
             if which_form == 'both':
-                rev_form = RevisionForm(post_data)
+                rev_form = RevisionValidationForm(post_data)
 
             # If we are submitting the whole form, we need to check that
             # the Revision is valid before saving the Document.
             if doc_form.is_valid() and (which_form == 'doc' or
                                         rev_form.is_valid()):
+                rev_form = RevisionForm(post_data)
                 doc = doc_form.save(parent_doc)
 
                 # Possibly schedule a rebuild.
@@ -1304,16 +1322,17 @@ def translate(request, document_slug, document_locale, revision_id=None):
             doc_slug = doc.slug
 
         if doc and user_has_rev_perm and which_form in ['rev', 'both']:
-
             post_data = request.POST.copy()
 
-            # append final slug
-            parent_slug_split.append(post_data['slug'])
-            post_data['slug'] = '/'.join(parent_slug_split)
-
-            rev_form = RevisionForm(post_data)
+            rev_form = RevisionValidationForm(post_data)
             rev_form.instance.document = doc  # for rev_form.clean()
+
             if rev_form.is_valid() and not doc_form_invalid:
+                # append final slug
+                parent_slug_split.append(post_data['slug'])
+                post_data['slug'] = '/'.join(parent_slug_split)
+                rev_form = RevisionForm(post_data)
+
                 _save_rev_and_notify(rev_form, request.user, doc)
                 url = reverse('wiki.document', args=[doc.full_path],
                               locale=doc.locale)


### PR DESCRIPTION
This is an incredibly naive, n00b attempt at preventing slashes in the new/edit document forms.  

We cannot add the "/" check in the DocumentForm and RevisionForm classes because any slug with a child and "/" would break any time there was a child (i.e. after the parent/child/grandchild) slug has been built.  Les mentioned we'd need a new form class.

"DisallowSlugSlashForm" isn't a good form name, but I guess I'm submitting this to get some sort of feedback on how best to accomplish this. 

Please keep giggles and fury to a minimum... :)
