### PR TITLE
fix bug 779423 - change devmo_url calls for kuma

### DIFF
--- a/apps/docs/templates/docs/docs.html
+++ b/apps/docs/templates/docs/docs.html
@@ -30,27 +30,27 @@
       </header>
       <ul id="doc-topics">
         <li>
-          <h3><a href="{{ devmo_url(_('/en/HTML')) }}">{{ _('HTML') }}</a></h3>
+          <h3><a href="{{ devmo_url('HTML') }}">{{ _('HTML') }}</a></h3>
           <p>{{ _('HyperText Markup Language, the core language of the web.') }}</p>
         </li>
         <li>
-          <h3><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}">{{ _('HTML5') }}</a></h3>
+          <h3><a href="{{ devmo_url('HTML/HTML5') }}">{{ _('HTML5') }}</a></h3>
           <p>{{ _('The next generation of HTML, HTML5 adds powerful new capabilities for web sites and web applications.') }}</p>
         </li>
         <li>
-          <h3><a href="{{ devmo_url(_('/en/JavaScript')) }}">{{ _('JavaScript') }}</a></h3>
+          <h3><a href="{{ devmo_url('JavaScript') }}">{{ _('JavaScript') }}</a></h3>
           <p>{{ _('The scripting language that powers modern web applications.') }}</p>
         </li>
         <li>
-          <h3><a href="{{ devmo_url(_('/en/CSS')) }}">{{ _('CSS') }}</a></h3>
+          <h3><a href="{{ devmo_url('CSS') }}">{{ _('CSS') }}</a></h3>
           <p>{{ _('Cascading Style Sheets provide advanced layout and formatting of web content.') }}</p>
         </li>
         <li>
-          <h3><a href="{{ devmo_url(_('/en/DOM')) }}">{{ _('DOM') }}</a></h3>
+          <h3><a href="{{ devmo_url('DOM') }}">{{ _('DOM') }}</a></h3>
           <p>{{ _('The Document Object Model describes the structure and content of web pages.') }}</p>
         </li>
         <li>
-          <h3><a href="{{ devmo_url(_('/en/AJAX')) }}">{{ _('AJAX') }}</a></h3>
+          <h3><a href="{{ devmo_url('AJAX') }}">{{ _('AJAX') }}</a></h3>
           <p>{{ _('"Asynchronous JavaScript and XML" is a term that describes the use of all these technologies together to create powerful web applications.') }}</p>
         </li>
       </ul>
@@ -95,29 +95,29 @@
         <div class="section">
           <h4><a href="{{ url('mobile') }}" class="mobile">{{ _('Mobile') }}</a></h4>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/Mobile')) }}">{{ _('Firefox Mobile for developers') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Detecting_device_orientation')) }}">{{ _('Detecting device orientation') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_geolocation')) }}">{{ _('Using geolocation') }}</a></li>
+            <li><a href="{{ devmo_url('Mobile') }}">{{ _('Firefox Mobile for developers') }}</a></li>
+            <li><a href="{{ devmo_url('Detecting_device_orientation') }}">{{ _('Detecting device orientation') }}</a></li>
+            <li><a href="{{ devmo_url('Using_geolocation') }}">{{ _('Using geolocation') }}</a></li>
           </ul>
         </div>
         <div class="section">
           <h4><a href="{{ url('addons') }}" class="addons">{{ _('Add-ons') }}</a></h4>
           <ul>
             <li><a href="https://addons.mozilla.org/en-US/developers/">{{ _('AMO Developer Hub') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Extensions')) }}">{{ _('Extensions') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Plugins')) }}">{{ _('Plugins') }}</a></li>
+            <li><a href="{{ devmo_url('Extensions') }}">{{ _('Extensions') }}</a></li>
+            <li><a href="{{ devmo_url('Plugins') }}">{{ _('Plugins') }}</a></li>
             <li><a href="https://builder.mozillalabs.com/">{{ _('Add-ons Builder') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Themes')) }}">{{ _('Themes') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Creating_OpenSearch_plugins_for_Firefox')) }}">{{ _('Search engine plugins') }}</a></li>
+            <li><a href="{{ devmo_url('Themes') }}">{{ _('Themes') }}</a></li>
+            <li><a href="{{ devmo_url('Creating_OpenSearch_plugins_for_Firefox') }}">{{ _('Search engine plugins') }}</a></li>
           </ul>
         </div>
         <div class="section">
           <h4><a href="{{ url('mozilla') }}" class="mozilla">{{ _('Mozilla') }}</a></h4>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/Participating_in_the_Mozilla_project')) }}">{{ _('Participating in the Mozilla project') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_Mozilla_code_in_other_projects')) }}">{{ _('Using Mozilla code in other projects') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/Localization')) }}">{{ _('Localization') }}</a></li>
-            <li><a href="{{ devmo_url(_('/en/QA')) }}">{{ _('Quality Assurance') }}</a></li>
+            <li><a href="{{ devmo_url('Participating_in_the_Mozilla_project') }}">{{ _('Participating in the Mozilla project') }}</a></li>
+            <li><a href="{{ devmo_url('Using_Mozilla_code_in_other_projects') }}">{{ _('Using Mozilla code in other projects') }}</a></li>
+            <li><a href="{{ devmo_url('Localization') }}">{{ _('Localization') }}</a></li>
+            <li><a href="{{ devmo_url('QA') }}">{{ _('Quality Assurance') }}</a></li>
           </ul>
         </div>
       </div>

--- a/apps/docs/templates/docs/glossary.html
+++ b/apps/docs/templates/docs/glossary.html
@@ -1,26 +1,26 @@
 <ul id="glossary">
   <li>
     <ul class="cols-4">
