### PR TITLE
fix bug 826456 - send review_tags to kumascript

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -131,6 +131,8 @@ def get(document, cache_control, base_url, timeout=None):
             attachments=files,  # Just for sake of verbiage?
             slug=document.slug,
             tags=[x.name for x in document.tags.all()],
+            review_tags=[x.name for x in
+                         document.current_revision.review_tags.all()],
             modified=time.mktime(document.modified.timetuple()),
             cache_control=cache_control,
         )


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=826456

To test: add `<%= env.review_tags %>` to a KumaScript template used by a page. Then add/remove review tags to the page via the 'Technical' , 'Editorial', and/or 'Template' checkboxes. The template output should change to reflect the page's review tags.
