### PR TITLE
Enable USE_X_FORWARDED_HOST by default

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -25,6 +25,7 @@ ADMINS = (
 SITE_URL = 'https://developer.mozilla.org'
 PROTOCOL = 'https://'
 DOMAIN = 'developer.mozilla.org'
+USE_X_FORWARDED_HOST = True
 
 MANAGERS = ADMINS
 


### PR DESCRIPTION
Docs say "This should only be enabled if a proxy which sets this header is in use", but this should be the case in almost all deployment & vagrant dev scenarios