-      <li><a href="{{ devmo_url(_('/en/HTML')) }}">{{ _('HTML') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/CSS')) }}">{{ _('CSS') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/JavaScript')) }}">{{ _('JavaScript') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}">{{ _('HTML5') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/DOM')) }}">{{ _('DOM') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/SVG')) }}">{{ _('SVG') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/HTML/Element/canvas')) }}">{{ _('Canvas') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/AJAX')) }}">{{ _('AJAX') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/CSS/Media_queries')) }}">{{ _('Media Queries') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/WebGL')) }}">{{ _('WebGL') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/DOM/Storage')) }}">{{ _('Web Storage') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">{{ _('Audio') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">{{ _('Video') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Using_web_workers')) }}">{{ _('Web Workers') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Using_files_from_web_applications')) }}">{{ _('Files') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/DragDrop/Drag_and_Drop')) }}">{{ _('Drag and Drop') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/CSS/Using_CSS_transforms')) }}">{{ _('CSS Transforms') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Using_gradients')) }}">{{ _('CSS Gradients') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/Security')) }}">{{ _('Security') }}</a></li>
-      <li><a href="{{ devmo_url(_('/en/IndexedDB')) }}">{{ _('IndexedDB') }}</a></li>
+      <li><a href="{{ devmo_url('HTML') }}">{{ _('HTML') }}</a></li>
+      <li><a href="{{ devmo_url('CSS') }}">{{ _('CSS') }}</a></li>
+      <li><a href="{{ devmo_url('JavaScript') }}">{{ _('JavaScript') }}</a></li>
+      <li><a href="{{ devmo_url('HTML/HTML5') }}">{{ _('HTML5') }}</a></li>
+      <li><a href="{{ devmo_url('DOM') }}">{{ _('DOM') }}</a></li>
+      <li><a href="{{ devmo_url('SVG') }}">{{ _('SVG') }}</a></li>
+      <li><a href="{{ devmo_url('HTML/Element/canvas') }}">{{ _('Canvas') }}</a></li>
+      <li><a href="{{ devmo_url('AJAX') }}">{{ _('AJAX') }}</a></li>
+      <li><a href="{{ devmo_url('CSS/Media_queries') }}">{{ _('Media Queries') }}</a></li>
+      <li><a href="{{ devmo_url('WebGL') }}">{{ _('WebGL') }}</a></li>
+      <li><a href="{{ devmo_url('DOM/Storage') }}">{{ _('Web Storage') }}</a></li>
+      <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">{{ _('Audio') }}</a></li>
+      <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">{{ _('Video') }}</a></li>
+      <li><a href="{{ devmo_url('Using_web_workers') }}">{{ _('Web Workers') }}</a></li>
+      <li><a href="{{ devmo_url('Using_files_from_web_applications') }}">{{ _('Files') }}</a></li>
+      <li><a href="{{ devmo_url('DragDrop/Drag_and_Drop') }}">{{ _('Drag and Drop') }}</a></li>
+      <li><a href="{{ devmo_url('CSS/Using_CSS_transforms') }}">{{ _('CSS Transforms') }}</a></li>
+      <li><a href="{{ devmo_url('Using_gradients') }}">{{ _('CSS Gradients') }}</a></li>
+      <li><a href="{{ devmo_url('Security') }}">{{ _('Security') }}</a></li>
+      <li><a href="{{ devmo_url('IndexedDB') }}">{{ _('IndexedDB') }}</a></li>
     </ul>
   </li>
 </ul>

--- a/apps/landing/templates/landing/addons.html
+++ b/apps/landing/templates/landing/addons.html
@@ -59,7 +59,7 @@
             <p class="entry-summary">{{ _('The official documentation on APIs and languages. What you need, when you need it, to create your masterpiece.') }}</p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Extensions')) }}" rel="bookmark">{{ _('Extensions') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Extensions') }}" rel="bookmark">{{ _('Extensions') }}</a></h4>
             <p class="entry-summary">{{ _('Complete documentation for developing extensions for Mozilla applications.') }}</p>
           </li>
           <li class="hentry">

--- a/apps/landing/templates/landing/apps.html
+++ b/apps/landing/templates/landing/apps.html
@@ -23,7 +23,7 @@
       <div class="boxed">
         <h2>{{ _('Getting Started') }}</h2>
         {% if waffle.switch('apps-market-launch') %}
-          {% trans apps_url=devmo_url(_('/en/Apps')) %}
+          {% trans apps_url=devmo_url('Apps') %}
             <p>The Mozilla Web Apps platform lets you <a href="{{ apps_url }}">build apps</a> powered by Web standards like HTML5, CSS3, JavaScript and related APIs.</p>
           {% endtrans %}
         {% else %}
@@ -31,7 +31,7 @@
             <p>The Mozilla Marketplace lets you build app experiences powered by Web standards like HTML5, CSS3, JavaScript and related APIs.</p>
           {% endtrans %}
         {% endif %}
-        <p class="more"><a href="{{ devmo_url(_('/en/Apps/Getting_Started')) }}" class="go">{{ _('Learn more') }}</a></p>
+        <p class="more"><a href="{{ devmo_url('Apps/Getting_Started') }}" class="go">{{ _('Learn more') }}</a></p>
       </div>
       
       <div class="boxed">
@@ -85,7 +85,7 @@
             </p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Apps/For_mobile_developers')) }}" rel="bookmark">{{ _('For mobile apps developers') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Apps/For_mobile_developers') }}" rel="bookmark">{{ _('For mobile apps developers') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             If you already develop apps for mobile devices, here's how to develop Open Web apps.
@@ -93,7 +93,7 @@
             </p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Apps/For_Web_developers')) }}" rel="bookmark">{{ _('For web developers') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Apps/For_Web_developers') }}" rel="bookmark">{{ _('For web developers') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             If you already develop websites, here's how to make them into installable apps.
@@ -101,7 +101,7 @@
             </p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Apps/Using_apps_offline')) }}" rel="bookmark">{{ _('Using apps offline') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Apps/Using_apps_offline') }}" rel="bookmark">{{ _('Using apps offline') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             How to design apps so they can be cached and used without an Internet connection.

