### PR TITLE
fix bug 859875 - email change notifications UI

### DIFF
--- a/apps/wiki/events.py
+++ b/apps/wiki/events.py
@@ -10,7 +10,7 @@ from tower import ugettext as _
 from devmo import email_utils
 from tidings.events import InstanceEvent, Event
 from sumo.urlresolvers import reverse
-from wiki.helpers import diff_table
+from wiki.helpers import revisions_unified_diff
 from wiki.models import Document
 
 
@@ -22,8 +22,7 @@ def context_dict(revision):
     document = revision.document
     from_revision = revision.get_previous()
     to_revision = revision
-    diff = diff_table(from_revision.content, to_revision.content,
-                           from_revision.id, to_revision.id)
+    diff = revisions_unified_diff(from_revision, to_revision)
 
     return {
         'document_title': document.title,

--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -113,6 +113,25 @@ def format_comment(rev):
 
 
 @register.function
+def revisions_unified_diff(from_revision, to_revision):
+    fromfile = u'[%s] %s #%s' % (from_revision.document.locale,
+                                 from_revision.document.title,
+                                 from_revision.id)
+    tofile = u'[%s] %s #%s' % (to_revision.document.locale,
+                               to_revision.document.title,
+                               to_revision.id)
+    tidy_from, errors = _massage_diff_content(from_revision.content)
+    tidy_to, errors = _massage_diff_content(to_revision.content)
+    diff = u'\n'.join(difflib.unified_diff(
+        tidy_from.splitlines(),
+        tidy_to.splitlines(),
+        fromfile=fromfile,
+        tofile=tofile
+    ))
+    return diff
+
+
+@register.function
 def diff_table(content_from, content_to, prev_id, curr_id):
     """Creates an HTML diff of the passed in content_from and content_to."""
     tidy_from, errors = _massage_diff_content(content_from)

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -1,4 +1,5 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
+{% from "wiki/includes/document_macros.html" import document_watch with context %}
 {% extends "wiki/base.html" %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 {% set classes = 'document' %}
@@ -131,11 +132,9 @@
         </div>
         <ul id="page-buttons">
             <li class="page-history"><a href="{{ url('wiki.document_revisions', document.full_path) }}">{{_('History')}}</a></li>
-            {#
-            {% if request.user.is_authenticated() %}
-              <li class="page-watch"><a href="{{ url('wiki.document_watch', document.full_path) }}">{{_('Watch')}}</a></li>
+            {% if request.user.is_authenticated() and waffle.flag('page_watch') %}
+              {{ document_watch(document, request.user) }}
             {% endif %}
-            #}
             {% if document.allows_revision_by(request.user) %}
               {% if fallback_reason %}
                 {% set edit_label = _('Edit English')  %}

--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -1,0 +1,17 @@
+{% macro document_watch(document, user) -%}
+  {% if user.is_authenticated() and document %}
+    <li class="page-watch">
+      {% if document.is_watched_by(user) %}
+        <form action="{{ url('wiki.document_unwatch', document.slug) }}" method="post">
+          {{ csrf() }}
+          <input type="submit" class="link-btn" value="{{ _('Stop article emails') }}" />
+        </form>
+      {% else %}
+        <form action="{{ url('wiki.document_watch', document.full_path) }}" method="post">
+          {{ csrf() }}
+          <input type="submit" class="link-btn" value="{{ _('Email me article changes') }}" />
+        </form>
+      {% endif %}
+    </li>
+  {% endif %}
+{%- endmacro %}

--- a/apps/wiki/tests/__init__.py
+++ b/apps/wiki/tests/__init__.py
@@ -27,8 +27,13 @@ class TestCaseBase(TestCase):
         ke_flag, created = Flag.objects.get_or_create(name='kumaediting')
         ke_flag.everyone = True
         ke_flag.save()
-
         self.kumaediting_flag = ke_flag
+
+        pw_flag, created = Flag.objects.get_or_create(name='page_watch')
+        pw_flag.everyone = True
+        pw_flag.save()
+        self.page_watch_flag = pw_flag
+
 
     def tearDown(self):
         self.kumaediting_flag.delete()

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -198,12 +198,11 @@ class DocumentTests(TestCaseBase):
 
     def test_watch_includes_csrf(self):
         """The watch/unwatch forms should include the csrf tag."""
-        raise SkipTest()
         self.client.login(username='testuser', password='testpass')
         d = document(save=True)
         resp = self.client.get(d.get_absolute_url())
         doc = pq(resp.content)
-        assert doc('#doc-watch input[type=hidden]')
+        assert doc('.page-watch input[type=hidden]')
 
     def test_non_localizable_translate_disabled(self):
         """Non localizable document doesn't show tab for 'Localize'."""

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1666,6 +1666,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
 @require_POST
 @login_required
 @process_document_path
+@waffle_flag('page_watch')
 def watch_document(request, document_slug, document_locale):
     """Start watching a document for edits."""
     document = get_object_or_404(
@@ -1677,6 +1678,7 @@ def watch_document(request, document_slug, document_locale):
 @require_POST
 @login_required
 @process_document_path
+@waffle_flag('page_watch')
 def unwatch_document(request, document_slug, document_locale):
     """Stop watching a document for edits."""
     document = get_object_or_404(
@@ -1687,6 +1689,7 @@ def unwatch_document(request, document_slug, document_locale):
 
 @require_POST
 @login_required
+@waffle_flag('locale_watch')
 def watch_locale(request):
     """Start watching a locale for revisions ready for review."""
     ReviewableRevisionInLocaleEvent.notify(request.user, locale=request.locale)
@@ -1697,6 +1700,7 @@ def watch_locale(request):
 
 @require_POST
 @login_required
+@waffle_flag('local_watch')
 def unwatch_locale(request):
     """Stop watching a locale for revisions ready for review."""
     ReviewableRevisionInLocaleEvent.stop_notifying(request.user,
@@ -1993,7 +1997,6 @@ def _save_rev_and_notify(rev_form, creator, document):
     document.schedule_rendering('max-age=0')
 
     # Enqueue notifications
-    ReviewableRevisionInLocaleEvent(new_rev).fire(exclude=new_rev.creator)
     EditDocumentEvent(new_rev).fire(exclude=new_rev.creator)
 
 

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -270,16 +270,16 @@ a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333;
 .previewing .article-content { margin-top: 1em; border-color: #c7dae9; }
 
 #page-buttons { width: 50%; text-align: right; margin: 0; position: absolute; right: 4px; top: 20px; }
-#page-buttons li { display: inline; margin: 0 0 2px 10px; padding: 0; background: none; }
-#page-buttons a, #page-buttons button { display: inline-block; padding: 6px 8px 3px; color: #333; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; border: 0; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: 3px; -moz-box-shadow: 1px 1px 0 rgba(0,0,0,.25); -webkit-box-shadow: 1px 1px 0 rgba(0,0,0,.25); box-shadow: 1px 1px 0 rgba(0,0,0,.25); background-color: #ddd; }
+#page-buttons li, #page-buttons form { display: inline; margin: 0 0 2px 10px; padding: 0; background: none; }
+#page-buttons a, #page-buttons button, #page-buttons input { display: inline-block; padding: 6px 8px 3px; color: #333; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; border: 0; -moz-border-radius: 3px; -webkit-border-radius: 3px; border-radius: 3px; -moz-box-shadow: 1px 1px 0 rgba(0,0,0,.25); -webkit-box-shadow: 1px 1px 0 rgba(0,0,0,.25); box-shadow: 1px 1px 0 rgba(0,0,0,.25); background-color: #ddd; }
 #page-buttons a:hover, #page-buttons a:focus, #page-buttons a:active { text-decoration: none; }
-#page-buttons a { padding: 7px 8px 4px; }
+#page-buttons a, #page-buttons input { padding: 7px 8px 4px; }
 #page-buttons .page-edit a { padding-left: 32px; background: #a5d9f3 url("../img/wiki/button-edit.png") 0 50% repeat-x; }
 #page-buttons .page-edit a:hover, #page-buttons .page-edit a:focus, #page-buttons .page-edit a:active { background-color: #ade4ff; text-decoration: none; }
 #page-buttons .page-edit a.disabled { cursor: pointer; opacity: .75; background-color: #c8e6ed; }
-#page-buttons .page-watch a { padding-left: 35px; background: #f2d29e url("../img/wiki/button-watch.png") 0 50% repeat-x; }
-#page-buttons .page-watch a:hover, #page-buttons .page-watch a:focus, #page-buttons .page-watch a:active { background-color: #f8daa9; text-decoration: none; }
-#page-buttons .page-watch a.disabled { cursor: pointer; opacity: .75; background-color: #f0e4c7; }
+#page-buttons .page-watch input { padding-left: 35px; background: #f2d29e url("../img/wiki/button-watch.png") 0 50% repeat-x; }
+#page-buttons .page-watch input:hover, #page-buttons .page-watch a:focus, #page-buttons .page-watch a:active { background-color: #f8daa9; text-decoration: none; }
+#page-buttons .page-watch input.disabled { cursor: pointer; opacity: .75; background-color: #f0e4c7; }
 
 .btn-save { 
   background: #d7eca1; 

--- a/settings.py
+++ b/settings.py
@@ -782,7 +782,7 @@ CELERY_SEND_TASK_ERROR_EMAILS = True
 CELERYD_LOG_LEVEL = logging.INFO
 CELERYD_CONCURRENCY = 4
 
-CELERY_IMPORTS = ( 'wiki.tasks', 'search.tasks' )
+CELERY_IMPORTS = ( 'wiki.tasks', 'search.tasks', 'tidings.events' )
 
 # Wiki rebuild settings
 WIKI_REBUILD_TOKEN = 'sumo:wiki:full-rebuild'


### PR DESCRIPTION
Pre-req's:
1. Make sure you've run `vagrant provision` to add the django tidings tables via schematic
2. Make sure you're running `manage.py celeryd` to send the email via celery

Spot-check:
1. Add 'page_watch' waffle flag set to super-users
2. Verify only super-users see the new button on the document page
3. Watch a page
4. As another user, make an edit to the page
5. Check the django console for the email output.
