### PR TITLE
fix bug 913413 - Let editors add the summary block themselves

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -143,6 +143,7 @@ CKEDITOR.editorConfig = function(config) {
             { name: 'Two columns', element: 'div', attributes: { 'class': 'twocolumns' }, wrap: true },
             { name: 'Three columns', element: 'div', attributes: { 'class': 'threecolumns' }, wrap: true },
             { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' }, wrap: false },
+            { name: 'Article Summary', element: 'div', attributes: { 'class': 'summary' }, wrap: true },
             { name: 'Syntax Box', element: 'div', attributes: { 'class': 'syntaxbox' }, wrap: false },
             { name: 'Right Sidebar', element: 'div', attributes: { 'class': 'standardSidebar' }, wrap: false }
         ]);

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -195,12 +195,6 @@
         {% include 'wiki/includes/kumascript_errors.html' %}
       {% endif %}
 
-      {% if seo_summary %}
-        <div class="summary">
-          <p>{{ seo_summary }}</p>
-        </div>
-      {% endif %}
-
       <!-- just the article content -->
       {% set document_html_safe = document_html|section_hide(quick_links_section_id)|safe %}
       <article>

--- a/media/css/wiki-edcontent.css
+++ b/media/css/wiki-edcontent.css
@@ -9,7 +9,7 @@ body { min-height: 400px; font: 14px/1.286 "Lucida Grande", "Lucida Sans Unicode
 :link:hover, :link:focus, :link:active { color: #25a; text-decoration: underline; }
 :visited:hover, :visited:focus, :visited:active { color: #25a; text-decoration: underline; }
 
-/* seo plugin styles */
+/* seo and callout plugin styles */
 .seoSummary {
 	padding: 3px;
 	border: 1px dotted #ccc;
@@ -27,6 +27,16 @@ body { min-height: 400px; font: 14px/1.286 "Lucida Grande", "Lucida Sans Unicode
 	display: block;
 	opacity: 0.8;
 	cursor: default;
+}
+
+.summary {
+  background: #f4f7f8;
+  font-weight: bold;
+  padding: 20px;
+  margin-bottom: 20px;
+}
+.summary p:last-child {
+  margin-bottom: 0;
 }
 
 /* syntax highlighter update */


### PR DESCRIPTION
I'll let editors put these in themselves instead of prescribing.
