### PR TITLE
Ali and John homepage updates

### DIFF
--- a/apps/landing/templates/landing/home_new.html
+++ b/apps/landing/templates/landing/home_new.html
@@ -152,7 +152,7 @@
             </ul>
 
             {% if current_challenge_tag_name %}
-            <strong>{{ _('This month\'s Dev Derby:') }}</strong><br />
+            <strong>{{ _('This month\'s') }} <a href="{{ url('demos_devderby_landing') }}">{{ _('Dev Derby') }}</a>:</strong><br />
             <strong class="derby-topic" style="color:#995C00">{{ tag_meta(current_challenge_tag_name, 'short_title') }}</strong><br />
             <span class="derby-explain">{{ _('Submit your demo to the Derby to win an Android phone or other prizes.') }}</span>
             {% endif %}

--- a/media/css/new-homepage.css
+++ b/media/css/new-homepage.css
@@ -171,6 +171,9 @@
   padding: 10px 0;
   font-size: 0.85em;
 }
+.new-home .home-demos .home-demos-featured .flag {
+  display: none;
+}
 .new-home .home-demos .gallery {
   margin: 10px 0;
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -85,7 +85,7 @@
                       <li><a href="{{ devmo_url('Web/Reference') }}?menu">{{ _('References') }}</a></li>
                       <li><a href="{{ devmo_url('Web/Guide') }}?menu">{{ _('Developer Guides') }}</a></li>
                       <li><a href="{{ url('demos') }}?menu">{{ _('Demos') }}</a></li>
-                      <li><br /><br /><a href="{{ devmo_url('Web') }}?menu">{{ _('...more docs') }}</a></li>
+                      <li><br /><br /><a href="{{ url('docs') }}?menu">{{ _('...more docs') }}</a></li>
                     </ul>
                   </li>
                 </ul>


### PR DESCRIPTION
1.  Remove "featured" or "winner" ribbon from dev derby block
2.  Updated "more docs" address in menu
3.  Link directly to the dev derby landing page
