### PR TITLE
fix bug 773054 - Allow S&CE on edits

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -925,7 +925,6 @@
                 // metadata, since that can change the URL of the page and
                 // tangle up where the iframe posts.
                 ev.preventDefault();
-                $('#btn-save-and-edit').hide().attr('disabled', 'disabled');
                 $('#article-head .title').hide();
                 $('#article-head .metadata').show();
                 $('#article-head .metadata #id_title').focus();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=773054

Since we no longer allow slug changes on the edit forms (doc and template), there's no reason to not allow Save And Continue Editing.  To test:
1.  Open a document in one tab, the rev dash in another
2.  In the JS Console, execute:  `jQuery("#id_current_rev").attr("value");`
3.  Make a change to the doc, click S&CE
4.  After the spinner is done, execute `jQuery("#id_current_rev").attr("value");` again and see the revision incremented
5.  Switch over to the rev dash tab and refresh;  see the new revision

Rinse and repeat.
