### PR TITLE
Modified url pattern to allow slashes in tag names

### DIFF
--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -107,7 +107,7 @@ urlpatterns += patterns('wiki.views',
     url(r'^/feeds/(?P<format>[^/]+)/needs-review/?',
         DocumentsReviewFeed(), name="wiki.feeds.list_review"),
 
-    url(r'^/tag/(?P<tag>[^/]+)$', 'list_documents', name='wiki.tag'),
+    url(r'^/tag/(?P<tag>.+)$', 'list_documents', name='wiki.tag'),
 
     url(r'^/load/$', 'load_documents', name='wiki.load_documents'),
 


### PR DESCRIPTION
The view, forms and models allow slashes in tag names, so it makes sense for the url pattern to expect them as well.
