### PR TITLE
fix bug 771640: Title is NOT filtered or safe for un-escaped display in preview template

### DIFF
--- a/apps/wiki/templates/wiki/preview.html
+++ b/apps/wiki/templates/wiki/preview.html
@@ -2,7 +2,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 
 {% extends "wiki/base.html" %}
-{% block title %}{{ title|safe }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% set classes = 'document' %}
 {% block bodyclass %}document{% endblock %}
 
@@ -23,7 +23,7 @@
       <article class="article" role="main">
       <header id="article-head">
         <div class="title">
-            <h1 class="page-title">{{ title|safe }}</h1>
+            <h1 class="page-title">{{ title }}</h1>
         </div>
       </header>
       


### PR DESCRIPTION
Looks like this was introduced in PR #227. @groovecoder or @darkwing: Can either of you remember why `title` was marked with `|safe`?

https://github.com/mozilla/kuma/blame/master/apps/wiki/templates/wiki/preview.html
