### PR TITLE
Fix HTML landing page

### DIFF
--- a/apps/landing/templates/landing/learn_html.html
+++ b/apps/landing/templates/landing/learn_html.html
@@ -55,7 +55,7 @@
         <li>
           <h3 class="title"><a href="http://wikiversity.org/wiki/Web_Design/HTML_Challenges" rel="external">{{ _('HTML Challenges') }}</a></h3>
           <h4 class="source">Wikiversity</h4>
-          <p>{{ _('Use these challenges to hone your HTML skills (for example, "Should I use an <h2> element or a <strong> element?"), focusing on meaningful mark-up.') }}</p>
+          <p>{{ _('Use these challenges to hone your HTML skills (for example, "Should I use an &lt;h2&gt; element or a &lt;strong&gt; element?"), focusing on meaningful mark-up.') }}</p>
         </li>
         <li>
           <h3 class="title"><a href="{{ devmo_url('HTML/Element') }}">MDN HTML Element Reference</a></h3>
@@ -96,7 +96,7 @@
         <li>
           <h3 class="title"><a href="{{ devmo_url('Canvas_tutorial') }}">{{ _('Canvas Tutorial') }}</a> <span class="tag html5" title="{{ _('This site features HTML5') }}">(HTML5)</span></h3>
           <h4 class="source">{{ _('MDN') }}</h4>
-          <p>{{ _('Learn how to draw graphics using scripting using the <canvas> element.') }}</p>
+          <p>{{ _('Learn how to draw graphics using scripting using the &lt;canvas&gt; element.') }}</p>
         </li>
         <li>
           <h3 class="title"><a href="http://html5doctor.com/" rel="external">{{ _('HTML5 Doctor') }}</a> <span class="tag html5" title="{{ _('This site features HTML5') }}">(HTML5)</span></h3>


### PR DESCRIPTION
The HTML "Learn" page is hosed, probably because of a difference in component during upgrade.  This fixes the issue for now, though we'll probably need to do more to backport original functionality of {{ _('<tag>') }}.
