### PR TITLE
fix bug 773362 - Garbage content and "rendering for the first time" message on blank pages

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -22,6 +22,7 @@ from wiki import (KUMASCRIPT_TIMEOUT_ERROR, ReadOnlyException)
 def should_use_rendered(doc, params):
     """
       * The service isn't disabled with a timeout of 0
+      * The document isn't empty
       * The request has *not* asked for raw source
         (eg. ?raw)
       * The request has *not* asked for no macro evaluation
@@ -36,6 +37,7 @@ def should_use_rendered(doc, params):
     if doc:
         is_template = doc.is_template
     return (constance.config.KUMASCRIPT_TIMEOUT > 0 and
+            doc.html and
             not is_template and
             (force_macros or (not no_macros and not show_raw)))
 

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -97,7 +97,7 @@
             {% endif %}
         </ul>
 
-        {% if request.user.is_authenticated() %}
+        {% if request.user.is_authenticated() and document_html %}
           {% if render_raw_fallback %}
             <div id="doc-render-raw-fallback" class="warning">
             {% trans url=document.get_absolute_url() %}
@@ -201,7 +201,9 @@
         </div>
         {% endif %}
       {% if not fallback_reason %}
-        {% if document.is_template %}
+        {% if not document_html %}
+          {{ _("This article doesn't have any content yet.") }}
+        {% elif document.is_template %}
           <pre class="brush: js">{{ document_html }}</pre>
         {% else %}
           {{ document_html|safe }}

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -341,6 +341,8 @@ class KumascriptIntegrationTests(TestCaseBase):
         super(KumascriptIntegrationTests, self).setUp()
 
         self.d, self.r = doc_rev()
+        self.r.content = "TEST CONTENT"
+        self.r.save()
         self.d.tags.set('foo', 'bar', 'baz')
         self.url = reverse('wiki.document', 
                            args=(self.d.slug,),


### PR DESCRIPTION
- Don't make a request to kumascript for blank content
- Don't display rendering warnings when there's blank content
- When there's blank content, display a message to that effect in the
  content area in document template
