### PR TITLE
Moving position of the demo hover element, hide new submenu when clicked

### DIFF
--- a/media/js/demos.js
+++ b/media/js/demos.js
@@ -29,7 +29,7 @@ $(document).ready(function () {
         var $demo = $(this),
             content = $demo.html(), 
             offs = $demo.offset(),
-            $contentContainer = $('#content'),
+            $contentContainer = $('body'),
             fadeDuration = 200,
             $demoHover;
 

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -36,8 +36,8 @@ document.documentElement.className += ' js';
 				if(!initialized) {
 					initialized = 1;
 
-					// Hide the submenu when the main menu is blurred for hideDelay
-					$self.on('mouseleave', function() {
+					// Hide the submenu when the main menu item is blurred for hideDelay
+					$self.on('mouseleave click', function() {
 						clear(showTimeout);
 						closeSubmenu($submenu);
 					});


### PR DESCRIPTION
1.  Demo hover element is injected into the body to make positioning the same in the current and old designs
2.  Clicking main menu item hides submenu if present
