### PR TITLE
fix bug 784877 - Placing tags on new lines in RSS tag block

### DIFF
--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -116,10 +116,14 @@ def tag_diff_table(prev_tags, curr_tags, prev_id, curr_id):
     html_diff = difflib.HtmlDiff(wrapcolumn=DIFF_WRAP_COLUMN)
     prev_tag_lines = [prev_tags]
     curr_tag_lines = [curr_tags]
+
     diff = html_diff.make_table(prev_tag_lines, curr_tag_lines,
                                 _("Revision %s") % prev_id,
                                 _("Revision %s") % curr_id
                                )
+
+    # Simple formatting update: 784877
+    diff = diff.replace('",', '"<br />').replace('<td', '<td valign="top"')
     return jinja2.Markup(diff)
 
 


### PR DESCRIPTION
Doesn't use bullets, but does use separate lines:

https://bugzilla.mozilla.org/show_bug.cgi?id=784877
