### PR TITLE
fix bug 774383 - Adding list of pages using a given template

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -269,6 +269,28 @@
       {% endif %}
 
 
+      {% if user.has_perm('add_document') and document.is_template %}
+      <section id="template-pages">
+        <div id="document-list">
+          <h1>{{ _('Pages Using This Template') }}</h1>
+          {% if template_page_list %}
+            <ul class="documents cols-3">
+              {% for doc in template_page_list.object_list %}
+                <li>
+                  <a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a> ({{ doc.locale }})<br/>
+                  <small>{{ doc.get_absolute_url() }}</small>
+                </li>
+              {% endfor %}
+            </ul>
+            {{ template_page_list|paginator }}
+          {% else %}
+            <p>{{ _('There are no documents.') }}</p>
+          {% endif %}
+          <p class="approx-message">{{ _('This is only an approximation.  Some templates are embedded and are not included in this calculation.') }}</p>
+        </div>
+      </section>
+      {% endif %}
+
       <section id="doc-contributors">
         {% trans contributors=user_list(contributors) %}
           Contributors to this page: {{ contributors }}
@@ -288,6 +310,7 @@
           {% endif %}
         {% endif %}
       </section>
+
     </section>
   </article>
   <form id="wiki-page-edit" class="editing" method="post" action="{{ url('wiki.edit_document', document_path=document.full_path) }}">
@@ -316,6 +339,7 @@
       </form>
     {% endif %}
 </section>
+
 {% endblock %}
 
 {% block side %}

--- a/media/css/wiki-print.css
+++ b/media/css/wiki-print.css
@@ -35,6 +35,7 @@ ul.index,
 .edited-section-ui,
 .warning,
 footer .languages,
+#template-pages,
 #masthead { 
   display: none; 
 }

--- a/media/css/wiki.css
+++ b/media/css/wiki.css
@@ -239,6 +239,13 @@ article #toc ul li {
     text-decoration: underline;
 }
 
+#template-pages p.approx-message {
+    color: #aaa;
+    font-style: italic;
+    font-size: .875em;
+    margin-bottom: 0;
+}
+
 /* Wiki Document content */
 #doc-content {
     font-size: 14px;


### PR DESCRIPTION
Two things to consider here:
1.  My search method is naive; I'm assuming all template usages are "MyTemplateName(", i.e. function format.  Is there a better way?
2.  I believe templates can use other templates, and as such, I don't know that we can ever really provided an accurate number or page list.  Should we add some sort of messages mentioning that the list is an approximation?
