### PR TITLE
fix bug 913392 - Don't let crumbs go behind edit button

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -32,6 +32,15 @@
   {% set content_class = 'column-main' %}
 {% endif %}
 
+<!-- crumbs -->
+<nav class="crumbs" role="navigation"><ol>
+  <li><a href="/{{ request.locale }}/docs">MDN</a></li>
+  {% for doc in document.parents %}
+    <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
+  {% endfor %}
+  <li class="crumb">{{ document.title }}</li>
+</ol></nav>
+
 <!-- action buttons -->
 <ul class="page-buttons"><li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li style="position:relative;"><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }}><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a>
 
@@ -98,15 +107,6 @@
         </div>
       </div>
   </li></ul>
-
-<!-- crumbs -->
-<nav class="crumbs" role="navigation"><ol>
-  <li><a href="/{{ request.locale }}/docs">MDN</a></li>
-  {% for doc in document.parents %}
-    <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
-  {% endfor %}
-  <li class="crumb">{{ document.title }}</li>
-</ol></nav>
 
 <!-- heading -->
 <div class="document-head{% if from_search %} from-search{% endif %}">

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -32,6 +32,7 @@ article
 
 .document-head
   position relative
+  clear both
 
   h1
     font-family 'Open Sans Light'
@@ -45,7 +46,8 @@ article
 .crumbs
   font-size smaller-font-size
   margin-bottom (2 * grid-spacing)
-  margin-top (grid-spacing * 2)
+  float left
+  width 70%
 
   li
     display inline-block
@@ -66,11 +68,10 @@ article
   reverse-link-decoration()
 
 .page-buttons, #page-buttons
-  position absolute
-  right gutter-width
+  float right
   text-align right
   compat-only(width, auto)
-  compat-only(top, 0)
+  compat-only(top, auto)
 
   > li
     margin-left (grid-spacing / 2)


### PR DESCRIPTION
Good catch by Chris Mills.  Test by creating a massive list of crumbs.
