### PR TITLE
Move globals to one config object

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -34,10 +34,8 @@ CKEDITOR.on('instanceReady', function(ev) {
     callback && callback(ev);
 });
 
-// Any utilities we need to be globably available will go here
-CKEDITOR.mdn = CKEDITOR.mdn || {
-    redirectPattern: '{{ redirect_pattern|safe }}'
-};
+// Provide redirect pattern for corresponding plugin
+mdn.ckeditor.redirectPattern = '{{ redirect_pattern|safe }}';
 
 (function() {
     // Brick dialog "changed" prompts
@@ -60,7 +58,7 @@ CKEDITOR.mdn = CKEDITOR.mdn || {
     delete CKEDITOR.dtd.$removeEmpty['i'];
 
     // Manage key presses
-    var keys = CKEDITOR.mdn.keys = {
+    var keys = mdn.ckeditor.keys = {
             control2: CKEDITOR.CTRL + 50,
             control3: CKEDITOR.CTRL + 51,
             control4: CKEDITOR.CTRL + 52,

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -106,7 +106,6 @@
                 {% endif %}
                 {% if show_translation_parent_block %}
                 <li class="metadata-choose-parent">
-                    {% include 'wiki/includes/title_autosuggest_url.html' %}
                     {{_('Find the translation source with the lookup below and then click "Save Changes.')}}
                     <br />
                     <strong>{{_('Lookup:')}}</strong> <input type="text" id="parent_text" />
@@ -131,8 +130,6 @@
             {% endif %}
             <input type="hidden" name="form" value="rev" />
             {{ revision_form.hidden_fields()|join|safe }}
-            
-            {% include 'wiki/includes/title_autosuggest_url.html' %}
 
             {% include 'wiki/includes/revision_comment.html' %}
 

--- a/apps/wiki/templates/wiki/includes/attachment_list.html
+++ b/apps/wiki/templates/wiki/includes/attachment_list.html
@@ -14,8 +14,7 @@
   </p>
 
   <script>
-    // This is a global, but has to be :/
-    window.MDN_ATTACHMENTS = {{ (attachment_data_json | safe) or '[]' }};
+    mdn.wiki.attachments = {{ (attachment_data_json | safe) or '[]' }};
   </script>
   <table cellpadding="0" cellspacing="0" id="page-attachments-table" class="{% if not attachment_data|length %}hidden{% endif %}">
     <thead>

--- a/apps/wiki/templates/wiki/includes/title_autosuggest_url.html
+++ b/apps/wiki/templates/wiki/includes/title_autosuggest_url.html
@@ -1,1 +1,0 @@
-<div id="autosuggestTitleUrl" class="hidden" data-url="{{ url('wiki.autosuggest_documents') }}"></div>

--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -64,7 +64,6 @@
                   <div id="parentSuggestionInputContainer">
                       <input type="text" placeholder="{{ _('Parent Title') }}" id="parentSuggestion" disabled />
                   </div>
-                  {% include 'wiki/includes/title_autosuggest_url.html' %}
                 </dd>
               </dl>
             </li>

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -46,8 +46,6 @@
       {% if is_template %}
         <div id="ace_content"></div>
       {% endif %}
-      
-      {% include 'wiki/includes/title_autosuggest_url.html' %}
 
       {% include 'wiki/includes/revision_comment.html' %}
 

--- a/media/ckeditor/plugins/mdn-attachments/plugin.js
+++ b/media/ckeditor/plugins/mdn-attachments/plugin.js
@@ -3,11 +3,11 @@ CKEDITOR.plugins.add('mdn-attachments', {
 
         	// Utility method for updating the attachments dropdown
         	// Should be used within the mdn-link and image dialogs
-        	CKEDITOR.mdn.updateAttachments = function(select, url, filter) {
+        	mdn.ckeditor.updateAttachments = function(select, url, filter) {
         		if(!select) return;
 
 				var attachmentsArray = [],
-					mdnArray = window.MDN_ATTACHMENTS,
+					mdnArray = mdn.wiki.attachments,
 					validFiles = {};
 
 				// Clear the select
@@ -53,11 +53,13 @@ CKEDITOR.plugins.add('mdn-attachments', {
 			}
 
 			// Utility method to get an MDN attachment object by url
-			CKEDITOR.mdn.getObjectByUrl = function(url) {
-				if(!window.MDN_ATTACHMENTS) return;
+			mdn.ckeditor.getObjectByUrl = function(url) {
+				var attachments = mdn.wiki.attachments;
+
+				if(!attachments) return;
 				
 				var returnObj = false;
-				$.each(window.MDN_ATTACHMENTS, function() {
+				$.each(attachments, function() {
 					if(this.url == url) {
 						returnObj = this;
 					}

--- a/media/ckeditor/plugins/mdn-image/dialogs/image.js
+++ b/media/ckeditor/plugins/mdn-image/dialogs/image.js
@@ -377,7 +377,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 				// For some reason, setup() doesn't automagically get called on any input in this dialog
 				// So I'm calling it myself
 				var select = this.getContentElement("info", "attachment")._.children[0];
-				CKEDITOR.mdn.updateAttachments(select, this.getValueOf('info', 'txtUrl'), imageAttachmentFilter);
+				mdn.ckeditor.updateAttachments(select, this.getValueOf('info', 'txtUrl'), imageAttachmentFilter);
 			},
 			onOk : function()
 			{
@@ -521,7 +521,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 								onChange: function() {
 									var value = this.getValue(),
 										dialog = this.getDialog(),
-										alt = CKEDITOR.mdn.getObjectByUrl(value);
+										alt = mdn.ckeditor.getObjectByUrl(value);
 									dialog.setValueOf('info', 'txtUrl', value);
 									if(alt) {
 										dialog.setValueOf('info', 'txtAlt', alt.description);
@@ -529,7 +529,7 @@ For licensing, see LICENSE.html or http://ckeditor.com/license
 								},
 								setup: function(data) {
 									attachmentsSelect = this;
-									CKEDITOR.mdn.updateAttachments(this, imageAttachmentFilter);
+									mdn.ckeditor.updateAttachments(this, imageAttachmentFilter);
 								}
 							}]
 						},

--- a/media/ckeditor/plugins/mdn-keystrokes/plugin.js
+++ b/media/ckeditor/plugins/mdn-keystrokes/plugin.js
@@ -6,7 +6,7 @@ CKEDITOR.plugins.add('mdn-keystrokes', {
 	// Initialize
 	init: function(editor) {
 		
-		var keys = CKEDITOR.mdn.keys;
+		var keys = mdn.ckeditor.keys;
 
 		editor.on('key', function(event) {
 			event.stop();

--- a/media/ckeditor/plugins/mdn-link/dialogs/link.js
+++ b/media/ckeditor/plugins/mdn-link/dialogs/link.js
@@ -9,7 +9,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 	
 	// These vars are specific to the autocompleter
 	var autoCompleteCreated = false,
-		autoCompleteUrl = jQuery('#autosuggestTitleUrl').attr('data-url'),
+		autoCompleteUrl = mdn.wiki.autosuggestTitleUrl,
 		autoCompleteTextbox,
 		autoCompleteSelection,
 		attachmentsSelect;
@@ -504,7 +504,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 									},
 									setup: function(data) {
 										attachmentsSelect = this;
-										CKEDITOR.mdn.updateAttachments(this, this.getDialog().getValueOf('info', 'url'));
+										mdn.ckeditor.updateAttachments(this, this.getDialog().getValueOf('info', 'url'));
 									}
 								}]
 							},
@@ -1001,7 +1001,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 				lang;
 
 			// Update the dropdown
-			CKEDITOR.mdn.updateAttachments(attachmentsSelect, this.getValueOf('info', 'url'));
+			mdn.ckeditor.updateAttachments(attachmentsSelect, this.getValueOf('info', 'url'));
 
 			// Fill in all the relevant fields if there's already one link selected.
 			if ((element = plugin.getSelectedLink(editor)) && element.hasAttribute('href')) {
@@ -1015,7 +1015,7 @@ CKEDITOR.dialog.add( 'link', function( editor )
 			this.setupContent( parseLink.apply( this, [ editor, element ] ) );
 
 			// Update the attachments list
-			CKEDITOR.mdn.updateAttachments(attachmentsSelect, this.getValueOf('info', 'url'));
+			mdn.ckeditor.updateAttachments(attachmentsSelect, this.getValueOf('info', 'url'));
 			
 			// If there's an element, don't take action, let the editor handle it
 			this.hasSourceElement = !(element == null);

--- a/media/ckeditor/plugins/mdn-redirect/dialogs/mdn-redirect.js
+++ b/media/ckeditor/plugins/mdn-redirect/dialogs/mdn-redirect.js
@@ -2,7 +2,7 @@ CKEDITOR.dialog.add( 'mdn-redirect', function( editor ) {
 
 	var topLabel = gettext('MDN Redirect'),
 		docInfo = window.documentInfo,
-		autoCompleteUrl = jQuery('#autosuggestTitleUrl').attr('data-url'),
+		autoCompleteUrl = mdn.wiki.autosuggestTitleUrl,
 		autoCompleteTextbox,
 		$autoCompleteTextbox;
 
@@ -77,7 +77,7 @@ CKEDITOR.dialog.add( 'mdn-redirect', function( editor ) {
 			var editor = dialog.sender.getParentEditor(),
 				title = dialog.sender.getContentElement( 'info', 'autoselect' ).getValue()
 				url = dialog.sender.getContentElement( 'info', 'url' ).getValue(),
-				pattern = CKEDITOR.mdn.redirectPattern;
+				pattern = mdn.ckeditor.redirectPattern;
 			editor && title && url && editor.setData(
 				pattern.replace('%(href)s', url).replace('%(title)s', title)
 			);

--- a/media/ckeditor/plugins/mdn-sample-finder/dialogs/mdn-sample-finder.js
+++ b/media/ckeditor/plugins/mdn-sample-finder/dialogs/mdn-sample-finder.js
@@ -2,7 +2,7 @@ CKEDITOR.dialog.add( 'mdn-sample-finder', function( editor ) {
 
 	var topLabel = gettext('Sample Finder'),
 		docInfo = window.documentInfo,
-		autoCompleteUrl = jQuery('#autosuggestTitleUrl').attr('data-url'),
+		autoCompleteUrl = mdn.wiki.autosuggestTitleUrl,
 		autoCompleteTextbox,
 		$autoCompleteTextbox,
 		autoCompleteItem,

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -941,7 +941,7 @@
             $('#parent_text').mozillaAutocomplete({
                 minLength: 1,
                 requireValidOption: true,
-                autocompleteUrl: $('#autosuggestTitleUrl').attr('data-url'),
+                autocompleteUrl: mdn.wiki.autosuggestTitleUrl,
                 _renderItemAsLink: true,
                 buildRequestData: function(req) {
                     req.locale = 'en-US';
@@ -1256,8 +1256,7 @@
 
                 return $clone;
             }
-            var firstClone = clone();
-            firstClone.find('input[type="text"]')[0].focus();
+            clone().find('input[type="text"]')[0].focus();
         });
 
         // Add an "ajax" parameter to the form for the sake of the server
@@ -1291,8 +1290,8 @@
                             // Update attachment count
                             $attachmentsCount.text(parseInt($attachmentsCount.text(), 10) + 1);
                             // Add item to list
-                            if(window.MDN_ATTACHMENTS) {
-                                window.MDN_ATTACHMENTS.push(this);
+                            if(mdn.wiki.attachments) {
+                                mdn.wiki.attachments.push(this);
                             }
                             validIndexes.push(i);
                             // Remove the form row
@@ -1394,7 +1393,7 @@
          $suggestionInput.mozillaAutocomplete({
              minLength: 1,
              requireValidOption: true,
-             autocompleteUrl: $('#autosuggestTitleUrl').attr('data-url'),
+             autocompleteUrl: mdn.wiki.autosuggestTitleUrl,
              _renderItemAsLink: true,
              buildRequestData: function(req) {
                  req.locale = moveLocale;

--- a/templates/base.html
+++ b/templates/base.html
@@ -36,6 +36,19 @@
   <script src="{{ MEDIA_URL }}js/html5.js"></script>
   <![endif]-->
 
+  <script type="text/javascript">
+    // This represents the site configuration
+    // TODO:  Move this to its own module when we're AMD-ready
+    window.mdn = {
+      build: '{{ BUILD_ID_JS }}',
+      // Setting these objects up for later use
+      ckeditor: {},
+      wiki: {
+        autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
+      }
+    };
+  </script>
+
   {% block extrahead %}{% endblock %}
   {% include "includes/google_analytics.html" %}
 </head>


### PR DESCRIPTION
We've had a few globals floating around, and even an include with one element and an data-attribute.  Messy.  This creates a config "window.mdn" object within the base template.  This object will have a few properties to start and which will have properties added at different times.

Eventually this will be moved to an external JS file in AMD format, but until we make that switch, base is the best place to keep this.  We could move it to a config.js now, but that's another request and we'd want it preprocessed, making it slow the page down more.
