### PR TITLE
bug 769399: Stop generating IDs as part of document save, wait until after kumascript processing

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1195,11 +1195,6 @@ class Revision(ModelBase):
                                    'to a revision of the default-'
                                    'language document.')
 
-        if self.content and not self.document.is_template:
-            self.content = (wiki.content
-                            .parse(self.content)
-                            .injectSectionIDs()
-                            .serialize())
         if not self.title:
             self.title = self.document.title
         if not self.slug:

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -332,14 +332,19 @@ def document(request, document_slug, document_locale):
     toc_html = None
     if not doc.is_template:
 
+        doc_html = (wiki.content.parse(doc_html)
+                                .injectSectionIDs()
+                                .serialize())
+
         # Start applying some filters to the document HTML
-        tool = wiki.content.parse(doc_html)
-        doc_html = tool.serialize()
+        tool = (wiki.content.parse(doc_html))
+
         # Generate a TOC for the document using the sections provided by
         # SectionEditingLinks
         if doc.show_toc and not show_raw:
-            toc_html = wiki.content.parse(doc_html).filter(
-                wiki.content.SectionTOCFilter).serialize()
+            toc_html = (wiki.content.parse(tool.serialize())
+                                    .filter(wiki.content.SectionTOCFilter)
+                                    .serialize())
 
         # If a section ID is specified, extract that section.
         if section_id:


### PR DESCRIPTION
This should improve the [TOC issue](https://bugzilla.mozilla.org/show_bug.cgi?id=769399) by delaying ID generation until after kumascript has had a crack at the doc. [Still some quirks](https://bugzilla.mozilla.org/show_bug.cgi?id=769399#c6), but I think they're beyond the scope of ID generation
