### PR TITLE
fix bug 880899 - Show only mozhacks on the homepage

### DIFF
--- a/apps/devmo/__init__.py
+++ b/apps/devmo/__init__.py
@@ -31,9 +31,14 @@ class SECTION_WEB:
     twitter = 'twitter-web'
     updates = 'updates-web'
 
+class SECTION_HACKS:
+    short = 'hacks'
+    pretty = _(u'Moz Hacks')
+    twitter = 'twitter-moz-hacks'
+    updates = 'updates-moz-hacks'
 
-SECTION_USAGE = _sections = (SECTION_WEB, SECTION_MOBILE, SECTION_ADDONS,
-                             SECTION_APPS, SECTION_MOZILLA)
+
+SECTION_USAGE = _sections = (SECTION_HACKS,)
 
 SECTIONS = dict((section.short, section)
                 for section in _sections)

--- a/apps/landing/views.py
+++ b/apps/landing/views.py
@@ -13,7 +13,7 @@ from waffle.decorators import waffle_switch
 from waffle.models import Flag
 
 from devmo import (SECTION_USAGE, SECTION_ADDONS, SECTION_APPS, SECTION_MOBILE,
-                   SECTION_WEB, SECTION_MOZILLA)
+                   SECTION_WEB, SECTION_MOZILLA, SECTION_HACKS)
 from feeder.models import Bundle, Feed
 from demos.models import Submission
 from landing.forms import SubscriptionForm
@@ -25,17 +25,12 @@ def home(request):
                 .exclude(hidden=True)\
                 .order_by('-modified').all()[:1]
 
-    tweets = []
-    for section in SECTION_USAGE:
-        tweets += Bundle.objects.recent_entries(section.twitter)[:2]
-    tweets.sort(key=lambda t: t.last_published, reverse=True)
-
     updates = []
     for s in SECTION_USAGE:
-        updates += Bundle.objects.recent_entries(s.updates)[:1]
+        updates += Bundle.objects.recent_entries(s.updates)[:5]
 
     return render(request, 'landing/homepage.html',
-                  {'demos': demos, 'updates': updates, 'tweets': tweets,
+                  {'demos': demos, 'updates': updates,
                     'current_challenge_tag_name': 
                     str(constance.config.DEMOS_DEVDERBY_CURRENT_CHALLENGE_TAG).strip()})
 
@@ -66,6 +61,11 @@ def search(request):
 def mobile(request):
     """Mobile landing page."""
     return common_landing(request, section=SECTION_MOBILE)
+
+
+def hacks(request):
+    """Hacks landing page."""
+    return common_landing(request, section=SECTION_HACKS)
 
 
 def web(request):


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=880899

To test:
1.  Within admin, create a feed for moz-hacks (if you don't have one already) using  http://hacks.mozilla.org/feed/
2.  Create a bundle for said feed called "updates-moz-hacks"
3.  ./manage.py update_feeds

Now the homepage should just feature hacks content.
