### PR TITLE
fix bug 889631 - Add signup page for external documentation sources

### DIFF
--- a/apps/wiki/templates/wiki/mvp_signup.html
+++ b/apps/wiki/templates/wiki/mvp_signup.html
@@ -1,0 +1,69 @@
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "wiki/base.html" %}
+{% set title = _('MVP External Document Source Signup') %}
+{% block title %}{{ page_title(title) }}{% endblock %}
+
+{% block content %}
+<section id="content">
+  <div class="wrap">
+    <div id="content-main" class="full">
+  <article class="main-full" id="mvp-signup">
+    <div id="wikiArticle" class="page-content boxed">
+
+      {% if not submitted %}
+        {% trans %}
+        <h1>We put TFM in RTFM</h1>
+        <p>MDN has great docs, you have great docs.  Tell us where your great docs are and we'll work on adding them to the MDN collection.</p>
+        {% endtrans %}
+
+        {% if error %}
+        <p class="error">
+          {{ error }}
+        </pre>
+        {% endif %}
+        
+        <form action="/en-US/docs/mvp-signup" method="post">
+          {{ csrf() }}
+          <input type="text" value="{{ location }}" placeholder="{{ _('URL to hosted docs or repository') }}" name="location" autofocus required />
+          <button>{{ _('Add Your Docs to MDN') }}</button>
+        </form>
+
+        {% trans %}
+        <p>Note:  If your docs are in a sub-directory of a repository, please give us the full path to the docs directory.</p>
+        {% endtrans %}
+
+        <style type="text/css">
+          #mvp-signup input {
+            display: block;
+            width: 50%;
+            margin-bottom: 20px;
+
+            -moz-box-sizing: border-box;
+            -webkit-box-sizing: border-box;
+            box-sizing: border-box;
+          }
+
+          #mvp-signup button {
+            margin-bottom: 20px;
+            display: block;
+          }
+
+          #mvp-signup  .error {
+            color: #900;
+          }
+        </style>
+        </div>
+
+      {% else %}
+
+        {% trans %}
+        <h1>Thanks</h1>
+        <p>We will work on adding your docs in MDN.  If you'd like to help or follow along, watch or give us comments and feedback on <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=861981">bug 861981</a>.</p>
+        {% endtrans %}
+
+      {% endif %}
+  </article>
+    </div>
+   </div>
+</section>
+{% endblock %}

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -66,6 +66,7 @@ urlpatterns += patterns('wiki.views',
     url(r'^/preview-wiki-content$', 'preview_revision', name='wiki.preview'),
     
     url(r'^/get-documents$', 'autosuggest_documents', name='wiki.autosuggest_documents'),
+    url(r'^/mvp-signup$', 'mvp_signup', name='wiki.mvp_signup'),
     
     url(r'^/category/(?P<category>\d+)$', 'list_documents',
         name='wiki.category'),


### PR DESCRIPTION
This adds a "/en-US/docs/mvp-signup" endpoint for submitting links.  You'll need to add a MVP_SIGNUP_EMAIL setting to your settings_local file with an email address value.

Quick note:  I haven't been able to get emails working since Luke's original email-based PRs, so please let me know if/why emails aren't being sent properly.
