### PR TITLE
Fix bug 882555: Make /demos work again

### DIFF
--- a/urls.py
+++ b/urls.py
@@ -19,7 +19,7 @@ urlpatterns = patterns('',
     ('', include('devmo.urls')),
     (r'^logout/$', 'dekicompat.views.logout'),
     (r'^demos/', include('demos.urls')),
-    (r'^demos', lambda x: redirect('demos.views.home')),
+    (r'^demos', lambda x: redirect('demos')),
 
     # Django admin:
     (r'^admin/', include('smuggler.urls')),


### PR DESCRIPTION
Turns out our root URLConf had a random reference to the old view name.
