### PR TITLE
fix bug 821986: Strip out attributes starting with "on" from Document content before rendering editor

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -233,6 +233,10 @@ class ContentSectionTool(object):
         self.stream = IframeHostFilter(self.stream, hosts)
         return self
 
+    def filterEditorSafety(self):
+        self.stream = EditorSafetyFilter(self.stream)
+        return self
+
     def extractSection(self, id):
         self.stream = SectionFilter(self.stream, id)
         return self
@@ -778,6 +782,23 @@ class CodeSyntaxFilter(html5lib_Filter):
                             attrs['class'] = "brush: %s" % brush
                             del attrs['function']
                             token['data'] = attrs.items()
+            yield token
+
+
+class EditorSafetyFilter(html5lib_Filter):
+    """Minimal filter meant to strip out harmful attributes and elements before
+    rendering HTML for use in CKEditor"""
+    def __iter__(self):
+
+        for token in html5lib_Filter.__iter__(self):
+        
+            if ('StartTag' == token['type']):
+
+                # Strip out any attributes that start with "on"
+                token['data'] = [(k,v)
+                    for (k,v) in dict(token['data']).items()
+                    if not k.startswith('on')]
+
             yield token
 
 

--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -260,6 +260,7 @@ class RevisionForm(forms.ModelForm):
                 tool.injectSectionIDs()
                 if self.section_id:
                     tool.extractSection(self.section_id)
+                tool.filterEditorSafety()
                 content = tool.serialize()
             self.initial['content'] = content
 

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -802,6 +802,36 @@ class ContentSectionToolTests(TestCase):
                           .serialize())
             eq_(normalize_html(expected_line), normalize_html(result_line))
 
+    @attr('bug821986')
+    def test_editor_safety_filter(self):
+        """Markup that's hazardous for editing should be stripped"""
+        doc_src = """
+            <svg><circle onload=confirm(3)>
+            <h1 class="header1">Header One</h1>
+            <p>test</p>
+            <section>
+                <h1 class="header2">Header Two</h1>
+                <p>test</p>
+            </section>
+            <h1 class="header3">Header Three</h1>
+            <p>test</p>
+        """
+        expected_src = """
+            <svg><circle>
+            <h1 class="header1">Header One</h1>
+            <p>test</p>
+            <section>
+                <h1 class="header2">Header Two</h1>
+                <p>test</p>
+            </section>
+            <h1 class="header3">Header Three</h1>
+            <p>test</p>
+        """
+        result_src = (wiki.content.parse(doc_src)
+                      .filterEditorSafety()
+                      .serialize())
+        eq_(normalize_html(expected_src), normalize_html(result_src))
+
 
 class AllowedHTMLTests(TestCase):
     simple_tags = (

--- a/apps/wiki/tests/test_forms.py
+++ b/apps/wiki/tests/test_forms.py
@@ -1,10 +1,24 @@
 from nose.tools import eq_, ok_
+from nose.plugins.attrib import attr
 
 from sumo.tests import TestCase
 from wiki.forms import RevisionForm, RevisionValidationForm
 from wiki.tests import doc_rev, normalize_html
 
 
+class FormEditorSafetyFilterTests(TestCase):
+    fixtures = ['test_users.json']
+
+    @attr('bug821986')
+    def test_form_onload_attr_filter(self):
+        """RevisionForm should strip out any harmful onload attributes from
+        input markup"""
+        d, r = doc_rev("""
+            <svg><circle onload=confirm(3)>
+        """)
+        rev_form = RevisionForm(instance=r)
+        ok_('onload' not in rev_form.initial['content'])
+        
 class FormSectionEditingTests(TestCase):
     fixtures = ['test_users.json']
 


### PR DESCRIPTION
This seemed easy... too easy. Adding another filter to strip "on" attributes was pretty simple, and should be pretty easy to add new filtering logic if/when further CKEditor vulnerabilities can be solved that way.

I was worried about the filtering on edit thing, but it turns out we've been filtering in the RevisionForm the whole time already. :neckbeard:
