### PR TITLE
bug 665084: Revised SQL to anonymize a production DB clone

### DIFF
--- a/scripts/anonymize.py
+++ b/scripts/anonymize.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python
+"""
+This script performs all the steps needed to produce an anonymized DB dump:
+
+    * Produce a dump of the original DB
+    * Import the dump into a temporary DB
+    * Run anonymize.sql on the temporary DB
+    * Produce an anonymized dump from the temporary DB
+    * Drop the temporary DB
+    * Delete the dump of the original DB
+"""
+from datetime import datetime
+import os
+import os.path
+import sys
+from textwrap import dedent
+from optparse import OptionParser
+
+#
+# We don't just dump everything, because every new table needs to be reviewed
+# with regards to santizing.
+#
+# Whenever a new table is created, add appropriate steps to anonymize.sql and
+# then add the table here.
+#
+TABLES_TO_DUMP=[x.strip() for x in """
+    actioncounters_actioncounterunique
+    actioncounters_testmodel
+    auth_group
+    auth_group_permissions
+    auth_message
+    auth_permission
+    auth_user
+    auth_user_groups
+    auth_user_user_permissions
+    authkeys_key
+    authkeys_keyaction
+    constance_config
+    contentflagging_contentflag
+    dashboards_wikidocumentvisits
+    demos_submission
+    devmo_calendar
+    devmo_event
+    django_admin_log
+    django_cache
+    django_content_type
+    django_session
+    django_site
+    djcelery_crontabschedule
+    djcelery_intervalschedule
+    djcelery_periodictask
+    djcelery_periodictasks
+    djcelery_taskstate
+    djcelery_workerstate
+    feeder_bundle
+    feeder_bundle_feeds
+    feeder_entry
+    feeder_feed
+    gallery_image
+    gallery_video
+    notifications_eventwatch
+    notifications_watch
+    notifications_watchfilter
+    schema_version
+    soapbox_message
+    south_migrationhistory
+    tagging_tag
+    tagging_taggeditem
+    taggit_tag
+    taggit_taggeditem
+    threadedcomments_freethreadedcomment
+    threadedcomments_testmodel
+    threadedcomments_threadedcomment
+    user_profiles
+    users_emailchange
+    users_profile
+    users_registrationprofile
+    waffle_flag
+    waffle_flag_groups
+    waffle_flag_users
+    waffle_sample
+    waffle_switch
+    wiki_attachment
+    wiki_attachmentrevision
+    wiki_document
+    wiki_documentattachment
+    wiki_documenttag
+    wiki_editortoolbar
+    wiki_firefoxversion
+    wiki_helpfulvote
+    wiki_operatingsystem
+    wiki_relateddocument
+    wiki_reviewtag
+    wiki_reviewtaggedrevision
+    wiki_revision
+    wiki_taggeddocument
+""".splitlines() if x.strip()]
+
+
+def print_info(s):
+    if not opts.quiet: print s
+
+
+def print_debug(s):
+    if not opts.quiet and opts.debug: print s
+
+
+def main():
+    now = datetime.now().strftime('%Y%m%d') 
+
+    usage = """\
+        %%prog [options] DB_NAME
+
+        Performs the steps needed to produce an anonymized DB dump. 
+        
+        Examples:
+
+        %%prog mdn_prod
+            Connect to 127.0.0.1 as root, no password.
+            Dump "mdn_prod", import to temporary table.
+            Produce mdn_prod-anon-%(now)s.sql.gz
+            Both the temporary table and the input dump are deleted.
+
+        %%prog -i downloaded-dump.sql.gz
+            Connect to 127.0.0.1 as root, no password.
+            Import downloaded-dump.sql.gz.
+            Produce mdn_prod-anon-%(now)s.sql.gz
+            Input dump is not deleted.
+    """ % dict(
+        now=now
+    )
+    options = OptionParser(dedent(usage.rstrip()))
+
+    options.add_option('-u', '--user',
+                       default='root',
+                       help='MySQL user name')
+    options.add_option('-p', '--password',
+                       default='',
+                       help='MySQL password')
+    options.add_option('-H', '--host',
+                       default='127.0.0.1',
+                       help='MySQL host')
+    options.add_option('-i', '--input',
+                       help='Input SQL dump filename')
+    options.add_option('-o', '--output',
+                       help='Output SQL dump filename')
+    options.add_option('-q', '--quiet',
+                       action='store_true',
+                       help='Quiet all output')
+    options.add_option('-D', '--debug',
+                       action='store_true',
+                       help='Enable debug output')
+
+    options.add_option('--skip-input-dump',
+                       action='store_true',
+                       help='Skip the initial input DB dump')
+    options.add_option('--skip-temp-create',
+                       action='store_true',
+                       help='Skip creation of the temporary DB')
+    options.add_option('--skip-temp-import',
+                       action='store_true',
+                       help='Skip import of the input DB dump into the '
+                            'temporary DB')
+    options.add_option('--skip-anonymize',
+                       action='store_true',
+                       help='Skip anonymization of the temporary DB')
+    options.add_option('--skip-output-dump',
+                       action='store_true',
+                       help='Skip the post-anonymization DB dump')
+    options.add_option('--skip-drop-temp-db',
+                       action='store_true',
+                       help='Skip dropping the temporary DB')
+    options.add_option('--skip-delete-input',
+                       action='store_true',
+                       help='Skip deleting the input DB dump')
+
+    global opts, args
+    (opts, args) = options.parse_args()
+
+    if len(args) < 1:
+        options.error("Need an input DB name")
+
+    input_db = args[0]
+
+    base_dir = os.path.dirname(__file__)
+
+    mysql_conn = '-u%(user)s %(password)s -h%(host)s' % dict(
+        user=opts.user,
+        password=opts.password and ('-p%s' % opts.password) or '',
+        host=opts.host,
+    )
+
+    if opts.input:
+        input_dump_fn = opts.input
+    else:
+        input_dump_fn = '%s-%s.sql.gz' % (input_db, now)
+
+    output_dump_fn = '%s-anon-%s.sql.gz' % (input_db, now)
+
+    if not opts.skip_input_dump and not opts.input:
+        print_info("Dumping input DB to %s" % input_dump_fn)
+        dump_cmd = ('mysqldump %(mysql_conn)s %(input_db)s %(tables)s | '
+                    'gzip > %(input_dump_fn)s' % dict(
+            mysql_conn=mysql_conn,
+            input_db=input_db, tables=' '.join(TABLES_TO_DUMP),
+            input_dump_fn=input_dump_fn 
+        ))
+        print_debug('\t%s' % dump_cmd)
+        os.system(dump_cmd)
+
+    temp_db = '%s_anontmp_%s' % (input_db, now)
+
+    if not opts.skip_temp_create:
+        print_info('Creating temporary DB %s' % temp_db)
+        os.system('mysqladmin %(mysql_conn)s -f drop %(temp_db)s' %
+                  dict(mysql_conn=mysql_conn, temp_db=temp_db))
+        os.system('mysqladmin %(mysql_conn)s create %(temp_db)s' %
+                  dict(mysql_conn=mysql_conn, temp_db=temp_db))
+
+    if not opts.skip_temp_import:
+        print_info('Importing the input dump into the temporary DB')
+        os.system('cat %(input_dump_fn)s | gzip -dc | mysql %(mysql_conn)s '
+                  '%(temp_db)s' % dict(
+            input_dump_fn=input_dump_fn, mysql_conn=mysql_conn,
+            temp_db=temp_db
+        ))
+
+    if not opts.skip_anonymize:
+        anon_sql_fn = os.path.join(base_dir, 'anonymize.sql')
+        print_info('Applying %s to the temporary DB' % anon_sql_fn)
+        os.system('cat %(anon_sql_fn)s | mysql %(mysql_conn)s '
+                  '%(temp_db)s' % dict(
+            anon_sql_fn=anon_sql_fn, mysql_conn=mysql_conn,
+            temp_db=temp_db
+        ))
+
+    if not opts.skip_output_dump:
+        print_info("Dumping temporary DB to %s" % output_dump_fn)
+        dump_cmd = ('mysqldump %(mysql_conn)s %(temp_db)s | '
+                    'gzip > %(output_dump_fn)s' % dict(
+            mysql_conn=mysql_conn, temp_db=temp_db,
+            output_dump_fn=output_dump_fn 
+        ))
+        print_debug('\t%s' % dump_cmd)
+        os.system(dump_cmd)
+
+    if not opts.skip_drop_temp_db:
+        print_info("Dropping temporary db %s" % temp_db)
+        os.system('mysqladmin %(mysql_conn)s -f drop %(temp_db)s' %
+                  dict(mysql_conn=mysql_conn, temp_db=temp_db))
+
+    if not opts.skip_delete_input and not opts.input:
+        print_info('Deleting input DB dump %s' % input_dump_fn)
+        os.remove(input_dump_fn)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/anonymize.sql
+++ b/scripts/anonymize.sql
@@ -1,16 +1,67 @@
--- Does a quick anonymization of a kuma database. Note that this does
--- not necessarily clear out all confidential information and should
--- not be considered approval to distribute this kuma database.
--- Talk to lcrouch if you have questions.
+--
+-- MDN Kuma anonymization / sanitization
+--
+-- Run this on a COPY of a production DB - NEVER ON THE REAL THING!
+-- This nukes all kinds of data from orbit.
+--
+-- See also: https://mana.mozilla.org/wiki/display/SECURITY/Database+Sanitization+Policy+-+Draft
+--
+-- Confidential, private or personal data is any data that contains the
+-- following:
+-- 
+--     First Name
+--     Last Name
+--     Physical Address Information
+--     IP Addresses
+--     Passwords and/or Password Hashes
+--     Ages
+--     Gender
+--     Any database record or data which could be tied to the identity of an
+--         individual
+-- 
+-- When exporting this data, referred as Personally Identifiable Information
+-- (PII) data must be removed such that no data would be specifically tied to
+-- an individual. 
+
+SET @common_hash_secret=rand();
+
+SET FOREIGN_KEY_CHECKS=0;
+
+TRUNCATE actioncounters_actioncounterunique;
+TRUNCATE auth_message;
+TRUNCATE authkeys_key;
+TRUNCATE authkeys_keyaction;
+TRUNCATE contentflagging_contentflag;
+TRUNCATE django_admin_log;
+TRUNCATE django_session;
+TRUNCATE djcelery_crontabschedule;
+TRUNCATE djcelery_intervalschedule;
+TRUNCATE djcelery_periodictask;
+TRUNCATE djcelery_periodictasks;
+TRUNCATE djcelery_taskstate;
+TRUNCATE djcelery_workerstate;
+TRUNCATE notifications_eventwatch;
+TRUNCATE notifications_watch;
+TRUNCATE notifications_watchfilter;
+TRUNCATE threadedcomments_freethreadedcomment;
+TRUNCATE threadedcomments_threadedcomment;
+TRUNCATE threadedcomments_testmodel;
+TRUNCATE users_emailchange;
+-- `user_profiles` is the real profiles table, not this. I know, it's weird.
+TRUNCATE users_profile;
+TRUNCATE users_registrationprofile;
 
 UPDATE auth_user SET
