### PR TITLE
fix bug 772647: Fixed "About MDN" link in footer.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -177,10 +177,10 @@
       <img src="{{ MEDIA_URL }}img/mdn-logo-tiny.png" alt="" width="42" height="48">
       <p id="copyright">&copy; {{ thisyear() }} Mozilla Developer Network</p>
       <p>
-      {% trans copyright_url=devmo_url(_('Project:Copyrights')) %}
+      {% trans copyright_url=devmo_url(_('/en-US/docs/Project:Copyrights')) %}
       Content is available under <a href="{{ copyright_url }}">these licenses</a>
       {% endtrans %}
-      &bull; <a href="{{ devmo_url(_('Project:About')) }}">{{ _('About MDN') }}</a> &bull;
+      &bull; <a href="{{ devmo_url(_('/en-US/docs/Project:About')) }}">{{ _('About MDN') }}</a> &bull;
       <a href="http://www.mozilla.org/en-US/privacy">{{ _('Privacy Policy') }}</a> &bull;
       <a href="/forums/viewtopic.php?f=3&amp;t=5">{{ _('Help') }}</a></p>
     </div>


### PR DESCRIPTION
Wasn't able to spot check this one -- doing so requires changing the kumawiki flag, which requires a superuser account, which I can't create because manage.py is giving me errors about the MySQLdb module.

Thoughts on my setup welcome. Aside from that, the change should work just fine.
