### PR TITLE
Add Twitter METAs to individual demos for better sharing

### DIFF
--- a/apps/demos/templates/demos/detail.html
+++ b/apps/demos/templates/demos/detail.html
@@ -2,6 +2,7 @@
 
 {% set full_url = request.build_absolute_uri(submission.get_absolute_url()) %}
 {% set short_url = full_url | bitly_shorten %}
+{% set screenshot = request.build_absolute_uri(submission.screenshot_url(1)) %}
 
 {% block pageid %}demostudio{% endblock %}
 {% block bodyclass %}section-demos detail{% endblock %}
@@ -10,11 +11,18 @@
 {% block extrahead %}
     <meta property="og:title" content="{{ submission.title }}"/>
     <meta property="og:type" content="website"/>
-    <meta property="og:image" content="{{ request.build_absolute_uri(submission.screenshot_url(1)) }}"/>    
+    <meta property="og:image" content="{{ screenshot }}"/>    
     <meta property="og:site_name" content="{{ page_title(_('Demo Studio')) }}"/>
     <meta property="og:description" content="{{ submission.summary }}"/>
-
     <meta name="description" content="{{ submission.summary }}" />
+
+    <meta name="twitter:title" content="{{ submission.title }}" />
+    <meta name="twitter:image" content="{{ screenshot }}" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:url" content="{{ full_url }}" />
+    <meta name="twitter:site" content="@mozhacks" />
+    <meta name="twitter:creator" content="@mozhacks" />
+    <meta name="twitter:description" content="{{ submission.summary }}" />
 {% endblock %}
 
 {% block content %}


### PR DESCRIPTION
I'm betting individual demos get shared a lot, so this will help us be more social about it.
