### PR TITLE
Bug 768492: Quick hack to enable a wiki doc to be treated as wiki CSS

### DIFF
--- a/apps/wiki/templates/wiki/base.html
+++ b/apps/wiki/templates/wiki/base.html
@@ -1,8 +1,13 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "base.html" %}
 
-{% block extrahead %}
+{% block site_css %}
+    {{ super() }}
     {{ css('wiki-print', media='print') }}
+    {% if config.KUMA_CUSTOM_CSS_PATH %}
+      <link rel="stylesheet" type="text/css"
+            href="{{ config.KUMA_CUSTOM_CSS_PATH }}?raw=1" />
+    {% endif %}
 {% endblock %}
 
 {% if not styles %}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -348,7 +348,9 @@ def document(request, document_slug, document_locale):
     if show_raw:
         response = HttpResponse(doc_html)
         response['x-frame-options'] = 'Allow'
-        if doc.is_template:
+        if constance.config.KUMA_CUSTOM_CSS_PATH == doc.get_absolute_url():
+            response['Content-Type'] = 'text/css; charset=utf-8'
+        elif doc.is_template:
             # Treat raw, un-bleached template source as plain text, not HTML.
             response['Content-Type'] = 'text/plain; charset=utf-8'
         return set_common_headers(response)

--- a/settings.py
+++ b/settings.py
@@ -975,6 +975,14 @@ CONSTANCE_CONFIG = dict(
         'kumascript. Passed along in a Cache-Control: max-age={value} header, '
         'which tells kumascript whether or not to serve up a cached response.'
     ),
+
+    KUMA_CUSTOM_CSS_PATH = (
+        '/en-US/docs/Template:CustomCSS',
+        'Path to a wiki document whose raw content will be loaded as a CSS '
+        'stylesheet for the wiki base template. Will also cause the ?raw '
+        'parameter for this path to send a Content-Type: text/css header. Empty '
+        'value disables the feature altogether.',
+    ),
 )
 
 BROWSERID_VERIFICATION_URL = 'https://browserid.org/verify'


### PR DESCRIPTION
This is a quick & dirty way to use a page from the wiki as a customizable CSS resource. Ideally, a Template, so that we can use the permission to protect it from edits.

This isn't a perfect solution, so we should probably keep the bug itself open. But, this should let us allow site editors to customize the styles in the meantime