-    email = CONCAT('user',id,'@example.com'),
-    password = 'sha256$f538347e82$5098e89186fd307d4bb6fe29ac476e72cf96175617fa933a9bd6b3d89a8b0946'; -- 'testpass'
+    -- username left alone, because it's public info
+    password = NULL, 
+    email = CONCAT('user-', id, '@example.com'),
+    first_name = ROUND(RAND()*1000000), 
+    last_name = ROUND(RAND()*1000000);
 
-TRUNCATE notifications_eventwatch;
+-- Does this table need more scrubbing? It's profile data made intentionally
+-- public by users.
+UPDATE user_profiles SET
+    location = ROUND(RAND()*1000000),
+    homepage = ROUND(RAND()*1000000);
 
-TRUNCATE django_session;
-
-UPDATE django_site SET
-    domain = 'kuma-stage.mozilla.org',
-    name = 'kuma-stage.mozilla.org';
+SET FOREIGN_KEY_CHECKS=1;


### PR DESCRIPTION
This is not the total fix to bug 665084 (and in turn bug 802203), but I think it's a first step.

However, I'm not currently able to ssh into a production machine to grab a DB dump to try this out on. While I figure that out, I'm submitting this PR to get eyes on it.

IMPORTANT: Do not run this on production. Do not run this on anything important. It deletes data like crazy. It's meant to be run on a clone of a production DB, a dump of which will be intended for staging and dev boxes.
