### PR TITLE
bug 799155 - smarter font access and caching controls

### DIFF
--- a/media/fonts/.htaccess
+++ b/media/fonts/.htaccess
@@ -1,10 +1,10 @@
 # block hotlinking to .woff and .eof files
 RewriteCond "%{HTTP_REFERER}" "!https?://.*mozilla\.(com|org)/.*$"
-RewriteRule \.(woff|eot)$ - [F,NC,L]
+RewriteRule \.(woff|eot)$ - [F,NC,L,E=!CORS]
 
 <FilesMatch "\.(ttf|woff|eot)$">
-    Header append vary "Referer"
+    Header append vary "Origin"
     ExpiresActive On
     ExpiresDefault "access plus 2 weeks"
-    Header set Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Origin "*" env=CORS
 </FilesMatch>


### PR DESCRIPTION
new approach for https://bugzilla.mozilla.org/show_bug.cgi?id=799155#c13 considering https://bugzilla.mozilla.org/show_bug.cgi?id=540859
1. Prevent hot-linking AND cross-origin sharing of the font.
2. Vary the cache on the origin rather than the Referer.
