### PR TITLE
fix bug 772116 - Adding SEO to documents, preventing Google from taking wrong text

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -16,8 +16,17 @@
 {% endif %}
 
 {% block extrahead %}
-  <link rel="alternate" type="application/json" 
-    href="{{ url('wiki.json_slug', document.full_path) }}">
+  <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.full_path) }}" />
+
+  <meta property="og:title" content="{{ document.title }}"/>
+  <meta property="og:type" content="website"/>
+  <meta property="og:image" content="{{ request.build_absolute_uri('/media/img/mdn-logo-sm.png') }}"/>    
+  <meta property="og:site_name" content="Mozilla Developer Network"/>
+
+  {% if seo_summary %}
+  <meta property="og:description" content="{{ seo_summary }}"/>
+  <meta name="description" content="{{ seo_summary }}" />
+  {% endif %}
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
OK, major SEO improvement here.  Spot checked and working on many different locales.  This provides open graph tags for better sharing capabilities, and I added logic so that warning messages, deprecation warnings, etc. aren't added.
