### PR TITLE
fix bug 785993 - show amount of words changed to revision comment

### DIFF
--- a/apps/wiki/templates/wiki/document_revisions.html
+++ b/apps/wiki/templates/wiki/document_revisions.html
@@ -64,7 +64,7 @@
                 <a href="{{ url('devmo.views.profile_view', username=rev.creator) }}">{{ rev.creator }}</a>
               </div>
               <div class="comment">
-                {{ format_comment(rev) }}
+                {{ format_comment(rev) }} {{ comment_diff_words(rev) }}
               </div>
               {% if document.current_revision.id != rev.id and user.has_perm('wiki.delete_revision') %}
               <div class="creator">


### PR DESCRIPTION
I have created 2 helper functions `comment_diff_percent` and `comment_diff_words` for giving estimation of content changed in terms of percent and words respectively. 

I created percent function in case words changed didn't give expected results.

Please let me know if I can refactor my code.
