### PR TITLE
Fix bug 848878: Include gmaps using https

### DIFF
--- a/apps/devmo/templates/devmo/calendar.html
+++ b/apps/devmo/templates/devmo/calendar.html
@@ -81,6 +81,6 @@
 {% endblock %}
 
 {% block js %}
-<script src="http://maps.google.com/maps?file=api&amp;v=2&amp;sensor=false&amp;key={{ google_maps_api_key }}" type="text/javascript"></script>
+<script src="https://maps.google.com/maps?file=api&amp;v=2&amp;sensor=false&amp;key={{ google_maps_api_key }}" type="text/javascript"></script>
 {{ js('events') }}
 {% endblock %}


### PR DESCRIPTION
Chrome blocks insecure resources. Use https to load the Google Maps script.
