### PR TITLE
Remove button styles from external notice.  Looks bad.

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -87,7 +87,7 @@
         {% if waffle.flag('external_signup') %}
         <div class="notice" style="margin-bottom:30px;"><p>
           Do you have docs you want to automatically add to MDN from an external source? 
-          <a href="{{ url('wiki.external_signup') }}" class="button neutral" style="margin-left: 10px;">Let us know!</a>
+          <a href="{{ url('wiki.external_signup') }}">Let us know!</a>
         </p></div>
         {% endif %}
         <header id="article-head">


### PR DESCRIPTION
Very minor -- looks better as a basic link.
