### PR TITLE
fix bug 912084: Remap wiki URLs constructed via sumo.urlresolvers.reverse() for content zones

### DIFF
--- a/apps/sumo/urlresolvers.py
+++ b/apps/sumo/urlresolvers.py
@@ -74,11 +74,11 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
             else:
                 zone_locale = settings.WIKI_DEFAULT_LANGUAGE
         # Get DocumentZone remaps for the current locale.
-        zones = DocumentZone.objects.get_for_url_remaps(zone_locale)
-        for zone in zones:
-            orig_url = '/docs/%s' % zone.document.slug
-            if url.startswith(orig_url) and zone_locale == zone.document.locale:
-                url = url.replace(orig_url, '/%s' % zone.url_root, 1)
+        remaps = DocumentZone.objects.get_url_remaps(zone_locale)
+        for remap in remaps:
+            if url.startswith(remap['original_path']):
+                url = url.replace(remap['original_path'],
+                                  remap['new_path'], 1)
                 break
 
     if prefixer:

--- a/apps/wiki/middleware.py
+++ b/apps/wiki/middleware.py
@@ -29,15 +29,14 @@ class DocumentZoneMiddleware(object):
     incoming path_info to point at the internal wiki path
     """
     def process_request(self, request):
-        zones = DocumentZone.objects.get_for_url_remaps(request.locale)
-        for zone in zones:
-            root = '/%s' % zone.url_root
-            orig_path = '/docs/%s' % zone.document.slug
+        remaps = DocumentZone.objects.get_url_remaps(request.locale)
+        for remap in remaps:
 
-            if request.path_info.startswith(orig_path):
+            if request.path_info.startswith(remap['original_path']):
                 # Is this a request for the "original" wiki path? Redirect to
                 # new URL root, if so.
-                new_path = request.path_info.replace(orig_path, root, 1)
+                new_path = request.path_info.replace(remap['original_path'],
+                                                     remap['new_path'], 1)
                 new_path = '/%s%s' % (request.locale, new_path)
                 
                 query = request.GET.copy()
@@ -47,9 +46,9 @@ class DocumentZoneMiddleware(object):
 
                 return HttpResponseRedirect(new_path)
 
-            elif request.path_info.startswith(root):
+            elif request.path_info.startswith(remap['new_path']):
                 # Is this a request for the relocated wiki path? If so, rewrite
                 # the path as a request for the proper wiki view.
                 request.path_info = request.path_info.replace(
-                    root, '/docs/%s' % zone.document.slug, 1)
+                    remap['new_path'], remap['original_path'], 1)
                 break

--- a/apps/wiki/tests/test_middleware.py
+++ b/apps/wiki/tests/test_middleware.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.test.client import Client
 from django.http import Http404
 from django.utils.encoding import smart_str
+from django.core.cache import get_cache
 
 import mock
 from nose import SkipTest
@@ -21,9 +22,7 @@ from sumo.urlresolvers import reverse
 
 from . import TestCaseBase, FakeResponse
 
-from wiki.models import (VersionMetadata, Document, Revision, Attachment,
-                         DocumentZone,
-                         AttachmentRevision, DocumentAttachment, TOC_DEPTH_H4)
+from wiki.models import (Document, Attachment, DocumentZone, SECONDARY_CACHE_ALIAS)
 from wiki.tests import (doc_rev, document, new_document_data, revision,
                         normalize_html, create_template_test_users)
 from wiki.views import _version_groups, DOCUMENT_LAST_MODIFIED_CACHE_KEY_TMPL
@@ -34,6 +33,10 @@ class DocumentZoneMiddlewareTestCase(TestCaseBase):
 
     def setUp(self):
         super(DocumentZoneMiddlewareTestCase, self).setUp()
+
+        s_cache = get_cache(SECONDARY_CACHE_ALIAS)
+        s_cache.clear()
+
         self.zone_root = 'ExtraWiki'
         self.zone_root_content = 'This is the Zone Root'
 
@@ -97,6 +100,14 @@ class DocumentZoneMiddlewareTestCase(TestCaseBase):
         eq_(200, response.status_code)
         eq_(self.sub_doc.html, response.content)
 
+        self.root_zone.url_root = 'NewRoot'
+        self.root_zone.save()
+
+        url = '/en-US/%s/Middle/SubPage?raw' % 'NewRoot'
+        response = self.client.get(url, follow=False)
+        eq_(200, response.status_code)
+        eq_(self.sub_doc.html, response.content)
+
     def test_actual_wiki_url_redirect(self):
         """Ensure a request for the 'real' path to a document results in a
         redirect to the internal redirect path"""
@@ -105,6 +116,14 @@ class DocumentZoneMiddlewareTestCase(TestCaseBase):
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
         eq_('http://testserver/en-US/ExtraWiki/Middle?raw=1', response['Location'])
+
+        self.root_zone.url_root = 'NewRoot'
+        self.root_zone.save()
+
+        url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
+        response = self.client.get(url, follow=False)
+        eq_(302, response.status_code)
+        eq_('http://testserver/en-US/NewRoot/Middle?raw=1', response['Location'])
 
     def test_blank_url_root(self):
         """Ensure a blank url_root does not trigger URL remap"""
@@ -137,3 +156,10 @@ class DocumentZoneMiddlewareTestCase(TestCaseBase):
         url = reverse('wiki.edit_document',
                       args=[self.middle_doc.slug])
         eq_('/ExtraWiki/Middle$edit', url)
+
+        self.root_zone.url_root = 'NewRoot'
+        self.root_zone.save()
+
+        url = reverse('wiki.edit_document',
+                      args=[self.middle_doc.slug])
+        eq_('/NewRoot/Middle$edit', url)

--- a/puppet/files/vagrant/settings_local.py
+++ b/puppet/files/vagrant/settings_local.py
@@ -96,6 +96,31 @@ MIGRATION_DATABASES = {
     },
 }
 
+CACHES = {
+    'default': {
+        # HACK: We currently have 'default' memcache disabled in production.
+        # This reflects that in local dev.
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        #'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        #'LOCATION': [
+        #    '127.0.0.1:11211',
+        #],
+        'TIMEOUT': 3600,
+        'KEY_PREFIX': 'kuma',
+    },
+    'secondary': {
+        'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+        'LOCATION': [
+            '127.0.0.1:11211',
+        ],
+        'TIMEOUT': 3600,
+        'KEY_PREFIX': 'kuma',
+    }
+}
+
+# TODO: Switch this to 'default' when main cache issues are resolved
+SECONDARY_CACHE_ALIAS = 'secondary'
+
 # Use IP:PORT pairs separated by semicolons.
 CACHE_BACKEND = 'memcached://localhost:11211?timeout=60'
 CONSTANCE_DATABASE_CACHE_BACKEND = CACHE_BACKEND

--- a/settings.py
+++ b/settings.py
@@ -73,8 +73,19 @@ CACHES = {
         'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
         'TIMEOUT': 60,
         'KEY_PREFIX': 'kuma',
+    },
+    # NOTE: The 'secondary' cache should be the same as 'default' in
+    # settings_local. The only reason it exists is because we had some issues
+    # with caching, disabled 'default', and wanted to selectively re-enable
+    # caching on a case-by-case basis to resolve the issue.
+    'secondary': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'TIMEOUT': 60,
+        'KEY_PREFIX': 'kuma',
     }
 }
+
+SECONDARY_CACHE_ALIAS = 'secondary'
 
 # Addresses email comes from
 DEFAULT_FROM_EMAIL = 'notifications@developer.mozilla.org'


### PR DESCRIPTION
- Hack in sumo.urlresolvers.reverse() to apply URL remaps for wiki
  content zones
- Quick bug fix for zones across locales
- Tests
