### PR TITLE
Display zone landing summary in appropriate spot

### DIFF
--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -214,6 +214,18 @@ def section_extract(val, section_id):
                         .extractSection(section_id, ignore_heading=True)
                         .serialize())
 
+@register.filter
+def selector_content_find(document, selector):
+    """
+    Provided a selector, returns the relevant content from the document
+    """
+    summary = ''
+    try:
+      page = pq(document.rendered_html)
+      summary = page.find(selector).text()
+    except:
+      pass
+    return summary
 
 @register.filter
 def zone_section_extract(document, section_id):

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -92,7 +92,7 @@
 
       <div class="column-container">
         <div class="column-strip">&nbsp;</div>
-        <div class="column-5 masthead-text"><p>Zombie ipsum brains reversus ab cerebellum viral inferno, brein nam rick mend grimes malum cerveau cerebro.</p></div>
+        <div class="column-5 masthead-text"><p>{{ document|selector_content_find('.summary') }}</p></div>
       </div>
 
       <div class="zone-image"></div>

--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -79,7 +79,7 @@
 <!-- start the main content container -->
 <div id="wiki-column-container">
 
-  {% if show_left or show_right %}
+  {% if not is_zone_root and show_left %}
   <!-- additional controls row; hidden unless needed -->
   <div id="wiki-controls" class="column-container column-container-reverse">
     <div class="column-strip">

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -41,7 +41,10 @@
       color rgba(255, 255, 255, 0.7)
 
   .zone-subnav-container
-    margin-top -200px
+    margin-top -140px
+    
+  .summary
+    display none
 
 .zone-landing-header
   create-gradient-background(#0095dd)


### PR DESCRIPTION
Pulling out the page summary for zone landing pages so that it displays up in the masthead as it should.
