### PR TITLE
fix bug 809523: API access to document summary

### DIFF
--- a/apps/wiki/tests/test_helpers.py
+++ b/apps/wiki/tests/test_helpers.py
@@ -1,10 +1,57 @@
 from nose.tools import eq_
 from test_utils import TestCase
 
+from wiki.tests import normalize_html
 from wiki.helpers import get_seo_description
 
 
 class GetSEODescriptionTests(TestCase):
+
+    def test_summary_section(self):
+        content = (u'<h2 id="Summary">Summary</h2><p>The <strong>Document Object '
+             'Model'
+             '</strong> (<strong>DOM</strong>) is an API for '
+             '<a href="/en-US/docs/HTML" title="en-US/docs/HTML">HTML</a> and '
+             '<a href="/en-US/docs/XML" title="en-US/docs/XML">XML</a> '
+             'documents. It provides a structural representation of the '
+             'document, enabling you to modify its content and visual '
+             'presentation by using a scripting language such as '
+             '<a href="/en-US/docs/JavaScript" '
+             'title="https://developer.mozilla.org/en-US/docs/JavaScript">'
+             'JavaScript</a>.</span></p>')
+        expected = ('The Document Object Model (DOM) is an API for HTML and '
+            'XML documents. It provides a structural representation of the'
+            ' document, enabling you to modify its content and visual'
+            ' presentation by using a scripting language such as'
+            ' JavaScript.')
+        eq_(expected, get_seo_description(content, 'en-US'))
+
+    def test_keep_markup(self):
+        content = """
+            <h2 id="Summary">Summary</h2>
+            <p>The <strong>Document Object Model </strong>
+            (<strong>DOM</strong>) is an API for <a href="/en-US/docs/HTML"
+            title="en-US/docs/HTML">HTML</a> and <a href="/en-US/docs/XML"
+            title="en-US/docs/XML">XML</a> documents. It provides a structural
+            representation of the document, enabling you to modify its content
+            and visual presentation by using a scripting language such as <a
+            href="/en-US/docs/JavaScript"
+            title="https://developer.mozilla.org/en-US/docs/JavaScript">
+            JavaScript</a>.</span></p>
+         """
+        expected = """
+            The <strong>Document Object Model </strong>
+            (<strong>DOM</strong>) is an API for <a href="/en-US/docs/HTML"
+            title="en-US/docs/HTML">HTML</a> and <a href="/en-US/docs/XML"
+            title="en-US/docs/XML">XML</a> documents. It provides a structural
+            representation of the document, enabling you to modify its content
+            and visual presentation by using a scripting language such as <a
+            href="/en-US/docs/JavaScript"
+            title="https://developer.mozilla.org/en-US/docs/JavaScript">
+            JavaScript</a>.</span>
+        """
+        eq_(normalize_html(expected),
+            normalize_html(get_seo_description(content, 'en-US', False)))
 
     def test_html_elements_spaces(self):
         # No spaces with html tags

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -275,8 +275,10 @@ def _get_document_for_json(doc, addLocaleToTitle=False):
         title += ' [' + doc.locale + ']'
 
     summary = ''
-    if doc.current_revision:
+    if doc.current_revision and doc.current_revision.summary:
         summary = doc.current_revision.summary
+    else:
+        summary = get_seo_description(doc.html, doc.locale, False)
 
     # Map out translations
     translations = []
@@ -420,6 +422,7 @@ def document(request, document_slug, document_locale):
     # Grab some parameters that affect output
     section_id = request.GET.get('section', None)
     show_raw = request.GET.get('raw', False) is not False
+    show_summary = request.GET.get('summary', False) is not False
     is_include = request.GET.get('include', False) is not False
     need_edit_links = request.GET.get('edit_links', False) is not False
 
@@ -503,6 +506,10 @@ def document(request, document_slug, document_locale):
         # If this is an include, filter out the class="noinclude" blocks.
         if is_include:
             doc_html = (wiki.content.filter_out_noinclude(doc_html))
+    
+    # If ?summary is on, just serve up the summary as doc HTML
+    if show_summary:
+        doc_html = get_seo_description(doc_html, doc.locale, False)
 
     # if ?raw parameter is supplied, then we respond with raw page source
     # without template wrapping or edit links. This is also permissive for
@@ -1278,6 +1285,7 @@ def get_children(request, document_slug, document_locale):
                 'slug': d.slug,
                 'locale': d.locale,
                 'url':  d.get_absolute_url(),
+                'summary': get_seo_description(d.html, d.locale, False),
                 'subpages': []
             }
 


### PR DESCRIPTION
- ?summary option on document URLs to serve just the summary (combines
  with ?raw & etc)
- $children doc view now includes summaries, for page.subpages in
  kumascript
- $json doc view now includes summary, for wiki.getPage in kumascript
- Added option to get_seo_summary to strip / not strip markup
- get_seo_summary will now first look for a "Summary" section
