### PR TITLE
fix bug 780120 - Prevent google from indexing revisions

### DIFF
--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -9,6 +9,10 @@
                  (None, _('Revision {num}')|f(num=revision.id))] %}
 {% set classes = 'document' %}
 
+{% block extrahead %}
+  <meta name="robots" content="noindex" />
+{% endblock %}
+
 {% block content %}
 <section id="content">
   <div class="wrap">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=780120
