### PR TITLE
Make autosuggest view bail out on bad querystring

### DIFF
--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -2722,6 +2722,11 @@ class MindTouchRedirectTests(TestCaseBase):
 class AutosuggestDocumentsTests(TestCaseBase):
     """ Test the we're properly filtering out the Redirects from the document list """
 
+    def test_autosuggest_no_term(self):
+        url = reverse('wiki.autosuggest_documents', locale=settings.WIKI_DEFAULT_LANGUAGE)
+        resp = self.client.get(url)
+        eq_(400, resp.status_code)
+
     def test_document_redirects(self):
 
         # All contain "e", so that will be the search term

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1325,7 +1325,12 @@ def autosuggest_documents(request):
     locale = request.GET.get('locale', False)
     current_locale = request.GET.get('current_locale', False)
     exclude_current_locale = request.GET.get('exclude_current_locale', False)
-
+    
+    if not partial_title:
+        # Only handle actual autosuggest requests, not requests for a
+        # memory-busting list of all documents.
+        return HttpResponseBadRequest(_lazy('Autosuggest requires a partial title. For a full document index, see the main page.'))
+        
     # Retrieve all documents that aren't redirects or templates
     docs = (Document.objects.
         extra(select={'length': 'Length(slug)'}).


### PR DESCRIPTION
This (hopefully) solves some memory issues -- we've been seeing a lot
of intermittent cases of this view being hit with no search term, and
eventually hitting a MemoryError.
