### PR TITLE
Fix out-of-order edit processing scripts

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -178,4 +178,6 @@
     {% else %}
       {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
+
+    {{ js('wiki-edit') }}
 {% endblock %}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -87,4 +87,6 @@
       {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
 
+    {{ js('wiki-edit') }}
+
 {% endblock %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -162,4 +162,6 @@
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
   <script src="{{ MEDIA_URL }}js/wiki_ckeditor_translate.js?build={{ BUILD_ID_JS }}"></script>
+
+  {{ js('wiki-edit') }}
 {% endblock %}

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -838,8 +838,10 @@
             ace_editor.on && ace_editor.on('change', callback);
         }
         else {
-
-            getCKEditor && getCKEditor().on('key', callback);
+            try {
+                getCKEditor && getCKEditor().on('key', callback);
+            }
+            catch(e) {}
         }
 
         // Clear draft upon discard

--- a/settings.py
+++ b/settings.py
@@ -668,6 +668,8 @@ MINIFY_BUNDLES = {
             'js/libs/jquery-ui-1.10.3.custom/js/jquery-ui-1.10.3.custom.min.js',
             'js/moz-jquery-plugins.js',
             'js/main.js',
+        ),
+        'wiki-edit': (
             'js/wiki.js',
             'js/libs/tag-it.js',
             'js/wiki-tags-edit.js',


### PR DESCRIPTION
Our current settings say to instantiate CKEditor and Ace Editor before we load them.  That is not good.  This fixes that.
