### PR TITLE
Stop using kumawiki waffle flag entirely

### DIFF
--- a/apps/devmo/templates/devmo/profile.html
+++ b/apps/devmo/templates/devmo/profile.html
@@ -113,9 +113,8 @@
         </section>
     {% endif %}
 
-    {% if waffle.flag('kumawiki') %}
       {% if wiki_activity and wiki_activity | length > 0 %}
-          <section id="docs-activity" class="profile-section kumawiki">
+          <section id="docs-activity" class="profile-section">
             <header>
               <h2>{{_("Recent Docs Activity")}}</h2>
             </header>
@@ -155,7 +154,7 @@
             </table>
           </section>
       {% else %}
-        <section id="docs-activity" class="profile-section kumawiki">
+        <section id="docs-activity" class="profile-section">
           <header>
             <h2>{{_('Recent Docs Activity')}}</h2>
           </header>
@@ -166,70 +165,6 @@
           {% endif %}
         </section>
       {% endif %}
-    {% else %}
-      {% if docs_feed_items and docs_feed_items | length > 0 %}
-        <section id="docs-activity" class="profile-section mindtouch">
-          <header>
-            <h2>{{_("Recent Docs Activity")}}</h2>
-            <p class="more"><a href="/Special:Contributions?target={{profile.user.username | urlencode}}">{{_("See more history")}}</a></p>
-          </header>
-          <table class="activity">
-            <thead>
-              <th scope="col" class="page">{{_("Page")}}</th>
-              <th scope="col" class="date">{{_("Date")}}</th>
-              <th scope="col" class="summary">{{_("Edit summary")}}</th>
-            </thead>
-            <tbody>
-              {% for item in docs_feed_items %}
-              <tr>
-                <th scope="row">
-                    <h3>
-                        {% if item.view_url %}
-                          <a href="{{ item.view_url }}">{{ item.rc_title }}</a>
-                        {% else %}
-                          <span>{{ item.rc_title }}</span>
-                        {% endif %}
-                    </h3>
-                    <ul class="actions">
-                        {% if item.edit_url %}
-                            <li><a href="{{ item.edit_url }}" class="edit">{{_("Edit page")}}</a></li>
-                        {% endif %}
-                        {% if item.diff_url %}
-                            <li><a href="{{ item.diff_url }}" class="diff">{{_("View complete diff")}}</a></li>
-                        {% endif %}
-                        {% if item.history_url %}
-                            <li><a href="{{ item.history_url }}" class="history">{{_("View page history")}}</a></li>
-                        {% endif %}
-                    </ul>
-                </th>
-                <td>{{ item.rc_timestamp.strftime('%B %d, %Y') }}<br>
-                    {{ item.rc_timestamp.strftime('%I:%M %p') }}</td>
-                <td>{{ item.rc_comment }}</td>
-              </tr>
-              {% endfor %}
-            </tbody>
-            <tfoot>
-              <tr>
-                <td colspan="3">
-                    <a href="/index.php?title=Special:Contributions&feed=rss&target={{profile.user.username | urlencode}}" rel="alternate" class="feed">{{_("Feed")}}</a>
-                </td>
-              </tr>
-            </tfoot>
-          </table>
-        </section>
-      {% else %}
-        <section id="docs-activity" class="profile-section mindtouch">
-          <header>
-              <h2>{{_('Recent Docs Activity')}}</h2>
-          </header>
-        {% if profile.user == request.user %}
-          {% trans docs_url=url('docs.views.docs') %}
-              <p class="none">You haven't contributed to any MDN docs. <a href="{{docs_url}}">Pitch in!</a></p>
-          {% endtrans %}
-        {% endif %}
-        </section>
-      {% endif %}
-    {% endif %}
 
   </section><!-- /#content-main -->
 </div>

--- a/apps/devmo/tests/test_views.py
+++ b/apps/devmo/tests/test_views.py
@@ -145,19 +145,6 @@ class ProfileViewsTest(TestCase):
         except PageNotAnInteger:
             ok_(False, "Non-numeric page number should not cause an error")
 
-    def test_kumawiki_docs_activity(self):
-        profile = UserProfile.objects.get(user__username='testuser')
-        user = profile.user
-        url = reverse('devmo.views.profile_view',
-                      args=(user.username,))
-        r = self.client.get(url, follow=True)
-        doc = pq(r.content)
-        ok_(doc.find('#docs-activity').hasClass('mindtouch'))
-        Flag.objects.create(name='kumawiki', everyone=True)
-        r = self.client.get(url, follow=True)
-        doc = pq(r.content)
-        ok_(doc.find('#docs-activity').hasClass('kumawiki'))
-
     @mock_put_mindtouch_user
     @mock_fetch_user_feed
     def test_profile_edit(self):

