### PR TITLE
Added link to Bugzilla from login page.

### DIFF
--- a/apps/users/templates/users/browserid_register.html
+++ b/apps/users/templates/users/browserid_register.html
@@ -9,14 +9,19 @@
   <div class="wrap">
     <section id="content-main" role="main">
       <article id="browser_register" class="main">
-  
+
         <h1>{{ _('Persona is here!') }}</h1>
         <p>{% trans browserid_href='https://persona.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
         MDN has switched to <a href="{{ browserid_href }}" rel="external">Persona</a>,
         a safe and simple way to sign in with just your e-mail address. <a href="{{ why_browserid }}" rel="external">Learn more about it.</a>
-        {% endtrans %}</p> 
-    
-    
+        {% endtrans %}</p>
+
+        <p>
+        {% trans bug_href='http://mzl.la/mdn-bug' %}
+        Having trouble logging in? <a href="{{ bug_href }}" rel="external">Let us know.</a>
+        {% endtrans %}
+        </p>
+
         <form id="create_user" class="boxed" method="post" action="">
           <h2>{{ _('New MDN Members') }}</h2>
           <p>{% trans %}
@@ -24,12 +29,12 @@
             you can pick an MDN username now and complete your registration.
           {% endtrans %}</p>
           <p>{% trans %}
-            You can access everything on the MDN website even without an account, 
-            but when you join you'll be able to edit docs, submit demos, and have 
+            You can access everything on the MDN website even without an account,
+            but when you join you'll be able to edit docs, submit demos, and have
             your own profile page.
           {% endtrans %}</p>
           {{ errorlist(register_form) }}
-          
+
           {{ csrf() }}
           <input type="hidden" name="action" value="register">
           <fieldset>
@@ -44,7 +49,7 @@
             </ul>
           </fieldset>
         </form>
-    
+
         <form id="existing_user" class="boxed" method="post" action="">
           <h2>{{ _('Returning MDN Members') }}</h2>
           <p>{% trans %}
@@ -53,7 +58,7 @@
             now on.
           {% endtrans %}</p>
           {{ errorlist(login_form) }}
-          
+
           {{ csrf() }}
           <input type="hidden" name="action" value="login">
           <fieldset>


### PR DESCRIPTION
A few people have been unable to log in with Persona lately. Most often,
this is because they do not have an email address associated with their
account and additionally cannot remember their former account password.

The fix is simple -- manually set their email address -- but they need
to get in touch with us to make that possible. This link should help
them do that.
