### PR TITLE
fix bug 647796 - get_best_language without NSL bug

### DIFF
--- a/apps/devmo/tests/test_middleware.py
+++ b/apps/devmo/tests/test_middleware.py
@@ -31,7 +31,3 @@ class BestLanguageTests(TestCase):
         """en-US is a better match for en-gb, es;q=0.2 than es."""
         best = get_best_language('en-gb, es;q=0.2')
         eq_('en-US', best)
-
-    def test_serbian(self):
-        """sr -> sr-CYRL, not sr-LATN."""
-        eq_('sr-CYRL', get_best_language('sr'))

--- a/settings.py
+++ b/settings.py
@@ -100,11 +100,6 @@ SUMO_LANGUAGES = (
     'zh-TW',
 )
 
-#LANGUAGE_CHOICES = tuple([(i, LOCALES[i].native) for i in SUMO_LANGUAGES])
-#LANGUAGES = dict([(i.lower(), LOCALES[i].native) for i in SUMO_LANGUAGES])
-
-#LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in SUMO_LANGUAGES])
-
 # Accepted locales
 MDN_LANGUAGES = ('en-US', 'ar', 'bn-BD', 'de', 'el', 'es', 'fa', 'fi', 'fr',
                  'cs', 'ca', 'fy-NL', 'ga-IE', 'he', 'hr', 'hu', 'id', 'it',
@@ -120,17 +115,19 @@ DEV_POOTLE_PRODUCT_DETAILS_MAP = {
 
 # Locales that are known but unsupported. Keys are the locale, values
 # are an optional fallback locale, or None, to use the LANGUAGE_CODE.
+'''SUMO's list is a good start, but we don't need them until users ask
+'af': None,
+'an': 'es',
+'br': 'fr',
+'csb': 'pl',
+'lij': 'it',
+'nb-NO': 'no',
+'nn-NO': 'no',
+'oc': 'fr',
+'sr': 'sr-CYRL',  # Override the tendency to go sr->sr-LATN.
+'sv-SE': 'sv',
+'''
 NON_SUPPORTED_LOCALES = {
-    'af': None,
-    'an': 'es',
-    'br': 'fr',
-    'csb': 'pl',
-    'lij': 'it',
-    'nb-NO': 'no',
-    'nn-NO': 'no',
-    'oc': 'fr',
-    'sr': 'sr-CYRL',  # Override the tendency to go sr->sr-LATN.
-    'sv-SE': 'sv',
 }
 
 try:


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=647796

Same change as #918 but I made our NON_SUPPORTED_LANGUAGES empty for now. To test, to to https://developer-local.allizom.org/ with default language, supported language (e.g., French 'fr') and un-supported language (e.g., Serbian 'sr').
