### PR TITLE
Move zone images to DIVs to stylable by zone leaders

### DIFF
--- a/apps/landing/templates/redesign-stubs/zone-article.html
+++ b/apps/landing/templates/redesign-stubs/zone-article.html
@@ -9,8 +9,7 @@
 	<div class="zone-title">Main Zone Title</div>
 
 	<!-- zone image -->
-	<img src="/media/redesign/img/temporary-zone-image.png" alt="Main Zone Title" />
-
+  <div class="zone-image" style="background-image:url(/media/redesign/img/temporary-zone-image.png);"></div>
 </div></div>
 {% endblock %}
 

--- a/apps/landing/templates/redesign-stubs/zone-landing.html
+++ b/apps/landing/templates/redesign-stubs/zone-landing.html
@@ -15,7 +15,7 @@
 		<div class="column-5 masthead-text"><p>Zombie ipsum brains reversus ab cerebellum viral inferno, brein nam rick mend grimes malum cerveau cerebro.</p></div>
 	</div>
 
-	<img src="/media/redesign/img/temporary-zone-image.png" alt="Firefox OS Phone" />
+	<div class="zone-image" style="background-image:url(/media/redesign/img/temporary-zone-image.png);"></div>
 </div></div>
 {% endblock %}
 
@@ -24,7 +24,7 @@
 	<div class="column-container zone-content">
 
 		<div class="column-strip zone-subnav-container">
-			
+
 			<ol class="subnav accordion">
 				<li class="toggleable current">
 					<a href="#toc" class="title toggler">Design<i></i></a>

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -21,7 +21,7 @@
         color #fff
 
 .zone-landing
-        
+
   h1
     color #fff
 
@@ -48,11 +48,13 @@
       font-weight light-font-weight
       margin (2 * grid-spacing) 0 0 0
 
-  img
+  .zone-image
     position absolute
     right -140px
     top 60px
     display block
+    width 468px
+    height 900px
 
   a.button
     compat-important(color, #fff)
@@ -75,12 +77,14 @@
     color #fff
     font-style italic
 
-  img
+  .zone-image
     position absolute
     right 0
     top 0
     display block
     width 200px
+    height 400px
+    background-size contain
 
 .zone-content
   padding-top 38px


### PR DESCRIPTION
Making the zone images DIVs will make them more easily stylable by the zone content leaders.
