### PR TITLE
Remove the 'boxed' styles that appear throughout the site

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -135,7 +135,11 @@ main
 	padding-top first-content-top-padding
 
 
-
+.boxed
+	compat-only(border, 0)
+	compat-only(box-shadow, none)
+	compat-only(padding, 0)
+	compat-only(margin, 0)
 
 
 


### PR DESCRIPTION
The "boxed" CSS class is used in many parts of the site and it adds a dimension to our flat design that we don't want.  This CSS counter-acts that.
