### PR TITLE
fix bug 781926 - Show revision content in revision page

### DIFF
--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -86,7 +86,7 @@
     <details class="h2">
       <summary>{{ _('Revision Content') }}</summary>
       <div id="doc-content">
-        {{ revision.content_parsed|safe }}
+        <div class="page-content boxed">{{ revision.content|safe }}</div>
       </div>
     </details>
   </article>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=781926

This PR shows the "raw" content of the revision; it does not render templates or create a TOC.  Since templates may have changed since a given revision, I don't know that showing the template content would be accurate.
