### PR TITLE
fix bug 828533 - Allow title change with page move

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -495,6 +495,15 @@ class AttachmentRevisionForm(forms.ModelForm):
         return rev
 
 class TreeMoveForm(forms.Form):
+    title = StrippedCharField(min_length=1, max_length=255,
+                                required=False,
+                                widget=forms.TextInput(
+                                    attrs={'placeholder': TITLE_PLACEHOLDER}),
+                                label=_lazy(u'Title:'),
+                                help_text=_lazy(u'Title of article'),
+                                error_messages={'required': TITLE_REQUIRED,
+                                                'min_length': TITLE_SHORT,
+                                                'max_length': TITLE_LONG})
     slug = StrippedCharField(min_length=1, max_length=255,
                              widget=forms.TextInput(),
                              label=_lazy(u'New slug:'),

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1040,7 +1040,7 @@ class Document(NotificationsMixin, ModelBase):
                 pass
         return conflicts
 
-    def _move_tree(self, new_slug, user=None):
+    def _move_tree(self, new_slug, user=None, title=None):
         """
         Move this page and all its children.
 
@@ -1060,6 +1060,8 @@ class Document(NotificationsMixin, ModelBase):
         rev.creator = user
         rev.created = datetime.now()
         rev.slug = new_slug
+        if title:
+            rev.title = title
 
         rev.save(force_insert=True)
 

--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -17,7 +17,7 @@
     <div id="content-main" class="full">
         
         <h1>{{ title }}</h1>
-        <p>Please provide a new slug for this page using the field below.</p>
+        <p>{{ _('Please provide a new slug for this page using the field below.') }}</p>
 
         {% if conflicts: %}
         <div class="warning">
@@ -39,19 +39,19 @@
           <ul class="description">
             <li>
               <dl>
-                <dt>Current Slug: </dt>
+                <dt>{{ _('Current Slug:') }} </dt>
                 <dd>{{ document.slug }}</dd>
               </dl>
             </li>
             <li>
               <dl>
-                <dt>Current Title: </dt>
-                <dd><input type="text" name="title" value="{{ document.title }}" autofocus /></dd>
+                <dt><label for="title">{{ _('Title:') }}</label> </dt>
+                <dd><input id="title" type="text" name="title" value="{{ document.title }}" autofocus /></dd>
               </dl>
             </li>
             <li>
               <dl>
-                <dt>New Slug: </dt>
+                <dt><label for="moveSlug">{{ _('New Slug:') }}</label> </dt>
                 <dd>
                   <input type="text" name="slug" id="moveSlug" value="" />
                   <input type="hidden" value="{{ document.slug }}" id="currentSlug" />

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -3468,7 +3468,8 @@ class PageMoveTests(TestCaseBase):
 
 
         # move page to new slug
-        data = {'slug': page_moved_slug}
+        new_title = page_to_move_title + ' Moved'
+        data = {'slug': page_moved_slug, 'title': new_title}
         self.client.login(username='admin', password='testpass')
         self.client.post(reverse('wiki.move',
                                  args=(page_to_move_doc.slug,),
@@ -3482,6 +3483,7 @@ class PageMoveTests(TestCaseBase):
 
         ok_('REDIRECT' in page_to_move_doc.html)
         ok_(page_moved_slug in page_to_move_doc.html)
+        ok_(new_title in page_to_move_doc.html)
         ok_(page_moved_doc)
         ok_('REDIRECT' in page_child_doc.html)
         ok_(page_moved_slug in page_child_doc.html)

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1222,7 +1222,8 @@ def move(request, document_slug, document_locale):
                 pass
 
             doc._move_tree(form.cleaned_data['slug'],
-                           user=request.user)
+                           user=request.user,
+                           title=form.cleaned_data['title'])
 
             return redirect(reverse('wiki.document',
                                     args=(form.cleaned_data['slug'],),


### PR DESCRIPTION
Changing the page title as well as slug within a page move changes the page title in the next revision.

May be best to have @ubernostrum check this out to make sure it's to his liking;

https://bugzilla.mozilla.org/show_bug.cgi?id=828533
