### PR TITLE
fix bug 773252; edit title of translations

### DIFF
--- a/apps/wiki/templates/wiki/includes/translate_description.html
+++ b/apps/wiki/templates/wiki/includes/translate_description.html
@@ -1,0 +1,55 @@
+{% set desc_form = revision_form %}
+{% if document_form %}
+  {% set desc_form = document_form %}
+{% endif %}
+      <details id="trans-description"{% if disclose_description %} open="open"{% endif %}>
+        <summary>{{ _('Translate Description') }}</summary>
+        {{ errorlist(desc_form) }}
+            <ul class="description">
+              <li>
+                <dl class="approved">
+                  <dt>{{ _('Title:') }}</dt>
+                  <dd>{{ parent.title }}</dd>
+                </dl>
+                <dl class="localized">
+                  <dt><label for="{{ desc_form.title.auto_id }}" title="{{ desc_form.title.help_text }}">{{ _('Title in {locale}:')|f(locale=language) }}</label></dt>
+                  <dd>{{ desc_form.title|safe }}</dd>
+                </dl>
+              </li>
+              {% if document_form %}
+                <li>
+                  <dl class="approved">
+                    <dt>{{ _('Slug:') }}</dt>
+                    <dd>{{ specific_slug }}</dd>
+                  </dl>
+                  <dl class="localized">
+                    <dt><label for="{{ desc_form.slug.auto_id }}" title="{{ desc_form.slug.help_text }}">{{ _('Slug in {locale}:')|f(locale=language) }}</label></dt>
+                    <dd>{{ desc_form.slug|safe }}</dd>
+                  </dl>
+                </li>
+                {% if parent_slug %}
+                <li>
+                  <dl class="approved">
+                    <dt>{{ _('Parent:') }}</dt>
+                    <dd>{{ parent_slug }}</dd>
+                  </dl>
+                  <dl class="localized">
+                    &nbsp;
+                  </dl>
+                </li>
+                {% endif %}
+              {% endif %}
+              {% if not document.is_template %}
+                <li>
+                  <dl class="approved">
+                    <dt>&nbsp;</dt>
+                    <dd>&nbsp;</dd>
+                  </dl>
+                  <dl class="localized">
+                    <dt><label><abbr title="{{_('Generate table of contents')}}">{{_('TOC:')}}</abbr></label></dt>
+                    <dd>{{ revision_form.show_toc | safe }}</dd>
+                  </dl>
+                </li>
+                {% endif %}
+            </ul>
+      </details>

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -44,57 +44,7 @@
     {% endif %}
     </header>
 
-    {% if document_form %}
-      <details id="trans-description"{% if disclose_description %} open="open"{% endif %}>
-        <summary>{{ _('Translate Description') }}</summary>
-        {{ errorlist(document_form) }}
-            <ul class="description">
-              <li>
-                <dl class="approved">
-                  <dt>{{ _('Title:') }}</dt>
-                  <dd>{{ parent.title }}</dd>
-                </dl>
-                <dl class="localized">
-                  <dt><label for="{{ document_form.title.auto_id }}" title="{{ document_form.title.help_text }}">{{ _('Title in {locale}:')|f(locale=language) }}</label></dt>
-                  <dd>{{ document_form.title|safe }}</dd>
-                </dl>
-              </li>
-              <li>
-                <dl class="approved">
-                  <dt>{{ _('Slug:') }}</dt>
-                  <dd>{{ specific_slug }}</dd>
-                </dl>
-                <dl class="localized">
-                  <dt><label for="{{ document_form.slug.auto_id }}" title="{{ document_form.slug.help_text }}">{{ _('Slug in {locale}:')|f(locale=language) }}</label></dt>
-                  <dd>{{ document_form.slug|safe }}</dd>
-                </dl>
-              </li>
-              {% if parent_slug %}
-              <li>
-                <dl class="approved">
-                  <dt>{{ _('Parent:') }}</dt>
-                  <dd>{{ parent_slug }}</dd>
-                </dl>
-                <dl class="localized">
-                  &nbsp;
-                </dl>
-              </li>
-              {% endif %}
-              {% if not document.is_template %}
-                <li>
-                  <dl class="approved">
-                    <dt>&nbsp;</dt>
-                    <dd>&nbsp;</dd>
-                  </dl>
-                  <dl class="localized">
-                    <dt><label><abbr title="{{_('Generate table of contents')}}">{{_('TOC:')}}</abbr></label></dt>
-                    <dd>{{ revision_form.show_toc | safe }}</dd>
-                  </dl>
-                </li>
-                {% endif %}
-            </ul>
-      </details>
-    {% endif %}
+    {% include 'wiki/includes/translate_description.html' %}
 
     {% if revision_form %}
       <details id="trans-content" open="open">

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -1011,6 +1011,8 @@ class TranslateTests(TestCaseBase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(1, len(doc('form textarea[name="content"]')))
+        # initial translation should include slug input
+        eq_(1, len(doc('form input[name="slug"]')))
         assert (u'Espa' in doc('div.change-locale').text())
 
     def test_translate_disallow(self):
@@ -1109,6 +1111,13 @@ class TranslateTests(TestCaseBase):
         eq_(data['content'], rev.content)
         edited_fire.assert_called()
         ready_fire.assert_called()
+
+        # subsequent translations should NOT include slug input
+        self.client.logout()
+        self.client.login(username='testuser', password='testpass')
+        response = self.client.get(translate_uri)
+        doc = pq(response.content)
+        eq_(0, len(doc('form input[name="slug"]')))
 
     def test_translate_form_maintains_based_on_rev(self):
         """Revision.based_on should be the rev that was current when the


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=773252

Per discussions on bug and IRC, we're only restoring the ability to edit the title during a translation. Editing slugs will be a link to the page-move feature.
