### PR TITLE
Prevent massive images from bleeding out of content area

### DIFF
--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -33,6 +33,9 @@ h4
     display inline-block
     text-decoration none
 
+img
+  max-width 100%
+
 p
   margin-bottom content-block-margin
 


### PR DESCRIPTION
For pages like this:  https://developer.mozilla.org/en-US/docs/Tools/Debugger
