### PR TITLE
Fix bug 856124: Use Django's X-Frame-Options middleware.

### DIFF
--- a/apps/demos/views.py
+++ b/apps/demos/views.py
@@ -15,6 +15,7 @@ from django.contrib.contenttypes.models import ContentType
 
 from django.utils.translation import ugettext_lazy as _
 
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.generic.list_detail import object_list
 
 from devmo.models import UserProfile
@@ -181,18 +182,16 @@ def unlike(request, slug):
         submission.likes.decrement(request)
     return _like_feedback(request, submission, 'unliked')
 
-
+@xframe_options_sameorigin
 def _like_feedback(request, submission, event):
     if request.GET.get('iframe', False):
-        response = jingo.render(request, 'demos/iframe_utils.html', dict(
+        return jingo.render(request, 'demos/iframe_utils.html', dict(
             submission=submission, event=event
         ))
-        response['x-frame-options'] = 'SAMEORIGIN'
-        return response
     return HttpResponseRedirect(reverse(
         'demos.views.detail', args=(submission.slug,)))
 
-
+@xframe_options_sameorigin
 def flag(request, slug):
     submission = get_object_or_404(Submission, slug=slug)
 
@@ -216,11 +215,8 @@ def flag(request, slug):
             return HttpResponseRedirect(reverse(
                 'demos.views.detail', args=(submission.slug,)))
 
-    #TODO liberate?
-    response = jingo.render(request, 'demos/flag.html', {
+    return jingo.render(request, 'demos/flag.html', {
         'form': form, 'submission': submission})
-    response['x-frame-options'] = 'SAMEORIGIN'
-    return response
 
 
 def download(request, slug):
@@ -297,6 +293,7 @@ def edit(request, slug):
         'form': form, 'submission': submission, 'edit': True})
 
 
+@xframe_options_sameorigin
 def delete(request, slug):
     """Delete a submission"""
     submission = get_object_or_404(Submission, slug=slug)
@@ -308,10 +305,8 @@ def delete(request, slug):
         _invalidate_submission_listing_helper_cache()
         return HttpResponseRedirect(reverse('demos.views.home'))
 
-    response = jingo.render(request, 'demos/delete.html', {
+    return jingo.render(request, 'demos/delete.html', {
         'submission': submission})
-    response['x-frame-options'] = 'SAMEORIGIN'
-    return response
 
 
 @login_required
@@ -340,6 +335,7 @@ def new_comment(request, slug, parent_id=None):
         'demos.views.detail', args=(submission.slug,)))
 
 
+@xframe_options_sameorigin
 def delete_comment(request, slug, object_id):
     """Delete a comment on a submission, if permitted."""
     tc = get_object_or_404(ThreadedComment, id=int(object_id))
@@ -350,11 +346,9 @@ def delete_comment(request, slug, object_id):
         tc.delete()
         return HttpResponseRedirect(reverse(
             'demos.views.detail', args=(submission.slug,)))
-    response = jingo.render(request, 'demos/delete_comment.html', {
+    return jingo.render(request, 'demos/delete_comment.html', {
         'comment': tc
     })
-    response['x-frame-options'] = 'SAMEORIGIN'
-    return response
 
 
 def hideshow(request, slug, hide=True):

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from django.http import HttpResponseRedirect, Http404
 from django.views.decorators.http import (require_http_methods, require_GET,
                                           require_POST)
+from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.csrf import csrf_exempt
 
 from django.shortcuts import get_object_or_404
@@ -230,6 +231,7 @@ def browserid_register(request):
 
 
 @ssl_required
+@xframe_options_sameorigin
 def login(request):
     """Try to log the user in."""
     next_url = _clean_next_url(request)
@@ -246,10 +248,8 @@ def login(request):
             form.cleaned_data.get('username'),
             form.cleaned_data.get('password'))
 
-    response = jingo.render(request, 'users/login.html',
+    return jingo.render(request, 'users/login.html',
                             {'form': form, 'next_url': next_url})
-    response['x-frame-options'] = 'SAMEORIGIN'
-    return response
 
 
 @ssl_required

--- a/settings.py
+++ b/settings.py
@@ -354,7 +354,7 @@ MIDDLEWARE_CLASSES = (
     'sumo.middleware.RemoveSlashMiddleware',
     'inproduct.middleware.EuBuildMiddleware',
     'commonware.middleware.NoVarySessionMiddleware',
-    'commonware.middleware.FrameOptionsHeader',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
@@ -1150,3 +1150,4 @@ LOGGING = {
 
 
 CSRF_COOKIE_SECURE = True
+X_FRAME_OPTIONS = 'DENY'


### PR DESCRIPTION
This does the following things:
- Enable the middleware, with the default setting (which is SAMEORIGIN)
- Remove places where we've hacked in code just to send a SAMEORIGIN header value.
- Apply Django's decorators as needed to handle cases where we don't want SAMEORIGIN.
- Clean up the places where we still manually set the header, by making sure it matches what the middleware looks for when deciding whether to add it.
