### PR TITLE
Make code sample extraction selector more robust, to find brush:html; and friends in syntaxhighlighter conventions

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -73,8 +73,15 @@ def extract_code_sample(id, src):
         else:
             # If no section, fall back to plain old ID lookup
             sample = pq(src).find('#%s' % id)
-        for x in parts:
-            data[x] = sample.find('.%s' % x).text()
+        for part in parts:
+            selector = ','.join(x % (part,) for x in (
+                '.%s',
+                # HACK: syntaxhighlighter (ab)uses the className as a
+                # semicolon-separated options list...
+                'pre[class*="brush:%s"]',
+                'pre[class*="%s;"]'
+            ))
+            data[part] = sample.find(selector).text()
     except:
         pass
     return data

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -513,15 +513,15 @@ class ContentSectionToolTests(TestCase):
             <p>This is a page. Deal with it.</p>
 
             <h3 id="sample0">This is a section</h3>
-            <pre class="brush: html">section html</pre>
-            <pre class="brush: css">section css</pre>
+            <pre class="brush:html; highlight: [5, 15]; html-script: true">section html</pre>
+            <pre class="brush:css;">section css</pre>
             <pre class="brush: js">section js</pre>
 
             <h3>The following is a new section</h3>
 
             <div id="sample1" class="code-sample">
-                <pre class="brush: html">Ignore me</pre>
-                <pre class="brush: css">Ignore me</pre>
+                <pre class="brush: html;">Ignore me</pre>
+                <pre class="brush:css;">Ignore me</pre>
                 <pre class="brush: js">Ignore me</pre>
             </div>
 
@@ -530,7 +530,7 @@ class ContentSectionToolTests(TestCase):
                     <pre class="brush: html">%s</pre>
                 </li>
                 <li><span>CSS</span>
-                    <pre class="brush: css">%s</pre>
+                    <pre class="brush:css;random:crap;in:the;classname">%s</pre>
                 </li>
                 <li><span>JS</span>
                     <pre class="brush: js">%s</pre>


### PR DESCRIPTION
As-is, the code sample extraction code only matches `.html`, `.css`, and `.js`, which makes the assumption that code blocks have something like `class="brush: html`

However, something like this is also [to be expected in syntaxhighlighter world](http://alexgorbatchev.com/SyntaxHighlighter/manual/configuration/#parameters):

```
<pre class="brush:html; highlight: [5, 15]; html-script: true">section html</pre>
```

This PR expands the selector used for code sample extraction to handle more of these cases
