### PR TITLE
Force re-rendering of document after quick review

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1986,6 +1986,7 @@ def quick_review(request, document_slug, document_locale):
             new_rev.review_tags.set(*new_tags)
         else:
             new_rev.review_tags.clear()
+    doc.schedule_rendering('max-age=0')
     return HttpResponseRedirect(doc.get_absolute_url())
 
 


### PR DESCRIPTION
This should clear up issues with the unreviewed cached version hanging around afterward.
