### PR TITLE
bug 762252: Disable NoCacheHttpsMiddleware to allow caching under HTTPS

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -314,7 +314,6 @@ MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
     'sumo.middleware.RemoveSlashMiddleware',
     'inproduct.middleware.EuBuildMiddleware',
-    'sumo.middleware.NoCacheHttpsMiddleware',
     'commonware.middleware.NoVarySessionMiddleware',
     'commonware.middleware.FrameOptionsHeader',
     'django.middleware.csrf.CsrfViewMiddleware',


### PR DESCRIPTION
Kitsune disabled caching under https:// to address [bug 584931](https://bugzilla.mozilla.org/show_bug.cgi?id=584931). It seems like the main thing there was that personalized info (eg. logged in username) was being cached. But, we send a `Vary: Cookie` header, which should prevent that by requiring a logged in user's cookie to be considered in caching. So, it seems safe to turn this off for us.
