### PR TITLE
Use dash instead of pipe for SEO title

### DIFF
--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -637,9 +637,9 @@ class DocumentEditingTests(TestCaseBase):
 
         # Test nested document titles
         _make_doc('One', 'One | MDN', 'one')
-        _make_doc('Two', 'Two | One | MDN', 'one/two')
-        _make_doc('Three', 'Three | One | MDN', 'one/two/three')
-        _make_doc(u'Special Φ Char', u'Special Φ Char | One | MDN', 'one/two/special_char')
+        _make_doc('Two', 'Two - One | MDN', 'one/two')
+        _make_doc('Three', 'Three - One | MDN', 'one/two/three')
+        _make_doc(u'Special Φ Char', u'Special Φ Char - One | MDN', 'one/two/special_char')
 
 
     def test_seo_script(self):

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -511,7 +511,7 @@ def document(request, document_slug, document_locale):
         try:
             root_doc = Document.objects.get(locale=document_locale,
                                             slug=slug_dict['root'])
-            seo_parent_title = ' | ' + root_doc.title
+            seo_parent_title = ' - ' + root_doc.title
         except Document.DoesNotExist:
             logging.debug('Root document could not be found')
 


### PR DESCRIPTION
Minor optimization; teoli wanted dashes instead.
