### PR TITLE
Pulling zone subnav and placing it within the sidebar

### DIFF
--- a/apps/landing/templates/redesign-stubs/zone-article.html
+++ b/apps/landing/templates/redesign-stubs/zone-article.html
@@ -19,50 +19,42 @@
 
 	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a></li><li><a href="">Section title</a></li><li><a href="">Design</a></li><li><a href="">Design patterns</a></li><li>Navigation patterns</li></ol></nav>
 
-	<h1>Zone Subpage</h1>
+	<h1 style="clear:both;">Zone Subpage</h1>
 
 	<div class="column-container">
 
-		<div class="column-strip zone-subnav-container">
-			<div class="subnav">
-				<div class="toggleable current">
-					<a href="#toc" class="title toggler">Design<i></i></a>
-					<ol class="toggle-container">
-						<li><a href="">Concept: a great app</a></li>
-						<li><a href="">UI Guidelines</a></li>
-						<li>
-							<div class="toggleable">
-								<a href="" class="toggler">Design Patterns<i></i></a>
-								<ol class="toggle-container">
-									<li><a href="">UI Guidelines</a></li>
-									<li class="current"><a href="">Concept: a great app</a></li>
-									<li><a href="">Layouts</a></li>
-								</ol>
-							</ul>
-						</li>
-						<li><a href="">Style guides</a></li>
-					</ol>
-				</div>
-				<div class="toggleable closed">
-					<a href="#toc" class="toggler">Code<i></i></a>
-					<ol class="toggle-container">
-						<li><a href="">Concept: a great app</a></li>
-						<li><a href="">UI Guidelines</a></li>
-						<li><a href="">Style guides</a></li>
-					</ol>
-				</div>
-				<div class="toggleable closed">
-					<a href="" class="toggler">Publish<i></i></a>
-				</div>
-				<div class="toggleable closed">
-					<a href="" class="toggler">Tools<i></i></a>
-				</div>
-				<div class="toggleable closed">
-					<a href="" class="toggler">APIs<i></i></a>
-				</div>
-				<div class="toggleable closed">
-					<a href="" class="toggler">Support<i></i></a>
-				</div>
+		<div class="column-strip">
+			<div class="zone-subnav-container">
+        <div class="subnav">
+			  <ol>
+          <li><a href="#toc">Design</a>
+            <ol>
+              <li><a href="">Concept: a great app</a></li>
+              <li><a href="">UI Guidelines</a></li>
+              <li><a class="toggler" href="">Design Patterns</a>
+                <ol>
+                  <li><a href="">UI Guidelines</a></li>
+                  <li><a href="">Concept: a great app</a></li>
+                  <li><a href="/en-US/docs/Zone">Zone Page</a></li>
+                  <li><a href="">Layouts</a></li>
+                </ol>
+              </li>
+              <li><a href="">Style guides</a></li>
+            </ol>
+          </li>
+          <li><a href="#toc">A Heading</a>
+            <ol>
+              <li><a href="">Concept: a great app</a></li>
+              <li><a href="">UI Guidelines</a></li>
+              <li><a href="">Style guides</a></li>
+            </ol>
+          </li>
+          <li><a href="">Publish</a></li>
+          <li><a href="">Tools</a></li>
+          <li><a href="">APIs</a></li>
+          <li><a href="">Support</a></li>
+        </ol>
+        </div>
 			</div>
 		</div>
 
@@ -116,7 +108,10 @@
 {% block site_css %}
     {{ super() }}
     {{ css('wiki-print', media='print') }}
-    {% if waffle.flag('redesign') %}
-      {{ css('redesign-wiki') }}
-    {% endif %}
+    {{ css('redesign-wiki') }}
+{% endblock %}
+
+{% block site_js %}
+  {{ super() }}
+  {{ js('redesign-wiki') }}
 {% endblock %}

--- a/apps/landing/templates/redesign-stubs/zone-landing.html
+++ b/apps/landing/templates/redesign-stubs/zone-landing.html
@@ -8,7 +8,7 @@
 
 	<nav class="crumbs" role="navigation"><ol><li><a href="">MDN</a></li><li><a href="">Section title</a></li><li><a href="">Design</a></li><li><a href="">Design patterns</a></li><li>Navigation patterns</li></ol></nav>
 
-	<h1 class="column-6">Navigation patterns</h1>
+	<h1>Navigation patterns</h1>
 
 	<div class="column-container">
 		<div class="column-strip">&nbsp;</div>
