### PR TITLE
Ensure set vars work in sub-sub templates

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content.html
+++ b/apps/wiki/templates/wiki/includes/document_content.html
@@ -1,5 +1,17 @@
 {% from "wiki/includes/document_macros.html" import document_watch with context %}
 
+{% if document.parent %}
+  {# If there is a parent doc, use it for translating. #}
+  {% set translate_url = url('wiki.select_locale', document_path=document.parent.full_path) %}
+{% else %}
+  {% set translate_url = url('wiki.select_locale', document_path=document.full_path, locale=document.locale) %}
+{% endif %}
+{% if fallback_reason == 'no_translation' %}
+  {% set help_link = url('wiki.translate', document_path=document.full_path, locale=document.locale)|urlparams(tolocale=request.locale) %}
+{% elif fallback_reason == 'translation_not_approved' %}
+  {% set help_link = url('wiki.translate', document_path=document.parent.full_path, locale=document.parent.locale)|urlparams(tolocale=request.locale) %}
+{% endif %}
+
 <!-- top toolbar -->
 <section id="nav-toolbar"><div><div class="wrap">
   <!-- right floated navigation -->

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -1,5 +1,17 @@
 {% from "wiki/includes/document_macros.html" import document_watch with context %}
 
+{% if document.parent %}
+  {# If there is a parent doc, use it for translating. #}
+  {% set translate_url = url('wiki.select_locale', document_path=document.parent.full_path) %}
+{% else %}
+  {% set translate_url = url('wiki.select_locale', document_path=document.full_path, locale=document.locale) %}
+{% endif %}
+{% if fallback_reason == 'no_translation' %}
+  {% set help_link = url('wiki.translate', document_path=document.full_path, locale=document.locale)|urlparams(tolocale=request.locale) %}
+{% elif fallback_reason == 'translation_not_approved' %}
+  {% set help_link = url('wiki.translate', document_path=document.parent.full_path, locale=document.parent.locale)|urlparams(tolocale=request.locale) %}
+{% endif %}
+
 {# get attachments and tags ready for use #}
 {% set tags = document.tags.all() %}
 {% set attachments = document.attachments.all() %}


### PR DESCRIPTION
The translate_url wasn't passing through to sub-sub templates from the redesign, so this fixes that issue within the wiki.
