### PR TITLE
Fix bug 914725 - Show tags and attachments in tablet view

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -460,7 +460,7 @@ span.cke_skin_kuma
     margin-bottom grid-spacing
 
     .tag-attach-list
-      display none
+      display inline-block
 
     enable-toc-toggle()
 


### PR DESCRIPTION
Moves tags and the attachment number under the TOC in tablet view.
