### PR TITLE
bug 839559: Enable section editing

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -221,10 +221,6 @@ class ContentSectionTool(object):
         self.stream = SectionIDFilter(self.stream)
         return self
 
-    def injectSectionEditingLinks(self, full_path, locale):
-        self.stream = SectionEditLinkFilter(self.stream, full_path, locale)
-        return self
-
     def annotateLinks(self, base_url):
         self.stream = LinkAnnotationFilter(self.stream, base_url)
         return self
@@ -483,54 +479,6 @@ class SectionIDFilter(html5lib_Filter):
                 yield start
                 for t in tmp:
                     yield t
-
-
-class SectionEditLinkFilter(html5lib_Filter):
-    """Filter which injects editing links for sections with IDs"""
-
-    def __init__(self, source, full_path, locale):
-        html5lib_Filter.__init__(self, source)
-        self.full_path = full_path
-        self.locale = locale
-
-    def __iter__(self):
-        input = html5lib_Filter.__iter__(self)
-
-        for token in input:
-
-            yield token
-
-            if ('StartTag' == token['type'] and
-                    token['name'] in SECTION_TAGS):
-                attrs = dict(token['data'])
-                id = attrs.get('id', None)
-                if id:
-                    out = (
-                        {'type': 'StartTag', 'name': 'a',
-                         'data': {
-                             'title': _('Edit section'),
-                             'class': 'edit-section',
-                             'data-section-id': id,
-                             'data-section-src-url': u'%s?%s' % (
-                                 reverse('wiki.document',
-                                         args=[self.full_path],
-                                         locale=self.locale),
-                                 urlencode({'section': id.encode('utf-8'),
-                                            'raw': 'true'})
-                              ),
-                              'href': u'%s?%s' % (
-                                 reverse('wiki.edit_document',
-                                         args=[self.full_path],
-                                         locale=self.locale),
-                                 urlencode({'section': id.encode('utf-8'),
-                                            'edit_links': 'true'})
-                              )
-                         }},
-                        {'type': 'Characters', 'data': _('Edit')},
-                        {'type': 'EndTag', 'name': 'a'}
-                    )
-                    for t in out:
-                        yield t
 
 
 class SectionTOCFilter(html5lib_Filter):

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -329,6 +329,7 @@
          conflict is detected. It needs to be server side in order to get supplied
          with a CSRF token. #}
       <form class="conflict-bouncer template" method="POST" action="">
+        {{ csrf() }}
         <input type="hidden" name="form" value="rev">
         <input type="hidden" name="current_rev" value="">
         <input type="hidden" name="content" value="">

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -286,35 +286,6 @@ class ContentSectionToolTests(TestCase):
                   .serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
