### PR TITLE
fixes celery.decorators deprecation warning

### DIFF
--- a/apps/search/tasks.py
+++ b/apps/search/tasks.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.db.models.signals import post_save, pre_delete
 
-from celery.decorators import task
+from celery.task import task
 
 
 @task


### PR DESCRIPTION
Spot-check: make sure live indexing still works. i.e., 
0. make sure `manage.py celeryd` is running 
1. update a doc
2. check https://developer-local.allizom.org/elastic/_plugin/head/
2a. (connect to https://developer-local.allizom.org/elastic/)
