### PR TITLE
Prevent create-on-404 if the user isn't logged in

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -393,7 +393,8 @@ def document(request, document_slug, document_locale):
             # If any of these parameters are present, throw a real 404.
             if (request.GET.get('raw', False) is not False or
                 request.GET.get('include', False) is not False or
-                request.GET.get('nocreate', False) is not False):
+                request.GET.get('nocreate', False) is not False or
+                not request.user.is_authenticated()):
                 raise Http404
 
             # The user may be trying to create a child page; if a parent exists

--- a/templates/404.html
+++ b/templates/404.html
@@ -26,10 +26,8 @@
     <p>We're sorry, we couldn't find what you were looking for.</p>
     
     <p>You can <a href="#q">try a search</a> or start over on the <a href="{{ url('home') }}">home page</a>.</p>
-    
-    <p>If you were following a broken link, please
-    <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Mozilla%20Developer%20Network&component=Website" rel="nofollow">file a bug.</a>
-    Thanks!</p>
+
+    <p>If you were following a documentation link, you can <a href="/login/next={{ request.get_full_path() }}" class="browserid-signin" aria-haspopup="true" title="{{ _('Sign in with Persona') }}">sign in</a> and create the page. Otherwise, please <a href="https://bugzilla.mozilla.org/enter_bug.cgi?product=Mozilla%20Developer%20Network&component=Website" rel="nofollow">file a bug</a>. Thanks!</p>
     
     <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>
     


### PR DESCRIPTION
Users get confused when they are redirected to login when a page doesn't exist.  Let's prevent that with this bandaid.
