### PR TITLE
fix bug 886017 - Show image previews

### DIFF
--- a/apps/wiki/templates/wiki/attachment_detail.html
+++ b/apps/wiki/templates/wiki/attachment_detail.html
@@ -18,7 +18,7 @@
         <ul>
           <li>
             <mark>{{ _('Revision slug:') }}</mark>
-            <span>{{ revision.slug }}</span>
+            <span><a href="{{ attachment.get_file_url() }}">{{ revision.slug }}</a></span>
           </li>
           <li>
             <mark>{{ _('Revision title:') }}</mark>
@@ -34,7 +34,7 @@
           </li>
           <li>
             <mark>{{ _('Creator:') }}</mark>
-            <span>{{ revision.creator }}</span>
+            <span><a href="{{ url('devmo.views.profile_view', username=revision.creator) }}">{{ revision.creator }}</a></span>
           </li>
           <li>
             <mark>{{ _('MIME Type:') }}</mark>
@@ -69,7 +69,11 @@
     <details class="h2">
       <summary>{{ _('Attachment Preview') }}</summary>
       <div id="doc-content">
-        Image thumbnail or document content here
+        {% if preview_content %}
+          {{ preview_content|safe }}
+        {% else %}
+          {{ _('No preview is available.') }}
+        {% endif %}
       </div>
     </details>
   </article>

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -2189,8 +2189,15 @@ def mindtouch_file_redirect(request, file_id, filename):
 def attachment_detail(request, attachment_id):
     """Detail view of an attachment."""
     attachment = get_object_or_404(Attachment, pk=attachment_id)
+    preview_content = ''
+    current = attachment.current_revision
+
+    if current.mime_type in ['image/png', 'image/jpeg', 'image/jpg', 'image/gif']:
+        preview_content = '<img src="%s" alt="%s" />' % (attachment.get_file_url(), current.title)
+
     return render(request, 'wiki/attachment_detail.html',
                         {'attachment': attachment,
+                         'preview_content': preview_content,
                          'revision': attachment.current_revision})
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=886017

Only added the image types for now, and we can add more as requested.  Since I'm building the content for imagery, I used |safe as I felt it reasonable.
