### PR TITLE
Puppet can now find upstart scripts

### DIFF
--- a/puppet/manifests/classes/statsd.pp
+++ b/puppet/manifests/classes/statsd.pp
@@ -70,15 +70,25 @@ class statsd {
         unless => "/usr/bin/sqlite3 /opt/graphite/storage/graphite.db 'select * from auth_user' | /bin/grep -q admin",
         require => Exec['graphite-syncdb']
     }
+    file { '/etc/init.d/carbon-cache':
+        ensure => link,
+        target => '/etc/init/carbon-cache.conf',
+        require => File['/etc/init/carbon-cache.conf']
+    }
     service { 'carbon-cache':
         ensure => running,
         enable => true,
-        require => File['/etc/init/carbon-cache.conf']
+        require => File['/etc/init.d/carbon-cache']
+    }
+    file { '/etc/init.d/statsd':
+        ensure => link,
+        target => '/etc/init/statsd.conf',
+        require => File['/etc/init/statsd.conf']
     }
     service { 'statsd':
         ensure => running,
         enable => true,
-        require => File['/etc/init/statsd.conf']
+        require => File['/etc/init.d/statsd']
     }
         
 }


### PR DESCRIPTION
Puppet looks in /etc/init.d for statsd and carbon-cache and since these two do
not exists, error is thrown. This patch creates a symlink between:
- /etc/init.d/statsd and /etc/init/statsd.conf
- /etc/init.d/carbon-cache and /etc/init/carbon-cache.conf
