### PR TITLE
Prevent build / cron errors from stylus

### DIFF
--- a/push.txt
+++ b/push.txt
@@ -5,6 +5,7 @@ Every Time
 2. git submodule update --init
 3. pushd vendor && git pull origin master && git submodule update --init && popd
 4. Find and remove any *.pyc files.
+5. ./scripts/compile-stylesheets
 5. manage.py compress_assets
 6. pushd locale && svn up && ./compile-mo.sh . && popd
 7. schematic migrations

--- a/settings.py
+++ b/settings.py
@@ -595,9 +595,6 @@ MINIFY_BUNDLES = {
             'js/prism-mdn/plugins/line-numbering/prism-line-numbering.css',
             'js/prism-mdn/components/prism-json.css',
         ),
-        'redesign': (
-            'css/redesign/main.css',
-        ),
     },
     'js': {
         'mdn': (
@@ -683,9 +680,6 @@ MINIFY_BUNDLES = {
             'js/libs/ace/mode-javascript.js',
             'js/libs/ace/theme-dreamweaver.js',
             'js/libs/ace/worker-javascript.js',
-        ),
-        'redesign': (
-            'redesign/js/main.js',
         ),
     },
 }

--- a/templates/base_redesign.html
+++ b/templates/base_redesign.html
@@ -4,7 +4,7 @@
 	<title>{% block title %}{{ _('Mozilla Developer Network') }}{% endblock %}</title>
 
 	{% block site_css %}
-		{{ css('redesign') }}
+		{# {{ css('redesign') }} #}
 	{% endblock %}
 	<link rel="stylesheet" type="text/css" media="print" href="{{ MEDIA_URL }}css/redesign/print.css" />
 
@@ -41,7 +41,7 @@
 
 	<!-- Site JavaScript -->
 	{% block site_js %}
-		{{ js('redesign') }}
+		{# {{ js('redesign') }} #}
 	{% endblock %}
 	{% block js %}{% endblock %}
 	<script src="/{{ request.locale }}/waffles.js" type="text/javascript" async></script>


### PR DESCRIPTION
Added `compile-stylesheets` to build.sh and update_site.py and I still get errors when I try to compress_assets, so I'm going to remove the redesign pieces of settings.py.  Since we haven't launched yet, I can hardcode paths while I dev.
