### PR TITLE
fix bug 783853 - remove CKEDITOR js files if user not logged in

### DIFF
--- a/apps/wiki/templates/wiki/base.html
+++ b/apps/wiki/templates/wiki/base.html
@@ -16,8 +16,3 @@
 {% if not scripts %}
   {% set scripts = ('wiki',) %}
 {% endif %}
-{% block js %}
-  <script src="{{ MEDIA_URL }}ckeditor/ckeditor.js"></script>
-  <script src="{{ MEDIA_URL }}ckeditor/adapters/jquery.js"></script>
-  <script src="{{ MEDIA_URL }}js/wiki_ckeditor.js"></script>
-{% endblock %}

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -321,3 +321,7 @@
 {% block side %}
   {% include 'wiki/includes/support_for_selectors.html' %}
 {% endblock %}
+
+{% block js %}
+    {% include 'wiki/includes/ckeditor_scripts.html' %}
+{% endblock %}

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -177,6 +177,7 @@
         type="text/javascript" charset="utf-8"></script>
       <script src="{{ MEDIA_URL }}ace/mode-javascript.js"
         type="text/javascript" charset="utf-8"></script>
+    {% else %}
+      {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
-
 {% endblock %}

--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -1,0 +1,5 @@
+{% if request.user.is_authenticated() %}
+<script src="{{ MEDIA_URL }}ckeditor/ckeditor.js"></script>
+<script src="{{ MEDIA_URL }}ckeditor/adapters/jquery.js"></script>
+<script src="{{ MEDIA_URL }}js/wiki_ckeditor.js"></script>
+{% endif %}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -77,6 +77,8 @@
         type="text/javascript" charset="utf-8"></script>
       <script src="{{ MEDIA_URL }}ace/mode-javascript.js"
         type="text/javascript" charset="utf-8"></script>
+    {% else %}
+      {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Fixes:

https://bugzilla.mozilla.org/show_bug.cgi?id=783853
https://bugzilla.mozilla.org/show_bug.cgi?id=785412

To check:
1.  Go to document.html page (any doc) while not logged in.  In the console type "CKEDITOR";  you should get an error because CKEDITOR is not loaded
2.  Log in, go to any document, the edit page, and translate pages -- each should have CKEDITOR present.
