### PR TITLE
Disabling [section editing] until 771686 is fixed

### DIFF
--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -170,7 +170,7 @@ div.note p, div.tip p { margin-bottom: .75em; }
 
 .template { display: none; }
 
-a.edit-section { float: right; padding: .25em 5px .15em; margin-top: .25em; border: 0; border-radius: 3px; box-shadow: 1px 1px 0 rgba(0,0,0,.25); color: #333; background: #a5d9f3 url("../img/light-shade.png") 0 .75em repeat-x; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; text-decoration: none; }
+a.edit-section { float: right; padding: .25em 5px .15em; margin-top: .25em; border: 0; border-radius: 3px; box-shadow: 1px 1px 0 rgba(0,0,0,.25); color: #333; background: #a5d9f3 url("../img/light-shade.png") 0 .75em repeat-x; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; text-decoration: none; display: none; }
 a.edit-section:before { content: "\25c0\00a0"; font-size: .857em; }
 a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333; background-color: #ade4ff; text-decoration: none; }
 


### PR DESCRIPTION
So this bug:

https://bugzilla.mozilla.org/show_bug.cgi?id=771686

...scares the crap out of me.  This bug hides section editing via CSS, so we can test on live site if necessary.
