### PR TITLE
Fix bug 781350: Do not clean out timezone field

### DIFF
--- a/apps/devmo/forms.py
+++ b/apps/devmo/forms.py
@@ -46,6 +46,3 @@ class UserProfileEditForm(forms.ModelForm):
                 "subset of interests"))
 
         return cleaned_data['expertise']
-
-    def clean_timezone(self):
-        pass


### PR DESCRIPTION
I guess this was cleaned because we got profile data from MindTouch some ages ago, but it prevents us from persisting the timezone in the user profile now ([bug 781350](https://bugzilla.mozilla.org/show_bug.cgi?id=781350)).
