### PR TITLE
bug 845923: Set up statsd and graphite under vagrant

### DIFF
--- a/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
+++ b/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
@@ -1,3 +1,5 @@
+Listen 8080
+
 WSGISocketPrefix /var/run/wsgi
 
 <VirtualHost *:80>
@@ -64,4 +66,40 @@ WSGISocketPrefix /var/run/wsgi
     RewriteCond %{REQUEST_URI} /media/uploads/
     RewriteRule ^/media/uploads/(.*)$ https://developer.mozilla.org/media/uploads/$1 [P,L]
 
+</VirtualHost>
+
+<VirtualHost *:8080>
+    ServerName developer-local.allizom.org
+
+    DocumentRoot "/opt/graphite/webapp"
+    ErrorLog /opt/graphite/storage/log/webapp/error.log
+    CustomLog /opt/graphite/storage/log/webapp/access.log common
+
+    # Set up graphite via mod_wsgi
+    WSGIDaemonProcess graphite processes=5 threads=5 display-name='%{GROUP}' inactivity-timeout=120
+    WSGIProcessGroup graphite
+    WSGIApplicationGroup %{GLOBAL}
+    WSGIImportScript /opt/graphite/conf/graphite.wsgi process-group=graphite application-group=%{GLOBAL}
+    WSGIScriptAlias / /opt/graphite/conf/graphite.wsgi 
+    
+    Alias /content/ /opt/graphite/webapp/content/
+    <Location "/content/">
+            SetHandler None
+    </Location>
+
+    # XXX In order for the django admin site media to work you
+    # must change @DJANGO_ROOT@ to be the path to your django
+    # installation, which is probably something like:
+    # /usr/lib/python2.6/site-packages/django
+    Alias /media/ "/usr/local/lib/python2.7/dist-packages/django/contrib/admin/media/"
+    <Location "/media/">
+            SetHandler None
+    </Location>
+
+    # The graphite.wsgi file has to be accessible by apache. It won't
+    # be visible to clients because of the DocumentRoot though.
+    <Directory /opt/graphite/conf/>
+            Order deny,allow
+            Allow from all
+    </Directory>
 </VirtualHost>

--- a/puppet/files/etc/init/carbon-cache.conf
+++ b/puppet/files/etc/init/carbon-cache.conf
@@ -1,0 +1,11 @@
+description "Graphite Carbon Cache Daemon"
+
+start on runlevel [23]
+stop on shutdown
+
+expect daemon
+respawn
+
+pre-start exec rm -f /opt/graphite/storage/carbon-cache-a.pid
+
+exec /opt/graphite/bin/carbon-cache.py start

--- a/puppet/files/etc/init/statsd.conf
+++ b/puppet/files/etc/init/statsd.conf
@@ -1,0 +1,14 @@
+# cat /etc/init/statsd.conf
+description "statsd"
+author      "lorchard"
+
+start on startup
+stop on shutdown
+
+expect daemon
+respawn
+
+script  
+    export HOME="/home/vagrant"
+    exec sudo -u vagrant node /home/vagrant/node_modules/.bin/statsd /home/vagrant/statsd-config.js
+end script

--- a/puppet/files/home/vagrant/statsd-config.js
+++ b/puppet/files/home/vagrant/statsd-config.js
@@ -1,0 +1,5 @@
+{
+    graphitePort: 2003,
+    graphiteHost: "127.0.0.1",
+    port: 8125
+}

--- a/puppet/files/opt/graphite/conf/storage-schemas.conf
+++ b/puppet/files/opt/graphite/conf/storage-schemas.conf
@@ -1,0 +1,10 @@
+# Schema definitions for Whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds.
+#
+# [name]
+# pattern = regex
+# retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+[stats]
+priority = 110
+pattern = ^stats\..*
+retentions = 10s:6h,1m:7d,10m:1y

