### PR TITLE
change mdn_prod logging to admin emails

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1107,9 +1107,9 @@ LOGGING = {
             'level': LOG_LEVEL,
         },
         'mdn_prod': {
-            'class': 'logging.handlers.SysLogHandler',
+            'class': 'django.utils.log.AdminEmailHandler',
             'formatter': 'mdn_default',
-            'level': LOG_LEVEL,
+            'level': logging.ERROR,
         },
     },
     'loggers': {
@@ -1118,6 +1118,5 @@ LOGGING = {
             'level': LOG_LEVEL,
             'propagate': False,
         },
-        
     },
 }


### PR DESCRIPTION
make sure dev/stage/prod servers (i.e., those with `DEBUG=False` in settings_local.py) are using django's admin emails logging handler for server errors.
