### PR TITLE
Hide empty fields in comparison

### DIFF
--- a/apps/wiki/templates/wiki/includes/revision_diff.html
+++ b/apps/wiki/templates/wiki/includes/revision_diff.html
@@ -38,17 +38,23 @@
       <dd class="rev-from">{{ revision_from.slug }}</dd>
       <dd class="rev-to">{{ revision_to.slug }}</dd>
       
+      {% if revision_from.tags or revision_to.tags %}
       <dt>{{ _('Tags:') }}</dt>
       <dd class="rev-from">{{ revision_from.tags }}</dd>
       <dd class="rev-to">{{ revision_to.tags }}</dd>
+      {% endif %}
       
+      {% if revision_from.keywords or revision_to.keywords %}
       <dt>{{ _('Keywords:') }}</dt>
       <dd class="rev-from">{{ revision_from.keywords }}</dd>
       <dd class="rev-to">{{ revision_to.keywords }}</dd>
+      {% endif %}
       
+      {% if revision_from.summary or revision_to.summary %}
       <dt>{{ _('Search results summary:') }}</dt>
       <dd class="rev-from">{{ revision_from.summary }}</dd>
       <dd class="rev-to">{{ revision_to.summary }}</dd>
+      {% endif %}
       
       <dt>{{ _('Content:') }}</dt>
       <dd>{{ diff_table(revision_from.content, revision_to.content, revision_from.id, revision_to.id) }}</dd>


### PR DESCRIPTION
Kinda ugly showing empty lines for keywords, tags, and summary when neither document has any.
