### PR TITLE
bug 862080: Tools to define and display zone nav

### DIFF
--- a/admin_dashboard.py
+++ b/admin_dashboard.py
@@ -26,6 +26,7 @@ class CustomIndexDashboard(Dashboard):
             column=1,
             models=(
                 'wiki.models.Document',
+                'wiki.models.DocumentZone',
                 'wiki.models.Revision',
                 'wiki.models.Attachment',
                 'wiki.models.AttachmentRevision',

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1731,9 +1731,13 @@ class DocumentType(SearchMappingType, Indexable):
 class DocumentZone(models.Model):
     """Model object declaring a content zone root at a given Document, provides
     attributes inherited by the topic hierarchy beneath it."""
+
     document = models.ForeignKey(Document, related_name='zones', unique=True)
     styles = models.TextField(null=True, blank=True)
 
+    def __unicode__(self):
+        return u'DocumentZone %s (%s)' % (self.document.get_absolute_url(),
+                                          self.document.title)
 
 class ReviewTag(TagBase):
     """A tag indicating review status, mainly for revisions"""

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -20,7 +20,10 @@
 {% set disabled_class = ('disabled' if not is_logged_in else '') %}
 {% set disabled_attr = ('title="%s"' % _('Please log in to use this feature.') if not is_logged_in else '') %}
 
-{% set show_left = (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
+{% set quick_links_section_id = 'Quick_Links' %}
+{% set quick_links_html = document|zone_section_extract(quick_links_section_id) %}
+
+{% set show_left = quick_links_html or (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
 {% set show_right = (toc_html or tags|length or num_attachments) %}
 {% set content_class = '' %}
 {% if show_left and show_right %}
@@ -198,6 +201,7 @@
       {% endif %}
 
       <!-- just the article content -->
+      {% set document_html_safe = document_html|section_hide(quick_links_section_id)|safe %}
       <article>
         {% if not fallback_reason %}
           {% if not document_html %}
@@ -205,10 +209,10 @@
           {% elif document.is_template %}
             <pre class="brush: js">{{ document_html }}</pre>
           {% else %}
-            {{ document_html|safe }}
+            {{ document_html_safe }}
           {% endif %}
         {% elif fallback_reason == 'no_translation' %}
-          {{ document_html|safe }}
+          {{ document_html_safe }}
         {% elif fallback_reason == 'translation_not_approved' %}
           {{ document.parent.html|safe }}
         {% else %}
@@ -225,10 +229,12 @@
     {% if show_left %}
       <!-- quick links strip -->
       <div id="wiki-left" class="column-strip wiki-column">
-        {#
+        {% if quick_links_html %}
         <!-- quick links -->
         <div class="quick-links" id="quick-links">
           <a href="#quick-links" class="title" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide QuickLinks') }}</a>
+          {{ quick_links_html|safe }}
+          {% if False %}
           <ol>
             <li class="toggleable closed"><a href="" class="toggler"><i class="icon-caret-up"></i>Application Cache API</a>
               <ol class="toggle-container">
@@ -241,8 +247,9 @@
             <li><a href="">Something</a></li>
             <li><a href="">Something</a></li>
           </ol>
+          {% endif %}
         </div>
-        #}
+        {% endif %}
 
         <!-- approvals -->
         {% if request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) %}

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -877,6 +877,62 @@ class ContentSectionToolTests(TestCase):
                       .serialize())
         eq_(normalize_html(expected_src), normalize_html(result_src))
 
+    def test_ignore_heading_section_extract(self):
+        doc_src = """
+            <p>test</p>
+            <h1 id="s4">Head 4</h1>
+            <p>test</p>
+            <h2 id="s4-1">Head 4-1</h2>
+            <p>test</p>
+            <h3 id="s4-2">Head 4-1-1</h3>
+            <p>test s4-2</p>
+            <h1 id="s4-next">Head</h1>
+            <p>test</p>
+        """
+        expected = """
+            <p>test</p>
+            <h3 id="s4-2">Head 4-1-1</h3>
+            <p>test s4-2</p>
+        """
+        result = (wiki.content
+                  .parse(doc_src)
+                  .extractSection(id="s4-1", ignore_heading=True)
+                  .serialize())
+        eq_(normalize_html(expected), normalize_html(result))
+
+    def test_ignore_heading_section_replace(self):
+        doc_src = """
+            <h1 id="s1">Head 1</h1>
+            <p>test</p>
+            <p>test</p>
+            <h1 id="s2">Head 2</h1>
+            <p>test</p>
+            <p>test</p>
+            <h1 id="s3">Head 3</h1>
+            <p>test</p>
+            <p>test</p>
+        """
+        replace_src = """
+            <p>replacement worked yay hooray</p>
+        """
+        expected = """
+            <h1 id="s1">Head 1</h1>
+            <p>test</p>
+            <p>test</p>
+            <h1 id="s2">Head 2</h1>
+            <p>replacement worked yay hooray</p>
+            <h1 id="s3">Head 3</h1>
+            <p>test</p>
+            <p>test</p>
+        """
+        result = (wiki.content
+                  .parse(doc_src)
+                  .replaceSection(id="s2",
+                                  replace_src=replace_src,
+                                  ignore_heading=True)
+                  .serialize())
+        eq_(normalize_html(expected), normalize_html(result))
+
 
 class AllowedHTMLTests(TestCase):
     simple_tags = (


### PR DESCRIPTION
- (redesign only) Populate quick links sidebar from a "Quick Links"
  section in the current document, or any parent DocumentZone documents
- (redesign only) Hide any "Quick Links" section in the current
  document, since it should get moved into the sidebar
- Helpers to deal with extracting & hiding sections in document content
  (section_extract, zone_section_extract, section_hide)
- Tweak to wiki.content.{extract,replace}Section to ignore the heading
  that defines a section
- Add DocumentZone to admin dashboard, tweak unicode repr
- Tests
