### PR TITLE
Tidy up docs menu styles

### DIFF
--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -251,8 +251,9 @@ p.notice { padding-bottom: 10px; top: 0; margin-bottom: 15px; }
 
 #nav-main #nav-sub-docs ul { font-size: 12px; }
 .hasJS .new-menu #nav-main #nav-sub-docs, .new-menu #nav-main .menu:hover #nav-sub-docs { margin-left: -100px; }
-.new-menu #nav-main #nav-sub-docs { width: 210px; padding: 10px 15px; font-size: .857em; border-color: #fb9500; }
+.new-menu #nav-main #nav-sub-docs { width: 310px; padding: 10px 15px; font-size: .857em; border-color: #fb9500; }
 .new-menu #nav-main #nav-sub-docs > ul > li { width: 49.9%; }
+.new-menu #nav-main #nav-sub-docs li { text-align: start; }
 
 .new-menu #nav-main .menu { background: url("../img/nav-arrows.png") 100% -530px no-repeat; }
 .new-menu #nav-main .menu:hover { background-position: 100% -580px; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -71,12 +71,11 @@
                       <li><a href="{{ devmo_url('Web/HTML') }}">{{ _('HTML') }}</a></li>
                       <li><a href="{{ devmo_url('Web/CSS') }}">{{ _('CSS') }}</a></li>
                       <li><a href="{{ devmo_url('Web/JS') }}">{{ _('JavaScript') }}</a></li>
-                      <li><a href="{{ devmo_url('Web/Graphics') }}">{{ _('Graphics (SVG, Canvas, WebGL)') }}</a></li>
+                      <li><a href="{{ devmo_url('Web/Graphics') }}">{{ _('Graphics') }}</a></li>
                       <li><a href="{{ devmo_url('Web/API') }}">{{ _('APIs / DOM') }}</a></li>
                       <li><a href="{{ devmo_url('Apps') }}">{{ _('Apps') }}</a></li>
                       <li><a href="{{ devmo_url('Tools') }}">{{ _('Dev Tools') }}</a></li>
                       <li><a href="{{ devmo_url('Web/MathML') }}">{{ _('MathML') }}</a></li>
-                      <li><a href="{{ devmo_url('Web') }}">{{ _('...more docs') }}</a></li>
                     </ul>
                   </li>
                   <li>
@@ -85,6 +84,7 @@
                       <li><a href="{{ devmo_url('Web/References') }}">{{ _('References') }}</a></li>
                       <li><a href="{{ devmo_url('Web/Guide') }}">{{ _('Developer Guides') }}</a></li>
                       <li><a href="{{ url('demos') }}">{{ _('Demos') }}</a></li>
+                      <li><br /><br /><a href="{{ devmo_url('Web') }}">{{ _('...more docs') }}</a></li>
                     </ul>
                   </li>
                 </ul>


### PR DESCRIPTION
Aligns text to the left, wider menu, moved "more docs" to the right side so it doesn't get lost.
