### PR TITLE
Fix bug 850656: Set based_on field correctly

### DIFF
--- a/apps/dashboards/views.py
+++ b/apps/dashboards/views.py
@@ -177,7 +177,9 @@ def revisions(request):
             articleUrl = '<a href="%s" target="_blank">%s</a>' % (doc_url, jinja2.escape(rev.document.slug))
             articleLocale = '<span class="dash-locale">%s</span>' % rev.document.locale
             articleComment = '<span class="dashboard-comment">%s</span>' % format_comment(rev)
-            articleIsNew = '<span class="dashboard-new">New: </span>' if rev.based_on_id is None else ''
+            articleIsNew = ''
+            if rev.based_on_id is None and not rev.document.is_redirect:
+                articleIsNew = '<span class="dashboard-new">New: </span>' 
             richTitle = articleIsNew + articleUrl + articleLocale + articleComment
 
             revision_json['aaData'].append({

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -915,6 +915,8 @@ class Document(NotificationsMixin, ModelBase):
             return unique_attr()
 
     def revert(self, revision, user):
+        if revision.document.original == self:
+            revision.based_on = revision
         revision.id = None
         revision.comment = "Revert to revision of %s by %s" % (
                 revision.created, revision.creator)

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1623,6 +1623,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
                 post_data['show_toc'] = based_on_rev.show_toc
 
                 rev_form = RevisionForm(post_data)
+                rev_form.instance.document = doc  # for rev_form.clean()
 
                 if rev_form.is_valid():
                     _save_rev_and_notify(rev_form, request.user, doc)


### PR DESCRIPTION
This tries to make sure that the "New:" keyboard in the revision dashboard is (more) correct.

1) Don't mark **page moves** as new (dashboard/views.py):
I'm just checking if rev.document.is_redirect.

2) Don't mark **reverts** as new (wiki/models.py):
If in the default locale, set based_on to the revision we reverted from (it's null currently, that's why they appear as _New:_). Leave translations alone, as they always refer to a revision of the default language document.

3) Don't mark **all translations** as new (wiki/views.py):
This looks really unfortunate :( We forgot the document instance for the validation and so there is no based_on reference for translation revisions at all. That information is badly needed to compare against the English version (once we have a l10n dashboard, we will miss this data :-/)

Not yet resolved:
As said in 3) all translation revisions will need the based_on reference and so does the very first revision of a translation. That means that new translations aren't marked as _New:_ currently. (Maybe count that the revision is the only one for a document?)
