### PR TITLE
fix bug 784754 - Create revert UI page

### DIFF
--- a/apps/wiki/templates/wiki/confirm_revision_revert.html
+++ b/apps/wiki/templates/wiki/confirm_revision_revert.html
@@ -1,1 +1,40 @@
- 
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "wiki/base.html" %}
+{% set title = _('Revert Revision | {document}')|f(document=document.title) %}
+{% block title %}{{ page_title(title) }}{% endblock %}
+{% block bodyclass %}revert-document{% endblock %}
+{% set crumbs = [(url('wiki.category', document.category), document.get_category_display()),
+                 (document.get_absolute_url(), document.title),
+                 (None, _('Revert Revision'))] %}
+
+{% block content %}
+<section id="content">
+  <div class="wrap">
+    <div id="content-main" class="full">
+      <article id="delete-revision" class="main">
+        <h1 class="title">{{ _('Are you sure you want to revert to this revision?') }}</h1>
+
+        <label><strong>{{ _('Document') }}</strong></label>
+        <div>{{ document.title }}</div>
+
+        <label><strong>{{ _('Creator') }}</strong></label>
+        <div><a href="{{ url('devmo.views.profile_view', username=revision.creator) }}">{{ revision.creator }}</a></div>
+        <label><strong>{{ _('Date') }}</strong></label>
+        <div>{{ datetimeformat(revision.created, format='longdatetime') }}</div>
+        <label><strong>{{ _('Content') }}</strong></label>
+        <pre class="brush: html">{{ revision.content }}</pre>
+        <form action="" method="post">
+          {{ csrf() }}
+          <p>
+            {{ _('You are about to revert the document to this revision.  Click "submit" to revert to the content&nbsp;above.')|safe }}
+          </p>
+          <div class="submit">
+            <input type="submit" value="{{ _('Revert') }}" />
+            <a href="{{ url('wiki.document_revisions', document.slug) }}">{{ _('Cancel') }}</a>
+          </div>
+        </form>
+      </article>
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/apps/wiki/templates/wiki/document_revisions.html
+++ b/apps/wiki/templates/wiki/document_revisions.html
@@ -80,6 +80,11 @@
               <div class="comment">
                 {{ rev.comment }}
               </div>
+              {% if document.current_revision.id != rev.id and user.has_perm('wiki.delete_revision') %}
+              <div class="creator">
+                <a href="{{ url('wiki.revert_document', document.full_path, rev.id) }}">Revert</a>
+              </div>
+              {% endif %}
             </li>
             {% if loop.last %}</ul>{% endif %}
           {% endfor %}

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -43,6 +43,10 @@
             initTabBox();
         }
 
+        if ($body.is('.revert-document')) {
+            initSyntaxHighlighter();
+        }
+
         if ($body.is('.home')) {
             initClearOddSections();
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=784754

To check:
1.  Create a document
2.  Edit the doc a few times
3.  Go to the document history page
4.  Click one of the "Revert" links
5.  Press the "Revert" button.  
6.  Voila.
