### PR TITLE
fix bug 920258 - Don't allow arrow / link overlap

### DIFF
--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -49,7 +49,7 @@
 /* subnav */
 .subnav
   .toggler, > ol > li > a
-    padding grid-spacing
+    padding grid-spacing (2 * grid-spacing) grid-spacing grid-spacing
     border-bottom 1px dotted #d4dde4
     text-transform uppercase
     display block


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=920258
