### PR TITLE
Replace deprecated function with its new name

### DIFF
--- a/media/js/mdn/init.js
+++ b/media/js/mdn/init.js
@@ -135,7 +135,7 @@ jQuery.extend({
   function bindBrowserIDSignin() {
     $('.browserid-signin').click(function (e) {
       if ( !$(this).hasClass('toggle') ) {
-        navigator.id.getVerifiedEmail(function(assertion) {
+        navigator.id.get(function(assertion) {
           if (!assertion) { return; }
           $('input[name="assertion"]').val(assertion.toString());
           $('form.browserid').first().submit();


### PR DESCRIPTION
navigator.id.getVerifiedEmail() is deprecated and will be removed
in the future:

  https://developer.mozilla.org/en-US/docs/DOM/navigator.id.getVerifiedEmail
