### PR TITLE
Removing homepage 'close' link

### DIFF
--- a/apps/landing/templates/landing/home.html
+++ b/apps/landing/templates/landing/home.html
@@ -13,21 +13,6 @@
 
 {% block content %}
 
-<header id="welcome-bar">
-<div class="wrap">
-
-  <h1>{% trans %}It's the Web. <b>You drive.</b>{% endtrans %}</h1>
-  <h2>{{_("Welcome to the Mozilla Developer Network.")}}</h2>
-  <p>{% trans %}We are an open community of developers building resources for a better web, 
-  regardless of brand, browser or platform. Anyone can contribute and each person 
-  who does makes us stronger. Together we can continue to drive innovation on the 
-  Web to serve the greater good. It starts here, with you.{% endtrans %}</p>
-  
-  <button type="button" id="welcome-close">{{_("Close")}}</button>
-
-</div>
-</header>
-
 <section id="content">
 <div class="wrap">
 
@@ -195,20 +180,6 @@
 
 {% block js %}
 {{ super() }}
-    
-<script type="text/javascript">
-// <![CDATA[
-	$("#welcome-bar").ready(function(){
-		$("#welcome-close").click(function(){
-		  $("#welcome-bar").slideUp("fast").after('<div class="wrap"><button type="button" id="welcome-open">About MDN</button></div>');
-		  $("#welcome-open").click(function(){ 
-		    $("#welcome-bar").slideDown();
-		    $(this).parents("div.wrap").fadeOut("fast").remove(); 
-		  });
-		});
-	});
-// ]]>
-</script>
   
 <script type="text/javascript" src="{{MEDIA_URL}}js/mdn/jquery.hoverIntent.minified.js"></script>
 <script type="text/javascript">

--- a/media/css/ie6.css
+++ b/media/css/ie6.css
@@ -157,7 +157,6 @@ body.section-labs #masthead { border-bottom-color: #f8d575; }
 #nav-section .current a { color: #000; font-weight: bold; background-position: 50% -460px; }
 
 #section-head { padding: 15px 0; background: #eae7dc; border-top: 1px solid #000; }
-#welcome-bar { padding: 15px 0; background: #6e0000; border-top: 3px solid #c02700; color: #fff; }
 
 /*** @Slides *********/
 #slideshow.js { position: relative; width: 660px; margin: 0 0 2em; }

--- a/media/css/mdn-ie7.css
+++ b/media/css/mdn-ie7.css
@@ -30,9 +30,6 @@ ul.sortable .remove { font-family: sans-serif; margin-top: -1.25em; }
 
 #promote-buttons #button-preview.fixed { margin-left: 31px; }
 
-#welcome-bar { zoom: 1; margin-bottom: 20px; }
-#welcome-open { width: 80px; }
-
 .home-promos { zoom: 1; margin-bottom: 40px; }
 .home-promos .promo div { position: absolute; left: 0; }
 .home-promos .promo a { position: absolute; left: 0; width: 80%; padding: 20px 10%; }

--- a/media/css/mdn-print.css
+++ b/media/css/mdn-print.css
@@ -9,7 +9,6 @@ Created by Craig Cook - focalcurve.com
 #site-search, 
 #nav, 
 #utility,
-#welcome-bar, 
 #section-head, 
 .user-state, 
 #contact, 

--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -401,18 +401,6 @@ footer .languages { float: right; text-align: right; margin: 0 0 .5em; }
 #section-head .util-discuss a { background-position: 0 -400px; }
 
 /* @Home *********/
-/*** @Welcome *********/
-#welcome-bar { background: #000 url("../img/bg-check-lt.png"); border-bottom: 4px solid #f8d575; border-top: 4px solid #333; margin-top: -4px; color: #ccc; text-shadow: 1px 1px 0 rgba(0,0,0,.75); -moz-box-shadow: 0 1px 0 rgba(0,0,0,.25); -webkit-box-shadow: 0 1px 0 rgba(0,0,0,.25); box-shadow: 0 1px 0 rgba(0,0,0,.25); }
-#welcome-bar .wrap { padding: 25px 160px; width: 620px; }
-#welcome-bar h1 { font: normal 42px/1 "Museo Sans", sans-serif; text-align: center; color: #f8d475; margin: 0 0 .3em; }
-#welcome-bar h1 b { font-weight: normal; color: #cc3435; }
-#welcome-bar h2 { font-size: 1em; text-align: center; color: #fff; }
-#welcome-bar p { font-size: .857em; line-height: 1.6; margin: 0; text-align: justify; }
-#welcome-close { cursor: pointer; width: 28px; height: 28px; position: absolute; right: 15px; top: 15px; text-indent: -999em; overflow: hidden; background: #000 url("../img/icons-welcome.png") 0 -550px no-repeat; -moz-border-radius: 0; -webkit-border-radius: 0; border-radius: 0; }
-#welcome-close:hover, #welcome-close:focus { background-position: 0 -600px; }
-
-#welcome-open { position: absolute; right: 10px; top: -2px; z-index: 20; cursor: pointer; padding: 3px 8px; font: .785em/1 "Lucida Grande", "Lucida Sans Unicode", "DejaVu Sans", Lucida, Arial, Helvetica, sans-serif; text-transform: none; letter-spacing: normal; color: #444; background: #f8d575 none; -moz-border-radius: 0 0 3px 3px; -webkit-border-radius: 0 0 3px 3px; border-radius: 0 0 3px 3px; }
-#welcome-open:hover, #welcome-open:focus { color: #000; cursor: pointer; }
 
 /*** @Top @Docs *********/
 #top-docs { background: #fff; margin: 20px 0 40px; padding: 19px; border: 1px solid #e8e8e8; overflow: hidden; -moz-box-shadow: 0 2px 2px rgba(0,0,0,.15); -webkit-box-shadow: 0 2px 2px rgba(0,0,0,.15); box-shadow: 0 2px 2px rgba(0,0,0,.15); }

--- a/media/css/print.css
+++ b/media/css/print.css
@@ -9,7 +9,6 @@ Created by Craig Cook - focalcurve.com
 #site-search, 
 #nav, 
 #utility,
-#welcome-bar, 
 #section-head, 
 .user-state, 
 #contact, 

--- a/media/css/wiki-print.css
+++ b/media/css/wiki-print.css
@@ -21,7 +21,6 @@ Created by Craig Cook - focalcurve.com
 #site-search, 
 #nav, 
 #utility,
-#welcome-bar, 
 #section-head, 
 .user-state, 
 #contact, 


### PR DESCRIPTION
The homepage [x] link / hider doesn't persist and doing so would involve cookies as the most elegant solution.  The other solution is sliding in that block or sliding it out, each of which is clunky.  We may as well remove it for now, keep that header there, and not repeat this on the new design.
