### PR TITLE
fix bug 775161 - Preventing CSS overflow in translate

### DIFF
--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -138,7 +138,7 @@
             <header>
               <h3>{{ _('Approved {default_locale} version:')|f(default_locale=settings.LANGUAGES[settings.WIKI_DEFAULT_LANGUAGE.lower()]) }}</h3>
             </header>
-            <div class="boxed">
+            <div class="boxed translate-display">
               {{ based_on.content|safe }}
             </div>
           </article>

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -399,6 +399,14 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 
 #trans-content #cke_contents_wikiArticle { min-height: 800px; }
 
+.translate-display {
+  overflow-x: hidden;
+}
+
+.translate-display pre {
+  white-space: normal;
+}
+
 /* The .no-details styles will get applied only if JavaScript is enabled and <details> is not natively supported. */
 /* Add focus styles (for keyboard accessibility) */
 .no-details summary:hover, .no-details summary:focus { background: rgba(170,160,130,.1); outline: 0; }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=775161

Can be tested/viewed on: 

/en-US/docs/CSS/border-image$translate?tolocale=fr

The code block should wrap and the lower table should flow "under" the box.
