### PR TITLE
Honor timeout disabling Kumascript during deferred rendering

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -722,9 +722,13 @@ class Document(NotificationsMixin, ModelBase):
         self.render_started_at = now
 
         # Perform rendering and update document
-        self.rendered_html, errors = kumascript.get(self, cache_control,
-                                                    base_url, timeout=timeout)
-        self.rendered_errors = errors and json.dumps(errors) or None
+        if not constance.config.KUMASCRIPT_TIMEOUT:
+            # A timeout of 0 should shortcircuit kumascript usage.
+            self.rendered_html, self.rendered_errors = self.html, []
+        else:
+            self.rendered_html, errors = kumascript.get(self, cache_control,
+                                                        base_url, timeout=timeout)
+            self.rendered_errors = errors and json.dumps(errors) or None
 
         # Finally, note the end time of rendering and update the document.
         self.last_rendered_at = datetime.now()

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -1044,6 +1044,7 @@ class DeferredRenderingTests(TestCase):
     def test_get_rendered(self, mock_kumascript_get):
         """get_rendered() should return rendered content when available,
         attempt a render() when it's not"""
+        constance.config.KUMASCRIPT_TIMEOUT = 1.0
         mock_kumascript_get.return_value = (self.rendered_content, None)
 
         # First, try getting the rendered version of a document. It should
@@ -1067,6 +1068,8 @@ class DeferredRenderingTests(TestCase):
         result_rendered, _ = d1_fresh.get_rendered(None, 'http://testserver/')
         ok_(not mock_kumascript_get.called)
         eq_(self.rendered_content, result_rendered)
+
+        constance.config.KUMASCRIPT_TIMEOUT = 0.0
 
     @mock.patch('wiki.kumascript.get')
     def test_one_render_at_a_time(self, mock_kumascript_get):
@@ -1100,6 +1103,7 @@ class DeferredRenderingTests(TestCase):
     def test_long_render_sets_deferred(self, mock_kumascript_get):
         """A rendering that takes more than a desired response time marks the
         document as in need of deferred rendering in the future."""
+        constance.config.KUMASCRIPT_TIMEOUT = 1.0
         rendered_content = self.rendered_content
         def my_kumascript_get(self, cache_control, base_url, timeout):
             time.sleep(1.0)
@@ -1113,6 +1117,7 @@ class DeferredRenderingTests(TestCase):
         constance.config.KUMA_DOCUMENT_FORCE_DEFERRED_TIMEOUT = 0.5
         self.d1.render('', 'http://testserver/')
         ok_(self.d1.defer_rendering)
+        constance.config.KUMASCRIPT_TIMEOUT = 0.0
 
     @mock.patch('wiki.kumascript.get')
     @mock.patch_object(tasks.render_document, 'delay')

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -389,6 +389,16 @@ class KumascriptIntegrationTests(TestCaseBase):
             "kumascript not should have been used")
 
     @mock.patch('wiki.kumascript.get')
+    def test_disabled_rendering(self, mock_kumascript_get):
+        """When disabled, the kumascript service should not be used in rendering"""
+        mock_kumascript_get.return_value = (self.d.html, None)
+        constance.config.KUMASCRIPT_TIMEOUT = 0.0
+        settings.CELERY_ALWAYS_EAGER = True
+        self.d.schedule_rendering('max-age=0')
+        ok_(not mock_kumascript_get.called,
+            "kumascript not should have been used")
+
+    @mock.patch('wiki.kumascript.get')
     def test_nomacros(self, mock_kumascript_get):
         mock_kumascript_get.return_value = (self.d.html, None)
         constance.config.KUMASCRIPT_TIMEOUT = 1.0


### PR DESCRIPTION
I don't think there's a bug for this, but I was finally able to reproduce the issue where the kumascript service gets hit by tests on my vagrant box when it shouldn't. This should fix it.

Whether or not this affects jenkins' long test runs, I don't know. I have a hunch that _maybe_ it will.