--- a/apps/landing/templates/landing/home.html
+++ b/apps/landing/templates/landing/home.html
@@ -38,46 +38,46 @@
       <ul>
         <li>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/HTML')) }}">HTML</a></li>
-            <li><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}">HTML5</a></li>
-            <li><a href="{{ devmo_url(_('/en/CSS')) }}">CSS</a></li>
-            <li><a href="{{ devmo_url(_('/en/JavaScript')) }}">JavaScript</a></li>
-            <li><a href="{{ devmo_url(_('/en/DOM')) }}">DOM</a></li>
+            <li><a href="{{ devmo_url('HTML') }}">HTML</a></li>
+            <li><a href="{{ devmo_url('HTML/HTML5') }}">HTML5</a></li>
+            <li><a href="{{ devmo_url('CSS') }}">CSS</a></li>
+            <li><a href="{{ devmo_url('JavaScript') }}">JavaScript</a></li>
+            <li><a href="{{ devmo_url('DOM') }}">DOM</a></li>
           </ul>
         </li>
         <li>
           <ul> 
-            <li><a href="{{ devmo_url(_('/en/HTML/Canvas')) }}">Canvas</a></li>
-            <li><a href="{{ devmo_url(_('/en/SVG')) }}">SVG</a></li>
-            <li><a href="{{ devmo_url(_('/en/WebGL')) }}">WebGL</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">Video</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">Audio</a></li>
+            <li><a href="{{ devmo_url('HTML/Canvas') }}">Canvas</a></li>
+            <li><a href="{{ devmo_url('SVG') }}">SVG</a></li>
+            <li><a href="{{ devmo_url('WebGL') }}">WebGL</a></li>
+            <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">Video</a></li>
+            <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">Audio</a></li>
           </ul>
         </li>
         <li>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/Using_gradients')) }}">Gradients</a></li>
-            <li><a href="{{ devmo_url(_('/en/CSS/Using_CSS_transforms')) }}">Transforms</a></li>
-            <li><a href="{{ devmo_url(_('/en/CSS/CSS_transitions')) }}">Transitions</a></li>
-            <li><a href="{{ devmo_url(_('/en/CSS/CSS_animations')) }}">Animations</a></li>
-            <li><a href="{{ devmo_url(_('/en/CSS/Media_queries')) }}">Media Queries</a></li>
+            <li><a href="{{ devmo_url('Using_gradients') }}">Gradients</a></li>
+            <li><a href="{{ devmo_url('CSS/Using_CSS_transforms') }}">Transforms</a></li>
+            <li><a href="{{ devmo_url('CSS/CSS_transitions') }}">Transitions</a></li>
+            <li><a href="{{ devmo_url('CSS/CSS_animations') }}">Animations</a></li>
+            <li><a href="{{ devmo_url('CSS/Media_queries') }}">Media Queries</a></li>
           </ul>
         </li>
         <li>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/Ajax')) }}">AJAX</a></li>
-            <li><a href="{{ devmo_url(_('/en/WebSockets')) }}">WebSockets</a></li>
-            <li><a href="{{ devmo_url(_('/en/Offline_resources_in_Firefox')) }}">Offline Cache</a></li>
-            <li><a href="{{ devmo_url(_('/en/DOM/Storage')) }}">Local Storage</a></li>
-            <li><a href="{{ devmo_url(_('/en/IndexedDB')) }}">IndexedDB</a></li>
+            <li><a href="{{ devmo_url('Ajax') }}">AJAX</a></li>
+            <li><a href="{{ devmo_url('WebSockets') }}">WebSockets</a></li>
+            <li><a href="{{ devmo_url('Offline_resources_in_Firefox') }}">Offline Cache</a></li>
+            <li><a href="{{ devmo_url('DOM/Storage') }}">Local Storage</a></li>
+            <li><a href="{{ devmo_url('IndexedDB') }}">IndexedDB</a></li>
           </ul>
         </li>
         <li>
           <ul>
-            <li><a href="{{ devmo_url(_('/en/Using_geolocation')) }}">Geolocation</a></li>
-            <li><a href="{{ devmo_url(_('/en/DragDrop/Drag_and_Drop')) }}">Drag &amp; Drop</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_files_from_web_applications')) }}">File API</a></li>
-            <li><a href="{{ devmo_url(_('/en/Using_web_workers')) }}">Web Workers</a></li>
+            <li><a href="{{ devmo_url('Using_geolocation') }}">Geolocation</a></li>
+            <li><a href="{{ devmo_url('DragDrop/Drag_and_Drop') }}">Drag &amp; Drop</a></li>
+            <li><a href="{{ devmo_url('Using_files_from_web_applications') }}">File API</a></li>
+            <li><a href="{{ devmo_url('Using_web_workers') }}">Web Workers</a></li>
             <li><a href="{{ url('docs') }}" class="more">{{_("and more")}}&hellip;</a></li>
           </ul>
         </li>
@@ -111,7 +111,7 @@
       </div>
       
       <div class="promo" id="promo-foxdev">
-        <a href="{{ devmo_url(_('/en/Firefox_for_developers')) }}">
+        <a href="{{ devmo_url('Firefox_for_developers') }}">
           <h2>{{_("Firefox for Devs")}}</h2>
           <p>{{_("See what's new for Web developers in the latest version of Firefox.")}}</p>
         </a>

--- a/apps/landing/templates/landing/learn_css.html
+++ b/apps/landing/templates/landing/learn_css.html
@@ -29,7 +29,7 @@
       <h2>{{ _('Introductory Level') }}</h2>
       <ul class="link-list">
         <li>
-          <h3 class="title"><a href="{{ devmo_url('/en/CSS/Getting_Started') }}">{{ _('CSS Getting Started') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('CSS/Getting_Started') }}">{{ _('CSS Getting Started') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('This tutorial introduces you to Cascading Style Sheets (CSS). It guides you through the basic features of CSS with practical examples that you can try for yourself on your own computer.') }}</p>
         </li>
