### PR TITLE
fix bug 802700 - Prevent SPANs and URL linking

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -617,6 +617,12 @@
 
     function initSyntaxHighlighter() {
         SyntaxHighlighter.defaults.toolbar = false;
+        $('pre').each(function() {
+            var $this = $(this),
+                newText = $this.text().replace(/<span class="nowiki">(.*)<\/span>/g, '$1');
+            this.className += " auto-links: false;";
+            $this.text(newText);
+        });
         SyntaxHighlighter.all();
     }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=802700

To spot-check:
1.  Create a document with two or more blocks like this:

https://developer.mozilla.org/en-US/docs/User:trevorh/bTest
1.  Look at this page without the fix -- you'll see a weird SPAN element in there and the URL is linked
2.  Then use this fix -- no span, no link.
