### PR TITLE
bug 873327: Waffle flag to enable/disable deferred wiki rendering via celery

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -758,7 +758,8 @@ class Document(NotificationsMixin, ModelBase):
         Document.objects.filter(pk=self.pk).update(render_scheduled_at=now)
         self.render_scheduled_at = now
 
-        if not self.defer_rendering:
+        if (waffle.switch_is_active('wiki_force_immediate_rendering') or
+                not self.defer_rendering):
             # Attempt an immediate rendering.
             self.render(cache_control, base_url)
         else:

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -1203,15 +1203,31 @@ class DeferredRenderingTests(TestCase):
                                              mock_kumascript_get):
         mock_kumascript_get.return_value = (self.rendered_content, None)
 
+        switch = Switch.objects.create(name='wiki_force_immediate_rendering')
+
         # When defer_rendering == False, the rendering should be immediate.
+        switch.active = False
+        switch.save()
         self.d1.rendered_html = ''
         self.d1.defer_rendering = False
         self.d1.save()
         result_rendered, _ = self.d1.get_rendered(None, 'http://testserver/')
         ok_(not mock_render_document_delay.called)
 
+        # When defer_rendering == True but the waffle switch forces immediate,
+        # the rendering should be immediate.
+        switch.active = True
+        switch.save()
+        self.d1.rendered_html = ''
+        self.d1.defer_rendering = True
+        self.d1.save()
+        result_rendered, _ = self.d1.get_rendered(None, 'http://testserver/')
+        ok_(not mock_render_document_delay.called)
+
         # When defer_rendering == True, the rendering should be deferred and an
         # exception raised if the content is blank.
+        switch.active = False
+        switch.save()
         self.d1.rendered_html = ''
         self.d1.defer_rendering = True
         self.d1.save()


### PR DESCRIPTION
Looks like deferred rendering of pages through celery is failing, now that the celery queue is actually working. I suspect it has something to do with network flows, possibly configuration of the kumascript service URL.

I'm probably going to self-merge & push this if/when jenkins test pass, since this is currently breaking the site.
