### PR TITLE
Tweak vagrant install docs so that the initial advised clone enables pushes

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -21,7 +21,7 @@ Getting up and running
 #. Clone your fork of Kuma and update submodules (**don't** try to use the same working
    directory as for the local installation)::
 
-       git clone git://github.com/<your_account>/kuma.git
+       git clone git@github.com:<your_username>/kuma.git
        cd kuma
        git submodule update --init --recursive
 


### PR DESCRIPTION
@a2sheppy just discovered that a clone made from a `git://` URL does not enable pushes. Tweaking the docs to an ssh-based repo URL that does.
