### PR TITLE
Minor wiki RTL updates to TOC and crumbs

### DIFF
--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -146,3 +146,13 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     i
       left 10px
       right auto
+
+  #toc
+    > ol
+      compat-important(padding-left, 0);
+      compat-important(padding-right, (grid-spacing + (grid-spacing/2)))
+
+    li:before
+      text-align left
+      right -(grid-spacing + (grid-spacing/2))
+      left auto

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -476,10 +476,19 @@ span.cke_skin_kuma
 
 
 
-
 /* rtl */
 .html-rtl
 
   .page-buttons, #page-buttons
     left gutter-width
     right auto
+
+  .crumbs
+    li
+      margin-right 0
+      margin-left (grid-spacing / 2)
+    a
+      &:after
+        content "\f053"
+        margin-left 0
+        margin-right 4px


### PR DESCRIPTION
With my previous RTL PR  and other wiki PRs in, I can now fix the TOC and crumb arrow direction for RTL.

In console:
$("body").removeClass("html-ltr").addClass("html-rtl"); $("html").attr("dir", "rtl");
