### PR TITLE
bug 771730 - show table diff in feed

### DIFF
--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -81,7 +81,7 @@ def _massage_diff_content(content):
 
 
 @register.function
-def diff_table(content_from, content_to):
+def diff_table(content_from, content_to, prev_id, curr_id):
     """Creates an HTML diff of the passed in content_from and content_to."""
     tidy_from, errors = _massage_diff_content(content_from)
     tidy_to, errors = _massage_diff_content(content_to)
@@ -89,8 +89,12 @@ def diff_table(content_from, content_to):
     from_lines = tidy_from.splitlines()
     to_lines = tidy_to.splitlines()
     try:
-        diff = html_diff.make_table(from_lines, to_lines, context=True,
-                                numlines=constance.config.DIFF_CONTEXT_LINES)
+        diff = html_diff.make_table(from_lines, to_lines,
+                                    _("Revision %s") % prev_id,
+                                    _("Revision %s") % curr_id,
+                                    context=True,
+                                    numlines=constance.config.DIFF_CONTEXT_LINES
+                                   )
     except RuntimeError:
         # some diffs hit a max recursion error
         message = _(u'There was an error generating the content.')
@@ -105,6 +109,30 @@ def diff_inline(content_from, content_to):
     sm = difflib.SequenceMatcher(None, tidy_from, tidy_to)
     diff = show_diff(sm)
     return jinja2.Markup(diff)
+
+
+@register.function
+def tag_diff_table(prev_tags, curr_tags, prev_id, curr_id):
+    html_diff = difflib.HtmlDiff(wrapcolumn=DIFF_WRAP_COLUMN)
+    prev_tag_lines = [prev_tags]
+    curr_tag_lines = [curr_tags]
+    diff = html_diff.make_table(prev_tag_lines, curr_tag_lines,
+                                _("Revision %s") % prev_id,
+                                _("Revision %s") % curr_id
+                               )
+    return jinja2.Markup(diff)
+
+
+@register.function
+def colorize_diff(diff):
+    diff = diff.replace('<span class="diff_add"', '<span class="diff_add" '
+                'style="background-color: #afa; text-decoration: none;"')
+    diff = diff.replace('<span class="diff_sub"', '<span class="diff_sub" '
+                'style="background-color: #faa; text-decoration: none;"')
+    diff = diff.replace('<span class="diff_chg"', '<span class="diff_chg" '
+                'style="background-color: #fe0; text-decoration: none;"')
+    return diff
+
 
 
 @register.function

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -83,7 +83,7 @@
 
             {% if content and current_revision.content and content != current_revision.content %}
                 <h4>{{ _('Content:') }}</h4>
-                {{ diff_table(content, current_content) }}
+                {{ diff_table(content, current_content, current_revision.id, "Proposed") }}
             {% endif %}
 
           </div>

--- a/apps/wiki/templates/wiki/includes/revision_diff.html
+++ b/apps/wiki/templates/wiki/includes/revision_diff.html
@@ -51,7 +51,7 @@
       <dd class="rev-to">{{ revision_to.summary }}</dd>
       
       <dt>{{ _('Content:') }}</dt>
-      <dd>{{ diff_table(revision_from.content, revision_to.content) }}</dd>
+      <dd>{{ diff_table(revision_from.content, revision_to.content, revision_from.id, revision_to.id) }}</dd>
     </dl>
   </section>
 {% endif %}

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -64,7 +64,8 @@ def revision(save=False, **kwargs):
 
     defaults = {'summary': 'Some summary', 'content': 'Some content',
                 'significance': SIGNIFICANCES[0][0], 'comment': 'Some comment',
-                'creator': kwargs.get('creator', get_user()), 'document': d}
+                'creator': kwargs.get('creator', get_user()), 'document': d,
+                'tags': '"some", "tags"'}
 
     defaults.update(kwargs)
 

--- a/apps/wiki/tests/test_feeds.py
+++ b/apps/wiki/tests/test_feeds.py
@@ -60,12 +60,12 @@ class FeedTests(TestCaseBase):
         d = document(title='HTML9')
         d.save()
         for i in xrange(1, 6):
-            revision(save=True, document=d,
+            r = revision(save=True, document=d,
                          title='HTML9', comment='Revision %s' % i,
-                         content="Some Content %s" % i,
+                         content = "Some Content %s" % i,
                          is_approved=True,
                          created=datetime.datetime.now()\
-                         + datetime.timedelta(seconds=5 * i))
+                         + datetime.timedelta(seconds=5*i))
 
         resp = self.client.get(reverse('wiki.feeds.recent_revisions',
                                        args=(), kwargs={'format': 'rss'}))
@@ -74,13 +74,42 @@ class FeedTests(TestCaseBase):
         eq_(5, len(feed.find('item')))
         for i, item in enumerate(feed.find('item')):
             desc_text = pq(item).find('description').text()
-            ok_('by: testuser' in desc_text)
+            ok_('by:</h3><p>testuser</p>' in desc_text)
             if "Edited" in desc_text:
-                ok_('Comment: Revision' in desc_text)
-                ok_('<ins' in desc_text)
+                ok_('<h3>Comment:</h3><p>Revision' in desc_text)
+                ok_('diff_chg' in desc_text)
                 ok_('$compare?to' in desc_text)
                 ok_('$edit' in desc_text)
                 ok_('$history' in desc_text)
+
+    def test_revisions_feed_diffs(self):
+        d = document(title='HTML9')
+        d.save()
+        revision(save=True, document=d,
+                    title='HTML9', comment='Revision 1',
+                    content = "First Content",
+                    is_approved=True,
+                    created=datetime.datetime.now())
+        r = revision(save=True, document=d,
+                    title='HTML9', comment='Revision 2',
+                    content = "First Content",
+                    is_approved=True,
+                    created=datetime.datetime.now()\
+                        +datetime.timedelta(seconds=1),
+                    tags='"some", "more", "tags"')
+        r.review_tags.set(*[u'editorial'])
+
+        resp = self.client.get(reverse('wiki.feeds.recent_revisions',
+                                       args=(), kwargs={'format': 'rss'}))
+        eq_(200, resp.status_code)
+        feed = pq(resp.content)
+        for i, item in enumerate(feed.find('item')):
+            desc_text = pq(item).find('description').text()
+            if "Edited" in desc_text:
+                ok_('<h3>Tag changes:</h3>' in desc_text)
+                ok_('<span class="diff_add" style="background-color: #afa; text-decoration: none;">"more",&nbsp;</span>' in desc_text)
+                ok_('<h3>Review changes:</h3>' in desc_text)
+                ok_('<span class="diff_add" style="background-color: #afa; text-decoration: none;">editorial</span>' in desc_text)
 
     def test_feed_locale_filter(self):
         """Documents and Revisions in feeds should be filtered by locale"""


### PR DESCRIPTION
add tag diff

review diff; revision label on diff tables

colorize and test diffs

I used https://addons.mozilla.org/en-US/firefox/addon/newsfox/ to spot-check the colorized diff's.
