### PR TITLE
fix bug 826444 - Prevent fullscreen plugin for editing

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -95,7 +95,7 @@ CKEDITOR.editorConfig = function(config) {
     config.toolbar_MDN = [
         ['Source', 'mdnSave', 'mdnSaveExit', '-', 'PasteText', 'PasteFromWord', '-', 'SpellChecker', 'Scayt', '-', 'Find', 'Replace', '-', 'ShowBlocks'],
         ['BulletedList', 'NumberedList', 'DefinitionList', 'DefinitionTerm', 'DefinitionDescription', '-', 'Outdent', 'Indent', 'Blockquote', '-', 'Image', 'MDNTable', '-', 'TextColor', 'BGColor', '-', 'BidiLtr', 'BidiRtl'],
-        ['Maximize'],
+        CKEDITOR.isSectionEdit ? null : ['Maximize'],
         '/',
         ['h1Button', 'h2Button', 'h3Button', 'h4Button', 'h5Button', 'h6Button', 'Styles'],
         ['preButton', 'mdn-syntaxhighlighter', 'mdn-sampler', 'mdn-sample-finder'],

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -190,6 +190,7 @@
             .before(ui)
             .removeClass('edited-section-loading');
         // Fire up the CKEditor, stash it in the UI's data store
+        CKEDITOR.isSectionEdit = 1;
         $('.edited-section-ui.current')
             .data('edit_url', section_edit_url)
             .data('editor',


### PR DESCRIPTION
Adding this property to the main CKEDITOR object because I can't get to the config before the instance is created.

https://bugzilla.mozilla.org/show_bug.cgi?id=826444
