### PR TITLE
fix bug 871638 - fix list for dupe named tags

### DIFF
--- a/apps/wiki/admin.py
+++ b/apps/wiki/admin.py
@@ -7,7 +7,8 @@ from django.core import serializers
 
 from sumo.urlresolvers import reverse, split_path
 
-from wiki.models import (Document, Revision, EditorToolbar,
+from wiki.models import (Document, DocumentTag, Revision,
+                         EditorToolbar,
                          Attachment, AttachmentRevision)
 
 
@@ -271,6 +272,7 @@ class AttachmentRevisionAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Document, DocumentAdmin)
+admin.site.register(DocumentTag, admin.ModelAdmin)
 admin.site.register(Revision, RevisionAdmin)
 admin.site.register(EditorToolbar, admin.ModelAdmin)
 admin.site.register(Attachment, AttachmentAdmin)

--- a/apps/wiki/tests/test_templates.py
+++ b/apps/wiki/tests/test_templates.py
@@ -722,6 +722,7 @@ class DocumentListTests(TestCaseBase):
         eq_(Document.objects.filter(locale=self.locale).count(),
             len(doc('#document-list ul.documents li')))
 
+    @attr('tags')
     def test_tag_list(self):
         """Verify the tagged documents list view."""
         tag = DocumentTag(name='Test Tag', slug='test-tag')
@@ -729,6 +730,24 @@ class DocumentListTests(TestCaseBase):
         self.doc.tags.add(tag)
         response = self.client.get(reverse('wiki.tag',
                                    args=[tag.name]))
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        eq_(1, len(doc('#document-list ul.documents li')))
+
+    # http://bugzil.la/871638
+    @attr('tags')
+    def test_tag_list_duplicates(self):
+        """
+        Verify the tagged documents list view, even for duplicate tags
+        """
+        en_tag = DocumentTag(name='CSS Reference', slug='css-reference')
+        en_tag.save()
+        fr_tag = DocumentTag(name='CSS Référence', slug='css-reference_1')
+        fr_tag.save()
+        self.doc.tags.add(en_tag)
+        self.doc.tags.add(fr_tag)
+        response = self.client.get(reverse('wiki.tag',
+                                   args=[en_tag.name]))
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.documents li')))

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -750,7 +750,14 @@ def list_documents(request, category=None, tag=None):
 
     # Taggit offers a slug - but use name here, because the slugification
     # stinks and is hard to customize.
-    tag_obj = tag and get_object_or_404(DocumentTag, name=tag) or None
+    tag_obj = None
+    if tag:
+        matching_tags = DocumentTag.objects.filter(name=tag)
+        if len(matching_tags) == 0:
+            raise Http404
+        for matching_tag in matching_tags:
+            if matching_tag.name == tag:
+                tag_obj = matching_tag
     docs = Document.objects.filter_for_list(locale=request.locale,
                                              category=category_id,
                                              tag=tag_obj)


### PR DESCRIPTION
some tag names evaluate as equal between ascii & non-ascii representations
