### PR TITLE
fix bug 765647 - Keeping locale when attempting edit

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1197,7 +1197,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
         Document, locale=settings.WIKI_DEFAULT_LANGUAGE, slug=document_slug)
     user = request.user
 
-    if not revision_id:
+    if not revision_id and not document_locale:
         # HACK: Seems weird, but sticking the translate-to locale in a query
         # param is the best way to avoid the MindTouch-legacy locale
         # redirection logic.


### PR DESCRIPTION
This fixes the issue described here:

https://bugzilla.mozilla.org/show_bug.cgi?id=765647

The manual "translate()" call from within the edit_document() definition isn't using the provided document_slug in any way.  With the change in the PR, I was able to update a DE document repeatedly while staying on the DE locale.

I don't, however, know why this hack was put in in the first place, so I don't know what else should be tested.
