### PR TITLE
Remove custom smuggler change_list template from demos app.

### DIFF
--- a/apps/demos/admin.py
+++ b/apps/demos/admin.py
@@ -130,8 +130,6 @@ delete_selected.short_description = ugettext_lazy(
 
 
 class SubmissionAdmin(admin.ModelAdmin):
-    change_list_template = 'smuggler/change_list.html'
-
     actions = (delete_selected, censor_selected,)
 
     list_display = ('title', 'creator', 'featured', 'censored', 'hidden',


### PR DESCRIPTION
This might be why the admin change list for demos isn't working.
