### PR TITLE
fix bug 844528 - Disable robots on dev servers

### DIFF
--- a/apps/wiki/cron.py
+++ b/apps/wiki/cron.py
@@ -74,6 +74,27 @@ def rebuild_kb():
 
 
 @cronjobs.register
+def build_robots():
+    if settings.ENGAGE_ROBOTS:
+        content = """User-Agent: *
+Crawl-delay: 5
+Sitemap: https://developer.mozilla.org/sitemap.xml
+Request-rate: 1/5
+
+Disallow: /*feed=rss
+Disallow: /*type=feed
+Disallow: /skins
+Disallow: /template:
+Disallow: /media"""
+    else:
+        content = """User-agent: *
+Disallow: /"""
+    handle = open('%s/robots.txt' % settings.MEDIA_ROOT, 'w')
+    handle.write(content)
+    handle.close()
+
+
+@cronjobs.register
 def build_sitemaps():
     sitemap_element = "<sitemap><loc>%s</loc><lastmod>%s</lastmod></sitemap>"
     sitemap_index = "<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"

--- a/media/robots.txt
+++ b/media/robots.txt
@@ -1,10 +1,2 @@
 User-Agent: *
-Crawl-delay: 5
-Sitemap: https://developer.mozilla.org/sitemap.xml
-Request-rate: 1/5
-
-Disallow: /*feed=rss
-Disallow: /*type=feed
-Disallow: /skins
-Disallow: /template:
-Disallow: /media
+Disallow: /


### PR DESCRIPTION
A few things here:
1.  I've added a cron routine to create the robots.txt file
2.  I'm hard-coding the robots.txt content in the view; history shows we never touch it.
3.  I'm uploading a new, disallow-all robots.txt to replace anything on a dev server so that if they don't have CRONs already, we don't need to do a bunch of config

STOP!  TWO IMPORTANT THINGS:
1.  WE MUST MAKE SURE THAT "ENGAGE_ROBOTS" IS "True" IN PRODUCTION
2.  WE MUST RUN THIS CRON IN PRODUCTION AS SOON AS IT'S PUSHED SO WE DON'T DISALLOWING INDEXING IN PRODUCTION.  WE WOULD BE HOSED.

That is all.
