### PR TITLE
Add color, box-shadow, and gradients to the CSS whitelist

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -79,7 +79,7 @@ ALLOWED_STYLES = [
     'color',
     'box-shadow', '-moz-box-shadow', '-webkit-box-shadow', '-o-box-shadow',
     'linear-gradient', '-moz-linear-gradient', '-webkit-linear-gradient',
-    'radial-gradient', '-moz-radial-gradient', '-webkit-linear-gradient'
+    'radial-gradient', '-moz-radial-gradient', '-webkit-radial-gradient'
 ]
 
 # Disruptiveness of edits to translated versions. Numerical magnitude indicate


### PR DESCRIPTION
This will help fix a bunch of templates (not all, just a bunch).
