### PR TITLE
fix bug 794037: Remove "Help" link.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -167,7 +167,6 @@
       {% endtrans %}
       &bull; <a href="{{ devmo_url('Project:About') }}">{{ _('About MDN') }}</a> &bull;
       <a href="http://www.mozilla.org/en-US/privacy">{{ _('Privacy Policy') }}</a> &bull;
-      <a href="/discussions">{{ _('Help') }}</a></p>
     </div>
     {% include "includes/login.html" %}
     {% block lang_switcher %}


### PR DESCRIPTION
The "Help" menu item linked to the /discussions page, which was removed
in commit 9a1705e.
