### PR TITLE
Only show quick-review UI to logged-in users.

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -284,7 +284,7 @@
       {% include 'wiki/includes/attachment_list.html' %}
       {% endif %}
 
-      {% if document.current_revision and document.allows_revision_by(request.user) %}
+      {% if request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) %}
         {% if document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review() %}
           <section class="page-meta">
             <h2>{{ _('Quick review') }}</h2>


### PR DESCRIPTION
sheppy mentioned it seems to sometimes be showing to non-logged-in users, even though they'll just get a login prompt when they try to use it (and will lose their POST state in the process, so we probably shouldn't be showing it to them).
