### PR TITLE
bug 877374 - add tags to ES index and results

### DIFF
--- a/apps/search/templates/search/results.html
+++ b/apps/search/templates/search/results.html
@@ -4,12 +4,18 @@
                ('WT.oss_r', num_results)) %}
 
 {% macro doc_block(doc) -%}
-  {% set url = '%s%s' % (settings.SITE_URL, url('wiki.document', doc.slug, locale=doc.locale)) %}
+  {% set doc_url = '%s%s' % (settings.SITE_URL, url('wiki.document', doc.slug, locale=doc.locale)) %}
   <li class="doc-result" data-url="{{ url }}" data-locale="{{ doc.locale }}" tabindex="0">
-    <h3><a href="{{ url }}">{{ doc.title }}</a> 
+    <h3><a href="{{ doc_url }}">{{ doc.title }}</a> 
       {% if request.locale != doc.locale %} <span class="locale">({{ doc.locale }})</span>{% endif %}
     </h3>
     <div class="searchMeta">
+      <ul class="tags">
+        {% for tag in doc.tags %}
+          {% set tag_url = url('wiki.tag', tag) %}
+        <li><a href="{{ tag_url }}">{{ tag }}</a></li>
+        {% endfor %}
+      </ul>
       {#
       <ul class="crumbs">
         {% for doc in doc.parents %}

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1538,7 +1538,8 @@ class DocumentType(SearchMappingType, Indexable):
             'slug': obj.slug,
             'locale': obj.locale,
             'modified': obj.modified,
-            'content': strip_tags(obj.rendered_html)
+            'content': strip_tags(obj.rendered_html),
+            'tags': [tag.name for tag in obj.tags.all()]
         }
 
     @classmethod
@@ -1549,7 +1550,8 @@ class DocumentType(SearchMappingType, Indexable):
             'slug': {'type': 'string'},
             'locale': {'type': 'string', 'index': 'not_analyzed'},
             'modified': {'type': 'date'},
-            'content': {'type': 'string', 'analyzer': 'wikiMarkup'}
+            'content': {'type': 'string', 'analyzer': 'wikiMarkup'},
+            'tags': {'type': 'string', 'analyzer': 'snowball'},
         }
 
     @classmethod


### PR DESCRIPTION
`manage.py reindex` to reindex docs with tags
https://developer-local.allizom.org/en-US/search?q=web to see an ugly list of tags in the results display

needs some styling.
