### PR TITLE
Set crumb arrows on pseudo-elements for easier RTL support

### DIFF
--- a/apps/landing/templates/redesign-stubs/article.html
+++ b/apps/landing/templates/redesign-stubs/article.html
@@ -6,7 +6,7 @@
 		<li><a href="$edit" class="button">{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li><a href="" class="button only-icon"><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a></li>
 	</ul>
 
-	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a><i class="icon-chevron-right"></i></li><li><a href="">Section title</a><i class="icon-chevron-right"></i></li><li><a href="">Design</a><i class="icon-chevron-right"></i></li><li><a href="">Design patterns</a><i class="icon-chevron-right"></i></li><li>Navigation patterns</li></ol></nav>
+	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a></li><li><a href="">Section title</a></li><li><a href="">Design</a></li><li><a href="">Design patterns</a></li><li>Navigation patterns</li></ol></nav>
 
 	<h1>Navigation patterns</h1>
 
@@ -15,16 +15,16 @@
 		<!-- additional controls; hidden unless needed -->
 		<div id="wiki-controls" class="column-container">
 			<div class="column-strip quick-links hidden">
-				<a href="" class="title smaller" id="show-quick-links"><i class="icon-caret-down"></i>{{ _('Show QuickLinks') }}</a>	
+				<a href="" class="title smaller" id="show-quick-links"><i class="icon-caret-down"></i>{{ _('Show QuickLinks') }}</a>
 			</div>
 			<div class="column-half">
 				&nbsp;
 			</div>
 			<div class="column-strip">
-				
+
 			</div>
 		</div>
-		
+
 		<!-- main content area -->
 		<div class="column-container">
 			<div id="wiki-left" class="column-strip wiki-column">
@@ -67,7 +67,7 @@
 
 				<p>Zombie ipsum brains reversus ab cerebellum viral inferno, brein nam rick mend grimes malum cerveau cerebro. De carne cerebro lumbering animata cervello corpora quaeritis. Summus thalamus brains sit​​, morbo basal ganglia vel maleficia? De braaaiiiins apocalypsi gorger omero prefrontal cortex undead survivor fornix dictum mauris. Hi brains mindless mortuis limbic cortex soulless creaturas optic nerve, imo evil braaiinns stalking monstra hypothalamus adventus resi hippocampus dentevil vultus brain comedat cerebella pitiutary gland viventium.</p>
 
-				
+
 
 			</article>
 

--- a/apps/landing/templates/redesign-stubs/zone-article.html
+++ b/apps/landing/templates/redesign-stubs/zone-article.html
@@ -18,7 +18,7 @@
 
 	<ul class="page-buttons"><li><a href="$edit" class="button">{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li><a href="" class="button only-icon"><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a></li></ul>
 
-	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a><i class="icon-chevron-right"></i></li><li><a href="">Section title</a><i class="icon-chevron-right"></i></li><li><a href="">Design</a><i class="icon-chevron-right"></i></li><li><a href="">Design patterns</a><i class="icon-chevron-right"></i></li><li>Navigation patterns</li></ol></nav>
+	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a></li><li><a href="">Section title</a></li><li><a href="">Design</a></li><li><a href="">Design patterns</a></li><li>Navigation patterns</li></ol></nav>
 
 	<h1>Zone Subpage</h1>
 

--- a/apps/landing/templates/redesign-stubs/zone-landing.html
+++ b/apps/landing/templates/redesign-stubs/zone-landing.html
@@ -6,7 +6,7 @@
 <div class="zone-landing-header"><div class="center" style="min-height:300px;">
 	<ul class="page-buttons"><li><a href="$edit" class="button">{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li><a href="" class="button only-icon"><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a></li></ul>
 
-	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a><i class="icon-chevron-right"></i></li><li><a href="">Section title</a><i class="icon-chevron-right"></i></li><li><a href="">Design</a><i class="icon-chevron-right"></i></li><li><a href="">Design patterns</a><i class="icon-chevron-right"></i></li><li>Navigation patterns</li></ol></nav>
+	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a></li><li><a href="">Section title</a></li><li><a href="">Design</a></li><li><a href="">Design patterns</a></li><li>Navigation patterns</li></ol></nav>
 
 	<h1 class="column-6">Navigation patterns</h1>
 
@@ -24,7 +24,7 @@
 	<div class="column-container zone-content">
 
 		<div class="column-strip zone-subnav-container">
-			
+
 			<ol class="subnav accordion">
 				<li class="toggleable current">
 					<a href="#toc" class="title toggler">Design<i></i></a>

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -96,9 +96,9 @@
 
 <!-- crumbs -->
 <nav class="crumbs" role="navigation"><ol>
-  <li><a href="/{{ request.locale }}/docs">MDN</a><i class="icon-chevron-right"></i></li>
+  <li><a href="/{{ request.locale }}/docs">MDN</a></li>
   {% for doc in document.parents %}
-    <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a><i class="icon-chevron-right"></i></li>
+    <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
   {% endfor %}
   <li class="crumb">{{ document.title }}</li>
 </ol></nav>
@@ -119,7 +119,7 @@
         <li><a href="">Blah blah blah</a></li>
       </ol>
     </div>
-    <a href="" class="from-search-next only-icon"><i class="icon-chevron-right"></i></a>
+    <a href="" class="from-search-next only-icon"></a>
   {% endif %}
   <h1>{{ document.title }}</h1>
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -51,11 +51,17 @@ article
     display inline-block
     margin-right (grid-spacing / 2)
 
-  i
-    color #c1c2c4
-    display inline-block
-    margin 0 7px 0 5px
-    font-size 70%
+  a
+    display block
+
+    &:after
+      display inline-block
+      font-family FontAwesome
+      text-decoration none
+      content "\f054"
+      color #c1c2c4
+      margin-left 4px
+      font-size 70%
 
   reverse-link-decoration()
 


### PR DESCRIPTION
We can't change `<i>` tag classes for RTL but we can change the CSS.  Yay.
