### PR TITLE
fix bug 671717: Feed of documents with updated translation parents

### DIFF
--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -22,6 +22,12 @@
   {% else %}
       <link rel="alternate" type="application/atom+xml" title="{{title}}" 
           href="{{ url('wiki.feeds.recent_documents', format='atom') }}" />
+      {% if (request.locale != 'en-US'): %}
+        {# TODO: Someday, en-US won't be special in l10n. #}
+        <link rel="alternate" type="application/atom+xml" 
+              title="{{_('Translation updates needed')}}" 
+              href="{{ url('wiki.feeds.l10n_updates', format='atom') }}" />
+      {% endif %}
   {% endif %}
 {% endblock %}
 

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -3,7 +3,8 @@ from django.conf.urls.defaults import patterns, url, include
 from kbforums.feeds import ThreadsFeed, PostsFeed
 from sumo.views import redirect_to
 from wiki.feeds import (DocumentsRecentFeed, DocumentsReviewFeed, RevisionsFeed,
-                        AttachmentsFeed)
+                        AttachmentsFeed,
+                        DocumentsUpdatedTranslationParentFeed,)
 
 
 # These patterns inherit from /discuss
@@ -100,6 +101,8 @@ urlpatterns += patterns('wiki.views',
 
     url(r'^/feeds/(?P<format>[^/]+)/all/?',
         DocumentsRecentFeed(), name="wiki.feeds.recent_documents"),
+    url(r'^/feeds/(?P<format>[^/]+)/l10n-updates/?',
+        DocumentsUpdatedTranslationParentFeed(), name="wiki.feeds.l10n_updates"),
     url(r'^/feeds/(?P<format>[^/]+)/tag/(?P<tag>[^/]+)',
         DocumentsRecentFeed(), name="wiki.feeds.recent_documents"),
     url(r'^/feeds/(?P<format>[^/]+)/category/(?P<category>[^/]+)',


### PR DESCRIPTION
- New feed that lists documents in the current locale whose translation
  parent has been modified since the translation was last modified. (ie.
  The translations need updating)
- Test for the new feed.
- Auto-discovery link for the new feed in /docs/all page header
- Report document modified date in feeds, rather than current revision
- Bump default MAX_FEED_ITEMS up to 100
