### PR TITLE
fix bug 773638 - Erroneous "first time render" message when kumascript is unresponsive

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -536,11 +536,6 @@ class Document(NotificationsMixin, ModelBase):
             except DocumentRenderingInProgress:
                 pass
 
-        # If the above resulted in an immediate render, we might have content.
-        if not self.rendered_html:
-            # But, no such luck, so bail out.
-            raise DocumentRenderedContentNotAvailable()
-
         # Parse JSON errors, if available.
         errors = None
         try:
@@ -548,6 +543,14 @@ class Document(NotificationsMixin, ModelBase):
                       json.loads(self.rendered_errors) or None)
         except ValueError:
             pass
+
+        # If the above resulted in an immediate render, we might have content.
+        if not self.rendered_html:
+            if errors:
+                return ('', errors)
+            else:
+                # But, no such luck, so bail out.
+                raise DocumentRenderedContentNotAvailable()
 
         return (self.rendered_html, errors)
 

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -115,7 +115,7 @@
               please <a href="{{ url }}">reload this page</a> in a few minutes.
             {% endtrans %}
             </div>
-          {% elif document.is_rendering_scheduled %}
+          {% elif document.is_rendering_scheduled and not kumascript_errors %}
             <div id="doc-rendering-scheduled" class="warning">
             {% trans url=document.get_absolute_url(), scheduled_at=document.render_scheduled_at %}
               An update to this document 


### PR DESCRIPTION
- Try not to show "first time" or "scheduled" rendering messages when
  there are actually kumascript errors
