### PR TITLE
Updated judge heading on Derby landing page.

### DIFF
--- a/apps/demos/templates/demos/devderby_landing.html
+++ b/apps/demos/templates/demos/devderby_landing.html
@@ -144,7 +144,7 @@
             your demo with others and encourage them to visit Dev Derby to
             &ldquo;vote.&rdquo;</p>
       {% endtrans %}
-        <h2>{{ _("Current Judges") }}</h2>
+        <h2>{{ _("Expert Judges") }}</h2>
         <ul class="judges">
           <li class="vcard">
             <h3><a href="http://devthought.com" class="fn url">Guillermo Rauch<img src="{{MEDIA_URL}}img/devderby/judges/guillermorauch.jpg" alt="" class="photo" width="100" height="100"></a></h3>


### PR DESCRIPTION
Just a minor copy update. When we first started listing previous judges
below current judges on the Derby landing page, we changed the main
heading from "Expert Judges" to "Current Judges". Now that previous
judges are not listed, the former makes more sense again.
