### PR TITLE
fix bug 782686 - Ensure scrolling in maximized state

### DIFF
--- a/media/ckeditor/plugins/mdn-maximize/plugin.js
+++ b/media/ckeditor/plugins/mdn-maximize/plugin.js
@@ -179,6 +179,9 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 
 						if ( this.state == CKEDITOR.TRISTATE_OFF )		// Go fullscreen if the state is off.
 						{
+							// Bug #782686
+							editor.document.getDocumentElement().addClass('maximized');
+
 							// Add event handler for resizing.
 							mainWindow.on( 'resize', resizeHandler );
 
@@ -244,6 +247,9 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 						}
 						else if ( this.state == CKEDITOR.TRISTATE_ON )	// Restore from fullscreen if the state is on.
 						{
+							// Bug #782686
+							editor.document.getDocumentElement().removeClass('maximized');
+
 							// Remove event handler for resizing.
 							mainWindow.removeListener( 'resize', resizeHandler );
 

--- a/media/css/wiki-edcontent.css
+++ b/media/css/wiki-edcontent.css
@@ -1,5 +1,6 @@
 /* styles for the WYSIWYG editor which we cannot take directly from screen.css */
 html { background: #fff; }
+html.maximized { overflow-y: auto !important; }
 body { min-height: 400px; font: 14px/1.286 "Lucida Grande", "Lucida Sans Unicode", "DejaVu Sans", Lucida, Arial, Helvetica, sans-serif; margin: 0 auto; color: #333; padding: 0 20px; }
 
 /* links */


### PR DESCRIPTION
There's a collision between the maximize and autogrow plugins, so this bit of CSS fixes the issue.  Hate using !important but it's really the only way to go here.
