### PR TITLE
fix bug 770400 - Search results use current hostname for links

### DIFF
--- a/media/js/mdn/gsearch.js
+++ b/media/js/mdn/gsearch.js
@@ -6,16 +6,16 @@ google.load("search", "1", {
 
 $(document).ready(function() {
     // Place branding
-    google.search.Search.getBranding(document.getElementById("site-search-gg"));
+    google.search.Search.getBranding($("#site-search-gg")[0]);
 
     /* Run a Google Search through the API */
-    var sr = $('#search-results'),
-        query = sr.attr("data-q");
-    if (!sr.length || !query)
+    var $sr = $('#search-results'),
+        query = $sr.attr("data-q");
+    if (!$sr.length || !query)
         return;
 
     // branding
-    google.search.Search.getBranding(document.getElementById("google-branding"));
+    google.search.Search.getBranding($("#google-branding")[0]);
 
     // restrict to MDN only
     var siteSearch = new google.search.WebSearch();
@@ -25,13 +25,24 @@ $(document).ready(function() {
     siteSearch.clearResults();
 
     var done = function() {
+        var clone;
+
         for (i in siteSearch.results) {
-            sr.append(siteSearch.results[i].html.cloneNode(true));
+            clone = siteSearch.results[i].html.cloneNode(true);
+
+            /* START:  Remove before launch */
+            $(clone.childNodes).each(function() {
+                var $this = $(this);
+                $this.html($this.html().replace(/developer.mozilla\.org/g, window.location.hostname));
+            });
+            /* FINISH:  Remove before launch */
+            
+            $sr.append(clone);
         }
 
         var cursor = siteSearch.cursor;
         if (!cursor && siteSearch.results.length == 0) {
-            sr.html("<p>No results found.</p>");
+            $sr.html("<p>No results found.</p>");
         } else if (cursor.currentPageIndex < cursor.pages.length - 1) {
             // this is recursive. google.search will re-call its callback, i.e.
             // this function when it gets the next page of result.


### PR DESCRIPTION
Google search results will now use the current hostname for result links instead of using "developer.mozilla.org".  We'll want to remove this after we have our official launch since it's wasteful processing.
