### PR TITLE
Bare-bones feed of file edits.

### DIFF
--- a/apps/wiki/feeds.py
+++ b/apps/wiki/feeds.py
@@ -20,7 +20,7 @@ from sumo.urlresolvers import reverse
 from devmo.models import UserProfile
 
 from wiki.helpers import diff_table, diff_inline
-from wiki.models import Document, Revision
+from wiki.models import Document, Revision, AttachmentRevision
 
 
 MAX_FEED_ITEMS = getattr(settings, 'MAX_FEED_ITEMS', 15)
@@ -234,6 +234,41 @@ class RevisionsFeed(DocumentsFeed):
 
     def item_link(self, item):
         return reverse('wiki.document', args=[item.document.full_path])
+
+    def item_pubdate(self, item):
+        return item.created
+
+    def item_author_name(self, item):
+        return '%s' % item.creator
+
+    def item_author_link(self, item):
+        return self.request.build_absolute_uri(
+            reverse('devmo.views.profile_view',
+                    args=(item.creator.username,)))
+
+    def item_categories(self, item):
+        return []
+
+
+class AttachmentsFeed(DocumentsFeed):
+    title = _("MDN recent file changes")
+    subtitle = _("Recent revisions to MDN file attachments")
+
+    def items(self):
+        return AttachmentRevision.objects.order_by('-created')[:50]
+
+    def item_title(self, item):
+        return item.title
+
+    def item_description(self, item):
+        previous = item.get_previous()
+        if previous is None:
+            return '<p>Created by: %s</p>' % item.creator.username
+        return "<p>Edited by %s: %s" % (item.creator.username, item.comment)
+
+    def item_link(self, item):
+        return self.request.build_absolute_url(
+            item.attachment.get_absolute_url())
 
     def item_pubdate(self, item):
         return item.created

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1483,3 +1483,13 @@ class AttachmentRevision(models.Model):
         self.attachment.slug = self.slug
         self.attachment.current_revision = self
         self.attachment.save()
+
+    def get_previous(self):
+        previous_revisions = self.attachment.revisions.filter(
+            is_approved=True,
+            created__lt=self.created,
+            ).order_by('-created')
+        if len(previous_revisions):
+            return previous_revisions[0]
+        else:
+            return None


### PR DESCRIPTION
This is almost entirely lifted from the existing feed of revisions of
documents, tweaked a bit to match the way the file models are laid
out. To make it easier to determine if a given file revision is a new
file, a get_previous() method is added to AttachmentRevision (and
probably should've been there anyway).