@@ -59,7 +59,7 @@
           <p>{{ _('Video tutorial on styling pages with CSS.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/Common_CSS_Questions'))}}">{{ _('Common CSS Questions') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('Common_CSS_Questions')}}">{{ _('Common CSS Questions') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('Common questions and answers for beginners.') }}</p>
         </li>
@@ -70,7 +70,7 @@
       <h2>{{ _('Intermediate Level') }}</h2>
       <ul class="link-list">
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/CSS_Reference'))}}">{{ _('CSS Reference') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('CSS_Reference')}}">{{ _('CSS Reference') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('Complete reference to CSS, with details on support by Firefox and other browsers.') }}</p>
         </li>
@@ -111,12 +111,12 @@
           <p>{{ _('A quick introduction to some of the core features introduced in CSS3.') }}</p>
         </li>
         <li>  
-          <h3 class="title"><a href="{{ devmo_url(_('/En/CSS/Using_CSS_transforms'))}}">{{ _('Using CSS Transforms') }}</a> <span class="tag css3" title="{{ _('This site features CSS3') }}">(CSS3)</span></h3>
+          <h3 class="title"><a href="{{ devmo_url('/En/CSS/Using_CSS_transforms')}}">{{ _('Using CSS Transforms') }}</a> <span class="tag css3" title="{{ _('This site features CSS3') }}">(CSS3)</span></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('Apply rotation, skewing, scaling, and translation using CSS.') }}</p>
         </li>
         <li>  
-          <h3 class="title"><a href="{{ devmo_url(_('/en/CSS/CSS_transitions'))}}">{{ _('CSS Transitions') }}</a> <span class="tag css3" title="{{ _('This site features CSS3') }}">(CSS3)</span></h3>
+          <h3 class="title"><a href="{{ devmo_url('CSS/CSS_transitions')}}">{{ _('CSS Transitions') }}</a> <span class="tag css3" title="{{ _('This site features CSS3') }}">(CSS3)</span></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('CSS transitions, part of the draft CSS3 specification, provide a way to animate changes to CSS properties, instead of having the changes take effect instantly.') }}</p>
         </li>

--- a/apps/landing/templates/landing/learn_html.html
+++ b/apps/landing/templates/landing/learn_html.html
@@ -58,7 +58,7 @@
           <p>{{ _('Use these challenges to hone your HTML skills (for example, "Should I use an &lt;h2&gt; element or a &lt;strong&gt; element?"), focusing on meaningful mark-up.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/HTML/Element')) }}">MDN HTML Element Reference</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('HTML/Element') }}">MDN HTML Element Reference</a></h3>
           <h4 class="source">{{ _('MDN') }}</h4>
           <p>{{ _('A comprehensive reference for HTML elements, and how Firefox and other browsers support them.') }}</p>
         </li>
@@ -69,7 +69,7 @@
       <h2>{{ _('Advanced Level') }}</h2>
       <ul class="link-list">
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/Tips_for_Authoring_Fast-loading_HTML_Pages')) }}">{{ _('Tips for Authoring Fast-loading HTML Pages') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('Tips_for_Authoring_Fast-loading_HTML_Pages') }}">{{ _('Tips for Authoring Fast-loading HTML Pages') }}</a></h3>
           <h4 class="source">{{ _('MDN') }}</h4>
           <p>{{ _('Optimize web pages to provide a more responsive site for visitors and reduce the load on your web server and Internet connection.') }}</p>
         </li>
@@ -94,7 +94,7 @@
           <p>{{ _('Learn meaningful mark-up that is extensible and backwards- and forwards-compatible.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/Canvas_tutorial')) }}">{{ _('Canvas Tutorial') }}</a> <span class="tag html5" title="{{ _('This site features HTML5') }}">(HTML5)</span></h3>
+          <h3 class="title"><a href="{{ devmo_url('Canvas_tutorial') }}">{{ _('Canvas Tutorial') }}</a> <span class="tag html5" title="{{ _('This site features HTML5') }}">(HTML5)</span></h3>
           <h4 class="source">{{ _('MDN') }}</h4>
           <p>{{ _('Learn how to draw graphics using scripting using the &lt;canvas&gt; element.') }}</p>
         </li>

--- a/apps/landing/templates/landing/learn_html5.html
+++ b/apps/landing/templates/landing/learn_html5.html
@@ -32,7 +32,7 @@
     
     <div id="topic-content">
       <section id="topic-html5" class="block">
-        {% trans html5=devmo_url(_('/en/HTML/HTML5')) %}<p><b><a href="{{ html5 }}">HTML5</a> is the set of
+        {% trans html5=devmo_url('HTML/HTML5') %}<p><b><a href="{{ html5 }}">HTML5</a> is the set of
         technology standards that support the next phase in the development of the Web.</b>
         From its beginning, Mozilla has championed Web standards to ensure freedom of choice
         for those who use the Web and independence for those who build it. Leaders from Mozilla
