### PR TITLE
fix bug 834296, 834297: Alternate Bleach whitelist switch

### DIFF
--- a/apps/wiki/kumascript.py
+++ b/apps/wiki/kumascript.py
@@ -43,7 +43,8 @@ def should_use_rendered(doc, params, html=None):
             (force_macros or (not no_macros and not show_raw)))
 
 
-def post(request, content, locale=settings.LANGUAGE_CODE):
+def post(request, content, locale=settings.LANGUAGE_CODE,
+         use_constance_bleach_whitelists=False):
     ks_url = settings.KUMASCRIPT_URL_TEMPLATE.format(path='')
     headers = {
         'X-FireLogger': '1.2',
@@ -61,7 +62,7 @@ def post(request, content, locale=settings.LANGUAGE_CODE):
                              data=data,
                              headers=headers)
     if resp:
-        resp_body = process_body(resp)
+        resp_body = process_body(resp, use_constance_bleach_whitelists)
         resp_errors = process_errors(resp)
         return resp_body, resp_errors
     else:
@@ -203,7 +204,7 @@ def add_env_headers(headers, env_vars):
     return headers
 
 
-def process_body(response):
+def process_body(response, use_constance_bleach_whitelists=False):
     # HACK: Assume we're getting UTF-8, which we should be.
     # TODO: Better solution would be to upgrade the requests module
     # in vendor from 0.6.1 to at least 0.10.6, and use resp.text,
@@ -214,7 +215,8 @@ def process_body(response):
     # through editing, source display, and raw output. But, we still
     # want sanitation, so it finally gets picked up here.
     from wiki.models import Document
-    return Document.objects.clean_content(resp_body)
+    return Document.objects.clean_content(resp_body,
+                                          use_constance_bleach_whitelists)
 
 
 def process_errors(response):

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -351,17 +351,25 @@ def _inherited(parent_attr, direct_attr):
 class DocumentManager(ManagerBase):
     """Manager for Documents, assists for queries"""
 
-    def clean_content(self, content_in):
+    def clean_content(self, content_in, use_constance_bleach_whitelists=False):
         allowed_hosts = constance.config.KUMA_CODE_SAMPLE_HOSTS.split(' ')
         out = (wiki.content
                .parse(content_in)
                .filterIframeHosts(allowed_hosts)
                .serialize())
-        out = bleach.clean(
-            out, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS,
-            styles=ALLOWED_STYLES, strip_comments=False,
-            skip_gauntlet=True
-        )
+        
+        if use_constance_bleach_whitelists:
+            tags = constance.config.BLEACH_ALLOWED_TAGS
+            attributes = constance.config.BLEACH_ALLOWED_ATTRIBUTES
+            styles = constance.config.BLEACH_ALLOWED_STYLES
+        else:
+            tags = ALLOWED_TAGS
+            attributes = ALLOWED_ATTRIBUTES
+            styles = ALLOWED_STYLES
+
+        out = bleach.clean(out, attributes=attributes, tags=tags,
+                           styles=styles, strip_comments=False,
+                           skip_gauntlet=True)
         return out
 
     def get_by_natural_key(self, locale, slug):

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -477,24 +477,32 @@ def document(request, document_slug, document_locale):
     doc_html, ks_errors = doc.html, None
     if kumascript.should_use_rendered(doc, request.GET):
 
-        # A logged-in user can schedule a full re-render with Shift-Reload
-        cache_control = None
-        if request.user.is_authenticated():
-            # Shift-Reload sends Cache-Control: no-cache
-            ua_cc = request.META.get('HTTP_CACHE_CONTROL')
-            if ua_cc == 'no-cache':
-                cache_control = 'no-cache'
+        if (request.GET.get('bleach_new', False) is not False and
+                request.user.is_authenticated()):
+            # Temporary bleach_new query option to switch to Constance-based
+            # Bleach whitelists, uses KumaScript POST for temporary rendering
+            doc_html, ks_errors = kumascript.post(request, doc_html,
+                                                  request.locale, True)
 
-        try:
-            r_body, r_errors = doc.get_rendered(cache_control, base_url)
-            if r_body:
-                doc_html = r_body
-            if r_errors:
-                ks_errors = r_errors
-        except DocumentRenderedContentNotAvailable:
-            # There was no rendered content available, and we were unable to
-            # render it on the spot. So, fall back to presenting raw content
-            render_raw_fallback = True
+        else:
+            # A logged-in user can schedule a full re-render with Shift-Reload
+            cache_control = None
+            if request.user.is_authenticated():
+                # Shift-Reload sends Cache-Control: no-cache
+                ua_cc = request.META.get('HTTP_CACHE_CONTROL')
+                if ua_cc == 'no-cache':
+                    cache_control = 'no-cache'
+
+            try:
+                r_body, r_errors = doc.get_rendered(cache_control, base_url)
+                if r_body:
+                    doc_html = r_body
+                if r_errors:
+                    ks_errors = r_errors
+            except DocumentRenderedContentNotAvailable:
+                # There was no rendered content available, and we were unable to
+                # render it on the spot. So, fall back to presenting raw content
+                render_raw_fallback = True
 
     toc_html = None
     if not doc.is_template:

--- a/settings.py
+++ b/settings.py
@@ -3,6 +3,7 @@ from datetime import date
 import logging
 import os
 import platform
+import json
 
 from django.utils.functional import lazy
 from django.utils.translation import ugettext_lazy as _
@@ -1044,6 +1045,27 @@ CONSTANCE_CONFIG = dict(
     GOOGLE_ANALYTICS_ACCOUNT = (
         '0',
         'Google Analytics Tracking Account Number (0 to disable)',
+    ),
+
+    BLEACH_ALLOWED_TAGS = (
+        json.dumps([
+            'a', 'p', 'div',
+        ]),
+        "JSON array of tags allowed through Bleach",
+    ),
+
+    BLEACH_ALLOWED_ATTRIBUTES = (
+        json.dumps({
+            '*': ['id', 'class', 'style'],
+        }),
+        "JSON object associating tags with lists of allowed attributes",
+    ),
+
+    BLEACH_ALLOWED_STYLES = (
+        json.dumps([
+            'font-size', 'text-align',
+        ]),
+        "JSON array listing CSS styles allowed on tags",
     ),
 )
 


### PR DESCRIPTION
- New Constance settings to allow runtime changes to alternate Bleach
  whitelists
- ?bleach_new query parameter for authenticated users that switches
  document view over to the Constance-defined Bleach whitelists
- Flag in DocumentManager.clean_content() to use Bleach whitelists
  defined in Constance settings
- Tweaks to kumascript.post() processing chain to use the
  alternate whitelist flag
- Tests