-    def test_section_edit_links(self):
-        doc_src = """
-            <h1 id="s1">Head 1</h1>
-            <p>test</p>
-            <p>test</p>
-            <h2 id="s2">Head 2</h2>
-            <p>test</p>
-            <p>test</p>
-            <h3 id="s3">Head 3</h3>
-            <p>test</p>
-            <p>test</p>
-        """
-        expected = """
-            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s1" href="/en-US/docs/some-slug$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>Head 1</h1>
-            <p>test</p>
-            <p>test</p>
-            <h2 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s2" href="/en-US/docs/some-slug$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>Head 2</h2>
-            <p>test</p>
-            <p>test</p>
-            <h3 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s3" href="/en-US/docs/some-slug$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>Head 3</h3>
-            <p>test</p>
-            <p>test</p>
-        """
-        result = (wiki.content
-                  .parse(doc_src)
-                  .injectSectionEditingLinks('some-slug', 'en-US')
-                  .serialize())
-        eq_(normalize_html(expected), normalize_html(result))
-
     def test_code_syntax_conversion(self):
         doc_src = """
             <h2>Some JavaScript</h2>:

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -2159,41 +2159,6 @@ class SectionEditingResourceTests(TestCaseBase):
         eq_(normalize_html(expected),
             normalize_html(response.content))
 
-    def test_raw_with_editing_links_source(self):
-        """The raw source for a document can be requested, with section editing
-        links"""
-        client = LocalizingClient()
-        client.login(username='admin', password='testpass')
-        d, r = doc_rev("""
-            <h1 id="s1">s1</h1>
-            <p>test</p>
-            <p>test</p>
-
-            <h1 id="s2">s2</h1>
-            <p>test</p>
-            <p>test</p>
-
-            <h1 id="s3">s3</h1>
-            <p>test</p>
-            <p>test</p>
-        """)
-        expected = """
-            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/%(full_path)s?raw=true&amp;section=s1" href="/en-US/docs/%(full_path)s$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>s1</h1>
-            <p>test</p>
-            <p>test</p>
-            <h1 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/%(full_path)s?raw=true&amp;section=s2" href="/en-US/docs/%(full_path)s$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>s2</h1>
-            <p>test</p>
-            <p>test</p>
-            <h1 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/%(full_path)s?raw=true&amp;section=s3" href="/en-US/docs/%(full_path)s$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>s3</h1>
-            <p>test</p>
-            <p>test</p>
-        """ % {'full_path': d.full_path}
-        response = client.get('%s?raw=true&edit_links=true' %
-                              reverse('wiki.document', args=[d.full_path]),
-                              HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(normalize_html(expected),
-            normalize_html(response.content))
-
     def test_raw_section_source(self):
         """The raw source for a document section can be requested"""
         client = LocalizingClient()

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -325,6 +325,13 @@ def document(request, document_slug, document_locale):
     base_url = request.build_absolute_uri('/')
     slug_dict = _split_slug(document_slug)
 
+    # Grab some parameters that affect output
+    section_id = request.GET.get('section', None)
+    show_raw = request.GET.get('raw', False) is not False
+    show_summary = request.GET.get('summary', False) is not False
+    is_include = request.GET.get('include', False) is not False
+    no_create = request.GET.get('nocreate', False) is not False
+
     # If a slug isn't available in the requested locale, fall back to en-US:
     try:
         doc = Document.objects.get(locale=document_locale, slug=document_slug)
@@ -367,10 +374,8 @@ def document(request, document_slug, document_locale):
         except Document.DoesNotExist:
 
             # If any of these parameters are present, throw a real 404.
-            if (request.GET.get('raw', False) is not False or
-                request.GET.get('include', False) is not False or
-                request.GET.get('nocreate', False) is not False or
-                not request.user.is_authenticated()):
+            if (show_raw or is_include or no_create or
+                    not request.user.is_authenticated()):
                 raise Http404()
 
             # The user may be trying to create a child page; if a parent exists
@@ -420,13 +425,6 @@ def document(request, document_slug, document_locale):
 
     # Utility to set common headers used by all response exit points
     response_headers = dict()
-
-    # Grab some parameters that affect output
-    section_id = request.GET.get('section', None)
-    show_raw = request.GET.get('raw', False) is not False
-    show_summary = request.GET.get('summary', False) is not False
-    is_include = request.GET.get('include', False) is not False
-    need_edit_links = request.GET.get('edit_links', False) is not False
 
     def set_common_headers(r):
         r['ETag'] = doc.calculate_etag(section_id)
@@ -500,13 +498,6 @@ def document(request, document_slug, document_locale):
         # Annotate links within the page, but only if not sending raw source.
         if not show_raw:
             tool.annotateLinks(base_url=base_url)
-
-        # If this user can edit the document, inject some section editing
-        # links.
-        if ((need_edit_links or not show_raw) and
-                request.user.is_authenticated() and
-                doc.allows_revision_by(request.user)):
-            tool.injectSectionEditingLinks(doc.full_path, doc.locale)
 
         doc_html = tool.serialize()
 
@@ -932,9 +923,11 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
         Document, locale=document_locale, slug=document_slug)
     user = request.user
 
-    # If this document has a parent, then the edit is handled by the
-    # translate view. Pass it on.
-    if doc.parent and doc.parent.id != doc.id:
+    section_id = request.GET.get('section', None)
+
+    # If this document has a parent and it's not a section edit, then the edit
+    # is handled by the translate view. Pass it on.
+    if not section_id and doc.parent and doc.parent.id != doc.id:
         return translate(request, doc.parent.slug, doc.locale, revision_id,
                          bypass_process_document_path=True)
     if revision_id:
@@ -950,9 +943,6 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
     # This is only for the edit form.
     rev.slug = slug_dict['specific']
 
-    section_id = request.GET.get('section', None)
-    if section_id and not request.is_ajax():
-        return HttpResponse(_("Sections may only be edited inline."))
     disclose_description = bool(request.GET.get('opendescription'))
 
     doc_form = rev_form = None
@@ -978,7 +968,6 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
     else:  # POST
         is_iframe_target = request.GET.get('iframe', False)
         is_raw = request.GET.get('raw', False)
-        need_edit_links = request.GET.get('edit_links', False)
         parent_id = request.POST.get('parent_id', '')
 
         # Attempt to set a parent
@@ -1087,16 +1076,30 @@ def edit_document(request, document_slug, document_locale, revision_id=None):
                     else:
                         view = 'wiki.document_revisions'
 
+                    if is_raw and section_id:
+                        # HACK: is_raw and section_id indicates an inline section
+                        # edit, so let's (ab)use the KumaScript preview mechanism
+                        # to offer immediate feedback while the rest of the page
+                        # has been scheduled for rendering
+                        wiki_content = rev_form.data['content']
+                        # There's a chance rendering might be disabled, so
+                        # check for that...
+                        should_render = kumascript.should_use_rendered(
+                                doc, {'raw': True, 'macros': True},
+                                html=wiki_content)
+                        if should_render:
+                            wiki_content, kumascript_errors = kumascript.post(
+                                    request, wiki_content,
+                                    request.locale)
+                            return HttpResponse(wiki_content)
+
                     # Construct the redirect URL, adding any needed parameters
                     url = reverse(view, args=[doc.full_path],
                                   locale=doc.locale)
                     params = {}
                     if is_raw:
+                        params['macros'] = 'true'
                         params['raw'] = 'true'
-                        if need_edit_links:
-                            # Only need to carry over ?edit_links with ?raw,
-                            # because they're on by default in the normal UI
-                            params['edit_links'] = 'true'
                         if section_id:
                             # If a section was edited, and we're using the raw
                             # content API, constrain to that section.
@@ -1173,8 +1176,9 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_iframe_target,
         response.status_code = 409
         return response
 
-    # Make this response iframe-friendly so we can hack around the
-    # save-and-edit iframe button
+    # Update the current_rev, so that a subsequent attempt to save will work.
+    rev_form.data['current_rev'] = curr_rev.id
+
     return render(request, 'wiki/edit_document.html',
                         {'collision': True,
                          'revision_form': rev_form,

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -219,7 +219,7 @@ div.note p:last-child, div.tip p:last-child, div.warning.review-technical p:last
 
 .template { display: none; }
 
-a.edit-section { display: none; margin-top: 0.5em; float: right; padding: .25em 5px .15em; border: 0; border-radius: 3px; box-shadow: 1px 1px 0 rgba(0,0,0,.25); color: #333; background: #a5d9f3 url("../img/light-shade.png") 0 .75em repeat-x; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; text-decoration: none; }
+a.edit-section { margin-top: 0.5em; float: right; padding: .25em 5px .15em; border: 0; border-radius: 3px; box-shadow: 1px 1px 0 rgba(0,0,0,.25); color: #333; background: #a5d9f3 url("../img/light-shade.png") 0 .75em repeat-x; font: 200 15px/1 "Bebas Neue", "League Gothic", Haettenschweiler, sans-serif; text-transform: uppercase; letter-spacing: .5px; text-decoration: none; }
 a.edit-section:before { content: "\25c0\00a0"; font-size: .857em; }
 a.edit-section:hover, a.edit-section:active, a.edit-section:focus { color: #333; background-color: #ade4ff; text-decoration: none; }
 

--- a/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
+++ b/puppet/files/etc/apache2/conf.d/mozilla-kuma-apache.conf
@@ -50,6 +50,8 @@ WSGISocketPrefix /var/run/wsgi
     ProxyPass /mwsgi http://localhost:8000 retry=1
     ProxyPassReverse /mwsgi http://localhost:8000
 
+    RequestHeader set X-Forwarded-Proto "https"
+
     # Proxy to reach elasticsearch
     ProxyPass /elastic http://localhost:9200
     ProxyPassReverse /elastic http://localhost:9200

--- a/puppet/files/vagrant/settings_local.py
+++ b/puppet/files/vagrant/settings_local.py
@@ -9,6 +9,7 @@ TEMPLATE_DEBUG = DEBUG
 SERVE_MEDIA = DEBUG
 
 SESSION_COOKIE_SECURE = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 DEMO_UPLOADS_ROOT = '/home/vagrant/uploads/demos'
 DEMO_UPLOADS_URL = '/media/uploads/demos/'


### PR DESCRIPTION
DO NOT MERGE (yet) - my eyes are totally glazing over on this one, and I'd like another fresh pair to take a look. I might have to take a break from this for a bit. 

I did find a few more rough edges to section editing, and I think this fixes them:
- Enable section editing for translated pages.
- Switch to injecting section editing buttons on the client side, rather
  than on the server, to fix some ID mismatch issues
- Use KumaScript preview POST to update the section after a save, to
  avoid a race condition with the deferred rendering system
- Ensure https:// links on redirect in Vagrant
