### PR TITLE
Typo in RTL beta bug link

### DIFF
--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -1150,7 +1150,7 @@ li.tag-expert label:hover { border-color: #bbb; }
 .html-rtl .user-state li + li { padding-right: 10px; margin-right: 8px; margin-left:0; padding-left:0; border-right: 1px solid #666; border-left: 0; }
 .html-rtl #masthead #tabzilla { position: absolute; left: 0; top: 0; right: auto; }
 
-.html-rl .reportBug { left: 20px; right: auto; }
+.html-rtl .reportBug { left: 20px; right: auto; }
 
 .html-rtl #welcome-close { right: auto; left: 15px; }
 .html-rtl #welcome-open { right: auto; left: 10px; }


### PR DESCRIPTION
Found a typo which made the BETA link show up in the wrong spot when in RTL.
