### PR TITLE
Fix layout of revision comment box in translate mode

### DIFF
--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -116,10 +116,10 @@
                 {% endif %}
               </section>
           </section>
-        </div>
 
-        {% include 'wiki/includes/revision_comment.html' %}
-        
+          {% include 'wiki/includes/revision_comment.html' %}
+
+        </div>
       </details>
     {% endif %}
 


### PR DESCRIPTION
Before the [fix for bug 844636](https://github.com/mozilla/kuma/commit/c5960d22b0748a63aaf1cdec2fe952020df80490#L3L121), there was a nasty inline style="clear:both;" on the "page-meta" section element. With this style missing now, the revision comment box is broken when in the translation editor. Having the template include within the "localized" div element should do the trick now.
