### PR TITLE
Bug 848883 - Editing the wording on the "Where is Mozilla?" page

### DIFF
--- a/apps/devmo/templates/devmo/calendar.html
+++ b/apps/devmo/templates/devmo/calendar.html
@@ -14,9 +14,12 @@
   <section id="content-main" class="full" role="main">
     <header id="page-head">
       <h1 class="page-title">{{ _('Where is Mozilla?') }}</h1>
-      <p>{% trans %}
-      Here you can see where Mozilla will be in the near future and what we are going to talk about. If you organize an event and you want a Mozillian to come around, please <a href="mailto:dev-events@mozilla.com">send us an email</a>. If you are a Mozillian speaking at an event that's not listed here, <a href="mailto:dev-events@mozilla.com">let us know</a>!
-      {% endtrans %}
+      <p>
+        {% trans %}
+        Here you can see some of the developer events at which Mozilla will be participating, and the topics on which our Mozillians will be speaking. 
+If you are organizing an event and would like a Mozillian to participate, please <a href="mailto:dev-events@mozilla.com">send us an email</a>. If you are a Mozillian speaking at an event that's not listed here, <a href="mailto:dev-events@mozilla.com">let us know</a>!
+You can also check out the <a href="https://reps.mozilla.org/events/#/period/future/">Mozilla Reps events</a> page to find a Mozilla Reps event near you!
+        {% endtrans %}
       </p>
     </header>
 
@@ -73,8 +76,7 @@
       </tr>
       {% endfor %}
 </tbody></table>
-</div>
-  </section><!-- /#content-main -->
+</section><!-- /#content-main -->
 
 </div>
 </section>


### PR DESCRIPTION
change text in events section & remove a not necessary < /div > tag
