### PR TITLE
Change the quick links extractor method to local method

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -21,7 +21,7 @@
 {% set disabled_attr = ('title="%s"' % _('Please log in to use this feature.') if not is_logged_in else '') %}
 
 {% set quick_links_section_id = 'Quick_Links' %}
-{% set quick_links_html = document|zone_section_extract(quick_links_section_id) %}
+{% set quick_links_html = document.rendered_html|section_extract(quick_links_section_id) %}
 
 {% set show_left = quick_links_html or (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
 {% set show_right = (toc_html or tags|length or num_attachments) %}


### PR DESCRIPTION
I believe Les mentioned last week that the Quick Links extraction method he used was the wrong one.  This should correct that, though he can tell me if I'm wrong.