@@ -49,15 +49,15 @@
         <h2>{{ _('CSS3 Styling') }}</h2>
 
         {% trans
-            CSS=devmo_url(_('/en/CSS')),
-            CSS_gradients=devmo_url(_('/en/CSS/Using_CSS_gradients')),
-            CSS_transforms=devmo_url(_('/en/CSS/Using_CSS_transforms')),
-            CSS_layouts=devmo_url(_('/en/CSS/Using_CSS_multi-column_layouts')),
-            flexbox=devmo_url(_('/en/Using_flexbox')),
-            calc=devmo_url(_('/en/CSS/calc')),
-            transitions=devmo_url(_('/en/CSS/CSS_transitions')),
-            animations=devmo_url(_('/en/CSS/CSS_animations')),
-            Media_queries=devmo_url(_('/en/CSS/Media_queries'))
+            CSS=devmo_url('CSS'),
+            CSS_gradients=devmo_url('CSS/Using_CSS_gradients'),
+            CSS_transforms=devmo_url('CSS/Using_CSS_transforms'),
+            CSS_layouts=devmo_url('CSS/Using_CSS_multi-column_layouts'),
+            flexbox=devmo_url('Using_flexbox'),
+            calc=devmo_url('CSS/calc'),
+            transitions=devmo_url('CSS/CSS_transitions'),
+            animations=devmo_url('CSS/CSS_animations'),
+            Media_queries=devmo_url('CSS/Media_queries')
         %}<p><a href="{{ CSS }}">Cascading Style Sheets</a> deliver a wide
         range of stylization and effects, enhancing web pages without sacrificing their semantic
         structure or performance. CSS3 is the latest
@@ -79,8 +79,8 @@
       <section id="topic-semantics" class="block">
         <h2>{{ _('Semantics') }}</h2>
         {% trans
-            new_elements=devmo_url(_('/en/Sections_and_Outlines_of_an_HTML5_document')),
-            new_forms=devmo_url(_('/en/HTML/Forms_in_HTML'))
+            new_elements=devmo_url('Sections_and_Outlines_of_an_HTML5_document'),
+            new_forms=devmo_url('HTML/Forms_in_HTML')
         %}<p>HTML5 introduces a number of
         <a href="{{ new_elements }}">new elements and attributes</a>
         to support content in more meaningful ways.
@@ -92,8 +92,8 @@
       <section id="topic-connectivity" class="block">
         <h2>{{ _('Connectivity') }}</h2>
         {% trans
-            websockets=devmo_url(_('/en/WebSockets')),
-            server_events=devmo_url(_('/en/Server-sent_events'))
+            websockets=devmo_url('WebSockets'),
+            server_events=devmo_url('Server-sent_events')
         %}<p>More efficient connectivity means more real-time chats, faster games, and better
         communication. <a href="{{ websockets }}">WebSockets</a> and
         <a href="{{ server_events }}">Server-Sent Events</a>
