### PR TITLE
fix bug 854878 - Remove leading slash and locale/docs from slug move

### DIFF
--- a/apps/wiki/__init__.py
+++ b/apps/wiki/__init__.py
@@ -6,6 +6,7 @@ KUMASCRIPT_TIMEOUT_ERROR = [
      "message": "Request to Kumascript service timed out",
      "args": ["TimeoutError"]}
 ]
+SLUG_CLEANSING_REGEX = '^\/?(([A-z-]+)?\/?docs\/)?'
 
 
 class ReadOnlyException(Exception):

--- a/apps/wiki/forms.py
+++ b/apps/wiki/forms.py
@@ -21,6 +21,7 @@ from wiki.models import (Document, Revision, FirefoxVersion, OperatingSystem,
                          GROUPED_FIREFOX_VERSIONS, GROUPED_OPERATING_SYSTEMS,
                          CATEGORIES, REVIEW_FLAG_TAGS, RESERVED_SLUGS,
                          TOC_DEPTH_CHOICES)
+from wiki import SLUG_CLEANSING_REGEX
 
 
 TITLE_REQUIRED = _lazy(u'Please provide a title.')
@@ -499,3 +500,12 @@ class TreeMoveForm(forms.Form):
                              error_messages={'required': SLUG_REQUIRED,
                                              'min_length': SLUG_SHORT,
                                              'max_length': SLUG_LONG})
+
+    def clean_slug(self):
+        # Removes leading slash and {locale/docs/} if necessary
+        # IMPORTANT: This exact same regex is used on the client side, so
+        # update both if doing so
+        self.cleaned_data['slug'] = re.sub(re.compile(SLUG_CLEANSING_REGEX), 
+                                      '', self.cleaned_data['slug'])
+
+        return self.cleaned_data['slug']

--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -54,7 +54,7 @@
               <dl>
                 <dt><label for="moveSlug">{{ _('New Slug:') }}</label> </dt>
                 <dd>
-                  <input type="text" name="slug" id="moveSlug" value="" />
+                  <input type="text" name="slug" id="moveSlug" value="" required="required" data-validator="{{ SLUG_CLEANSING_REGEX }}" />
                   <input type="hidden" value="{{ document.slug }}" id="currentSlug" />
                   <input type="hidden" value="{{ document.locale }}" id="moveLocale" />
                 </dd>

--- a/apps/wiki/tests/test_forms.py
+++ b/apps/wiki/tests/test_forms.py
@@ -2,7 +2,7 @@ from nose.tools import eq_, ok_
 from nose.plugins.attrib import attr
 
 from sumo.tests import TestCase
-from wiki.forms import RevisionForm, RevisionValidationForm
+from wiki.forms import RevisionForm, RevisionValidationForm, TreeMoveForm
 from wiki.tests import doc_rev, normalize_html
 
 
@@ -96,3 +96,25 @@ class RevisionValidationTests(TestCase):
         rev_form = RevisionValidationForm(data)
         rev_form.parent_slug = 'User:groovecoder'
         ok_(not rev_form.is_valid())
+
+
+class TreeMoveFormTests(TestCase):
+
+    def test_form_properly_strips_leading_cruft(self):
+        """ Tests that leading slash and {locale}/docs/ is removed if included """
+
+        #[submitted_value, properly_cleaned_value]
+        comparisons = [
+            ['/somedoc', 'somedoc'], # leading slash
+            ['/en-US/docs/mynewplace', 'mynewplace'], # locale and docs
+            ['something/else/more/docs/more', 'something/else/more/docs/more'], # valid
+            ['/docs/one/two', 'one/two'], # leading docs
+            ['docs/one/two', 'one/two'], # leading docs without slash
+            ['fr/docs/one/two', 'one/two'], # foreign locale with docs
+            ['docs/project/docs', 'project/docs'] # docs with later docs
+        ]
+
+        for comparison in comparisons:
+            form = TreeMoveForm({ 'slug': comparison[0] })
+            form.is_valid()
+            eq_(comparison[1], form.cleaned_data['slug'])

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -52,7 +52,7 @@ from access.decorators import permission_required, login_required
 from sumo.helpers import urlparams
 from sumo.urlresolvers import reverse
 from sumo.utils import paginate, smart_int
-from wiki import (DOCUMENTS_PER_PAGE, TEMPLATE_TITLE_PREFIX)
+from wiki import (DOCUMENTS_PER_PAGE, TEMPLATE_TITLE_PREFIX, SLUG_CLEANSING_REGEX)
 from wiki.decorators import check_readonly
 from wiki.events import (EditDocumentEvent, ReviewableRevisionInLocaleEvent,
                          ApproveRevisionInLocaleEvent)
@@ -1200,6 +1200,7 @@ def move(request, document_slug, document_locale):
                     'descendants':  descendants,
                     'descendants_count': len(descendants),
                     'conflicts': conflicts,
+                    'SLUG_CLEANSING_REGEX': SLUG_CLEANSING_REGEX,
                 })
             # Set new parent, if any
             new_slug_bits = form.cleaned_data['slug'].split('/')
@@ -1227,6 +1228,7 @@ def move(request, document_slug, document_locale):
         'document': doc,
         'descendants':  descendants,
         'descendants_count': len(descendants),
+        'SLUG_CLEANSING_REGEX': SLUG_CLEANSING_REGEX,
     })
 
 

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -1421,21 +1421,18 @@
          });
 
          // Hide lookup when the field is blurred
-         $suggestionInput.blur(onHide);
+         $suggestionInput.on('blur', onHide);
 
          // Go to link when blured
-         $moveSlug.blur(function() {
+         $moveSlug.on('blur', function() {
              $lookupLink.focus();
          });
 
          // Help on the client side for validating slugs to be moved
-         function formatSlug() {
-            var startValue = this.value;
-            if(startValue.length && startValue[0] == '/') {
-                this.value = startValue.substr(1);
-            }
-         }
-         $moveSlug.keyup(formatSlug).change(formatSlug).focus(formatSlug).blur(formatSlug);
+         var moveRegex = new RegExp($moveSlug.attr('data-validator'), 'i');
+         $moveSlug.on('change keyup focus blur', function() {
+            this.value = this.value.replace(moveRegex, '');
+         });
      }
 
     $(document).ready(init);


### PR DESCRIPTION
Remove leading "/" and "{locale}/docs" from slug moves to avoid problems.
