### PR TITLE
766608 events copy

### DIFF
--- a/apps/devmo/templates/devmo/calendar.html
+++ b/apps/devmo/templates/devmo/calendar.html
@@ -15,7 +15,7 @@
     <header id="page-head">
       <h1 class="page-title">{{ _('Where is Mozilla?') }}</h1>
       <p>{% trans %}
-      Here you can see where Mozilla will be in the near future and what we are going to talk about. If you organize an event and you want a Mozillian to come around, please <a href="https://www.mozilla.org/en-US/press/speakerrequest/">send us the information via this form</a>. If you are a Mozillian speaking at an event that's not listed here, <a href="http://bit.ly/whereismozillaevents">let us know</a>!
+      Here you can see where Mozilla will be in the near future and what we are going to talk about. If you organize an event and you want a Mozillian to come around, please <a href="mailto:dev-events@mozilla.com">send us an email</a>. If you are a Mozillian speaking at an event that's not listed here, <a href="mailto:dev-events@mozilla.com">let us know</a>!
       {% endtrans %}
       </p>
     </header>


### PR DESCRIPTION
I will need someone with more Django experience to take a look at this one. I tried verifying that the page looked ok after these edits, but whenever I try to load it I get the following error:

```
DoesNotExist: Calendar matching query does not exist.
```

This happens on master as well, so it doesn't seem to be related to my changes.
