### PR TITLE
Temporary measure to isolate disappearing pages

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1033,6 +1033,10 @@ class Document(NotificationsMixin, ModelBase):
         if title_changed:
             del self.old_title
 
+    def delete(self, *args, **kwargs):
+        # Temporary while we investigate disappearing pages.
+        raise Exception("Attempt to delete document %s: %s" % (self.id, self.title))
+
     def move(self, new_slug=None, user=None):
         """
         Complete the process of moving a page by leaving a redirect


### PR DESCRIPTION
This adds a delete() method to Document, and simply raises an exception, with a message outlining which Document was going to be deleted.

This _does_ break some unit tests that rely on the ability to delete a Document, but that's a tradeoff we need to make for now in order to isolate what's going on.
