### PR TITLE
Don't return null item redirects from children view

### DIFF
--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -36,7 +36,8 @@ class TestCaseBase(TestCase):
 def document(save=False, **kwargs):
     """Return an empty document with enough stuff filled out that it can be
     saved."""
-    defaults = {'category': CATEGORIES[0][0], 'title': str(datetime.now())}
+    defaults = {'category': CATEGORIES[0][0], 'title': str(datetime.now()),
+                'is_redirect': 0}
     defaults.update(kwargs)
     if 'slug' not in kwargs:
         defaults['slug'] = slugify(defaults['title'])

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -168,9 +168,13 @@ class ViewTests(TestCaseBase):
 
     def test_children_view(self):
         test_content = '<p>Test <a href="http://example.com">Summary</a></p>'
-        def _make_doc(title, slug, parent=None):
-            doc = document(title=title, slug=slug, save=True)
-            doc.html = test_content
+        def _make_doc(title, slug, parent=None, is_redir=False):
+            doc = document(title=title, slug=slug, save=True, is_redirect=is_redir)
+            if is_redir:
+                content = 'REDIRECT <a class="redirect" href="x">Blah</a>'
+            else:
+                content = test_content
+            doc.html = content
             if parent:
                 doc.parent_topic = parent
             doc.save()
@@ -185,6 +189,7 @@ class ViewTests(TestCaseBase):
         great_grandchild_doc_1 = _make_doc('Great Grandchild 1',
             'Root/Child_1/Grandchild_2/Great_Grand_Child_1', grandchild_doc_2)
         child_doc_2 = _make_doc('Child 2', 'Root/Child_2', root_doc)
+        child_doc_3 = _make_doc('Child 3', 'Root/Child_3', root_doc, True)
 
         resp = self.client.get(reverse('wiki.get_children', args=['Root'],
             locale=settings.WIKI_DEFAULT_LANGUAGE))

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1278,7 +1278,7 @@ def get_children(request, document_slug, document_locale):
     try:
         def _make_doc_structure(d, level):
             if d.is_redirect:
-                return
+                return None
 
             res = {
                 'title': d.title,
@@ -1293,8 +1293,9 @@ def get_children(request, document_slug, document_locale):
                 descendants = d.get_descendants(1)
                 descendants.sort(key=lambda item: item.title)
                 for descendant in descendants:
-                    res['subpages'].append(_make_doc_structure(descendant,
-                                                               level + 1))
+                    sp = _make_doc_structure(descendant, level + 1)
+                    if sp is not None:
+                        res['subpages'].append(sp)
             return res
 
         result = _make_doc_structure(Document.objects.


### PR DESCRIPTION
To spot check:
1.  Create a root page (slug: "root_doc")
2.  Create a child page
3.  Move the child page
4.  (In theory, the root page has 2 docs:  one a redirect, one not)
5.  Go to "/en-US/docs/root_doc$children"
6.  The redirect should not be listed.
