### PR TITLE
bug 775590: Annotate links for "new" or "external" on document view

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -886,7 +886,7 @@ class Document(NotificationsMixin, ModelBase):
                        args=[self.full_path])
 
     @staticmethod
-    def locale_and_slug_from_path(path, request=None):
+    def locale_and_slug_from_path(path, request=None, path_locale=None):
         """Given a proposed doc path, try to see if there's a legacy MindTouch
         locale or even a modern Kuma domain in the path. If so, signal for a
         redirect to a more canonical path. In any case, produce a locale and
@@ -913,9 +913,12 @@ class Document(NotificationsMixin, ModelBase):
                 locale = mdn_languages_lower[l_locale]
                 slug = maybe_slug
 
-        # No locale yet? Try the locale detected by the request.
-        if locale == '' and request:
-            locale = request.locale
+        # No locale yet? Try the locale detected by the request or in path
+        if locale == '':
+            if request:
+                locale = request.locale
+            elif path_locale:
+                locale = path_locale
 
         # Still no locale? Probably no request. Go with the site default.
         if locale == '':

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -219,6 +219,7 @@ def _format_attachment_obj(attachments):
 def document(request, document_slug, document_locale):
     """View a wiki document."""
     fallback_reason = None
+    base_url = request.build_absolute_uri('/')
 
     # If a slug isn't available in the requested locale, fall back to en-US:
     try:
@@ -348,7 +349,6 @@ def document(request, document_slug, document_locale):
                 cache_control = 'no-cache'
 
         try:
-            base_url = request.build_absolute_uri('/')
             r_body, r_errors = doc.get_rendered(cache_control, base_url)
             if r_body:
                 doc_html = r_body
@@ -379,6 +379,10 @@ def document(request, document_slug, document_locale):
         # If a section ID is specified, extract that section.
         if section_id:
             tool.extractSection(section_id)
+
+        # Annotate links within the page, but only if not sending raw source.
+        if not show_raw:
+            tool.annotateLinks(base_url=base_url)
 
         # If this user can edit the document, inject some section editing
         # links.


### PR DESCRIPTION
This flips things around on the use of `wiki.pageExists` per this comment:
https://bugzilla.mozilla.org/show_bug.cgi?id=775590#c6

Taking this out of KumaScript and doing it in Kuma should save 100's-1000's of internal HTTP requests per page, depending on the page.
