### PR TITLE
Add wikiArticle ID back to article blocks

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -138,7 +138,7 @@
 
       <!-- just the article content -->
       {% set document_html_safe = document_html|section_hide(zone_subnav_section_id, quick_links_section_id)|safe %}
-      <article>
+      <article id="wikiArticle">
         {% if not fallback_reason %}
           {% if not document_html %}
             {{ _("This article doesn't have any content yet.") }}

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -19,6 +19,8 @@
 
 /* wiki article display */
 article
+  position relative
+  
   a
     text-decoration underline
 


### PR DESCRIPTION
Putting this ID back in the redesign -- tests and CustomCSS rely on it.
