### PR TITLE
Change search animation width for tablet mq

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -72,6 +72,12 @@
 			overflow hidden
 			vendorize(transition-delay, 0)
 
+	@media media-query-tablet
+
+		&.expand
+			input
+				width 400px
+
 
 .search-wrap
 	background #fff


### PR DESCRIPTION
Search input can't stretch as far on tablet, so fixing that.
