### PR TITLE
Correct subnav bold subitems issue

### DIFF
--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -59,7 +59,9 @@
 
   .toggleable.current, > ol > li.current
     background light-background-color
-    font-weight bold
+
+    > a
+      font-weight bold
 
   i
     top (grid-spacing + 3px)


### PR DESCRIPTION
All links under the current subnav item become bold instead of just the link for said menu.  This fixes said issue.
