### PR TITLE
Fixed npm permission errors

### DIFF
--- a/puppet/manifests/classes/nodejs.pp
+++ b/puppet/manifests/classes/nodejs.pp
@@ -11,7 +11,6 @@ class nodejs {
     }
     exec { 'npm-install':
         cwd => "/vagrant/kumascript",
-        user => "vagrant",
         command => "/usr/bin/npm install",
         creates => "/vagrant/kumascript/node_modules/fibers",
         require => [

--- a/puppet/manifests/classes/statsd.pp
+++ b/puppet/manifests/classes/statsd.pp
@@ -2,7 +2,6 @@
 class statsd {
     exec { 'statsd-install':
         cwd => '/home/vagrant',
-        user => 'vagrant',
         # TODO: This revision works, but try to see what statsd runs in mozilla infra
         command => '/usr/bin/npm install git://github.com/etsy/statsd.git#922e9e58c57ae4e61268cbd6925c112f0e4e468c',
         creates => '/home/vagrant/node_modules/statsd',


### PR DESCRIPTION
npm tried to write into /root/.npm and vagrant up failed with error:
/Stage[langs]/Nodejs/Exec[npm-install]/returns: change from notrun to 0 failed:
/usr/bin/npm install returned 1 instead of one of [0] at
/tmp/vagrant-puppet/manifests/classes/nodejs.pp:21

or similar (/tmp/vagrant-puppet/manifests/classes/statsd.pp:14)
