### PR TITLE
fix bug 771586 - utf8 encode content posted to kumascript

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import httplib
 from urlparse import urljoin
 import json
 import base64
@@ -16,7 +15,7 @@ from django.contrib.sites.models import Site
 
 import constance.config
 
-from wiki import (KUMASCRIPT_TIMEOUT_ERROR, ReadOnlyException)
+from wiki import KUMASCRIPT_TIMEOUT_ERROR
 
 
 def should_use_rendered(doc, params):
@@ -49,8 +48,9 @@ def post(request, content):
         url=request.build_absolute_uri('/'),
     )
     add_env_headers(headers, env_vars)
+    data = content.encode('utf8')
     resp = requests.post(ks_url, timeout=constance.config.KUMASCRIPT_TIMEOUT,
-                        data=content, headers=headers)
+                        data=data, headers=headers)
     if resp:
         resp_body = process_body(resp)
         resp_errors = process_errors(resp)

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from django.contrib.auth.models import User, Group, Permission
 from django.template.defaultfilters import slugify
 
-import html5lib
 from html5lib.filters._base import Filter as html5lib_Filter
 
 from waffle.models import Flag
@@ -11,6 +10,7 @@ from waffle.models import Flag
 from sumo.tests import LocalizingClient, TestCase, get_user
 import wiki.content
 from wiki.models import Document, Revision, CATEGORIES, SIGNIFICANCES
+
 
 class TestCaseBase(TestCase):
     """Base TestCase for the wiki app test cases."""
@@ -178,3 +178,11 @@ def create_topical_parents_docs():
     d2.save()
     return d1, d2
 
+
+class FakeResponse:
+    """Quick and dirty mocking stand-in for a response object"""
+    def __init__(self, **entries):
+        self.__dict__.update(entries)
+
+    def read(self):
+        return self.body


### PR DESCRIPTION
spot-check:
1. verify kumascript is running
2. put in some non-ascii characters while translating a page (e.g., Français)
3. preview the page
4. no more UnicodeEncodeError
