### PR TITLE
fix bug 776603: Skip the CSS gauntlet for Kuma

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -212,7 +212,8 @@ def process_body(response):
     from wiki.models import (ALLOWED_ATTRIBUTES, ALLOWED_TAGS, ALLOWED_STYLES)
     resp_body = bleach.clean(
         resp_body, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS,
-        styles=ALLOWED_STYLES, strip_comments=False
+        styles=ALLOWED_STYLES, strip_comments=False,
+        skip_gauntlet=True
     )
     return resp_body
 

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1283,7 +1283,8 @@ class Revision(ModelBase):
             return self.content
         return bleach.clean(
             self.content, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS,
-            styles=ALLOWED_STYLES, strip_comments=False
+            styles=ALLOWED_STYLES, strip_comments=False,
+            skip_gauntlet=True
         )
 
     def get_previous(self):


### PR DESCRIPTION
Before review, this PR requires the bleach module under vendor to be updated to this commit:

https://github.com/lmorchard/bleach/commit/2906726af82ed0063a559124cee610bcd2e5859c

That commit comes from this PR on the Bleach project:

https://github.com/jsocol/bleach/pull/73
