### PR TITLE
fix bug 813964 - Fix RTL menus

### DIFF
--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -1156,3 +1156,5 @@ li.tag-expert label:hover { border-color: #bbb; }
 
 .html-rtl #welcome-close { right: auto; left: 15px; }
 .html-rtl #welcome-open { right: auto; left: 10px; }
+
+.html-rtl.hasJS #nav-main #nav-sub-docs, .html-rtl #nav-main .menu:hover #nav-sub-docs { right: -50px; }


### PR DESCRIPTION
Spotcheck:
1.  Within JS console, execute:

document.body.className = "html-rtl hasJS"; document.documentElement.setAttribute('dir', 'rtl');
1.  Open the "docs" menu

Yay, stays within the bounds of the page.
