### PR TITLE
Use the staticfiles app to serve static media in dev

### DIFF
--- a/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
+++ b/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
@@ -33,7 +33,6 @@ WSGISocketPrefix /var/run/wsgi
     </Directory>
 
     Alias /media/ "/vagrant/media/"
-    Alias /static/ "/vagrant/static/"
     Alias /uploads/ "/home/vagrant/uploads/"
 
     # This runs the python app through mod_wsgi

--- a/urls.py
+++ b/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls.defaults import include, patterns, url
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
 from django.views.i18n import javascript_catalog
 from django.views.decorators.cache import cache_page
@@ -78,6 +79,8 @@ urlpatterns = patterns('',
         {'document_root': settings.HUMANSTXT_ROOT, 'path': 'humans.txt'}),
 )
 
+if settings.DEBUG:
+    urlpatterns += staticfiles_urlpatterns()
 
 # Handle 404 and 500 errors
 def _error_page(request, status):


### PR DESCRIPTION
Looks like we [reconfigured apache in vagrant](https://github.com/mozilla/kuma/commit/18028cba8e35e6e514a230d78e0e4262915c32f7) to serve static media after a `collectstatic` command, like prod.

It's more useful to [serve static files using the staticfiles view](https://docs.djangoproject.com/en/dev/ref/contrib/staticfiles/#static-file-development-view) in dev. Otherwise, you have to run `collectstatic` each and every time a static resource is modified.
