### PR TITLE
Fix bug 816193: Correct locale in rev dash urls, PEP8 fixes

### DIFF
--- a/apps/dashboards/tests/test_views.py
+++ b/apps/dashboards/tests/test_views.py
@@ -50,7 +50,7 @@ class RevisionsDashTest(TestCase):
         eq_(200, response.status_code)
         ok_('text/html' in response['Content-Type'])
         ok_('dashboards/revisions.html' in
-            [template.name for template in response.template])
+            [template.name for template in response.templates])
 
     @attr('dashboards')
     def test_locale_filter(self):

--- a/apps/dashboards/views.py
+++ b/apps/dashboards/views.py
@@ -189,24 +189,36 @@ def revisions(request):
         for rev in revisions:
             prev = rev.get_previous()
             from_rev = str(prev.id if prev else rev.id)
-            doc_url = reverse('wiki.document', args=[rev.document.full_path], locale=rev.document.locale)
-            articleUrl = '<a href="%s" target="_blank">%s</a>' % (doc_url, jinja2.escape(rev.document.slug))
-            articleLocale = '<span class="dash-locale">%s</span>' % rev.document.locale
-            articleComment = '<span class="dashboard-comment">%s</span>' % format_comment(rev)
+            doc_url = reverse('wiki.document', args=[rev.document.full_path],
+                              locale=rev.document.locale)
+            articleUrl = '<a href="%s" target="_blank">%s</a>' % (doc_url,
+                    jinja2.escape(rev.document.slug))
+            articleLocale = ('<span class="dash-locale">%s</span>'
+                             % rev.document.locale)
+            articleComment = ('<span class="dashboard-comment">%s</span>'
+                              % format_comment(rev))
             articleIsNew = ''
             if rev.based_on_id is None and not rev.document.is_redirect:
-                articleIsNew = '<span class="dashboard-new">New: </span>' 
-            richTitle = articleIsNew + articleUrl + articleLocale + articleComment
+                articleIsNew = '<span class="dashboard-new">New: </span>'
+            richTitle = (articleIsNew + articleUrl + articleLocale +
+                         articleComment)
 
             revision_json['aaData'].append({
                 'id': rev.id,
                 'prev_id': from_rev,
                 'doc_url': doc_url,
-                'edit_url': reverse('wiki.edit_document', args=[rev.document.full_path], locale=rev.document.locale),
-                'compare_url': reverse('wiki.compare_revisions', args=[rev.document.full_path]) + '?from=%s&to=%s&raw=1' % (from_rev, str(rev.id)),
-                'revert_url': reverse('wiki.revert_document', args=[rev.document.full_path, rev.id]),
-                'history_url': reverse('wiki.document_revisions', args=[rev.document.full_path], locale=rev.document.locale),
-                'creator': '<a href="" class="creator">%s</a>' % jinja2.escape(rev.creator.username),
+                'edit_url': reverse('wiki.edit_document',
+                    args=[rev.document.full_path], locale=rev.document.locale),
+                'compare_url': reverse('wiki.compare_revisions',
+                    args=[rev.document.full_path], locale=rev.document.locale)
+                    + '?from=%s&to=%s&raw=1' % (from_rev, str(rev.id)),
+                'revert_url': reverse('wiki.revert_document',
+                    args=[rev.document.full_path, rev.id],
+                    locale=rev.document.locale),
+                'history_url': reverse('wiki.document_revisions',
+                    args=[rev.document.full_path], locale=rev.document.locale),
+                'creator': ('<a href="" class="creator">%s</a>'
+                            % jinja2.escape(rev.creator.username)),
                 'title': rev.title,
                 'richTitle': richTitle,
                 'date': rev.created.strftime('%b %d, %y - %H:%M'),


### PR DESCRIPTION
- Adds `locale=rev.document.locale` to compare_url and revert_url (fix for [bug 816193](https://bugzilla.mozilla.org/show_bug.cgi?id=816193)).
- Some PEP8 cleanup in views.py
- Fixes a deprecation warning in the test_main_view test (Django 1.3)