@@ -23,49 +23,40 @@
 
 	<div class="column-container zone-content">
 
-		<div class="column-strip zone-subnav-container">
-
-			<ol class="subnav accordion">
-				<li class="toggleable current">
-					<a href="#toc" class="title toggler">Design<i></i></a>
-					<ol class="toggle-container">
-						<li><a href="">Concept: a great app</a></li>
-						<li><a href="">UI Guidelines</a></li>
-						<li class="toggleable">
-							<div>
-								<a href="" class="toggler">Design Patterns<i></i></a>
-								<ol class="toggle-container">
-									<li><a href="">UI Guidelines</a></li>
-									<li class="current-page"><a href="">Concept: a great app</a></li>
-									<li><a href="">Layouts</a></li>
-								</ol>
-							</ul>
-						</li>
-						<li><a href="">Style guides</a></li>
-					</ol>
-				</li>
-				<li class="toggleable closed">
-					<a href="#toc" class="toggler">Code<i></i></a>
-					<ol class="toggle-container">
-						<li><a href="">Concept: a great app</a></li>
-						<li><a href="">UI Guidelines</a></li>
-						<li><a href="">Style guides</a></li>
-					</ol>
-				</li>
-				<li>
-					<a href="">Publish</a>
-				</li>
-				<li>
-					<a href="">Tools<i></i></a>
-				</li>
-				<li>
-					<a href="">APIs<i></i></a>
-				</li>
-				<li>
-					<a href="">Support<i></i></a>
-				</li>
-			</ol>
-		</div>
+		<div class="column-strip">
+			<div class="zone-subnav-container">
+        <div class="subnav">
+			  <ol>
+          <li><a href="#toc">Design</a>
+            <ol>
+              <li><a href="">Concept: a great app</a></li>
+              <li><a href="">UI Guidelines</a></li>
+              <li><a class="toggler" href="">Design Patterns</a>
+                <ol>
+                  <li><a href="">UI Guidelines</a></li>
+                  <li><a href="">Concept: a great app</a></li>
+                  <li><a href="/en-US/docs/Zone">Zone Page</a></li>
+                  <li><a href="">Layouts</a></li>
+                </ol>
+              </li>
+              <li><a href="">Style guides</a></li>
+            </ol>
+          </li>
+          <li><a href="#toc">A Heading</a>
+            <ol>
+              <li><a href="">Concept: a great app</a></li>
+              <li><a href="">UI Guidelines</a></li>
+              <li><a href="">Style guides</a></li>
+            </ol>
+          </li>
+          <li><a href="">Publish</a></li>
+          <li><a href="">Tools</a></li>
+          <li><a href="">APIs</a></li>
+          <li><a href="">Support</a></li>
+        </ol>
+        </div>
+      </div>
+    </div>
 
 		<div class="column-main zone-landing-lists">
 
@@ -154,7 +145,10 @@
 {% block site_css %}
     {{ super() }}
     {{ css('wiki-print', media='print') }}
