### PR TITLE
fix bug 915031 - Update contributor display and modify zone landing page structure

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -30,7 +30,7 @@
 {% set zone_subnav_html = document|zone_section_extract(zone_subnav_section_id) %}
 
 {% set show_left = zone_subnav_html or quick_links_html or (request.user.is_authenticated() and document.current_revision and document.allows_revision_by(request.user) and (document.current_revision.needs_technical_review() or document.current_revision.needs_editorial_review())) %}
-{% set show_right = (toc_html or tags|length or num_attachments) %}
+{% set show_right = (not is_zone_root and (toc_html or tags|length or num_attachments)) %}
 
 {% set content_class = 'column-all' %}
 {% if show_left and show_right %}
@@ -155,18 +155,20 @@
           {{ _("This article doesn't have approved content yet.") }}
         {% endif %}
       </article>
-
-      <!-- attachments list -->
-      {% if num_attachments %}
-        {% include 'wiki/includes/attachment_list.html' %}
+      
+      {% if not is_zone_root %}
+        <!-- attachments list -->
+        {% if num_attachments %}
+          {% include 'wiki/includes/attachment_list.html' %}
+        {% endif %}
+      
+        <!-- contributors -->
+        <div class="wiki-block contributors">
+        {% trans contributors=user_list(contributors) %}
+          <strong>Contributors to this page:</strong> {{ contributors }}
+        {% endtrans %}
+        </div>
       {% endif %}
-
-      <!-- contributors -->
-      <div class="wiki-block">
-      {% trans contributors=user_list(contributors) %}
-        <strong>Contributors to this page:</strong> {{ contributors }}
-      {% endtrans %}
-      </div>
     </div>
 
     {% if show_left %}

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -121,6 +121,9 @@ article
   compat-only(font-size, smaller-font-size)
   compat-only(font-family, site-font-family)
   compat-only(letter-spacing, normal)
+  
+.contributors
+  font-size smaller-font-size
 
 #toc
   compat-only(margin-left, 0)
@@ -339,7 +342,6 @@ div.bug > *:last-child, div.warning > *:last-child
 /* wiki new and edit pages */
 .page-meta section, #article-head
   compat-only(background, none)
-
 
 #page-tags, #page-comment
   @extend .wiki-block


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=915031

Also, this makes sure the right column, attachment list, and contributor lists don't display on zone landing pages.
