### PR TITLE
Fix bug 771649 - Updating dropdown height

### DIFF
--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -500,7 +500,7 @@ td.diff_header {
   width: 130px !important;
 }
 .cke_skin_kuma .cke_rcombopanel {
-  height: 200px !important;
+  height: 280px !important;
 }
 
 /* HTabs - Compatibility Tables */


### PR DESCRIPTION
Look at the WYSIWYG's "STYLE" dropdown, open it, all items should display.
