### PR TITLE
fix bug 775952: Skip reconstruction of active formatting elements in HTML5 serializations

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -52,6 +52,10 @@ class ContentSectionTool(object):
 
         self.tree = html5lib.treebuilders.getTreeBuilder("simpletree")
 
+        # HACK: for bug 775952, we don't actually *want* to reconstruct active
+        # formatting elements, no matter what the HTML5 spec says.
+        self.tree.reconstructActiveFormattingElements = lambda self: None
+
         self.parser = html5lib.HTMLParser(tree=self.tree,
             namespaceHTMLElements=False)
 

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -478,6 +478,35 @@ class ContentSectionToolTests(TestCase):
         except e:
             ok_(False, "There should not have been an exception")
 
+    def test_unclosed_anchor_bugfix(self):
+        doc_src = """
+            <h3><a name="x-1">Foo</h3>
+            <p>Lorem ipsum</p>
+            <p>Dolor amet</p>
+            <h3><a name="x-2"/>Bar</h3>
+            <p>Bacon bacon bacon</p>
+            <h3><a name="x-3">Baz</h3>
+            <p>Tofu tofu tofu</p>
+            <h3><a name="x-4"></a>Quux</h3>
+            <p>Peas peas peas</p>
+        """
+        expected = """
+            <h3 id="Foo"><a name="x-1">Foo</a></h3>
+            <p>Lorem ipsum</p>
+            <p>Dolor amet</p>            
+            <h3 id="Bar"><a name="x-2">Bar</a></h3>            
+            <p>Bacon bacon bacon</p>            
+            <h3 id="Baz"><a name="x-3">Baz</a></h3>
+            <p>Tofu tofu tofu</p>
+            <h3 id="Quux"><a name="x-4"></a>Quux</h3>
+            <p>Peas peas peas</p>
+        """
+        result = (wiki.content
+                  .parse(doc_src)
+                  .injectSectionIDs()
+                  .serialize())
+        eq_(normalize_html(expected), normalize_html(result))
+
     def test_link_annotation(self):
         d, r = doc_rev("This document exists")
         d.save()


### PR DESCRIPTION
After all the wrangling I tried and threw out, a 1-line fix seems too easy. But, it seems to work.

To spot check, try this in a document before switching to this branch:

```
        <h3><a name="x-1">Foo</h3>
        <p>Lorem ipsum</p>
        <p>Dolor amet</p>
        <h3><a name="x-2"/>Bar</h3>
        <p>Bacon bacon bacon</p>
        <h3><a name="x-3">Baz</h3>
        <p>Tofu tofu tofu</p>
        <h3><a name="x-4"></a>Quux</h3>
        <p>Peas peas peas</p>
```

The above should result in a mess of anchors strewn everywhere, between header blocks:

```
        <h3 id="Foo"><a name="x-1">Foo</a></h3><a name="x-1">
        <p>Lorem ipsum</p>
        <p>Dolor amet</p>
        </a><h3 id="Bar"><a name="x-1"></a><a name="x-2">Bar</a></h3><a name="x-2">
        <p>Bacon bacon bacon</p>
        </a><h3 id="Baz"><a name="x-2"></a><a name="x-3">Baz</a></h3><a name="x-3">
        <p>Tofu tofu tofu</p>
        </a><h3 id="Quux"><a name="x-3"></a><a name="x-4"></a>Quux</h3>
        <p>Peas peas peas</p>
```

Once the fix is applied, this should neaten up like so:

```
        <h3 id="Foo"><a name="x-1">Foo</a></h3>
        <p>Lorem ipsum</p>
        <p>Dolor amet</p>            
        <h3 id="Bar"><a name="x-2">Bar</a></h3>            
        <p>Bacon bacon bacon</p>            
        <h3 id="Baz"><a name="x-3">Baz</a></h3>
        <p>Tofu tofu tofu</p>
        <h3 id="Quux"><a name="x-4"></a>Quux</h3>
        <p>Peas peas peas</p>
```
