### PR TITLE
fix bug 781779 - Preserve show_toc value for edited translations

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1216,6 +1216,10 @@ def translate(request, document_slug, document_locale, revision_id=None):
             if rev_form.is_valid() and not doc_form_invalid:
                 # append final slug
                 post_data['slug'] = destination_slug
+
+                # update the post data with the show_toc of original
+                post_data['show_toc'] = based_on_rev.show_toc
+
                 rev_form = RevisionForm(post_data)
 
                 _save_rev_and_notify(rev_form, request.user, doc)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=781779

To test:
1. Create an en-US doc
2. Translate it
3. Edit the translation w/ a user that doesn't have permissions to edit title, slug, and TOC checkbox.
4. Save

The TOC should show after edit.
