### PR TITLE
fix bug 784758 - SAK button clears comment field upon save

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -1017,6 +1017,8 @@
             }
             // Stop loading state on button
             $('#btn-save-and-edit').removeClass('loading');
+            // Clear the review comment
+            $('#id_comment').val('');
             // Re-enable the form; it gets disabled to prevent double-POSTs
             $('#wiki-page-edit')
                 .data('disabled', false)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=784758