@@ -103,10 +103,10 @@
       <section id="topic-performance" class="block">
         <h2>{{ _('Performance & Integration') }}</h2>
         {% trans
-            web_workers=devmo_url(_('/en/Using_web_workers')),
-            xhr=devmo_url(_('/en/DOM/XMLHttpRequest')),
-            ajax=devmo_url(_('/en/AJAX')),
-            history=devmo_url(_('/en/DOM/Manipulating_the_browser_history'))
+            web_workers=devmo_url('Using_web_workers'),
+            xhr=devmo_url('DOM/XMLHttpRequest'),
+            ajax=devmo_url('AJAX'),
+            history=devmo_url('DOM/Manipulating_the_browser_history')
         %}<p>Make apps more seamless and make dynamic content load faster with a variety of techniques
         and technologies such as <a href="{{ web_workers }}">Web Workers</a>,
         <a href="{{ xhr }}">XMLHttpRequest Level 2</a> (the technology behind
@@ -117,10 +117,10 @@
       <section id="topic-offline" class="block">
         <h2>{{ _('Offline & Storage') }}</h2>
         {% trans
-            app_cache=devmo_url(_('/en/Using_the_Application_Cache')),
-            local_storage=devmo_url(_('/en/DOM/Storage')),
-            indexed_db=devmo_url(_('/en/IndexedDB')),
-            file_api=devmo_url(_('/en/Using_files_from_web_applications'))
+            app_cache=devmo_url('Using_the_Application_Cache'),
+            local_storage=devmo_url('DOM/Storage'),
+            indexed_db=devmo_url('IndexedDB'),
+            file_api=devmo_url('Using_files_from_web_applications')
         %}<p>Web apps can still function even if there is no internet connection, thanks
         to the <a href="{{ app_cache }}">HTML5 App Cache</a>,
         as well as the <a href="{{ local_storage }}">Local Storage</a>,
@@ -132,7 +132,7 @@
       
       <section id="topic-multimedia" class="block">
         <h2>{{ _('Multimedia') }}</h2>
-        {% trans html5_av=devmo_url(_('/en/Using_HTML5_audio_and_video')) %}<p>Incorporating audio or video into a web page has long required an additional plug-in
+        {% trans html5_av=devmo_url('Using_HTML5_audio_and_video') %}<p>Incorporating audio or video into a web page has long required an additional plug-in
         to add more capabilities to the browser that weren&#8217;t native to the browser itself, but
         that&#8217;s changing with HTML5. The new <a href="{{ html5_av }}">audio and video elements</a>
         allow web developers to embed sound and moving pictures into web pages without any
@@ -143,10 +143,10 @@
       <section id="topic-graphics" class="block">
         <h2>{{ _('3D, Graphics, & Effects') }}</h2>
         {% trans
-            svg=devmo_url(_('/en/SVG')),
-            canvas=devmo_url(_('/en/HTML/Canvas')),
-            webgl=devmo_url(_('/en/WebGL')),
-            css3d=devmo_url(_('/en/CSS/Using_CSS_transforms#3D_specific_CSS_properties'))
+            svg=devmo_url('SVG'),
+            canvas=devmo_url('HTML/Canvas'),
+            webgl=devmo_url('WebGL'),
+            css3d=devmo_url('CSS/Using_CSS_transforms#3D_specific_CSS_properties')
         %}<p>Images on the Web have always been flat and static, created once and then living forever
         in a permanent, unchanging, 2-dimensional state. Now <a href="{{ svg }}">SVG</a>
         and <a href="{{ canvas }}">canvas</a> can generate dynamic,
@@ -159,9 +159,9 @@
       <section id="topic-devices" class="block">
         <h2>{{ _('Device Access') }}</h2>
         {% trans
-            geolocation=devmo_url(_('/en/Using_geolocation')),
-            touch=devmo_url(_('/en/DOM/Touch_events')),
-            orientation=devmo_url(_('/en/detecting_device_orientation'))
+            geolocation=devmo_url('Using_geolocation'),
+            touch=devmo_url('DOM/Touch_events'),
+            orientation=devmo_url('detecting_device_orientation')
         %}<p>The Web is becoming more mobile every day, with an ever-growing number and variety of devices accessing it.
         With new technologies like the <a href="{{ geolocation }}">Geolocation API</a> and
         <a href="{{ touch }}">touch events</a>, web applications can
@@ -198,17 +198,17 @@
       <h3 class="mod-title">{{ _('MDN Docs') }}</h3>
       <p class="mod-intro">{{ _('Community docs of HTML5 features and related technologies') }}</p>
       <ul class="prose">
-        <li><a href="{{ devmo_url(_('/en/HTML')) }}">{{ _('HTML') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}">{{ _('HTML5') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/CSS')) }}">{{ _('CSS') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/Using_HTML5_audio_and_video')) }}">{{ _('HTML5 Audio and Video') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/HTML/Canvas')) }}">{{ _('Canvas') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/WebSockets')) }}">{{ _('WebSockets') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/Using_the_Application_Cache')) }}">{{ _('HTML5 App Cache') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/DOM/Storage')) }}">{{ _('Local Storage') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/IndexedDB')) }}">{{ _('Indexed Database') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/Using_files_from_web_applications')) }}">{{ _('File API') }}</a></li>
-        <li><a href="{{ devmo_url(_('/en/Using_geolocation')) }}">{{ _('Geolocation API') }}</a></li>
+        <li><a href="{{ devmo_url('HTML') }}">{{ _('HTML') }}</a></li>
+        <li><a href="{{ devmo_url('HTML/HTML5') }}">{{ _('HTML5') }}</a></li>
+        <li><a href="{{ devmo_url('CSS') }}">{{ _('CSS') }}</a></li>
+        <li><a href="{{ devmo_url('Using_HTML5_audio_and_video') }}">{{ _('HTML5 Audio and Video') }}</a></li>
+        <li><a href="{{ devmo_url('HTML/Canvas') }}">{{ _('Canvas') }}</a></li>
+        <li><a href="{{ devmo_url('WebSockets') }}">{{ _('WebSockets') }}</a></li>
+        <li><a href="{{ devmo_url('Using_the_Application_Cache') }}">{{ _('HTML5 App Cache') }}</a></li>
+        <li><a href="{{ devmo_url('DOM/Storage') }}">{{ _('Local Storage') }}</a></li>
+        <li><a href="{{ devmo_url('IndexedDB') }}">{{ _('Indexed Database') }}</a></li>
+        <li><a href="{{ devmo_url('Using_files_from_web_applications') }}">{{ _('File API') }}</a></li>
+        <li><a href="{{ devmo_url('Using_geolocation') }}">{{ _('Geolocation API') }}</a></li>
       </ul>
     </div>
   

--- a/apps/landing/templates/landing/learn_javascript.html
+++ b/apps/landing/templates/landing/learn_javascript.html
@@ -32,7 +32,7 @@
           <p>{{ _('Codecademy is the easiest way to learn how to code JavaScript. It\'s interactive, fun, and you can do it with your friends.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/JavaScript/Getting_Started')) }}">{{ _('Getting Started with JavaScript') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('JavaScript/Getting_Started') }}">{{ _('Getting Started with JavaScript') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('What is JavaScript and how can it help you?') }}</p>
         </li>
@@ -58,7 +58,7 @@
       <h2>{{ _('Intermediate Level') }}</h2>
       <ul class="link-list">
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/A_re-introduction_to_JavaScript')) }}">{{ _('A Re-introduction to JavaScript') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('A_re-introduction_to_JavaScript') }}">{{ _('A Re-introduction to JavaScript') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('A recap of the JavaScript programming language aimed at intermediate-level developers.') }}</p>
         </li>
@@ -77,7 +77,7 @@
           <p>{{ _('Douglas Crockford explores the language as it is today, and how it came to be.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/Introduction_to_Object-Oriented_JavaScript')) }}">{{ _('Introduction to Object-oriented JavaScript') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('Introduction_to_Object-Oriented_JavaScript') }}">{{ _('Introduction to Object-oriented JavaScript') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('Learn about the JavaScript object model.') }}</p>
         </li>
@@ -124,7 +124,7 @@
           <p>{{ _('Tips on improving the download performance of pages containing JavaScript.') }}</p>
         </li>
         <li>
-          <h3 class="title"><a href="{{ devmo_url(_('/en/JavaScript/Guide')) }}">{{ _('JavaScript Guide') }}</a></h3>
+          <h3 class="title"><a href="{{ devmo_url('JavaScript/Guide') }}">{{ _('JavaScript Guide') }}</a></h3>
           <h4 class="source">MDN</h4>
           <p>{{ _('A comprehensive, regularly updated guide to JavaScript for all levels of learning from beginner to advanced.') }}</p>
         </li>

--- a/apps/landing/templates/landing/mobile.html
+++ b/apps/landing/templates/landing/mobile.html
@@ -65,7 +65,7 @@
           <li class="hentry">
             <h4 class="entry-title"><a href="https://wiki.mozilla.org/Mobile/DeviceAPIs">{{ _('Location-Aware Applications') }}</a></h4>
             <p class="entry-summary">
-            {% trans geo_url=devmo_url(_('/en/Using_geolocation')) %}
+            {% trans geo_url=devmo_url('Using_geolocation') %}
             Learn how to use the <a href="{{ geo_url }}">Geolocation API</a> and put people on the
             right path. Location-Aware Browsing is a must when you're out and about on your mobile.
             Learn how to build innovative apps that delight your audience.
@@ -84,7 +84,7 @@
             </p>
           </li>
         </ul>
