### PR TITLE
Fix bug #852273 - Change the text of the dev-mdc@ link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -158,8 +158,7 @@
 <div class="wrap">
   <p>
   {% trans feedback_url=devmo_url('Project:Feedback') %}
-  What do you think of the new MDN? Please <a href="{{ feedback_url }}">share
-  your feedback</a> with us. <a id="dev-mdc-link" href="https://lists.mozilla.org/listinfo/dev-mdc">Join our mailing list</a> to discuss ways to help create great documentation.
+  Is MDN helpful to you? Please  <a href="{{ feedback_url }}">share your feedback</a> with us. Or join our  <a id="dev-mdc-link" href="https://lists.mozilla.org/listinfo/dev-mdc">mailing list about improving MDN content</a>.
   {% endtrans %}
   </p>
 </div>


### PR DESCRIPTION
Changed the footer link according to discussion on the [Bugzilla thread](https://bugzilla.mozilla.org/show_bug.cgi?id=852273)
