### PR TITLE
fix bug 776586 - Prevent phantom HTML5 error when no hidden content

### DIFF
--- a/media/js/wiki_ckeditor_translate.js
+++ b/media/js/wiki_ckeditor_translate.js
@@ -56,6 +56,9 @@
 
       $("#cke_contents_id_content").css({ height: $appBoxes.height() });
 
+      // remove the id_content required attribute
+      $('#id_content').removeAttr("required");
+
     });
     
     $window.resize(function() { // Recalculate box width on resize


### PR DESCRIPTION
Duh.

Can test on the live site reported in the ticket by executing the following in the console:

$('#id_content').removeAttr("required");

And then submitting the empty content.
