### PR TITLE
bug 917748: Preserve manually-supplied ID on <section>s

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -499,8 +499,10 @@ class SectionIDFilter(html5lib_Filter):
 
                 # If this is not a header, then generate a section ID.
                 if token['name'] not in HEAD_TAGS:
-                    attrs['id'] = self.gen_id()
-                    token['data'] = attrs.items()
+                    # But, only generate the ID if there's not already one
+                    if 'id' not in attrs:
+                        attrs['id'] = self.gen_id()
+                        token['data'] = attrs.items()
                     yield token
                     continue
 

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -46,6 +46,12 @@ class ContentSectionToolTests(TestCase):
 
             <h1 class="header3">Header Three</h1>
             <p>test</p>
+
+            <section id="Quick_Links" class="Quick_Links">
+                <ol>
+                    <li>Hey look, quick links</li>
+                </ol>
+            </section>
         """
 
         result_src = (wiki.content
@@ -59,6 +65,7 @@ class ContentSectionToolTests(TestCase):
             ('header2', 'Header_Two'),
             ('hasname', 'Constants'),
             ('hasid',   'This_text_clobbers_the_ID'),
+            ('Quick_Links', 'Quick_Links'),
         )
         for cls, id in expected:
             eq_(id, result_doc.find('.%s' % cls).attr('id'))


### PR DESCRIPTION
I think this should address [the issue where manual IDs get clobbered](https://bugzilla.mozilla.org/show_bug.cgi?id=917748#c6).
