### PR TITLE
Admin interface for user bans should use raw_id_fields

### DIFF
--- a/apps/users/admin.py
+++ b/apps/users/admin.py
@@ -8,7 +8,7 @@ class UserBanAdmin(admin.ModelAdmin):
     list_display = ('user', 'by', 'reason')
     list_filter = ('is_active',)
     raw_id_fields = ('user',)
-    search_fields = ('user', 'reason')
+    search_fields = ('user__username', 'reason')
 
 
 admin.site.register(UserBan, UserBanAdmin)


### PR DESCRIPTION
(instead of loading all the users)
