### PR TITLE
Fix bug 835401

### DIFF
--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -306,19 +306,6 @@ class RevisionForm(forms.ModelForm):
             existing_slug = self.instance.document.slug
             self.cleaned_data['slug'] = self.instance.slug = existing_slug
         cleaned_slug = self._clean_collidable('slug')
-
-        # If they're trying to change an existing slug, and the
-        # document has children, we need to use the page-move
-        # interface.
-        #
-        # Detecting this can be slightly cumbersome because there's no
-        # guarantee that we have a full Revision instance yet, that it
-        # has a Document yet, or that the Document has been saved yet.
-        if self.instance and \
-           self.instance.document_id and \
-           (cleaned_slug != self.instance.slug) and \
-           self.instance.document.has_children():
-            raise forms.ValidationError(MOVE_REQUIRED)
         return cleaned_slug
 
     def clean_content(self):


### PR DESCRIPTION
We no longer need this check, as far as I can tell, since we don't expose slug editing any other way than through page move, and it's interfering with translation.
