### PR TITLE
Bug 785218: Add custom permission for moving trees of documents.

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -663,6 +663,7 @@ class Document(NotificationsMixin, ModelBase):
         permissions = (
             ("add_template_document", "Can add Template:* document"),
             ("change_template_document", "Can change Template:* document"),
+            ("move_tree", "Can move a tree of documents"),
         )
 
     def _existing(self, attr, value):


### PR DESCRIPTION
This is the first page-move commit, and should be merged before any others. It's just a one-liner to add the permission object.
