### PR TITLE
fix bug 888631 - Prevent translations from getting English tags

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -266,7 +266,7 @@
     
     <section class="page-meta">
       {% if tags | length %}
-      <section id="page-tags">
+      <section class="page-tags">
         <h2><i class="icon-tags"></i>{{ _('Tags') }} ({{ tags | length}})</h2>
         <div id="deki-page-tags">
           <ul class="tags tagit ui-widget ui-widget-content">

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -135,7 +135,7 @@
 
             <section class="page-meta">
               {% set tags = document.tags.all() %}
-              <section id="page-tags">
+              <section id="page-tags" class="page-tags">
                 <h2><i class="icon-tags"></i>{{ _('Tags') }}</h2>
                 <input id="tagit_tags" type="text" name="tags" value="{% for tag in tags %}{{ tag.name }},{% endfor %}" maxlength="255" />
               </section>

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -50,7 +50,7 @@
       {% include 'wiki/includes/revision_comment.html' %}
 
       <section class="page-meta">
-        <section id="page-tags">
+        <section id="page-tags" class="page-tags">
           <h2><i class="icon-tags"></i>{{ _('Tags') }}</h2>
           <input id="tagit_tags" type="text" name="tags" value="{% for tag in initial_tags %}{{ tag.name }},{% endfor %}" maxlength="255" />
         </section>

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -93,15 +93,15 @@
             </div>
 
             <section class="page-meta">
-            <section id="page-tags">
+            <section class="page-tags">
               <h3><i class="icon-tag"></i>{{ _('Tags') }}</h3>
-                {% set tags = parent.tags.all() %}
+                {% set parent_tags = parent.tags.all() %}
               <div id="deki-page-tags">
-                {% if tags | length %}
+                {% if parent_tags | length %}
                   <ul class="tags tagit ui-widget ui-widget-content">
-                    {% for tag in tags %}
+                    {% for parent_tag in parent_tags %}
                     <li class="tagit-choice ui-widget-content ui-state-default">
-                        <a class="text tagit-label" href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a>
+                        <a class="text tagit-label" href="{{url('wiki.tag', parent_tag.name)}}">{{ parent_tag.name }}</a>
                     </li>
                     {% endfor %}
                   </ul>
@@ -128,7 +128,7 @@
         <div class="approved">&nbsp;</div>
         <div class="localized">
           <section class="page-meta">
-              <section id="page-tags">
+              <section id="page-tags" class="page-tags">
                 <h2><i class="icon-tag"></i>{{ _('Tags') }}</h2>
                 {% if document.tags %}
                   {% set tags = document.tags.all() %}

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -1790,10 +1790,10 @@ class DocumentEditingTests(TestCaseBase):
                                           args=[doc.full_path]), data)
             page = pq(response.content)
             for t in yes_tags:
-                eq_(1, page.find('#page-tags li a:contains("%s")' % t).length,
+                eq_(1, page.find('.page-tags li a:contains("%s")' % t).length,
                     '%s should NOT appear in document view tags' % t)
             for t in no_tags:
-                eq_(0, page.find('#page-tags li a:contains("%s")' % t).length,
+                eq_(0, page.find('.page-tags li a:contains("%s")' % t).length,
                     '%s should appear in document view tags' % t)
 
             # Check for the document title in the tag listing

--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -86,10 +86,10 @@ img.rwrap { background: #fff; padding: 0 0 .75em 20px; }
 textarea#id_content { width: 96%; padding: 15px; min-height: 300px; }
 
 /* tag editing; uses tagit */
-#page-tags #id_tags { width: 90%; }
-#page-tags ul.tagit { background: none repeat scroll 0 0 #FFFFFF; border: 1px solid #CBC8B9; padding: 6px 8px; min-height: 30px; }
-#page-tags ul.tagit .tagit-label { color: #333333; font-weight: normal; }
-#page-tags ul.tagit li.tagit-choice { margin-bottom:0; }
+.page-tags #id_tags { width: 90%; }
+.page-tags ul.tagit { background: none repeat scroll 0 0 #FFFFFF; border: 1px solid #CBC8B9; padding: 6px 8px; min-height: 30px; }
+.page-tags ul.tagit .tagit-label { color: #333333; font-weight: normal; }
+.page-tags ul.tagit li.tagit-choice { margin-bottom:0; }
 
 #deki-page-tags ul.tagit { background: transparent; border: 0; padding: 0; min-height: none; margin-top: 6px; }
 #deki-page-tags li.tagit-choice { padding-right: 10px; }
@@ -651,9 +651,9 @@ tr.release td.stepLabel { padding: 0 5px 15px 25px; width: 12%; text-align: righ
 .html-rtl #nav,
 .html-rtl #title, 
 .html-rtl #nav-toolbar .crumbs, 
-.html-rtl #page-tags h2, 
-.html-rtl #page-tags #deki-page-tags,
-.html-rtl #page-tags .tags-edit, 
+.html-rtl .page-tags h2, 
+.html-rtl .page-tags #deki-page-tags,
+.html-rtl .page-tags .tags-edit, 
 .html-rtl #site-info #legal, 
 .html-rtl .deki-pagination div, 
 .html-rtl .pagination span, 
@@ -682,9 +682,9 @@ tr.release td.stepLabel { padding: 0 5px 15px 25px; width: 12%; text-align: righ
 .html-rtl .compact #nav .nav-menu:hover .sub-menu, .html-rtl .compact #nav .hover .sub-menu, .html-rtl .compact #nav a:focus + ul { right: auto; }
 .html-rtl #article-nav { padding: 0 20px 1em 0; }
 .html-rtl .page-meta h2 { margin: 0 0 0 20px; }
-.html-rtl #page-tags #deki-page-tags-toggleview, .html-rtl .page-meta p.add { right: auto; left: 20px; text-align: left; }
-.html-rtl #page-tags #deki-page-tags .tagData { padding-right: 0; padding-left: 30px; }
-.html-rtl #page-tags #deki-page-tags .tagButtons { padding-left: 0; padding-right: 10px; float: left; }
+.html-rtl .page-tags #deki-page-tags-toggleview, .html-rtl .page-meta p.add { right: auto; left: 20px; text-align: left; }
+.html-rtl .page-tags #deki-page-tags .tagData { padding-right: 0; padding-left: 30px; }
+.html-rtl .page-tags #deki-page-tags .tagButtons { padding-left: 0; padding-right: 10px; float: left; }
 .html-rtl #page-buttons { right: auto; left: 20px; }
 .html-rtl #site-info #legal { padding: 0 55px 0 0; }
 .html-rtl #site-info #legal img { left: auto; right: 0; }


### PR DESCRIPTION
Switching tag block styling to classes instead of IDs prevents this problems.
