### PR TITLE
Temporarily remove tweets which are ISE'ing on production

### DIFF
--- a/apps/landing/templates/landing/addons.html
+++ b/apps/landing/templates/landing/addons.html
@@ -134,7 +134,7 @@
       </a>
     </figure>
 
-    {{ twitter(tweets, title=_('Tweets from the Add-ons developer community.')) }}
+    {# {{ twitter(tweets, title=_('Tweets from the Add-ons developer community.')) }} #}
   </aside>{# /#content-sub #}
 
 </div>

--- a/apps/landing/templates/landing/mobile.html
+++ b/apps/landing/templates/landing/mobile.html
@@ -196,7 +196,7 @@
       </a>
     </figure>
    
-    {{ twitter(tweets, title=_('Tweets from the Mobile developer community.')) }}
+    {# {{ twitter(tweets, title=_('Tweets from the Mobile developer community.')) }} #}
   </aside>{# /#content-sub #}
 
 </div>

--- a/apps/landing/templates/landing/mozilla.html
+++ b/apps/landing/templates/landing/mozilla.html
@@ -129,7 +129,7 @@
       </a>
     </figure>
   
-    {{ twitter(tweets, title=_('Tweets from the Mozilla developer community.')) }}
+    {# {{ twitter(tweets, title=_('Tweets from the Mozilla developer community.')) }} #}
   </aside>{# /#content-sub #}
 
 </div>

--- a/apps/landing/templates/landing/web.html
+++ b/apps/landing/templates/landing/web.html
@@ -133,7 +133,7 @@
       </a>
     </figure>
 
-    {{ twitter(tweets, title=_('Tweets from the Web developer community.')) }}
+    {# {{ twitter(tweets, title=_('Tweets from the Web developer community.')) }} #}
   </aside>{# /#content-sub #}
 
 </div>


### PR DESCRIPTION
We should disable these on prod temporarily so we do not continue 500'ing.  I'm wondering if the root issue is that the django package that grabs this information isn't capable of handling Twitter's new API stuff.  We'll look more into it though.
