### PR TITLE
fix bug 785455 - most 'simple' term match first

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -962,13 +962,13 @@ def autosuggest_documents(request):
     partial_title = request.GET.get('term', '')
 
     # TODO: isolate to just approved docs?
-    docs = (Document.objects.filter(title__icontains=partial_title,
+    docs = (Document.objects.extra(select={'length':'Length(slug)'}).filter(title__icontains=partial_title,
                                     is_template=0,
                                     locale=request.locale).
                              exclude(title__iregex=r'Redirect [0-9]+$').  # New redirect pattern
                              exclude(html__iregex=r'^(<p>)?(#)?REDIRECT').  #Legacy redirect
                              exclude(slug__icontains='Talk:').  # Remove old talk pages
-                             order_by('title'))
+                             order_by('title', 'length'))
 
     docs_list = []
     for d in docs:


### PR DESCRIPTION
To spot-check:
1.  Create "/en-US/docs/parent/match"
2.  Create "/en-US/docs/match"
3.  Open the link dialog, type "match", then hover over the first item;  you should see "/docs/match", and the parent match second.

https://bugzilla.mozilla.org/show_bug.cgi?id=785455
