### PR TITLE
Disable brace / quote / etc matching in ACE editor for templates

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -74,6 +74,7 @@
 
             var editor = window.ace_editor = ace.edit('ace_content');
             editor.setTheme('ace/theme/dreamweaver');
+            editor.setBehavioursEnabled(false);
             
             var JavaScriptMode = require('ace/mode/javascript').Mode;
 


### PR DESCRIPTION
No bug for this, but: It's been requested a few times, I finally figured out how to turn the feature off, and it was a 1-liner.
