### PR TITLE
fix bug 875780 - Display dropdown when item is cached

### DIFF
--- a/media/ckeditor/plugins/mdn-link/dialogs/link.js
+++ b/media/ckeditor/plugins/mdn-link/dialogs/link.js
@@ -1265,13 +1265,14 @@ CKEDITOR.dialog.add( 'link', function( editor )
 				
 			// Clear out the previous auto-creation text
 			autoCompleteSelection = null;
-			
+
 			// If there's selected text but not an element, search for an article
 			if(selectedText && !selectedElement) {
 				$autoComplete.val(selectedText);
+				autoCompleteTextbox.focus();
+				autoCompleteTextbox.select();
 				$autoComplete.mozillaAutocomplete('deselect');
 				$autoComplete.mozillaAutocomplete('search', selectedText);
-				autoCompleteTextbox.select();
 				return;
 			}
 			


### PR DESCRIPTION
To test:
1.  Go to "/docs/new"
2.  Type in the WYSIWYG the name of a document you've created, press COMMAND+K
3.  The "Article Title Lookup" field should show it in the dropdown list
4.  Close the dialog
5.  Type the same article again, press COMMAND+K again, ensure that the list pops up again.
