### PR TITLE
Add libtidy to the requirements section in the installation document.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,6 +36,8 @@ following things (in addition to Git, of course).
 
 * ``libmagic`` and headers.
 
+* ``libtidy`` and headers
+
 * Several Python packages. See `Installing the Packages`_.
 
 Installation for these is very system dependent. Using a package manager, like


### PR DESCRIPTION
See also bug 772122.
