### PR TITLE
fix bug 770338 - Preventing unnecessary redirect documents

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -387,9 +387,6 @@ class ReviewForm(forms.Form):
 class RevisionValidationForm(RevisionForm):
     """Created primarily to disallow slashes in slugs during validation"""
 
-    #def __init__(self, *args, **kwargs):
-    #    return super(RevisionValidationForm, self).__init__(self, *args, **kwargs)
-
     def clean_slug(self):
         # "/" disallowed in form input
         if '/' in self.cleaned_data['slug']:


### PR DESCRIPTION
Upon valid "new" and "translate" forms submissions, whereby a parent/child structure existed in the slug, an entry was created incorrectly for "/child" and then correctly for "parent/child".  This prevents the "/child" redirect from being created.

Tests also added.

How to spot-check:
1.  Create a parent document with slug "parentdoc"
2.  Create a child document with slug "childdoc"
3.  You should be at "en-US/docs/parentdoc/childdoc"
4.  Try to hit "en-US/docs/childdoc" -- you should get a 404
5.  Translate to new language; you should be at "es/docs/parentdoc/childdoc"
6.  Try to hit "es/docs/childdoc" -- you should get a 404.
