### PR TITLE
Adding tag and attachment display back to sidebar

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -157,6 +157,22 @@
           </ol>
         </div>
         {% endif %}
+
+        {% if tags|length %}
+        <!-- tags if present -->
+        <div class="tag-attach-list tags">
+          <i class="icon-tags"></i>
+          <ul class="tag-list">{% for tag in tags %}<li><a href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a></li>{% endfor %}</ul>
+        </div>
+        {% endif %}
+
+        {% if num_attachments %}
+        <!-- attachment list, if present -->
+        <div class="tag-attach-list attachments">
+          <i class="icon-paper-clip"></i>
+          <a href="#page-attachments">{{ _('%s Attachment%s' % (num_attachments, 's' if num_attachments > 1 else '')) }}</a>
+        </div>
+        {% endif %}
         </div>
       {% endif %}
 


### PR DESCRIPTION
Fixes layout issue here:

https://developer.mozilla.org/en-US/docs/Web

Tags and attachments were missing.  Issue that came about from the odd git merge from yesterday.  I simply missed it.  n00b
