### PR TITLE
Set based_on field for PUT API calls

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -954,6 +954,11 @@ class Document(NotificationsMixin, ModelBase):
             setattr(new_rev, n, getattr(self, n))
         if curr_rev:
             new_rev.toc_depth = curr_rev.toc_depth
+            original_doc = curr_rev.document.original
+            if original_doc == self:
+                new_rev.based_on = curr_rev
+            else:
+                new_rev.based_on = original_doc.current_revision
 
         # Accept optional field edits...
 


### PR DESCRIPTION
I was wondering why @lmorchard's ChiefHistory page always gets the "New" keyword on the revision dashboard and it looks like I forgot the PUT API when submitting [PR 931](https://github.com/mozilla/kuma/pull/931/). So, this is setting the based_on field for PUT calls, too. And again: Translations need refer to the original document here.
