### PR TITLE
Properly format sitemap lastmod date

### DIFF
--- a/apps/wiki/cron.py
+++ b/apps/wiki/cron.py
@@ -99,7 +99,7 @@ def build_sitemaps():
             sitemap_url = ("https://%s/sitemaps/%s/sitemap.xml" % (
                 Site.objects.get_current().domain, locale))
             sitemap_index = sitemap_index + sitemap_element % (sitemap_url,
-                time.strftime('%Y-%m-%dT%H:%M:%S', time.localtime()))
+                time.strftime('%Y-%m-%dT%H:%M:%S+00:00', time.gmtime()))
 
     sitemap_index = sitemap_index + "</sitemapindex>"
     index_file = open('%s/sitemap.xml' % settings.MEDIA_ROOT, 'w')


### PR DESCRIPTION
I tried resubmitting our main sitemap to GWT again and got this error:

"An invalid date was found. Please fix the date or formatting before resubmitting."

The only difference between our sitemap and my sitemap is a "+00:00" at the end of the date.  So I'm giving that a try so we can get this done once and for all.
