### PR TITLE
fix bug 726982 - Add open search to MDN

### DIFF
--- a/apps/search/templates/search/plugin.html
+++ b/apps/search/templates/search/plugin.html
@@ -1,10 +1,10 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
                        xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
-<ShortName>{{ _('Firefox Help') }}</ShortName>
-{# L10n: The description for the OpenSearch plugin. #}
-<Description>{{ _('Search the Firefox Support Knowledge Base and Support Forum.') }}</Description>
+<ShortName>{{ _('Mozilla Developer Network') }}</ShortName>
+{# L10n: Search Mozilla Developer Network documentation #}
+<Description>{{ _('Search Mozilla Developer Network documentation') }}</Description>
 <InputEncoding>UTF-8</InputEncoding>
-<Image width="16" height="16" type="image/png">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABEAAAARCAYAAAA7bUf6AAAAAXNSR0IArs4c6QAAAAlwSFlzAAALEwAACxMBAJqcGAAAAAd0SU1FB9kDEQYMLMwA8jAAAAI1SURBVDjLhZNdSFNhGMd/G2NYMNPIEULhJjkXahaMglbEopvo8y63KHfRdasI7AOtiyAsMIMu6qYVeqhuMomgC71aDJ3gREqP66wlqTEtTkg1lvh2sXPGPvWB9+I873t+7/t/nv9jEEJQLuod3lagClAVWYqWO2cohNQ7vHVAF3BKA+ihAgPAbUWWEmUh9Q5vAOhh/bikyNKDIkghwLrZgudAC7W1NSzMLxIemyYx96MkyCCE0LWP67sXfEfo6PQXXd/39B3dva/4/Tetp3YrshQ1aR8X9eyZk/vp6PQzPJsilEwTWV7BZTHhtpo56z8KQNfdPnL+8+svEbqEcPgxw7Mp7n/+Q0orV2zaB8Cz46/xbK/gxLGrfIzNAaDIksGoSQGgybENgFAyzeSUD4P4lycnlMzIaNlZl2cDY24brTXVAESWVzAbzajzjwDY0difzQM0Om257CojkO15/OsCAC6LifRqmuRyJO8lLkumhGORqdx0wqgZJwEwOhFnMhrDbTXT7OzPAzQ7+3FbzQCMjM9kDajIUsIEsHVLZe/qqujZuMHMjZtPGHx7L1ODypfZ7lTEP+Hx7KOltT23xcE8sy18SwqApaVfOJtsLH7/yaZqC0PvRzno2UP3nee8GPxAwRjYFFlSdZ/gPhwI7t1lb792/TznvLcYmYivZXsVOK3IklpqdnqAQGgoMxZXLj8sBUtogOh6U/ylxO0DwBtFloJFO0KIssve0FZlb2g7tNYZIQT/AV1CFURmrsy6AAAAAElFTkSuQmCC</Image>
+<Image width="16" height="16" type="image/png">https://developer.mozilla.org/media/img/favicon.ico</Image>
 <Url type="text/html" method="get" template="https://{{ site }}/{{ locale }}/search">
   <Param name="q" value="{searchTerms}"/>
   <Param name="w" value="3"/>

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,6 +21,9 @@
   <!--[if lte IE 6]><link rel="stylesheet" type="text/css" media="all" href="{{ MEDIA_URL }}css/mdn-ie6.css"><![endif]-->
   <link rel="stylesheet" type="text/css" media="print" href="{{ MEDIA_URL }}css/mdn-print.css">
   <link rel="stylesheet" href="//www.mozilla.org/tabzilla/media/css/tabzilla.css">
+
+  <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.locale }}/search/xml" title="{{ _('Mozilla Developer Network') }}" />
+
   {% endblock %}
 
   <!--[if IE]>


### PR DESCRIPTION
Add open search to MDN.  Please test this as caching is all weird on my machine and I'm still seeing "Firefox Help".
