### PR TITLE
fix bug 887428: Redirect for misprinted URL in promo materials

### DIFF
--- a/configs/htaccess-without-mindtouch
+++ b/configs/htaccess-without-mindtouch
@@ -30,6 +30,9 @@ RewriteRule ^robots.txt$ media/robots.txt [L]
 RewriteRule ^sitemap.xml$ media/sitemap.xml [L]
 RewriteRule ^sitemaps/([\w\-]*)/sitemap.xml$ media/sitemaps/$1/sitemap.xml [L]
 
+# Bug 887428 - Misprinted URL in promo materials
+RewriteRule ^Firefox_OS/Security$ docs/Mozilla/Firefox_OS/Security [R=301,L,NC]
+
 # Some blanket section moves / renames
 RewriteRule ^En/JavaScript/Reference/Objects/Array$ en-US/docs/JavaScript/Reference/Global_Objects/Array [R=301,L,NC]
 RewriteRule ^En/JavaScript/Reference/Objects$ en-US/docs/JavaScript/Reference/Global_Objects/Object [R=301,L,NC]


### PR DESCRIPTION
This seems to work. I tried it with a few different locales set in my browser, and they went to the right spots.

It even captures the case where the fr URL has changed from Security to securite, because [the document view handler does some gymnastics](https://github.com/mozilla/kuma/blob/master/apps/wiki/views.py#L324) to check in the en-US locale first and find the fr alternative for an existing en-US doc before throwing a 404 error.
- https://developer.mozilla.org/docs/Mozilla/Firefox_OS/Security -> https://developer.mozilla.org/fr/docs/Mozilla/Firefox_OS/securite
