### PR TITLE
fix bug 792417: Management command to repair breadcrumbs for translations without

### DIFF
--- a/apps/wiki/management/commands/repair_translation_breadcrumbs.py
+++ b/apps/wiki/management/commands/repair_translation_breadcrumbs.py
@@ -1,0 +1,38 @@
+"""
+Repair breadcrumb relations for translations that are missing parent topics.
+"""
+import logging
+from django.core.management.base import (BaseCommand)
+from wiki.models import Document
+
+
+class Command(BaseCommand):
+
+    help = "Repair breadcrumb trails for translations"
+
+    def handle(self, *args, **options):
+
+        # Gather up docs that claim to be translations,
+        # but have no topic parents.
+        # https://bugzilla.mozilla.org/show_bug.cgi?id=792417#c2
+        docs = (Document.objects
+                .exclude(parent__exact=None)
+                .filter(parent_topic__exact=None))
+
+        logging.debug("Attempting breadcrumb repair for %s translations" %
+                      (docs.count()))
+
+        for doc in docs:
+            doc.acquire_translated_topic_parent()
+            if not doc.parent_topic:
+                # Some translated pages really don't end up needing a
+                # breadcrumb repair, but we don't really know until we try and
+                # come up empty handed.
+                logging.debug(u'\t(root) -> /%s/docs/%s' % (
+                    doc.locale, doc.slug))
+            else:
+                # We got a new parent topic, so save and report the result
+                doc.save()
+                logging.debug(u'\t/%s/docs/%s -> /%s/docs/%s' % (
+                    doc.parent_topic.locale, doc.parent_topic.slug,
+                    doc.locale, doc.slug))


### PR DESCRIPTION
I expected this to be more involved. But, it turned out kind of simple. With a full wiki import, try this:

```
./manage.py repair_translation_breadcrumbs
```

And, you should get output something like this:

```
2012-10-03 13:51:29,490 DEBUG Repairing translated breadcrumbs for 200 docs...
2012-10-03 13:51:30,252 DEBUG   /fr/docs/en -> /fr/docs/BrowserID
2012-10-03 13:51:30,261 DEBUG   /de/docs/BrowserID -> /de/docs/BrowserID/Quick_Setup
2012-10-03 13:51:30,269 DEBUG   /pt-BR/docs/BrowserID -> /pt-BR/docs/BrowserID/Configuracao_Rapida
2012-10-03 13:51:30,279 DEBUG   /pt-BR/docs/Apps -> /pt-BR/docs/Apps/Manifest
2012-10-03 13:51:30,297 DEBUG   /ja/docs/JavaScript/Reference/Global_Objects/Function -> /ja/docs/JavaScript/Reference/Global_Objects/Function/name
2012-10-03 13:51:30,307 DEBUG   /pt-BR/docs/en -> /pt-BR/docs/JavaScript
2012-10-03 13:51:30,314 DEBUG   /pt-BR/docs/Apps -> /pt-BR/docs/Apps/Platform-specific_details
2012-10-03 13:51:30,325 DEBUG   /fr/docs/Mozilla -> /fr/docs/Mozilla/Boot_to_Gecko
2012-10-03 13:51:30,332 DEBUG   /zh-TW/docs/Mozilla -> /zh-TW/docs/Mozilla/Boot_to_Gecko
2012-10-03 13:51:30,344 DEBUG   /pt-BR/docs/Apps -> /pt-BR/docs/Apps/Submitting_an_app
2012-10-03 13:51:30,361 DEBUG   /ja/docs/JavaScript/Reference/Statements -> /ja/docs/Core_JavaScript_1.5_Reference/Statements/throw
2012-10-03 13:51:30,376 DEBUG   /pt-BR/docs/HTML/Element -> /pt-BR/docs/HTML/Element/Audio
2012-10-03 13:51:30,390 DEBUG   /ja/docs/JavaScript/Reference/Global_Objects/Function -> /ja/docs/JavaScript/Reference/Global_Objects/Function/caller
...
```
