### PR TITLE
720068 allow cors for wiki

### DIFF
--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -139,6 +139,8 @@ class ViewTests(TestCaseBase):
         url = reverse('wiki.json_slug', args=('article-title',),
                       locale=settings.WIKI_DEFAULT_LANGUAGE)
         resp = self.client.get(url)
+        ok_('Access-Control-Allow-Origin' in resp)
+        eq_('*', resp['Access-Control-Allow-Origin'])
         eq_(200, resp.status_code)
         data = json.loads(resp.content)
         eq_('an article title', data['title'])
@@ -158,6 +160,8 @@ class ViewTests(TestCaseBase):
                       locale=settings.WIKI_DEFAULT_LANGUAGE)
 
         resp = self.client.get(url)
+        ok_('Access-Control-Allow-Origin' in resp)
+        eq_('*', resp['Access-Control-Allow-Origin'])
         eq_(resp.content, '<ol><li><a href="#Head_2" rel="internal">Head 2</a>'
                           '<ol><li><a href="#Head_3" rel="internal">Head 3</a>'
                           '</ol></li></ol>')
@@ -182,6 +186,8 @@ class ViewTests(TestCaseBase):
 
         resp = self.client.get(reverse('wiki.get_children', args=['Root'],
             locale=settings.WIKI_DEFAULT_LANGUAGE))
+        ok_('Access-Control-Allow-Origin' in resp)
+        eq_('*', resp['Access-Control-Allow-Origin'])
         json_obj = json.loads(resp.content)
 
         # Basic structure creation testing
@@ -1896,6 +1902,8 @@ class SectionEditingResourceTests(TestCaseBase):
         response = client.get('%s?raw=true' %
                               reverse('wiki.document', args=[d.full_path]),
                               HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        ok_('Access-Control-Allow-Origin' in response)
+        eq_('*', response['Access-Control-Allow-Origin'])
         eq_(normalize_html(expected),
             normalize_html(response.content))
 
@@ -2415,6 +2423,9 @@ class AutosuggestDocumentsTests(TestCaseBase):
         url = reverse('wiki.autosuggest_documents', locale=settings.WIKI_DEFAULT_LANGUAGE) + '?term=e'
         resp = self.client.get(url)
 
+        ok_('Access-Control-Allow-Origin' in resp)
+        eq_('*', resp['Access-Control-Allow-Origin'])
+
         eq_(200, resp.status_code)
         data = json.loads(resp.content)
         eq_(len(data), len(validDocuments))
@@ -2478,6 +2489,8 @@ class CodeSampleViewTests(TestCaseBase):
         response = client.get(reverse('wiki.code_sample',
                               args=[d.full_path, 'sample1']),
                               HTTP_HOST='testserver')
+        ok_('Access-Control-Allow-Origin' in response)
+        eq_('*', response['Access-Control-Allow-Origin'])
         eq_(200, response.status_code)
         eq_(normalize_html(expected),
             normalize_html(response.content))

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -205,6 +205,17 @@ def prevent_indexing(func):
     return _added_header
 
 
+def allow_CORS_GET(func):
+    """Decorator to allow CORS for GET requests"""
+    @wraps(func)
+    def _added_header(request, *args, **kwargs):
+        response = func(request, *args, **kwargs)
+        if 'GET' == request.method:
+            response['Access-Control-Allow-Origin'] = "*"
+        return response
+    return _added_header
+
+
 def _format_attachment_obj(attachments):
     attachments_list = []
     for attachment in attachments:
@@ -292,6 +303,7 @@ def _get_document_for_json(doc, addLocaleToTitle=False):
 
 @csrf_exempt
 @require_http_methods(['GET', 'PUT', 'HEAD'])
+@allow_CORS_GET
 @accepts_auth_key
 @process_document_path
 @condition(last_modified_func=_document_last_modified)
@@ -1246,6 +1258,7 @@ def preview_revision(request):
 
 
 @require_GET
+@allow_CORS_GET
 @process_document_path
 def get_children(request, document_slug, document_locale):
     """Retrieves a document and returns its children in a JSON structure"""
@@ -1287,6 +1300,7 @@ def get_children(request, document_slug, document_locale):
 
 
 @require_GET
+@allow_CORS_GET
 def autosuggest_documents(request):
     """Returns the closest title matches for front-end autosuggests"""
     partial_title = request.GET.get('term', '')
@@ -1678,6 +1692,7 @@ def unwatch_approved(request):
 
 
 @require_GET
+@allow_CORS_GET
 @process_document_path
 @prevent_indexing
 def json_view(request, document_slug=None, document_locale=None):
@@ -1705,6 +1720,7 @@ def json_view(request, document_slug=None, document_locale=None):
 
 
 @require_GET
+@allow_CORS_GET
 @process_document_path
 @prevent_indexing
 def toc_view(request, document_slug=None, document_locale=None):
@@ -1734,6 +1750,7 @@ def toc_view(request, document_slug=None, document_locale=None):
 
 
 @require_GET
+@allow_CORS_GET
 @process_document_path
 def code_sample(request, document_slug, document_locale, sample_id):
     """Extract a code sample from a document and render it as a standalone


### PR DESCRIPTION
This is necessary for many kinds of content mashups, apropos of the discussion in [bug 839306](https://bugzilla.mozilla.org/show_bug.cgi?id=839306)
