### PR TITLE
fix bug 778206 - Remove 'autoclose' for link dialog

### DIFF
--- a/media/ckeditor/plugins/mdn-link/dialogs/link.js
+++ b/media/ckeditor/plugins/mdn-link/dialogs/link.js
@@ -406,12 +406,6 @@ CKEDITOR.dialog.add( 'link', function( editor )
 		// Set the link in the "link" pane, put value into place
 		//dialog.selectPage("info");
 		dialog.setValueOf('info', 'url', autoCompleteSelection.href);
-		
-		// Trigger "OK"
-		if(submit) {
-			dialog.definition.onOk.call(dialog);
-			dialog.hide();
-		}
 	}
 
 	// Returns the default slug for the give page ("/{lang}/docs/")


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=778206