-        <p class="all"><a href="{{ devmo_url(_('/en/Mobile')) }}" class="go">{{ _('All mobile development documentation') }}</a></p>
+        <p class="all"><a href="{{ devmo_url('Mobile') }}" class="go">{{ _('All mobile development documentation') }}</a></p>
       </section>
       
       <section id="videos">

--- a/apps/landing/templates/landing/mozilla.html
+++ b/apps/landing/templates/landing/mozilla.html
@@ -38,7 +38,7 @@
         
         <ul class="hfeed">
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Developer_Guide')) }}" rel="bookmark">{{ _('Mozilla Developer Guide') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Developer_Guide') }}" rel="bookmark">{{ _('Mozilla Developer Guide') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             Whether you're an old hand or just getting started, this is the
@@ -47,7 +47,7 @@
             </p>
           </li>
           <li class="hentry">
-          <h4 class="entry-title"><a href="{{ devmo_url(_('/en/The_Mozilla_platform')) }}" rel="bookmark">{{ _('The Mozilla Platform') }}</a></h4>
+          <h4 class="entry-title"><a href="{{ devmo_url('The_Mozilla_platform') }}" rel="bookmark">{{ _('The Mozilla Platform') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             Learn more about the technologies at the core of Mozilla products
@@ -56,7 +56,7 @@
             </p>
           </li>
           <li class="hentry">
-          <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Using_Mozilla_code_in_other_projects')) }}" rel="bookmark">{{ _('Using Mozilla code in other projects') }}</a></h4>
+          <h4 class="entry-title"><a href="{{ devmo_url('Using_Mozilla_code_in_other_projects') }}" rel="bookmark">{{ _('Using Mozilla code in other projects') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             There are several ways you can use Mozilla code in your own
@@ -66,7 +66,7 @@
             </p>
           </li>
           <li class="hentry">
-          <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Debugging')) }}" rel="bookmark">{{ _('Debugging') }}</a></h4>
+          <h4 class="entry-title"><a href="{{ devmo_url('Debugging') }}" rel="bookmark">{{ _('Debugging') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             Mozilla developers have come up with not just technologies
@@ -76,7 +76,7 @@
             </p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/Localization')) }}" rel="bookmark">{{ _('Localization') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('Localization') }}" rel="bookmark">{{ _('Localization') }}</a></h4>
             <p class="entry-summary">
             {% trans %}
             Localization (L10n) is the process of translating software user
@@ -87,7 +87,7 @@
             </p>
           </li>
         </ul>
-        <p class="all"><a href="{{ devmo_url(_('/en/Tools')) }}" class="go">{{ _('All applications development documentation') }}</a></p>
+        <p class="all"><a href="{{ devmo_url('Tools') }}" class="go">{{ _('All applications development documentation') }}</a></p>
       </section>
 
       <section id="fave-tools">
@@ -104,7 +104,7 @@
             <h4><a href="http://mxr.mozilla.org/">{{ _('MXR') }} <img src="{{ MEDIA_URL }}img/icn-tool-mozilla.png" alt="" width="65" /></a></h4>
             <p class="desc">{{ _('A Mozilla source tree browser.') }}</p>
           </li>
-          <li class="all"><a href="{{ devmo_url(_('/en/Tools')) }}" class="go">{{ _('All application development tools') }}</a></li>
+          <li class="all"><a href="{{ devmo_url('Tools') }}" class="go">{{ _('All application development tools') }}</a></li>
         </ul>
       </section>
       

--- a/apps/landing/templates/landing/web.html
+++ b/apps/landing/templates/landing/web.html
@@ -56,23 +56,23 @@
 
         <ul class="hfeed">
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}" rel="bookmark">{{ _('HTML5') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('HTML/HTML5') }}" rel="bookmark">{{ _('HTML5') }}</a></h4>
             <p class="entry-summary">{{ _('Find out what HTML5 is really all about and how you can develop for a better Web through open standards.') }}</p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/JavaScript')) }}" rel="bookmark">{{ _('JavaScript') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('JavaScript') }}" rel="bookmark">{{ _('JavaScript') }}</a></h4>
             <p class="entry-summary">{{ _('A great resource for anyone working with JS.') }}</p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/CSS')) }}" rel="bookmark">{{ _('CSS') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('CSS') }}" rel="bookmark">{{ _('CSS') }}</a></h4>
             <p class="entry-summary">{{ _("You'll find everything you need in the CSS reference and helpful tutorials to build pretty websites.") }}</p>
           </li>
           <li class="hentry">
-            <h4 class="entry-title"><a href="{{ devmo_url(_('/en/DOM')) }}" rel="bookmark">{{ _('DOM') }}</a></h4>
+            <h4 class="entry-title"><a href="{{ devmo_url('DOM') }}" rel="bookmark">{{ _('DOM') }}</a></h4>
             <p class="entry-summary">{{ _("The DOM is the architecture for Web documents; learn how to use the DOM and its API to look at and manipulate Web content.") }}</p>
           </li>
         </ul>
-        <p class="all"><a href="{{ devmo_url(_('/en/Web_Development')) }}" class="go">{{ _('All web development documentation') }}</a></p>
+        <p class="all"><a href="{{ devmo_url('Web_Development') }}" class="go">{{ _('All web development documentation') }}</a></p>
       </section>
 
       <section id="fave-tools">

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,42 +76,42 @@
               <ul>
                 <li>
                   <ul>
-                    <li><a href="{{ devmo_url(_('/en/HTML')) }}">{{ _('HTML') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/DOM')) }}">{{ _('DOM') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">{{ _('Video') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_audio_and_video_in_Firefox')) }}">{{ _('Audio') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/SVG')) }}">{{ _('SVG') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/WebGL')) }}">{{ _('WebGL') }}</a></li>
+                    <li><a href="{{ devmo_url('HTML') }}">{{ _('HTML') }}</a></li>
+                    <li><a href="{{ devmo_url('DOM') }}">{{ _('DOM') }}</a></li>
+                    <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">{{ _('Video') }}</a></li>
+                    <li><a href="{{ devmo_url('Using_audio_and_video_in_Firefox') }}">{{ _('Audio') }}</a></li>
+                    <li><a href="{{ devmo_url('SVG') }}">{{ _('SVG') }}</a></li>
+                    <li><a href="{{ devmo_url('WebGL') }}">{{ _('WebGL') }}</a></li>
                   </ul>
                 </li>
                 <li>
                   <ul>
-                    <li><a href="{{ devmo_url(_('/en/HTML/HTML5')) }}">{{ _('HTML5') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/WebSockets')) }}">{{ _('WebSockets') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Offline_resources_in_Firefox')) }}">{{ _('Offline Cache') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/DOM/Storage')) }}">{{ _('Local Storage') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/IndexedDB')) }}">{{ _('IndexedDB') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_files_from_web_applications')) }}">{{ _('File API') }}</a></li>
+                    <li><a href="{{ devmo_url('HTML/HTML5') }}">{{ _('HTML5') }}</a></li>
+                    <li><a href="{{ devmo_url('WebSockets') }}">{{ _('WebSockets') }}</a></li>
+                    <li><a href="{{ devmo_url('Offline_resources_in_Firefox') }}">{{ _('Offline Cache') }}</a></li>
+                    <li><a href="{{ devmo_url('DOM/Storage') }}">{{ _('Local Storage') }}</a></li>
+                    <li><a href="{{ devmo_url('IndexedDB') }}">{{ _('IndexedDB') }}</a></li>
+                    <li><a href="{{ devmo_url('Using_files_from_web_applications') }}">{{ _('File API') }}</a></li>
                   </ul>
                 </li>
                 <li>
                   <ul>
-                    <li><a href="{{ devmo_url(_('/en/CSS')) }}">{{ _('CSS') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_gradients')) }}">{{ _('Gradients') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/CSS/Using_CSS_transforms')) }}">{{ _('Transforms') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/CSS/CSS_transitions')) }}">{{ _('Transitions') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/CSS/CSS_animations')) }}">{{ _('Animations') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/CSS/Media_queries')) }}">{{ _('Media Queries') }}</a></li>
+                    <li><a href="{{ devmo_url('CSS') }}">{{ _('CSS') }}</a></li>
+                    <li><a href="{{ devmo_url('Using_gradients') }}">{{ _('Gradients') }}</a></li>
+                    <li><a href="{{ devmo_url('CSS/Using_CSS_transforms') }}">{{ _('Transforms') }}</a></li>
+                    <li><a href="{{ devmo_url('CSS/CSS_transitions') }}">{{ _('Transitions') }}</a></li>
+                    <li><a href="{{ devmo_url('CSS/CSS_animations') }}">{{ _('Animations') }}</a></li>
+                    <li><a href="{{ devmo_url('CSS/Media_queries') }}">{{ _('Media Queries') }}</a></li>
                   </ul>
                 </li>
                 <li>
                   <ul>
