### PR TITLE
Remove padding from homepage wrapper to allow correct homepage layout in redesign

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -129,6 +129,7 @@
 	compat-only(max-width, none)
 	compat-only(min-width, 0)
 	compat-only(width, auto)
+	compat-only(padding, 0)
 	
 main
 	padding-top first-content-top-padding


### PR DESCRIPTION
Bandage before we tell people about redesign on prod so we don't get beat up about this.
