### PR TITLE
In vagrant install docs, echo should not have a linebreak

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -72,8 +72,7 @@ Getting up and running
 
 -  Add developer-dev.mozilla.org to /etc/hosts::
 
-       echo '192.168.10.55 developer-local.allizom.org
-       mdn-local.mozillademos.org' >> /etc/hosts
+       echo '192.168.10.55 developer-local.allizom.org mdn-local.mozillademos.org' >> /etc/hosts
 
 -  Everything should be working now, from the host side::
 


### PR DESCRIPTION
Per #webdev chat around a contributor having problems with the vagrant setup:

[7:37am] Wraithan
That echo to /etc/hosts in that instruction set looks wrong
[7:37am] Wraithan
likely it shouldn't have a line break in the middle
