### PR TITLE
Fix echoing into /etc/hosts will always give permission errors in docs.

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -70,9 +70,9 @@ Getting up and running
    Note: If you decide to run nfs: false, the system will be a lot slower. There is also the potential of running into
    weird issues with puppet, since the current puppet configurations do not currently support nfs: false.
 
--  Add developer-dev.mozilla.org to /etc/hosts::
+-  Add developer-dev.mozilla.org to /etc/hosts to the end of your hosts file with this shell command::
 
-       echo '192.168.10.55 developer-local.allizom.org mdn-local.mozillademos.org' >> /etc/hosts
+       echo '192.168.10.55 developer-local.allizom.org mdn-local.mozillademos.org' | sudo tee /etc/hosts
 
 -  Everything should be working now, from the host side::
 


### PR DESCRIPTION
This is confusing for people who don't understand how the shell works and how file redirection works. It is better to give a command that can account for needing sudo.