--- a/apps/devmo/views.py
+++ b/apps/devmo/views.py
@@ -62,12 +62,7 @@ def profile_view(request, username):
     demos_page = demos_paginator.page(page_number)
 
     wiki_activity, docs_feed_items = None, None
-    if waffle.flag_is_active(request, 'kumawiki'):
-        wiki_activity = profile.wiki_activity()
-    else:
-        docs_feed_items = UserDocsActivityFeed(user.username).items
-        if docs_feed_items is not False:
-            docs_feed_items = docs_feed_items[:DOCS_ACTIVITY_MAX_ITEMS]
+    wiki_activity = profile.wiki_activity()
 
     return jingo.render(request, 'devmo/profile.html', dict(
         profile=profile, demos=demos, demos_paginator=demos_paginator,

--- a/apps/docs/templates/docs/docs.html
+++ b/apps/docs/templates/docs/docs.html
@@ -123,7 +123,6 @@
     </div>
     {% endif %}
 
-    {% if waffle.flag('kumawiki') %}
     {% set review_flags = (
         ('technical', _('Needs Technical Review')),
         ('editorial', _('Needs Editorial Review')),
@@ -143,7 +142,6 @@
         </div>
         {% endif %}
     {% endfor %}
-    {% endif %}
 
     {% if dotd %}
     <div class="module hfeed" id="doc-of-the-day">

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -20,13 +20,10 @@ class TestCaseBase(TestCase):
         super(TestCaseBase, self).setUp()
         self.client = LocalizingClient()
 
-        self.kumawiki_flag = Flag.objects.create(name='kumawiki',
-                                                 everyone=True)
         self.kumaediting_flag = Flag.objects.create(name='kumaediting',
                                                    everyone=True)
 
     def tearDown(self):
-        self.kumawiki_flag.delete()
         self.kumaediting_flag.delete()
 
 

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -289,7 +289,6 @@ def get_seo_description(content):
     return seo_summary
 
 
-@waffle_flag('kumawiki')
 @require_http_methods(['GET', 'HEAD'])
 @process_document_path
 @condition(last_modified_func=_document_last_modified)
@@ -535,7 +534,6 @@ def document(request, document_slug, document_locale):
     return set_common_headers(response)
 
 
-@waffle_flag('kumawiki')
 @prevent_indexing
 @process_document_path
 def revision(request, document_slug, document_locale, revision_id):
@@ -547,7 +545,6 @@ def revision(request, document_slug, document_locale, revision_id):
     return jingo.render(request, 'wiki/revision.html', data)
 
 
-@waffle_flag('kumawiki')
 @require_GET
 def list_documents(request, category=None, tag=None):
     """List wiki documents."""
@@ -574,7 +571,6 @@ def list_documents(request, category=None, tag=None):
                          'category': category,
                          'tag': tag})
 
-@waffle_flag('kumawiki')
 @require_GET
 def list_templates(request):
     """Returns listing of all templates"""
@@ -585,7 +581,6 @@ def list_templates(request):
                          'is_templates': True})
 
 
-@waffle_flag('kumawiki')
 @require_GET
 def list_documents_for_review(request, tag=None):
     """Lists wiki documents with revisions flagged for review"""
@@ -598,7 +593,6 @@ def list_documents_for_review(request, tag=None):
                          'tag_name': tag})
 
 
-@waffle_flag('kumawiki')
 @login_required
 @check_readonly
 @prevent_indexing
@@ -704,7 +698,6 @@ def new_document(request):
                          'parent_path': parent_path})
 
 
-@waffle_flag('kumawiki')
 @require_http_methods(['GET', 'POST'])
 @login_required  # TODO: Stop repeating this knowledge here and in
                  # Document.allows_editing_by.
@@ -989,7 +982,6 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_iframe_target,
     return response
 
 
-@waffle_flag('kumawiki')
 def ckeditor_config(request):
     """Return ckeditor config from database"""
     default_config = EditorToolbar.objects.filter(name='default').all()
@@ -1002,7 +994,6 @@ def ckeditor_config(request):
                        mimetype="application/x-javascript")
 
 
-@waffle_flag('kumawiki')
 @login_required
 @require_POST
 def preview_revision(request):
@@ -1024,7 +1015,6 @@ def preview_revision(request):
     return jingo.render(request, 'wiki/preview.html', data)
 
 
-@waffle_flag('kumawiki')
 @require_GET
 def autosuggest_documents(request):
     """Returns the closest title matches for front-end autosuggests"""
@@ -1065,7 +1055,6 @@ def autosuggest_documents(request):
     return HttpResponse(data, mimetype='application/json')
 
 
-@waffle_flag('kumawiki')
 @require_GET
 @process_document_path
 @prevent_indexing
