### PR TITLE
bug 889536 - mdn sphinx theme cleanup

### DIFF
--- a/apps/wiki/templates/wiki/sphinx.html
+++ b/apps/wiki/templates/wiki/sphinx.html
@@ -4,7 +4,7 @@
 
 <!-- top toolbar -->
 <section id="nav-toolbar"><div><div class="wrap">
-  
+
   <!-- left crumb navigation -->
   <nav class="crumbs" role="navigation">
     <ol>
@@ -12,7 +12,7 @@
         <li class="crumb">{{ '{{ title }}' }}</li>
     </ol>
   </nav>
-  
+
 </div></div></section>
 
 <section id="content">
@@ -46,5 +46,5 @@
 {% endblock %}
 
 {% block extrahead %}
-    {{ css('wiki') }}
+    {{ css('sphinx') }}
 {% endblock %}

--- a/media/css/sphinx.css
+++ b/media/css/sphinx.css
@@ -1,0 +1,14 @@
+a.headerlink {
+  display: none;
+}
+div.admonition p.admonition-title {
+  display: inline;
+  font-weight: bold;
+  margin: 0px 10px 5px 0px;
+}
+div.admonition p.admonition-title + p {
+  display: inline;
+}
+.section h4 a {
+  display: none;
+}

--- a/settings.py
+++ b/settings.py
@@ -578,6 +578,13 @@ MINIFY_BUNDLES = {
         'wiki-print': (
             'css/wiki-print.css',
         ),
+        'sphinx': (
+            'css/wiki.css',
+            'css/wiki-screen.css',
+            'js/libs/jquery-ui-1.10.3.custom/css/ui-lightness/jquery-ui-1.10.3.custom.min.css',
+            'css/jqueryui/moz-jquery-plugins.css',
+            'css/sphinx.css',
+        ),
         'dashboards': (
             'css/dashboards.css',
             'js/libs/DataTables-1.9.4/media/css/jquery.dataTables.css',

--- a/templates/base.html
+++ b/templates/base.html
@@ -91,6 +91,7 @@
 
   {{ site_css() }}
   
+  <meta charset="utf-8">
   <link rel="stylesheet" type="text/css" media="print" href="{{ MEDIA_URL }}redesign/css/print.css" />
 
   <!--[if IE]>
@@ -254,7 +255,7 @@
     {{ optimizely_script() }}
   {% endif %}
   <title>{{ page_title_macro() }}</title>
-  
+
   <meta charset="utf-8">
   <meta name="robots" content="index, follow">
   <link rel="home" href="{{ url('home') }}">


### PR DESCRIPTION
First, get the sphinx theme:

```
git clone https://github.com/lmorchard/mozilla-mdn-sphinx-theme.git
```

Now re-create the `layout.html` file for the theme:

```
vagrant provision # or manually update settings_local.py to add PRODUCTION_URL
manage.py generate_sphinx_template > layout.html
cp layout.html path/to/mozilla-mdn-sphinx-theme/mdn_theme/mdn/layout.html
```

Then get zamboni so you can build its api docs using the sphinx theme:

```
git clone https://github.com/mozilla/zamboni.git
cd zamboni/docs/api
```

Update the `html_theme_path` in `conf.py` to use your local theme with the updated layout.html - e.g.,

```
...
#import mdn_theme
html_theme_path = ['/Users/lcrouch/code/mozilla/mozilla-mdn-sphinx-theme/mdn_theme',]
...
```

Now re-make the API docs with new theme, and open them for testing:

```
make html
open _build/html/index.html
```

Everything mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=889536#c8 should be fixed.
