### PR TITLE
fix bug 902576 - Remove spaces from base template macros

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 {% macro page_title_macro(t) %}
-  {% block title %}{{ _('Mozilla Developer Network') }}{% endblock %}
+{% block title %}{{ _('Mozilla Developer Network') }}{% endblock %}
 {% endmacro %}
 
 {% macro site_css() %}
@@ -32,19 +32,19 @@
 {% endmacro %}
 
 {% macro extrahead() %}
-  {% block extrahead %}{% endblock %}
+{% block extrahead %}{% endblock %}
 {% endmacro %}
 
 {% macro pageid() %}
-  {% block pageid %}{% endblock %}
+{% block pageid %}{% endblock %}
 {% endmacro %}
 
 {% macro bodyclass() %}
-  {% block bodyclass %}{% endblock %}
+{% block bodyclass %}{% endblock %}
 {% endmacro %}
 
 {% macro page_content() %}
-  {% block content %}{% endblock %}
+{% block content %}{% endblock %}
 {% endmacro %}
 
 {% macro site_js() %}


### PR DESCRIPTION
No more landing page issues.  Stupid Django and its can-only-define-a-block-once philosophy.
