### PR TITLE
fix bug 772647: Fixed broken footer links.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -175,10 +175,10 @@
       <img src="{{ MEDIA_URL }}img/mdn-logo-tiny.png" alt="" width="42" height="48">
       <p id="copyright">&copy; {{ thisyear() }} Mozilla Developer Network</p>
       <p>
-      {% trans copyright_url=devmo_url('en-US/docs/Project:Copyrights') %}
+      {% trans copyright_url=devmo_url('Project:Copyrights') %}
       Content is available under <a href="{{ copyright_url }}">these licenses</a>
       {% endtrans %}
-      &bull; <a href="{{ devmo_url('en-US/docs/Project:About') }}">{{ _('About MDN') }}</a> &bull;
+      &bull; <a href="{{ devmo_url('Project:About') }}">{{ _('About MDN') }}</a> &bull;
       <a href="http://www.mozilla.org/en-US/privacy">{{ _('Privacy Policy') }}</a> &bull;
       <a href="/discussions">{{ _('Help') }}</a></p>
     </div>


### PR DESCRIPTION
Wasn't able to spot-check this one myself (still can't get Vagrant to use Kuma rather than Mindtouch). Do not merge unless you verify that this fixes the broken links in the footer.
