### PR TITLE
fix bug 781822 - Prevent attachment size issue

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -225,7 +225,7 @@ def _format_attachment_obj(attachments):
             'date': str(attachment.current_revision.created),
             'description': attachment.current_revision.description,
             'url': attachment.get_file_url(),
-            'size': attachment.current_revision.file.size,
+            'size': 0,
             'creator': attachment.current_revision.creator.username,
             'creatorUrl': reverse('devmo.views.profile_view', 
                             args=[attachment.current_revision.creator]),
@@ -233,6 +233,13 @@ def _format_attachment_obj(attachments):
             'id': attachment.id,
             'mime': attachment.current_revision.mime_type
         }
+
+        # Adding this to prevent "UnicodeEncodeError" for certain media
+        try:
+            obj['size'] = attachment.current_revision.file.size
+        except:
+            logging.debug('Cannot attain file size')
+
         obj['html'] = mark_safe(html.render({ 'attachment': obj }))
         attachments_list.append(obj)
     return attachments_list


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=781822

Cannot duplicate the exact issue locally, but using the traceback, I'm fairly certain this fix this ugly issue.  Showing "0" as the file size is much better than 500 errors.
