### PR TITLE
Work around duplicate migrated deki users.

### DIFF
--- a/apps/dekicompat/backends.py
+++ b/apps/dekicompat/backends.py
@@ -166,10 +166,10 @@ class DekiUserBackend(object):
         """
         try:
             # Try fetching an existing profile mapped to deki user
-            profile = UserProfile.objects.get(deki_user_id=deki_user.id)
+            profile = UserProfile.objects.filter(deki_user_id=deki_user.id)[0]
             user = profile.user
 
-        except ObjectDoesNotExist:
+        except IndexError:
             # No existing profile, so try creating a new profile and user
 
             # HACK: Usernames in Kuma are limited to 30 characters. There are


### PR DESCRIPTION
This is at best a temporary hack to get migration working again; it
simply changes out the get() call for filter(), and automatically
picks the first user returned. This may result in a need to fix
objects associated with a second account, but since currently the
migration blows up when attempting to call this method, hopefully it's
not been possible to create any such objects.
