### PR TITLE
fix bug 780295 - Prevent jQuery UI 404 image

### DIFF
--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -502,6 +502,9 @@ td.diff_header {
   height: 200px !important;
 }
 
+/* jQuery UI fix */
+.ui-state-default, .ui-widget-content .ui-state-default, .ui-widget-header .ui-state-default { background: #f6f6f6 !important; }
+
 /* HTabs - Compatibility Tables */
 .htab { margin: auto; display: inline-block; width: auto; }
 .htab > ul > li { background-image: none; width:150px; height:30px; list-style-type:none; display:inline; padding-bottom:3px; border: 1px solid #ddd; padding-top:5px; text-align:left; font-size:13px; font-weight:bold; margin:auto; position:relative; padding-left:6px; padding-right:6px; border-bottom:none; opacity:.5; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50); cursor:pointer; }


### PR DESCRIPTION
I don't like using "!important", but it allows us to avoid editing the jQuery UI source file.