@@ -1089,7 +1078,6 @@ def document_revisions(request, document_slug, document_locale):
                         {'revisions': revs_out, 'document': doc})
 
 
-@waffle_flag('kumawiki')
 @login_required
 @permission_required('wiki.review_revision')
 @process_document_path
@@ -1138,7 +1126,6 @@ def review_revision(request, document_slug, document_locale, revision_id):
     return jingo.render(request, template, data)
 
 
-@waffle_flag('kumawiki')
 @require_GET
 @process_document_path
 @prevent_indexing
@@ -1163,7 +1150,6 @@ def compare_revisions(request, document_slug, document_locale):
                          'revision_to': revision_to})
 
 
-@waffle_flag('kumawiki')
 @login_required
 @process_document_path
 def select_locale(request, document_slug, document_locale):
@@ -1173,7 +1159,6 @@ def select_locale(request, document_slug, document_locale):
     return jingo.render(request, 'wiki/select_locale.html', {'document': doc})
 
 
-@waffle_flag('kumawiki')
 @require_http_methods(['GET', 'POST'])
 @login_required
 @process_document_path
@@ -1341,7 +1326,6 @@ def translate(request, document_slug, document_locale, revision_id=None):
                          'specific_slug': slug_dict['specific'], 'parent_slug': slug_dict['parent']})
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 @process_document_path
@@ -1353,7 +1337,6 @@ def watch_document(request, document_slug, document_locale):
     return HttpResponseRedirect(document.get_absolute_url())
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 @process_document_path
@@ -1365,7 +1348,6 @@ def unwatch_document(request, document_slug, document_locale):
     return HttpResponseRedirect(document.get_absolute_url())
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 def watch_locale(request):
@@ -1376,7 +1358,6 @@ def watch_locale(request):
     return HttpResponseRedirect(reverse('dashboards.localization'))
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 def unwatch_locale(request):
@@ -1386,7 +1367,6 @@ def unwatch_locale(request):
     return HttpResponseRedirect(reverse('dashboards.localization'))
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 def watch_approved(request):
@@ -1399,7 +1379,6 @@ def watch_approved(request):
     return HttpResponseRedirect(reverse('dashboards.localization'))
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @login_required
 def unwatch_approved(request):
@@ -1412,7 +1391,6 @@ def unwatch_approved(request):
     return HttpResponseRedirect(reverse('dashboards.localization'))
 
 
-@waffle_flag('kumawiki')
 @require_GET
 @process_document_path
 @prevent_indexing
@@ -1441,7 +1419,6 @@ def json_view(request, document_slug=None, document_locale=None):
     return HttpResponse(data, mimetype='application/json')
 
 
-@waffle_flag('kumawiki')
 @require_GET
 @process_document_path
 @prevent_indexing
@@ -1464,7 +1441,6 @@ def code_sample(request, document_slug, document_locale, sample_id):
     return response
 
 
-@waffle_flag('kumawiki')
 @require_POST
 @process_document_path
 def helpful_vote(request, document_slug, document_locale):
@@ -1501,7 +1477,6 @@ def helpful_vote(request, document_slug, document_locale):
     return HttpResponseRedirect(document.get_absolute_url())
 
 
-@waffle_flag('kumawiki')
 @login_required
 @check_readonly
 def revert_document(request, document_path, revision_id):
@@ -1523,7 +1498,6 @@ def revert_document(request, document_path, revision_id):
                                 args=[document.full_path]))
     
 
-@waffle_flag('kumawiki')
 @login_required
 @permission_required('wiki.delete_revision')
 @check_readonly

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -36,17 +36,6 @@ Hacking on bleeding edge features
 =================================
 To hack on the features not yet ready for production you have to enable them first.
 
-Enable kumawiki in waffle
--------------------------
-
-The Kuma wiki is disabled by default using `django-waffle`_. To test out the wiki,
-open the django admin interface (``http://.../admin/``) and add a ``kumawiki`` flag
-in the Waffle section.
-
-Note that features disabled by a flag will show up as a 404 error.
-
-.. _django-waffle: https://github.com/jsocol/django-waffle
-
 Enable Kumascript
 -----------------
 

--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -138,4 +138,4 @@ What’s next?
 
        ./manage.py createsuperuser
 
--  To allow creation and editing of documents, go to /admin/, go to the waffle section and add flags called ``kumaediting`` and ``kumawiki``
+-  To allow creation and editing of documents, go to /admin/, go to the waffle section and add flags called ``kumaediting``


### PR DESCRIPTION
We don't even need the `kumawiki` waffle flag anymore, so here's a follow up to #662 that excises it from the project entirely.

Submitting this separately from #662, though, so its more widespread changes can be reviewed after the jenkins test build is fixed.
