### PR TITLE
Bug 900961: Provide a way to (sometimes) repair bad breadcrumbs.

### DIFF
--- a/apps/wiki/admin.py
+++ b/apps/wiki/admin.py
@@ -22,6 +22,12 @@ def dump_selected_documents(self, request, queryset):
 dump_selected_documents.short_description = "Dump selected documents as JSON"
 
 
+def repair_breadcrumbs(self, request, queryset):
+    for doc in queryset:
+        doc.repair_breadcrumbs()
+repair_breadcrumbs.short_description = "Repair translation breadcrumbs"
+        
+
 def enable_deferred_rendering_for_documents(self, request, queryset):
     queryset.update(defer_rendering=True)
     self.message_user(request, 'Enabled deferred rendering for %s Documents' %
@@ -221,7 +227,8 @@ class DocumentAdmin(admin.ModelAdmin):
                resave_current_revision,
                force_render_documents,
                enable_deferred_rendering_for_documents,
-               disable_deferred_rendering_for_documents)
+               disable_deferred_rendering_for_documents,
+               repair_breadcrumbs)
     change_list_template = 'admin/wiki/document/change_list.html'
     fields = ('locale', 'slug', 'title', 'defer_rendering', 'parent',
               'parent_topic', 'category',)

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -29,6 +29,9 @@ document_patterns = patterns('wiki.views',
     url(r'^\$samples/(?P<sample_id>.+)$', 'code_sample', name='wiki.code_sample'),
     url(r'^\$revert/(?P<revision_id>\d+)$', 'revert_document',
         name='wiki.revert_document'),
+    url(r'^\$repair_breadcrumbs$',
+        'repair_breadcrumbs',
+        name='wiki.repair_breadcrumbs'),
 
     # Un/Subscribe to document edit notifications.
     url(r'^\$watch$', 'watch_document', name='wiki.document_watch'),

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1251,6 +1251,19 @@ def move(request, document_slug, document_locale):
     })
 
 
+@login_required
+@process_document_path
+@check_readonly
+@transaction.autocommit
+def repair_breadcrumbs(request, document_slug, document_locale):
+    if not request.user.is_superuser:
+        raise PermissionDenied
+    doc = get_object_or_404(
+        Document, locale=document_locale, slug=document_slug)
+    doc.repair_breadcrumbs()
+    return redirect(doc.get_absolute_url())
+
+
 def ckeditor_config(request):
     """Return ckeditor config from database"""
     default_config = EditorToolbar.objects.filter(name='default').all()


### PR DESCRIPTION
This doesn't prevent the problem from recurring; doing that will
probably require digging down into the page-move code and figuring out
what exactly went wrong that broke the breadcrumbs in the first place.

This also will not fix every broken document; some are too bad for
this sort of fix to work on, and will have to be repaired manually.
