### PR TITLE
Signed-off-on front-end portion of toc level limit.

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -99,9 +99,7 @@
             <ul class="metadata">
                 <li><label>{{_('Title:')}}</label> {{ revision_form.title | safe }}</li>
                 {% if not document.is_template %}
-                  <li><label><dfn title="{{_('Generate table of contents')}}">{{_('TOC:')}}</dfn></label>
-                    {{ revision_form.show_toc | safe }}
-                  </li>
+                  {% include 'wiki/includes/document_toc_field.html' %}
                 {% endif %}
                 {% if show_translation_parent_block %}
                 <li class="metadata-choose-parent">

--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -2,4 +2,22 @@
 <script src="{{ MEDIA_URL }}ckeditor/ckeditor.js"></script>
 <script src="{{ MEDIA_URL }}ckeditor/adapters/jquery.js"></script>
 <script src="{{ MEDIA_URL }}js/wiki_ckeditor.js"></script>
+
+<script type="text/javascript">
+$(document).ready(function() {
+
+	var showing = 1,
+		$show_toc_depth_block = $('#show_toc_depth_block');
+
+	if($show_toc_depth_block.length) {
+		$('#toc_customize').click(updateTocLevel);
+		updateTocLevel();
+	}
+
+	function updateTocLevel() {
+		showing = !showing;
+		$show_toc_depth_block.animate({ 'opacity': showing ? 1 : 0 });
+	}
+});
+</script>
 {% endif %}

--- a/apps/wiki/templates/wiki/includes/document_toc_field.html
+++ b/apps/wiki/templates/wiki/includes/document_toc_field.html
@@ -1,0 +1,18 @@
+<li>
+  <label><dfn title="{{_('Generate table of contents')}}">{{_('TOC:')}}</dfn></label>
+
+  <div class="show_toc_block">
+    {{ revision_form.show_toc | safe }}
+    <a href="javascript:;" id="toc_customize">{{ _('customize') }}</a>
+  </div>
+  <div id="show_toc_depth_block">
+    <label for="show_toc_depth" class="inline">
+      {{ _('In table of contents, show only levels up to and including:') }}
+      <select name="show_toc_depth">
+        <option value="2">H2</option>
+        <option value="3">H3</option>
+        <option value="4" selected>H4</option>
+      </select>
+    </label>
+  </div>
+</li>

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -29,9 +29,7 @@
                 <a href="{{ parent_path }}" class="metadataDisplay" target="_blank">{{ parent_slug }}</a></li>
           {% endif %}
           {% if not is_template %}
-            <li><label><dfn title="{{_('Generate table of contents')}}">{{_('TOC:')}}</dfn></label>
-              {{ revision_form.show_toc | safe }}
-            </li>
+            {% include 'wiki/includes/document_toc_field.html' %}
           {% endif %}
         </ul>
         <input type="hidden" name="parent_topic" value="{{ parent_id | safe }}" />

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -242,6 +242,10 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 .new .editing .metadata { display: block; }
 .editing ul.metadata li { margin: 0; padding: 0; clear: both; }
 .editing ul.metadata li label { display: block; float: left; line-height: 2.5em; text-align: right; width: 10ex; font-weight: bold; padding-right: 0.25em; color: #888; }
+.editing ul.metadata li label.inline { color:#000; width:auto; font-weight:normal; float:none; text-align:left; display:inline-block; padding-left:34px; }
+.editing ul.metadata li .show_toc_block { padding: 7px 0 0 0; }
+.editing ul.metadata li a#toc_customize { /* display: inline-block; */ display: none; margin-left: 10px; font-size: 0.8em; color: #999; text-decoration: none; border-bottom: 1px dotted #999; }
+.editing ul.metadata li #show_toc_depth_block { margin-left: -12px; opacity: 0; }
 .editing ul.metadata li input, .editing ul.metadata li input#id_title { font-size: 1em; padding: 6px 8px; margin: 2px 0px; width: 70%; }
 .editing ul.metadata li input[type="checkbox"] { width: auto; margin-left: 6px; }
 .editing ul.metadata li .metadataDisplay { display:inline-block; padding: 8px 0 0 3px; }


### PR DESCRIPTION
This includes the signed-off-on part of:

https://bugzilla.mozilla.org/show_bug.cgi?id=845355

The "customize" link is hidden for now.

What we still need is the server-side portion of this, migration and value handling.  My thought was:
-  Change the current show_toc field from Boolean to Integer
-  The value scheme would be:

0 = No TOC
1 = TOC, show all headings
2 = TOC, show only H2 headings
3 = TOC, show only H2 and H3 headings
4 = TOC, show only H2, H3, and H4 headings

4 would be the default.
