### PR TITLE
Ensuring 'discard changes' button URL is correct for editing documents

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -565,7 +565,7 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
     # Update the slug, removing the parent path, and
     # *only* using the last piece.
     # This is only for the edit form.
-    doc.slug = rev.slug = slug_split[-1]
+    rev.slug = slug_split[-1]
     # Keep a parent slug
     # Create the slug prefix from the parent string
     slug_split.pop()


### PR DESCRIPTION
Noticed the discard URL was wrong on 'Edit' page.
