### PR TITLE
Minor cleanup for tag suggestions JS

### DIFF
--- a/apps/wiki/templates/wiki/includes/tag_suggestions.html
+++ b/apps/wiki/templates/wiki/includes/tag_suggestions.html
@@ -1,3 +1,4 @@
+{% set suggestions = WIKI_DOCUMENT_TAG_SUGGESTIONS or '[]' %}
 <script type="text/javascript">
-  mdn.wiki.tagSuggestions = {{ WIKI_DOCUMENT_TAG_SUGGESTIONS|safe }} || [];
+  mdn.wiki.tagSuggestions = {{ suggestions|safe }};
 </script>

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -917,6 +917,7 @@ def new_document(request):
                         {'is_template': is_template,
                          'document_form': doc_form,
                          'revision_form': rev_form,
+                         'WIKI_DOCUMENT_TAG_SUGGESTIONS': constance.config.WIKI_DOCUMENT_TAG_SUGGESTIONS,
                          'allow_add_attachment': allow_add_attachment,
                          'attachment_form': AttachmentRevisionForm(),
                          'parent_slug': parent_slug,


### PR DESCRIPTION
When creating a new page, you get a (lame) error saying you picked an invalid choice.  You also get a JS error that a variable isn't provided.  Fixed it and added a backup plan (i.e. just use [])
