### PR TITLE
Modify zone page display on mobiles

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -117,6 +117,18 @@
     vertical-align bottom
     padding-right grid-spacing
     
+/* mobile */
+@media media-query-mobile
+  .zone-landing
+    .zone-subnav-container
+      margin-top 0
+      
+  .zone-image
+    opacity 0.2
+    
+  .zone-landing-header
+    .masthead-text p
+      margin-top 0
     
 /* right to left */
 .html-rtl


### PR DESCRIPTION
Crunching down some margin for mobile phone, as well as adding opacity to zone heading images so we can included them and put text overtop them.
