### PR TITLE
fix bug 809495 - Add user ban front-end

### DIFF
--- a/apps/users/templates/users/user_banned.html
+++ b/apps/users/templates/users/user_banned.html
@@ -1,1 +1,32 @@
-You have been banned.
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "users/base.html" %}
+{% set title = _('You\'ve Been Banned') %}
+{% set classes = 'profile' %}
+{% block title %}{{ page_title(title) }}{% endblock %}
+
+{% block content %}
+<section id="content">
+  <div class="wrap">
+    <div id="content-main" class="full">
+	  <article id="profile-banned" class="main">
+	    <h1>{{ title }}</h1>
+	    <p>
+	    	{{ _('You have been banned for the following reason:') }}
+	    </p>
+	    <ul>
+	    	{% if bans | length %}
+		    	{% for ban in bans %}
+		    	<li>{{ ban.reason }}</li>
+		    	{% endfor %}
+		    {% endif %}
+	    </ul>
+
+	    {% trans %}
+	    <p><a href="mailto:mdn-admins@mozilla.org?subject=Ban Appeal">Click here</a> to appeal this ban.</p>
+	    {% endtrans %}
+
+	  </article>
+	</div>
+  </div>
+</section>
+{% endblock %}

--- a/apps/wiki/templates/wiki/revision.html
+++ b/apps/wiki/templates/wiki/revision.html
@@ -38,6 +38,10 @@
           <li>
             <mark>{{ _('Creator:') }}</mark>
             <span>{{ revision.creator }}</span>
+
+            {% if user.has_perm('users.add_userban') and revision.creator != request.user %}
+            (<a href="{{ url('admin:users_userban_add') }}?user={{revision.creator.id}}&by={{request.user.id}}">Ban user</a>)
+            {% endif %}
           </li>
           <li class="revision-is-reviewed">
             <mark>{{ _('Is reviewed?') }}</mark>

--- a/media/css/mdn-screen.css
+++ b/media/css/mdn-screen.css
@@ -1029,6 +1029,10 @@ li.tag-expert label:hover { border-color: #bbb; }
 #elsewhere .remove:hover { background-position: center -48px; }
 #elsewhere .errorlist { margin-left: 150px; width: 500px; }
 
+/* @Banned User *********/
+#profile-banned ul { padding-left: 22px; list-style-type: disc; }
+#profile-banned ul li { line-height: 1.5em; }
+
 /* @Error pages *********/
 .beast { float: right; margin: 20px 0 20px 20px; }
 


### PR DESCRIPTION
Adds a basic "you've been banned page" at login, as well as a "Ban User" link on the revision page if the user has the proper waffle.

I hope I put that querystring-ed link together properly.
