### PR TITLE
fix bug 875780 - Prevent empty docs from bombing requests

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -46,18 +46,21 @@ def parse(src):
     return ContentSectionTool(src)
 
 
-def get_content_sections(src = ''):
+def get_content_sections(src=''):
     """Gets sections in a document, """
     sections = []
 
     if src:
         attr = '[id]'
-        elements = pq(src).find(((attr + ',').join(SECTION_TAGS)) + attr)
-        
-        def objectify_pyquery_item(i):
-            sections.append({ 'title': i.text(), 'id': i.attr('id') })
+        try:
+            elements = pq(src).find(((attr + ',').join(SECTION_TAGS)) + attr)
 
-        elements.each(lambda e: objectify_pyquery_item(e))
+            def objectify_pyquery_item(i):
+                sections.append({'title': i.text(), 'id': i.attr('id')})
+
+            elements.each(lambda e: objectify_pyquery_item(e))
+        except:
+            pass
 
     return sections
 

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -15,7 +15,7 @@ import wiki.content
 from wiki.content import (CodeSyntaxFilter, DekiscriptMacroFilter,
                           SectionTOCFilter, SectionIDFilter, IframeHostFilter,
                           H2TOCFilter, H3TOCFilter,
-                          SECTION_TAGS, get_seo_description)
+                          SECTION_TAGS, get_seo_description, get_content_sections)
 from wiki.models import ALLOWED_TAGS, ALLOWED_ATTRIBUTES, Document
 from wiki.tests import normalize_html, doc_rev, document, revision
 from wiki.helpers import bugize_text
@@ -23,6 +23,12 @@ from wiki.helpers import bugize_text
 
 class ContentSectionToolTests(TestCase):
     fixtures = ['test_users.json']
+
+    def test_section_pars_for_empty_docs(self):
+        doc = document(title='Doc', locale=u'fr', slug=u'doc', save=True,
+                        html='<!-- -->')
+        res = get_content_sections(doc.html)
+        eq_(type(res).__name__, 'list')
 
     def test_section_ids(self):
 

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -311,7 +311,7 @@ def _get_document_for_json(doc, addLocaleToTitle=False):
     else:
         review_tags = [x.name for x in
                        doc.current_revision.review_tags.all()]
-     
+
     return {
         'title': title,
         'label': doc.title,


### PR DESCRIPTION
To test:
1.  Create a document with just an HTML comment as content: "<!-- -->"
2.  Use the WYSIWYG title lookup to find the doc
3.  It wont bomb!  Yay!
