### PR TITLE
bug 773126: Template calls with an unquoted number as a parameter did not import correctly

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -501,12 +501,6 @@ class DekiscriptMacroFilter(html5lib_Filter):
                 if ds_call.lower().startswith(prefix):
                     ds_call = ds_call[len(prefix):]
 
-            # Convert numeric args to quoted. eg. bug(123) -> bug("123")
-            num_re = re.compile(r'^([^(]+)\((\d+)')
-            m = num_re.match(ds_call)
-            if m:
-                ds_call = '%s("%s")' % (m.group(1), m.group(2))
-
             # template("template name", [ "params" ])
             wt_re = re.compile(
                 r'''^template\(['"]([^'"]+)['"],\s*\[([^\]]+)]''', re.I)

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -406,7 +406,6 @@ class ContentSectionToolTests(TestCase):
             <li><span class="script">Warning("Performing synchronous IO on the main thread can cause serious performance problems. As a result, this method of modifying the database is <strong>strongly</strong> discouraged!")</span></li>
             <li><span class="script">Note("Performing synchronous IO on the main thread can cause serious performance problems. As a result, this method of modifying the database is <strong class="important">strongly</strong> discouraged!")</span></li>
             <li><span class="script">MixedCaseName('parameter1', 'parameter2')</span></li>
-            <li><span class="script">bug(689641)</span></li>
             <li><span class="script">template.lowercasename('border')</span></li>
             <li><span class="script">Template.UpperCaseTemplate("foo")</span></li>
             <li><span class="script">wiki.template('英語版章題', [ "Reusing tabs" ])</span></li>
@@ -420,7 +419,6 @@ class ContentSectionToolTests(TestCase):
             <li>{{ Warning("Performing synchronous IO on the main thread can cause serious performance problems. As a result, this method of modifying the database is <strong>strongly</strong> discouraged!") }}</li>
             <li>{{ Note("Performing synchronous IO on the main thread can cause serious performance problems. As a result, this method of modifying the database is <strong class="important">strongly</strong> discouraged!") }}</li>
             <li>{{ MixedCaseName('parameter1', 'parameter2') }}</li>
-            <li>{{ bug("689641") }}</li>
             <li>{{ lowercasename('border') }}</li>
             <li>{{ UpperCaseTemplate("foo") }}</li>
             <li>{{ 英語版章題("Reusing tabs") }}</li>


### PR DESCRIPTION
- --fromlist option to use a file listing page titles as source for
  migration queries
- Stop attempting to put quotes around unquoted numeric macro parameter
- Small bugfixes to general migration
