### PR TITLE
fix bug 819999: Code sample extraction replaces non-breaking spaces with normal spaces

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -102,7 +102,11 @@ def extract_code_sample(id, src):
                 'pre[class*="brush:%s"]',
                 'pre[class*="%s;"]'
             ))
-            data[part] = sample.find(selector).text()
+            src = sample.find(selector).text()
+            if src is not None:
+                # Bug 819999: &nbsp; gets decoded to \xa0, which trips up CSS
+                src = src.replace(u'\xa0', u' ')
+            data[part] = src
     except:
         pass
     return data

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -495,7 +495,6 @@ class ContentSectionToolTests(TestCase):
         except e:
             ok_(False, "There should not have been an exception")
 
-    @attr('current')
     def test_sample_code_extraction(self):
         sample_html = u"""
             <div class="foo">
@@ -584,6 +583,24 @@ class ContentSectionToolTests(TestCase):
         eq_(None, result['html'])
         eq_(None, result['css'])
         eq_(None, result['js'])
+
+    def test_bug819999(self):
+        """Non-breaking spaces are turned to normal spaces in code sample
+        extraction."""
+        doc_src = """
+            <h2 id="bug819999">Bug 819999</h2>
+            <pre class="brush: css">
+            .widget select,
+            .no-widget .select {
+            &nbsp; position : absolute;
+            &nbsp; left&nbsp;&nbsp;&nbsp;&nbsp; : -5000em;
+            &nbsp; height&nbsp;&nbsp; : 0;
+            &nbsp; overflow : hidden;
+            }
+            </pre>
+        """
+        result = wiki.content.extract_code_sample('bug819999', doc_src)
+        ok_(result['css'].find(u'\xa0') == -1)
 
     def test_iframe_host_filter(self):
         slug = 'test-code-embed'


### PR DESCRIPTION
This should fix bug 819999. Looks like `&nbsp;`'s introduced by pasting code into CKEditor turn into `\0x0a` non-breaking space characters. But, these result in CSS parsing errors. So, this PR introduces a quick hack to convert `\0x0a` to normal spaces, which seems to address the issue.
