### PR TITLE
fix bug 773658 - Show message before leaving page

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -1,7 +1,7 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
-{% set title = _('{document} | Edit Article')|f(document=document.title) %}
+{% set title = _('Edit {title}')|fe(title=('Template' if document.is_template else 'Article')) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -2,7 +2,7 @@
 {% extends "wiki/base.html" %}
 {% from "layout/errorlist.html" import errorlist %}
 {% from "includes/common_macros.html" import content_editor %}
-{% set title = _('Create a New Article') %}
+{% set title = _('Create a New {title}')|fe(title=('Template' if is_template else 'Article')) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
 {# TODO: Change KB url to landing page when we have one #}
 {% set crumbs = [(None, _('New Article'))] %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -14,7 +14,7 @@
 <section id="content">
   <div class="wrap">
     <div id="content-main" class="full">
-      <form action="" method="post" data-json-url="{{ url('wiki.json') }}">
+      <form action="" method="post" data-json-url="{{ url('wiki.json') }}" id="wiki-page-translate">
         {{ csrf() }}
         <input type="hidden" name="form" value="both" />
 


### PR DESCRIPTION
There are a number of ways this should be tested:

```
1.  Immediately refresh the page
    - Should not prompt

2.  Don't change editor, press save
    - Should not prompt

3.  Don't change editor, press "discard"
    - Should not prompt

4.  Update content, press save
    - Should not prompt

5.  Update content, refresh page
    - Should prompt

6.  Update content, click a link
    - Should prompt
```

That's just for templates.  Same should be done with WYSIWYG, as well as the translate page.
