### PR TITLE
fix bug 811888 - add CORS for mdn.mozillademos.org

### DIFF
--- a/media/fonts/.htaccess
+++ b/media/fonts/.htaccess
@@ -1,5 +1,6 @@
 # CORS only for mozilla domains
 SetEnvIf Origin "https?://(.*\.mozilla\.(com|org|net))" CORS=$0
+SetEnvIf Origin "https?://(mdn\.mozillademos\.org)" CORS=$0
 Header set Access-Control-Allow-Origin %{CORS}e env=CORS
 
 # block hotlinking by referer to .woff, .eof, .ttf files except mozilla domains


### PR DESCRIPTION
Not a good way to test locally. Real test is production.
