### PR TITLE
Expose current revision ID to kumascript for versioning URLs

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -124,6 +124,7 @@ def get(document, cache_control, base_url, timeout=None):
             path=path,
             url=urljoin(base_url, path),
             id=document.pk,
+            revision_id=document.current_revision.pk,
             locale=document.locale,
             title=document.title,
             files=files,


### PR DESCRIPTION
Quick tweak which exposes the document's current revision ID as `env.revision_id` to templates. 

This should help with live samples, because we can add `?revision=<%=env.revision_id%>` to the iframe src URL and ensure it gets reloaded fresh when the page is edited - which doesn't happen all the time right now.
