### PR TITLE
Fix path to simplemodal JS file

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -632,7 +632,7 @@ MINIFY_BUNDLES = {
         ),
         'search': (
             'js/search.js',
-            'js/mdn/jquery.simplemodal.1.4.1.min.js',
+            'js/libs/jquery.simplemodal.1.4.1.min.js',
             'js/libs/jqueryui.min.js',
         ),
         'wiki': (


### PR DESCRIPTION
Updates path to existing simplemodal path for build.

This modal is used only in the demo area to report problems, so it will be gone soon.
