### PR TITLE
table.diff { background: #fff }

### DIFF
--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -479,6 +479,7 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 }
 
 table.diff {
+    background: #fff;
     border: 1px solid #ccc;
     clear: both;
     margin: 5px 0 15px;


### PR DESCRIPTION
Sometimes, horizontal scroll bar appears on the diff page.
If you scroll, the background will appear black, and character will difficult to read.

Coloring the background, to avoid such problems.
