### PR TITLE
fix bug 795092 - add statsd signin metrics

### DIFF
--- a/apps/users/utils.py
+++ b/apps/users/utils.py
@@ -5,6 +5,8 @@ from django.core.mail import send_mail
 from django.template.loader import render_to_string
 
 from tower import ugettext as _
+import waffle
+from django_statsd.clients import statsd
 
 from users.forms import RegisterForm, AuthenticationForm
 from users.models import RegistrationProfile
@@ -48,3 +50,8 @@ def send_reminder_email(user):
     send_to = user.email
     if send_to:
         send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [send_to])
+
+
+def statsd_waffle_incr(key, waffle_switch):
+    if waffle.switch_is_active(waffle_switch):
+        statsd.incr(key)


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=795092

Add some statsd calls behind a waffle switch. You can spot-check these locally in the django debug toolbar if you add statsd to it. In settings_local.py:

```
DEBUG_TOOLBAR_PANELS = (
...
    'django_statsd.panel.StatsdPanel',
...
)
...
STATSD_CLIENT = 'django_statsd.clients.toolbar'
...
```

should activate the statsd panel in the toolbar. Then go thru the browserid_register and sendemailreminder views where the statsd calls are made and verify that show up in the panel.
