### PR TITLE
django 1.4.5 i18n/l10n updates

### DIFF
--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -275,7 +275,6 @@ be big merging headaches.
 Updating strings is pretty easy. Check out the localizations as above, then::
 
     $ python manage.py extract
-    $ python manage.py verbatimize --rename
 
 Congratulations! You've now updated the POT file.
 

--- a/settings.py
+++ b/settings.py
@@ -277,6 +277,7 @@ MDC_PAGES_DIR = path('../mdc_pages')
 # to load the internationalization machinery.
 USE_I18N = True
 USE_L10N = True
+LOCALE_PATHS = path('locale')
 
 # Use the real robots.txt?
 ENGAGE_ROBOTS = False


### PR DESCRIPTION
spot-check:

make sure non-default locales still work

extract and compile l10n strings:

```
vagrant ssh
manage.py extract
cd locale
./compile-mo.sh .
```
