### PR TITLE
fix bug 790513 - Remove HTML from SEO descriptions

### DIFF
--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -668,6 +668,11 @@ class DocumentEditingTests(TestCaseBase):
                                   '<p class="seoSummary">b</p>',
                                   'a b')
 
+        # No brackets
+        make_page_and_compare_seo('nine',
+                                  u'<p>I <em>am</em> awesome. <a href="blah">A link</a> is also &lt;cool&gt;</p>',
+                                  'I am awesome. A link is also cool')
+
     def test_create_on_404(self):
         client = LocalizingClient()
         client.login(username='admin', password='testpass')


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=790513

Also moved the SEO block to its own method for future use.
