### PR TITLE
Wiki document admin improvements

### DIFF
--- a/media/js/wiki-admin.js
+++ b/media/js/wiki-admin.js
@@ -1,0 +1,29 @@
+// See also: http://stackoverflow.com/questions/6086651/minimize-the-list-filter-in-django-admin
+(function($){
+ListFilterCollapsePrototype = {
+    bindToggle: function(){
+        var that = this;
+        this.$filterTitle.click(function(){
+            that.$filterContent.slideToggle();
+            that.$list.toggleClass('filtered');
+        });
+    },
+    init: function(filterEl) {
+        this.$filterTitle = $(filterEl).children('h2');
+        this.$filterContent = $(filterEl).children('h3, ul');
+        $(this.$filterTitle).css('cursor', 'pointer');
+        this.$list = $('#changelist');
+        this.bindToggle();
+    }
+}
+function ListFilterCollapse(filterEl) {
+    this.init(filterEl);
+}
+ListFilterCollapse.prototype = ListFilterCollapsePrototype;
+
+$(document).ready(function(){
+    $('#changelist-filter').each(function(){
+        var collapser = new ListFilterCollapse(this);
+    });
+});
+})(django.jQuery);


### PR DESCRIPTION
No bug for this one, but scratching my own itch since I'm dealing with the admin tool quite a lot:
- Allow the "Filter" sidebar to be collapsed, for when the changelist
  table is too wide for the browser.
- Combine many columns into single-column lists to make the changelist
  more horizonally compact

Should look a bit like this:
https://dl.dropbox.com/u/2798055/Screenshots/v.png
