### PR TITLE
Fixing column-all CSS precidence

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -8,6 +8,7 @@
 
 .column-all
   width auto
+  
 
 /* This is a "helper" which automatically formats its column children, clears the floats afterward, removes margin from last item */
 .column-container
@@ -17,18 +18,24 @@
     margin-right grid-spacing
     float left
 
-    &:last-child
+    &:last-child, &.column-all
       margin-right 0
+      
+    &.column-all
+      float none
 
   &.column-container-reverse
     > [class^='column-']
       float right
 
-      &:first-child
+      &:first-child, &.column-all
         margin-right 0
 
       &:last-child
         margin-right grid-spacing
+        
+      &.column-all
+        float none
 
 
 /* Desktop Layout (default)


### PR DESCRIPTION
Turns out that an article w/out a TOC and quick links didn't span the full width like it should.  This fixes that.
