### PR TITLE
Mark helper as @nottest.

### DIFF
--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -5,7 +5,7 @@ from django.contrib.auth.models import User, Group, Permission
 from django.template.defaultfilters import slugify
 
 from html5lib.filters._base import Filter as html5lib_Filter
-
+from nose.tools import nottest
 from waffle.models import Flag
 
 from sumo.tests import LocalizingClient, TestCase, get_user
@@ -152,6 +152,7 @@ def normalize_html(input):
             .serialize())
 
 
+@nottest
 def create_template_test_users():
     perms = dict(
         (x, [Permission.objects.get(codename='%s_template_document' % x)])


### PR DESCRIPTION
This function matches the nose pattern for a test function, this decorator keeps it from being executed as a test.
