### PR TITLE
fix bug 770965: Override language switcher in footer with document locales

### DIFF
--- a/apps/docs/views.py
+++ b/apps/docs/views.py
@@ -3,6 +3,7 @@ import os.path
 import random
 
 from django.conf import settings
+from django.http import (HttpResponseRedirect)
 
 from caching.base import cached
 import commonware
@@ -21,6 +22,13 @@ MAX_REVIEW_DOCS = 5
 
 def docs(request):
     """Docs landing page."""
+
+    # Accept ?next parameter for redirects from language selector.
+    if 'next' in request.GET:
+        next = request.GET['next']
+        # Only accept site-relative paths, not absolute URLs to anywhere.
+        if next.startswith('/'):
+            return HttpResponseRedirect(next)
 
     # Doc of the day
     dotd = cached(_get_popular_item, 'kuma_docs_dotd', 24*60*60)

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -20,6 +20,25 @@
     href="{{ url('wiki.json_slug', document.full_path) }}">
 {% endblock %}
 
+{% block lang_switcher %}
+  {% if document.is_localizable or document.parent %}
+    <form class="languages go" method="get" action="{{ url('docs') }}">
+      <label for="language">{{ _('Other languages:') }}</label>
+      <select id="language" class="wiki-l10n" name="next" dir="ltr">
+        <option value="{{ url('wiki.document', document.full_path, locale=document.locale) }}" selected>
+          {{ document.language }}
+        </option>
+        {% for translation in document.other_translations %}
+          <option value="{{ url('wiki.document', translation.full_path, locale=translation.locale) }}">
+            {{ translation.language }}
+          </option>
+        {%- endfor %}
+      </select>
+      <noscript><button type="submit">{{ _('Go') }}</button></noscript>
+    </form>
+  {% endif %}
+{% endblock %}
+
 {% block content %}
 
 <!-- top toolbar -->

--- a/media/js/mdn/init.js
+++ b/media/js/mdn/init.js
@@ -78,9 +78,13 @@ jQuery.extend({
     // Submit locale form on change
     $('form.languages')
         .find('select').change(function(){
-            this.form.submit();
+            var sel = $(this);
+            if (sel.hasClass('wiki-l10n')) {
+                location.href = sel.val();
+            } else {
+                this.form.submit();
+            }
         });
-
 
   // Set up nav dropdowns  
   $(".toggle").click(function() {

--- a/templates/base.html
+++ b/templates/base.html
@@ -185,7 +185,9 @@
       <a href="/forums/viewtopic.php?f=3&amp;t=5">{{ _('Help') }}</a></p>
     </div>
     {% include "includes/login.html" %}
-    {% include "includes/lang_switcher.html" %}
+    {% block lang_switcher %}
+        {% include "includes/lang_switcher.html" %}
+    {% endblock %}
 </div>
 </footer>
 


### PR DESCRIPTION
Quick tweak to replace the footer language selector with one built from known translations for the current wiki page.
