### PR TITLE
nfs: false affects to puppet

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -65,7 +65,8 @@ Getting up and running
 
        nfs: false
 
-   The system will be a lot slower.
+   Note: If you decide to run nfs:false, the system will be a lot slower.  There is also the potential of running into
+   weird issues with puppet, since the current puppet configurations do not currently support nfs: false.
 
 -  Add developer-dev.mozilla.org to /etc/hosts::
 


### PR DESCRIPTION
Added a small change in the vagrant installation documentation to include a quick blurb about puppet being affected with nfs: false.