--- a/puppet/files/tmp/graphite_reqs.txt
+++ b/puppet/files/tmp/graphite_reqs.txt
@@ -1,0 +1,7 @@
+django==1.3
+python-memcached
+django-tagging
+twisted
+whisper==0.9.9
+carbon==0.9.9
+graphite-web==0.9.9

--- a/puppet/files/vagrant/kumascript_settings_local.json
+++ b/puppet/files/vagrant/kumascript_settings_local.json
@@ -7,7 +7,7 @@
         }
     },
     "statsd": {
-        "enabled": false,
+        "enabled": true,
         "host": "127.0.0.1",
         "port": 8125
     },

--- a/puppet/files/vagrant/settings_local.py
+++ b/puppet/files/vagrant/settings_local.py
@@ -30,7 +30,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 #EMAIL_FILE_PATH = '/home/vagrant/logs/kuma-email.log'
 
 # Uncomment to enable a real celery queue
-CELERY_ALWAYS_EAGER = False
+#CELERY_ALWAYS_EAGER = False
 
 INSTALLED_APPS = INSTALLED_APPS + (
     "django_extensions",
@@ -59,7 +59,6 @@ DEBUG_TOOLBAR_PANELS = (
     'debug_toolbar.panels.sql.SQLDebugPanel',
     'debug_toolbar.panels.signals.SignalDebugPanel',
     'debug_toolbar.panels.logger.LoggingPanel',
-    'django_statsd.panel.StatsdPanel',
 )
 
 DEVSERVER_MODULES = (
@@ -129,8 +128,6 @@ LOGIN_REDIRECT_URL = '/'
 LOGIN_REDIRECT_URL_FAILURE = '/'
 
 KUMASCRIPT_URL_TEMPLATE = 'http://localhost:9080/docs/{path}'
-
-STATSD_CLIENT = 'django_statsd.clients.toolbar'
 
 ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
 

--- a/puppet/manifests/classes/dev-hacks.pp
+++ b/puppet/manifests/classes/dev-hacks.pp
@@ -11,11 +11,13 @@ class dev_tools {
 class dev_hacks {
 
     exec { 'locale-gen':
-        command => "/usr/sbin/locale-gen en_US.utf8"
+        command => "/usr/sbin/locale-gen en_US.utf8",
+        unless => '/bin/grep -q "en_US.utf8" /etc/default/locale'
     }
 
     exec { 'update-locale':
         command => "/usr/sbin/update-locale LC_ALL='en_US.utf8'",
+        unless => '/bin/grep -q "en_US.utf8" /etc/default/locale',
         require => Exec['locale-gen']
     }
 

--- a/puppet/manifests/classes/statsd.pp
+++ b/puppet/manifests/classes/statsd.pp
@@ -1,0 +1,84 @@
+# see also: http://www.kinvey.com/blog/89/how-to-set-up-metric-collection-using-graphite-and-statsd-on-ubuntu-1204-lts
+class statsd {
+    exec { 'statsd-install':
+        cwd => '/home/vagrant',
+        user => 'vagrant',
+        # TODO: This revision works, but try to see what statsd runs in mozilla infra
+        command => '/usr/bin/npm install git://github.com/etsy/statsd.git#922e9e58c57ae4e61268cbd6925c112f0e4e468c',
+        creates => '/home/vagrant/node_modules/statsd',
+        require => [Package["nodejs"], Package["npm"]]
+    }
+    file { '/home/vagrant/statsd-config.js':
+        source => '/vagrant/puppet/files/home/vagrant/statsd-config.js',
+        owner => "vagrant", group => "vagrant", mode => 0664,
+        require => Exec['statsd-install']
+    }
+    package {
+        ['sqlite3', 'libcairo2', 'libcairo2-dev', 'python-cairo', 'pkg-config']:
+        ensure => present;
+    }
+    exec { 'graphite-install':
+         cwd => '/tmp',
+         timeout => 1200, # Too long, but this can take awhile
+         command => '/usr/bin/pip install --download-cache=/vagrant/puppet/cache/pip -r /vagrant/puppet/files/tmp/graphite_reqs.txt',
+         creates => '/opt/graphite/webapp/graphite/manage.py';
+    }
+    file { '/opt/graphite/conf/carbon.conf':
+        source => '/opt/graphite/conf/carbon.conf.example',
+        owner => "root", group => "www-data", mode => 0664,
+        require => Exec['graphite-install']
+    }
+    file { '/opt/graphite/webapp/graphite/local_settings.py':
+        source => '/opt/graphite/webapp/graphite/local_settings.py.example',
+        owner => "root", group => "www-data", mode => 0664,
+        require => Exec['graphite-install']
+    }
+    file { '/opt/graphite/conf/graphite.wsgi':
+        source => '/opt/graphite/conf/graphite.wsgi.example',
+        owner => "root", group => "www-data", mode => 0664,
+        require => Exec['graphite-install']
+    }
+    file { '/opt/graphite/storage/log/webapp':
+        ensure => directory,
+        owner => "www-data", group => "www-data", mode => 0775,
+        require => Exec['graphite-install']
+    }
+    file { '/opt/graphite/conf/storage-schemas.conf':
+        source => '/vagrant/puppet/files/opt/graphite/conf/storage-schemas.conf',
+        owner => "root", group => "www-data", mode => 0664,
+        require => Exec['graphite-install']
+    }
+    file { '/etc/init/statsd.conf':
+        source => '/vagrant/puppet/files/etc/init/statsd.conf',
+        owner => "root", group => "www-data", mode => 0775,
+        require => Exec['statsd-install']
+    }
+    file { '/etc/init/carbon-cache.conf':
+        source => '/vagrant/puppet/files/etc/init/carbon-cache.conf',
+        owner => "root", group => "www-data", mode => 0775,
+        require => Exec['graphite-install']
+    }
+    exec { 'graphite-syncdb':
+        cwd => '/opt/graphite/webapp/graphite',
+        command => '/usr/bin/python manage.py syncdb --noinput',
+        creates => '/opt/graphite/storage/graphite.db',
+        require => Exec['graphite-install']
+    }
+    exec { 'graphite-superuser':
+        cwd => '/opt/graphite/webapp/graphite',
+        command => '/usr/bin/python manage.py loaddata /vagrant/puppet/files/tmp/graphite_auth.json',
+        unless => "/usr/bin/sqlite3 /opt/graphite/storage/graphite.db 'select * from auth_user' | /bin/grep -q admin",
+        require => Exec['graphite-syncdb']
+    }
+    service { 'carbon-cache':
+        ensure => running,
+        enable => true,
+        require => File['/etc/init/carbon-cache.conf']
+    }
+    service { 'statsd':
+        ensure => running,
+        enable => true,
+        require => File['/etc/init/statsd.conf']
+    }
+        
+}

--- a/puppet/manifests/dev-vagrant.pp
+++ b/puppet/manifests/dev-vagrant.pp
@@ -17,7 +17,8 @@ class dev {
         tools:  before => Stage[basics];
         basics: before => Stage[langs];
         langs:  before => Stage[vendors];
-        vendors:   before => Stage[main];
+        vendors:   before => Stage[extras];
+        extras: before => Stage[main];
         vendors_post:  require => Stage[main];
         # Stage[main]
         hacks_post: require => Stage[vendors_post];
@@ -38,6 +39,8 @@ class dev {
 
         nodejs: stage => langs;
         python: stage => langs;
+
+        statsd:         stage => extras;
 
         site_config: stage => main;
         dev_hacks_post: stage => hacks_post;


### PR DESCRIPTION
Still wrestling a bit with the kumascript upgrade, trying to make sure everything works as I expect before trying a deploy. Part of this devolved into me yak shaving a statsd & graphite install into vagrant

If this works, you should be able to visit http://developer-local.allizom.org:8080 after a `vagrant provision` and see graphite being fed metrics and drawing graphs
