### PR TITLE
fix bug 776978 - Quote all tags to avoid space issues

### DIFF
--- a/media/js/wiki-tags-edit.js
+++ b/media/js/wiki-tags-edit.js
@@ -24,7 +24,7 @@
             // do nothing -- this is the item being removed
           }
           else {
-            itemTexts.push($(this).find(".tagit-label").text());
+            itemTexts.push('"' + $(this).find(".tagit-label").text() + '"');
           }
         });
         hiddenTags.val(itemTexts.join(","));


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=776978

To test:
1.  Create a document
2.  Edit said document
3.  Create a tag called "My First Tag", no commas
4.  Submit form
5.  Notice on document page that the tag is still one, singular tag.
