### PR TITLE
fix bug 810068 - Add boilerplate code button for live samples

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -84,7 +84,7 @@ CKEDITOR.mdn = {};
 
 CKEDITOR.editorConfig = function(config) {
 
-    config.extraPlugins = 'autogrow,definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort';
+    config.extraPlugins = 'autogrow,definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler';
     config.removePlugins = 'link,image,tab,enterkey,table';
     config.entities = false;
     
@@ -93,7 +93,7 @@ CKEDITOR.editorConfig = function(config) {
         ['BulletedList', 'NumberedList', 'DefinitionList', 'DefinitionTerm', 'DefinitionDescription', '-', 'Outdent', 'Indent', 'Blockquote', '-', 'Image', 'MDNTable', '-', 'TextColor', 'BGColor', '-', 'BidiLtr', 'BidiRtl'],
         ['Maximize'],
         '/',
-        ['h1Button', 'h2Button', 'h3Button', 'h4Button', 'h5Button', 'h6Button', '-', 'preButton', 'mdn-syntaxhighlighter', 'Styles'],
+        ['h1Button', 'h2Button', 'h3Button', 'h4Button', 'h5Button', 'h6Button', '-', 'preButton', 'mdn-syntaxhighlighter', 'mdn-sampler', 'Styles'],
         ['Link', 'Unlink', 'Anchor', '-', 'Bold', 'Italic', 'Underline', 'codeButton', 'Strike', 'Superscript', 'RemoveFormat', '-', 'JustifyLeft', 'JustifyCenter', 'JustifyRight']
     ];
     

--- a/media/ckeditor/plugins/mdn-sampler/plugin.js
+++ b/media/ckeditor/plugins/mdn-sampler/plugin.js
@@ -1,0 +1,50 @@
+/*
+	Customized plugin added by David Walsh (:davidwalsh, dwalsh@mozilla.com)
+	
+	This plugin inserts boilerplate live sample content
+*/
+CKEDITOR.plugins.add('mdn-sampler', {
+
+	requires: ['selection'],
+	
+	init: function(editor) {
+
+		editor.addCommand('mdnSampler', {
+			exec: function (editor, data) {
+
+				// Inject heading
+				var heading = new CKEDITOR.dom.element('h2', editor.document);
+				heading.setText(gettext('Sample Title'));
+				editor.insertElement(heading);
+
+				// Inject Pre[html]
+				var htmlPre = new CKEDITOR.dom.element('pre', editor.document);
+				htmlPre.setText(gettext('Sample HTML Content'));
+				htmlPre.setAttribute('class', 'brush:html;');
+				editor.insertElement(htmlPre);
+
+				// Inject Pre[css]
+				var cssPre = new CKEDITOR.dom.element('pre', editor.document);
+				cssPre.setText(gettext('Sample CSS Content'));
+				cssPre.setAttribute('class', 'brush:css;');
+				editor.insertElement(cssPre);
+
+				// Inject Pre[js]
+				var jsPre = new CKEDITOR.dom.element('pre', editor.document);
+				jsPre.setText(gettext('Sample JS Content'));
+				jsPre.setAttribute('class', 'brush:js;');
+				editor.insertElement(jsPre);
+			}
+		});
+
+		var label = 'Insert Code Sample Template';
+		editor.ui.addButton('mdn-sampler', {
+			label: label,
+			title: label,
+			className: 'cke_button_mdn_sampler',
+			command: 'mdnSampler',
+			iconOffset: 43,
+			icon: editor.skinPath + 'icons.png'
+		});
+	}
+});


### PR DESCRIPTION
Button shows up next to the syntax highlighter.  Click it and boilerplate section info will be created, as requested by Les.
