### PR TITLE
fix bug 775537 - Allow tag editing in translation interface

### DIFF
--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -152,9 +152,26 @@
           </article>
         </div>
         {{ revision_form.hidden_fields()|join|safe }}
+
+        
+        <div class="approved">&nbsp;</div>
+        <div class="localized">
+          <section class="page-meta">
+              <section id="page-tags">
+                <h2>{{ _('Tags') }}</h2>
+                {% if document.tags %}
+                  {% set tags = document.tags.all() %}
+                  <input id="tagit_tags" type="text" name="tags" value="{% for tag in tags %}{{ tag.name }},{% endfor %}" maxlength="255" />
+                {% else %}
+                  <input id="tagit_tags" type="text" name="tags" value="" maxlength="255" />
+                {% endif %}
+              </section>
+          </section>
+        </div>
         
       </details>
     {% endif %}
+
     <div id="preview"></div>
   </div>
 </form>

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -381,10 +381,10 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 .description li { clear: both; margin: 0 0 .5em; }
 .description li:after { content: "."; display: block; clear: both; height: 0; visibility: hidden; }
 .description dl { margin: 0; }
-.description dt { display: inline-block; margin-right: 10px; font-style: normal; font-weight: bold; }
+.description dt { display: inline-block; margin-right: 10px; font-style: normal; font-weight: bold; vertical-align: top; padding-top: 4px; }
 .description dd { display: inline-block; margin-left: 0; }
-.description .approved { width: 49%; float: left; }
-.description .localized { width: 49%; float: right; }
+.description .approved, #trans-content .approved { width: 49%; float: left; }
+.description .localized, #trans-content .localized { width: 49%; float: right; }
 
 .description input#id_title { font-size: 1.124em; width: 90%; margin: 0; }
 

--- a/media/js/wiki-tags-edit.js
+++ b/media/js/wiki-tags-edit.js
@@ -4,7 +4,7 @@
     var idTagsField = $("#tagit_tags");
 
     // Create a hidden input type for the purposes of saving
-    var hiddenTags = $('<input type="hidden" name="tags" id="hiddenTags" value="' + idTagsField.val() +  '" />').appendTo("#page-tags");
+    var hiddenTags = $('<input type="hidden" name="tags" id="hiddenTags" value="' + (idTagsField.val() || "") +  '" />').appendTo("#page-tags");
 
     // Grabs text from the list items, updates hidden input so tags are properly saved
     // Requires node reading because the tag-it widget incorrectly overrides the "singleNodeField"


### PR DESCRIPTION
Fixes:

https://bugzilla.mozilla.org/show_bug.cgi?id=775537

Tags display under the right side editor; uses tagit widget.
