### PR TITLE
Added MathML tags

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -54,7 +54,10 @@ ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'section', 'header', 'footer', 'nav', 'article', 'aside', 'figure',
     'dialog', 'hgroup', 'mark', 'time', 'meter', 'command', 'output',
     'progress', 'audio', 'video', 'details', 'datagrid', 'datalist', 'table',
-    'address', 'font'
+    'address', 'font',
+    # MathML tags
+    'math', 'mfenced', 'mtable', 'mtr', 'mtd', 'mo', 'mi', 'mn', 
+    'msub', 'msup', 'msubsup'
 ]
 ALLOWED_ATTRIBUTES = bleach.ALLOWED_ATTRIBUTES
 ALLOWED_ATTRIBUTES['p'] = ['style', 'class', 'id', 'align', 'lang']


### PR DESCRIPTION
We use matrix calculation at some places in the documentation. Using images for these is not pratical. These basic tags should cover most cases. See https://bugzilla.mozilla.org/show_bug.cgi?id=665732
