### PR TITLE
Update Dash link

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -131,7 +131,7 @@
 
             <div id="offline-dialog-content" title="{{ _('Read MDN Offline') }}">
               <p>{{ _('Did you know that you can read content offline by using one of these tools?  If you would like to read offline MDN content in another format, let us know by commenting on <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=665750" data-title="Bug 665750">Bug 665750</a>.') }}</p>
-              <a href="https://itunes.apple.com/us/app/dash-docs-snippets/id458034879?mt=12" class="offline-dialog-mac" data-title="Dash App">
+              <a href="http://kapeli.com/dash" class="offline-dialog-mac" data-title="Dash App">
                 <img src="{{ request.build_absolute_uri('/media/img/dash-app.png') }}" alt="Dash App" />
               </a>
               <a href="https://github.com/rgarcia/dochub#runnning-locally" target="_blank" class="offline-dialog-others" data-title="DocHub">


### PR DESCRIPTION
Update the Dash link to point to http://kapeli.com/dash as opposed to the App Store page. I believe the kapeli.com page does a better job at presenting what Dash can do.
