### PR TITLE
fix bug 776680 - Prevent reviewed error

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -289,7 +289,7 @@
           {{ _('Last updated by') }}:  
           <a href="{{ url('devmo.views.profile_view', username=current_revision.creator) }}">{{ current_revision.creator }}</a>, 
           {{ datetimeformat(current_revision.created, format='datetime') }}
-          {% if current_revision.reviewer %}
+          {% if current_revision.reviewer and current_revision.reviewed %}
             <br />
             {{ _('Last reviewed by') }}:  
             <a href="{{ url('devmo.views.profile_view', username=current_revision.reviewer) }}">{{ current_revision.reviewer }}</a>, 


### PR DESCRIPTION
Ensuring property exists before we use it...though it's hard to comprehend how there's a reviewer but not a reviewed time.