-                    <li><a href="{{ devmo_url(_('/en/JavaScript')) }}">{{ _('JavaScript') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/AJAX')) }}">{{ _('AJAX') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/HTML/Canvas')) }}">{{ _('Canvas') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_geolocation')) }}">{{ _('Geolocation') }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/DragDrop/Drag_and_Drop')) }}">{{ _('Drag &amp; Drop')|safe }}</a></li>
-                    <li><a href="{{ devmo_url(_('/en/Using_web_workers')) }}">{{ _('Web Workers') }}</a></li>
+                    <li><a href="{{ devmo_url('JavaScript') }}">{{ _('JavaScript') }}</a></li>
+                    <li><a href="{{ devmo_url('AJAX') }}">{{ _('AJAX') }}</a></li>
+                    <li><a href="{{ devmo_url('HTML/Canvas') }}">{{ _('Canvas') }}</a></li>
+                    <li><a href="{{ devmo_url('Using_geolocation') }}">{{ _('Geolocation') }}</a></li>
+                    <li><a href="{{ devmo_url('DragDrop/Drag_and_Drop') }}">{{ _('Drag &amp; Drop')|safe }}</a></li>
+                    <li><a href="{{ devmo_url('Using_web_workers') }}">{{ _('Web Workers') }}</a></li>
                   </ul>
                 </li>
               </ul>
@@ -175,10 +175,10 @@
       <img src="{{ MEDIA_URL }}img/mdn-logo-tiny.png" alt="" width="42" height="48">
       <p id="copyright">&copy; {{ thisyear() }} Mozilla Developer Network</p>
       <p>
-      {% trans copyright_url=devmo_url(_('/en-US/docs/Project:Copyrights')) %}
+      {% trans copyright_url=devmo_url('en-US/docs/Project:Copyrights') %}
       Content is available under <a href="{{ copyright_url }}">these licenses</a>
       {% endtrans %}
-      &bull; <a href="{{ devmo_url(_('/en-US/docs/Project:About')) }}">{{ _('About MDN') }}</a> &bull;
+      &bull; <a href="{{ devmo_url('en-US/docs/Project:About') }}">{{ _('About MDN') }}</a> &bull;
       <a href="http://www.mozilla.org/en-US/privacy">{{ _('Privacy Policy') }}</a> &bull;
       <a href="/discussions">{{ _('Help') }}</a></p>
     </div>


### PR DESCRIPTION
To fix https://bugzilla.mozilla.org/show_bug.cgi?id=779423 we need to update all devmo_url calls in Kuma to pass just the doc slug. With these fixed, the links on the home page and elsewhere will look for a locale-specific translation to avoid going straight to the English page or incurring an extra redirect.

To test this, I made an en-US HTML doc, then "translated" it into de. Went to the 'de' home page and the links to 'HTML' correctly go to /de/docs/HTML, while links to other non-translated docs still go to en-US.
