### PR TITLE
fix bug 821988: Use wiki bleach filter on revision content

### DIFF
--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -135,3 +135,9 @@ def colorize_diff(diff):
     diff = diff.replace('<span class="diff_chg"', '<span class="diff_chg" '
                 'style="background-color: #fe0; text-decoration: none;"')
     return diff
+
+
+@register.filter
+def wiki_bleach(val):
+    from wiki.models import Document
+    return jinja2.Markup(Document.objects.clean_content(val))

--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -82,7 +82,7 @@
     <details class="h2">
       <summary>{{ _('Revision Content') }}</summary>
       <div id="doc-content">
-        <div class="page-content boxed">{{ revision.content|safe }}</div>
+        <div class="page-content boxed">{{ revision.content|wiki_bleach }}</div>
       </div>
     </details>
   </article>

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -192,6 +192,18 @@ class ViewTests(TestCaseBase):
         json_obj = json.loads(resp.content)
         eq_(json_obj['subpages'][0]['title'], 'A Child')
 
+    def test_revision_view_bleached_content(self):
+        """Bug 821988: Revision content should be cleaned with bleach"""
+        d, r = doc_rev("""
+            <a href="#" onload=alert(3)>Hahaha</a>
+            <svg><svg onload=alert(3);>
+        """)
+        resp = self.client.get(r.get_absolute_url())
+        page = pq(resp.content)
+        ct = page.find('#doc-content .page-content').html()
+        ok_('<svg>' not in ct)
+        ok_('<a href="#">Hahaha</a>' in ct)
+
 
 class PermissionTests(TestCaseBase):
 


### PR DESCRIPTION
Revision content is decidedly not safe. So, pass it through a wiki bleach filter instead.