-    {% if waffle.flag('redesign') %}
-      {{ css('redesign-wiki') }}
-    {% endif %}
+    {{ css('redesign-wiki') }}
+{% endblock %}
+
+{% block site_js %}
+  {{ super() }}
+  {{ js('redesign-wiki') }}
 {% endblock %}

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -1,9 +1,17 @@
 {# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
-{% set classes = 'document' %}
+
+{% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_buttons, document_watch with context %}
+
 {% set canonical = request.build_absolute_uri(url('wiki.document', document.full_path)) %}
-{% block bodyclass %}document{% endblock %}
+
+{% set zone_stack = document.find_zone_stack() %}
+{% set is_zone = zone_stack|length %}
+{% set is_zone_root = is_zone and zone_stack[0].document == document %}
+
+{% block bodyclass %}document {% if is_zone %}zone{% endif %} {% if is_zone_root %}zone-landing{% endif %}{% endblock %}
+
 {% if document.parent %}
   {# If there is a parent doc, use it for translating. #}
   {% set translate_url = url('wiki.select_locale', document_path=document.parent.full_path) %}
@@ -69,14 +77,45 @@
   {% endif %}
 {% endblock %}
 
-{% block content %}
 
+{% if waffle.flag('redesign') and zone_stack|length %}
+{% block masthead %}
+  {% if is_zone_root %}
+    <div class="zone-landing-header"><div class="center">
+      <!-- edit, settings buttons -->
+      {{ get_document_buttons(document) }}
+      
+      <!-- crumbs -->
+      {{ build_document_crumbs(document) }}
+
+      <h1>{{ document.title }}</h1>
+
+      <div class="column-container">
+        <div class="column-strip">&nbsp;</div>
+        <div class="column-5 masthead-text"><p>Zombie ipsum brains reversus ab cerebellum viral inferno, brein nam rick mend grimes malum cerveau cerebro.</p></div>
+      </div>
+
+      <div class="zone-image"></div>
+    </div></div>
+  {% elif zone_stack|length %}
+    <div class="zone-article-header"><div class="center">
+      <!-- zone title -->
+      <div class="zone-title">{{ zone_stack[0].document.title }}</div>
+      <!-- zone image -->
+      <div class="zone-image"></div>
+    </div></div>
+  {% endif %}
+{% endblock %}
+{% endif %}
+
+
+
+{% block content %}
   {% if waffle.flag('redesign') %}
     {% include 'wiki/includes/document_content_redesign.html' %}
   {% else %}
     {% include 'wiki/includes/document_content.html' %}
   {% endif %}
-
 {% endblock %}
 
 {% block side %}

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -1,4 +1,4 @@
-{% from "wiki/includes/document_macros.html" import document_watch with context %}
+{% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_buttons, document_watch with context %}
 
 {% if document.parent %}
   {# If there is a parent doc, use it for translating. #}
@@ -23,7 +23,13 @@
 {% set quick_links_section_id = 'Quick_Links' %}
 {% set quick_links_html = document.rendered_html|section_extract(quick_links_section_id) %}
 
-{% set show_left = quick_links_html or (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
+{% set zone_stack = document.find_zone_stack() %}
+{% set is_zone = zone_stack|length %}
+{% set is_zone_root = is_zone and zone_stack[0].document == document %}
+{% set zone_subnav_section_id = 'Subnav' %}
+{% set zone_subnav_html = document|zone_section_extract(zone_subnav_section_id) %}
+
+{% set show_left = zone_subnav_html or quick_links_html or (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
 {% set show_right = (toc_html or tags|length or num_attachments) %}
 
 {% set content_class = 'column-all' %}
@@ -33,108 +39,42 @@
   {% set content_class = 'column-main' %}
 {% endif %}
 
-<!-- crumbs -->
-<nav class="crumbs" role="navigation"><ol>
-  <li><a href="/{{ request.locale }}/docs">MDN</a></li>
-  {% for doc in document.parents %}
-    <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
-  {% endfor %}
-  <li class="crumb">{{ document.title }}</li>
-</ol></nav>
+{% if not is_zone_root %}
 
-<!-- action buttons -->
-<ul class="page-buttons"><li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li style="position:relative;"><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }}><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a>
+  <!-- crumbs -->
+  {{ build_document_crumbs(document) }}
 
-      <div class="submenu">
-        <!-- this page -->
-        <div class="submenu-column">
-          <div class="title">{{ _('This Page') }}</div>
-          <ul>
-            <li class="page-print"><a href="#" onclick="return window.print();"  title="{{ _('Print page') }}">{{ _('Print this page') }}</a></li>
-              <li><a href="{{ url('wiki.document_revisions', document.full_path) }}">{{_('History')}}</a></li>
-              {% if user.is_authenticated() and document %}
-                <li class="page-watch">
-                {% if document.is_watched_by(user) %}
-                  <form action="{{ url('wiki.document_unwatch', document.slug) }}" method="post">
-                    {{ csrf() }}
-                    <a href="">{{ _('Unsubscribe') }}</a>
-                  </form>
-                {% else %}
-                  <form action="{{ url('wiki.document_watch', document.full_path) }}" method="post">
-                    {{ csrf() }}
-                    <a href="">{{ _('Subscribe') }}</a>
-                  </form>
-                {% endif %}
-              </li>{% endif %}
-              {% if not document.is_template %}
-                <li><a href="{{ url('wiki.new_document') }}?parent={{ document.id }}">{{ _('New sub-page') }}</a></li>
-                <li><a href="{{ url('wiki.new_document') }}?clone={{ document.id }}">{{ _('Clone this page') }}</a></li>
-              {% endif %}
-              {% if waffle.flag('page_move') %}
-                <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}">{{ _('Move this page') }}</a></li>
-              {% endif %}
-              {% if user.is_superuser %}
-                <li><a href="{{ url('admin:wiki_document_change', document.id) }}">{{ _('View in Admin') }}</a></li>
-              {% endif %}
+  <!-- action buttons -->
+  {{ get_document_buttons(document) }}
 
-              {% set policy_links = build_policy_admin_links(request.user, document) %}
-              {% if policy_links['change_one'] %}
-                <li><a target="_blank" href="{{ policy_links['change_one'] }}">{{ _('Manage access policy') }}</a></li>
-              {% elif policy_links['change_list'] %}
-                <li><a target="_blank" href="{{ policy_links['change_list'] }}">{{ _('Manage access policies') }}</a></li>
-              {% elif policy_links['add'] %}
-                <li><a target="_blank" href="{{ policy_links['add'] }}">{{ _('Add access policy') }}</a></li>
-              {% endif %}
-
-              {% set zone_links = document_zone_management_links(request.user, document) %}
-              {% if zone_links['change'] %}
-                <li><a target="_blank" href="{{ zone_links['change'] }}">{{ _('Manage content zone') }}</a></li>
-              {% endif %}
-              {% if zone_links['add'] %}
-                <li><a target="_blank" href="{{ zone_links['add'] }}">{{ _('Convert to content zone') }}</a></li>
-              {% endif %}
-          </ul>
-        </div><div class="submenu-column">
-          <div class="title">{{ _('Languages') }}</div>
-          <ul id="translations">
-              {% for translation in document.other_translations %}
-                <li><a rel="internal" href="{{ url('wiki.document', translation.full_path, locale=translation.locale) }}" title="{{ translation.title }}">{{ translation.language }}</a></li>
-              {% endfor %}
-
-              {% if document.is_localizable %}
-                <li><a href="{{ translate_url }}">{{ _('Add translation') }}</a></li>
-              {% endif %}
-            </ul>
-        </div>
+  <!-- heading -->
+  <div class="document-head{% if from_search %} from-search{% endif %}">
+    {% if from_search %}
+      <a href="" class="from-search-previous only-icon"><i class="icon-chevron-left"></i></a>
+      <a href="" class="from-search-navigate"><span class="from-search-navigate-up"><i class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i class="icon-double-angle-down"></i></span></a>
+      <div class="from-search-toc hidden">
+        <ol>
+          <li><a href="">Blah blah blah</a></li>
+          <li><a href="">Blah blah blah Blah blah blah Blah blah blah Blah blah blah</a></li>
+          <li><a href="">Blah blah blah</a></li>
+          <li><a href="">Blah blah blah</a></li>
+          <li><a href="" class="current">Blah blah blah</a></li>
+          <li><a href="">Blah blah blah</a></li>
+          <li><a href="">Blah blah blah</a></li>
+        </ol>
       </div>
-  </li></ul>
+      <a href="" class="from-search-next only-icon"></a>
+    {% endif %}
+    <h1>{{ document.title }}</h1>
 
-<!-- heading -->
-<div class="document-head{% if from_search %} from-search{% endif %}">
-  {% if from_search %}
-    <a href="" class="from-search-previous only-icon"><i class="icon-chevron-left"></i></a>
-    <a href="" class="from-search-navigate"><span class="from-search-navigate-up"><i class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i class="icon-double-angle-down"></i></span></a>
-    <div class="from-search-toc hidden">
-      <ol>
-        <li><a href="">Blah blah blah</a></li>
-        <li><a href="">Blah blah blah Blah blah blah Blah blah blah Blah blah blah</a></li>
-        <li><a href="">Blah blah blah</a></li>
-        <li><a href="">Blah blah blah</a></li>
-        <li><a href="" class="current">Blah blah blah</a></li>
-        <li><a href="">Blah blah blah</a></li>
-        <li><a href="">Blah blah blah</a></li>
-      </ol>
+    {% if redirected_from %}
+    <div class="redirected-from" id="redirected-from">
+      <p>{{ _('Redirected from <a href="{href}">{title}</a>')|fe(href=redirected_from.get_absolute_url()|urlparams(redirect='no'), title=redirected_from.title) }}</p>
     </div>
-    <a href="" class="from-search-next only-icon"></a>
-  {% endif %}
-  <h1>{{ document.title }}</h1>
-
-  {% if redirected_from %}
-  <div class="redirected-from" id="redirected-from">
-    <p>{{ _('Redirected from <a href="{href}">{title}</a>')|fe(href=redirected_from.get_absolute_url()|urlparams(redirect='no'), title=redirected_from.title) }}</p>
+    {% endif %}
   </div>
-  {% endif %}
-</div>
+
+{% endif %}
 
 <!-- start the main content container -->
 <div id="wiki-column-container">
@@ -197,7 +137,7 @@
       {% endif %}
 
       <!-- just the article content -->
-      {% set document_html_safe = document_html|section_hide(quick_links_section_id)|safe %}
+      {% set document_html_safe = document_html|section_hide(zone_subnav_section_id, quick_links_section_id)|safe %}
       <article>
         {% if not fallback_reason %}
           {% if not document_html %}
@@ -230,27 +170,23 @@
     </div>
 
     {% if show_left %}
-      <!-- quick links strip -->
+      <!-- quick links and zone subnav strip -->
       <div id="wiki-left" class="column-strip wiki-column">
+        
+        {% if zone_subnav_html %}
+          <!-- zone subnav -->
+          <div class="zone-subnav-container">
+            <div class="subnav" id="Subnav">
+              {{ zone_subnav_html|safe }}
+            </div>
+          </div>
+        {% endif %}
+        
         {% if quick_links_html %}
         <!-- quick links -->
         <div class="quick-links" id="quick-links">
           <a href="#quick-links" class="title" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide QuickLinks') }}</a>
           {{ quick_links_html|safe }}
-          {% if False %}
-          <ol>
-            <li class="toggleable closed"><a href="" class="toggler"><i class="icon-caret-up"></i>Application Cache API</a>
-              <ol class="toggle-container">
-                <li><a href="">Sub link</a></li>
-                <li><a href="">Sub link</a></li>
-                <li><a href="">Sub link</a></li>
-              </ol>
-            </li>
-            <li><a href="">Something</a></li>
-            <li><a href="">Something</a></li>
-            <li><a href="">Something</a></li>
-          </ol>
-          {% endif %}
         </div>
         {% endif %}
 

--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -15,3 +15,81 @@
     </li>
   {% endif %}
 {%- endmacro %}
+
+{% macro build_document_crumbs(document) %}
+  <nav class="crumbs" role="navigation"><ol>
+    <li><a href="/{{ request.locale }}/docs">MDN</a></li>
+    {% for doc in document.parents %}
+      <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
+    {% endfor %}
+    <li class="crumb">{{ document.title }}</li>
+  </ol></nav>
+{%- endmacro %}
+
+{% macro get_document_buttons(document) %}
+  <ul class="page-buttons"><li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit Page') }}<i class="icon-pencil"></i></a></li><li style="position:relative;"><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }}><span>{{ _('Settings') }}</span><i class="icon-cog"></i></a>
+
+        <div class="submenu">
+          <!-- this page -->
+          <div class="submenu-column">
+            <div class="title">{{ _('This Page') }}</div>
+            <ul>
+              <li class="page-print"><a href="#" onclick="return window.print();"  title="{{ _('Print page') }}">{{ _('Print this page') }}</a></li>
+                <li><a href="{{ url('wiki.document_revisions', document.full_path) }}">{{_('History')}}</a></li>
+                {% if user.is_authenticated() and document %}
+                  <li class="page-watch">
+                  {% if document.is_watched_by(user) %}
+                    <form action="{{ url('wiki.document_unwatch', document.slug) }}" method="post">
+                      {{ csrf() }}
+                      <a href="">{{ _('Unsubscribe') }}</a>
+                    </form>
+                  {% else %}
+                    <form action="{{ url('wiki.document_watch', document.full_path) }}" method="post">
+                      {{ csrf() }}
+                      <a href="">{{ _('Subscribe') }}</a>
+                    </form>
+                  {% endif %}
+                </li>{% endif %}
+                {% if not document.is_template %}
+                  <li><a href="{{ url('wiki.new_document') }}?parent={{ document.id }}">{{ _('New sub-page') }}</a></li>
+                  <li><a href="{{ url('wiki.new_document') }}?clone={{ document.id }}">{{ _('Clone this page') }}</a></li>
+                {% endif %}
+                {% if waffle.flag('page_move') %}
+                  <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}">{{ _('Move this page') }}</a></li>
+                {% endif %}
+                {% if user.is_superuser %}
+                  <li><a href="{{ url('admin:wiki_document_change', document.id) }}">{{ _('View in Admin') }}</a></li>
+                {% endif %}
+
+                {% set policy_links = build_policy_admin_links(request.user, document) %}
+                {% if policy_links['change_one'] %}
+                  <li><a target="_blank" href="{{ policy_links['change_one'] }}">{{ _('Manage access policy') }}</a></li>
+                {% elif policy_links['change_list'] %}
+                  <li><a target="_blank" href="{{ policy_links['change_list'] }}">{{ _('Manage access policies') }}</a></li>
+                {% elif policy_links['add'] %}
+                  <li><a target="_blank" href="{{ policy_links['add'] }}">{{ _('Add access policy') }}</a></li>
+                {% endif %}
+
+                {% set zone_links = document_zone_management_links(request.user, document) %}
+                {% if zone_links['change'] %}
+                  <li><a target="_blank" href="{{ zone_links['change'] }}">{{ _('Manage content zone') }}</a></li>
+                {% endif %}
+                {% if zone_links['add'] %}
+                  <li><a target="_blank" href="{{ zone_links['add'] }}">{{ _('Convert to content zone') }}</a></li>
+                {% endif %}
+            </ul>
+          </div><div class="submenu-column">
+            <div class="title">{{ _('Languages') }}</div>
+            <ul id="translations">
+                {% for translation in document.other_translations %}
+                  <li><a rel="internal" href="{{ url('wiki.document', translation.full_path, locale=translation.locale) }}" title="{{ translation.title }}">{{ translation.language }}</a></li>
+                {% endfor %}
+
+                {% if document.is_localizable %}
+                  <li><a href="{{ translate_url }}">{{ _('Add translation') }}</a></li>
+                {% endif %}
+              </ul>
+          </div>
+        </div>
+  </li></ul>
+{%- endmacro %}

--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -241,7 +241,7 @@
 
       function getTogglerComponents($li) {
         return {
-          $container: $li.find('.toggle-container'),
+          $container: $li.find('> .toggle-container'),
           $toggler: $li.find('> .toggler')
         };
       }

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -52,7 +52,7 @@ document.documentElement.className += ' js';
 
 
   /*
-    Togglers within articles, TOC, accordion subnav, etc. for example
+    Togglers within articles (i.e.)
   */
   $('.toggleable').mozTogglers();
 

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -1,19 +1,24 @@
 (function($) {
 
-  // Settings menu
+  /*
+    Create the settings menu
+  */
   (function() {
     var $settingsMenu = $('#settings-menu');
     $settingsMenu.mozMenu();
     $settingsMenu.parent().find('.submenu').mozKeyboardNav();
   })();
 
-  // New tag placeholder
-  // Has to be placed in ready call because the plugin is initialized in one
+  /*
+    New tag placeholder, needs $.ready because that's when the plugin is set
+  */
   $.ready(function() {
     $('.tagit-new input').attr('placeholder', gettext('New tag...'));
   });
 
-  // "From Search" submenu click
+  /*
+    Set up the "from search" buttons if user came from search
+  */
   (function() {
     var $fromSearchNav = $('.from-search-navigate');
     if($fromSearchNav.length) {
@@ -30,17 +35,10 @@
     Toggle for quick links show/hide
   */
   (function() {
-    
-    $('#quick-links').find('> ul > li, > ol > li').each(function() {
-      var $li = $(this);
-      var $sublist = $li.find('> ul, > ol');
-      
-      if($sublist.length) {
-        $li.addClass('toggleable closed');
-        $li.find('> a').addClass('toggler').prepend('<i class="icon-caret-up"></i>');
-        $sublist.addClass('toggle-container');
-      }
-    }).end().find('.toggleable').mozTogglers();
+    // Set up the quick links for the toggler
+    var $quickLinks = $('#quick-links');
+    setupTogglers($quickLinks.find('> ul > li, > ol > li'));
+    $quickLinks.find('.toggleable').mozTogglers();
     
     var side = $('#quick-links-toggle').closest('.wiki-column').attr('id');
     // Quick Link toggles
@@ -51,6 +49,29 @@
       $('#wiki-controls .quick-links').toggleClass('hidden');
     });
   })();
+  
+  /*
+    Set up the zone subnav accordion
+  */
+  $('.zone-subnav-container').each(function() {
+    var $subnavList = $(this).find('.subnav > ol');
+    if(!$subnavList.length) return; // Exit if the subnav isn't set up properly
+    
+    // Set the list items as togglers where needed
+    setupTogglers($subnavList.find('li'));
+    
+    // Make them toggleable!
+    $subnavList.find('.toggleable').mozTogglers();
+    
+    // Try to find the current page in the list, if found, open it
+    var $selected = $subnavList.find('a[href$="' + document.location.pathname + '"]');
+    $selected.each(function() {
+      $(this).parents('.toggleable').find('.toggler').trigger('click');
+    }).parent().addClass('current');
+    
+    // Mark this is an accordion so the togglers open/close properly
+    $subnavList.addClass('accordion');
+  });
 
   /*
     Subscribe / unsubscribe to an article
@@ -59,6 +80,20 @@
     e.preventDefault();
     $(this).closest('form').submit();
   });
+  
+  // Utility method for the togglers
+  function setupTogglers($elements) {
+    $elements.each(function() {
+      var $li = $(this);
+      var $sublist = $li.find('> ul, > ol');
+      
+      if($sublist.length) {
+        $li.addClass('toggleable closed');
+        $li.find('> a').addClass('toggler').prepend('<i class="icon-caret-up"></i>');
+        $sublist.addClass('toggle-container');
+      }
+    });
+  }
 
 
 })(jQuery);

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -48,13 +48,16 @@
 
 /* subnav */
 .subnav
-  .toggler, > li > a
+  .toggler, > ol > li > a
     padding grid-spacing
     border-bottom 1px dotted #d4dde4
     text-transform uppercase
     display block
+    
+  ol ol
+    display none /* prevents flash of unstyled content */
 
-  .toggleable.current
+  .toggleable.current, > ol > li.current
     background #f4f7f8
 
   i
@@ -83,7 +86,7 @@
       .toggle-container a
         padding-left grid-spacing + (grid-spacing / 2)
 
-    .current-page a
+    ol .current a
       position relative
       color text-color
 

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -180,7 +180,8 @@ a.persona-button
   compat-only(padding, 0)
 
 main
-  padding-top first-content-top-padding
+  > .center 
+    padding-top first-content-top-padding
 
 
 .boxed

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -61,7 +61,7 @@ slide-timing-function = cubic-bezier(0, 1, 0.5, 1)
 
 /* dimensions */
 gutter-width = 30px
-first-content-top-padding = 0 /*grid-spacing*/
+first-content-top-padding = (grid-spacing * 2) /*grid-spacing*/
 list-item-spacing = 8px
 content-block-margin = grid-spacing
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -12,8 +12,6 @@
 
 
 /* general wiki section */
-main > .center
-  margin-top (grid-spacing * 2)
 #content-main
   compat-only(padding, 0)
   compat-only(width, auto)

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -6,7 +6,7 @@
   #main-header, .zone-article-header
     create-gradient-background(#0095dd)
 
-  #main-nav > ul > li > a
+  #main-nav > ul > li > a, .user-state a
     compat-important(color, #fff)
 
   .search-wrap
@@ -24,6 +24,7 @@
 
   h1
     color #fff
+    @extend .column-6
 
   .crumbs
     color #fff
@@ -32,7 +33,7 @@
       color rgba(255, 255, 255, 0.7)
 
   .zone-subnav-container
-    margin-top -220px
+    margin-top -200px
 
 .zone-landing-header
   create-gradient-background(#0095dd)
@@ -40,7 +41,9 @@
   color #fff
   position relative
   overflow hidden
-  padding-top first-content-top-padding
+  
+  > .center
+    padding-top first-content-top-padding
 
   .masthead-text
     p
@@ -51,7 +54,7 @@
   .zone-image
     position absolute
     right -140px
-    top 60px
+    top 100px
     display block
     width 468px
     height 900px
@@ -105,3 +108,11 @@
   td
     vertical-align bottom
     padding-right grid-spacing
+    
+    
+/* right to left */
+.html-rtl
+  .zone-article-header
+    .zone-image
+      right auto
+      left 0


### PR DESCRIPTION
This is the first of a few PRs to get zones working with real content.  This PR encompasses:
-  Add a "Subnav" heading to the zone's landing page, and a nested list of links below it within OL's
-  The subnav will be pulled to the left side and an accordion will work for it.
-  The main header will display as a zone (blue background)
-  The accordion will open to the spot where the path is the same as the link path.

This PR will not format the zone landing page to look like a the stub (i.e. no massive image, title, etc.)
