### PR TITLE
Make shadow color variable to zone background

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -91,7 +91,7 @@
     compat-important(color, #fff)
     old-ie(background-color, #0095dd, true) /* old ie */
     compat-important(background-color, rgba(0, 0, 0, 0.1))
-    vendorize(box-shadow, inset 0 -1px #147ba5)
+    vendorize(box-shadow, inset 0 -1px rgba(0, 0, 0, .1))
 
 .zone-landing-lists li
   padding list-item-spacing 0


### PR DESCRIPTION
The shadow was hardcoded to a color (the color of the initial mockups) but that doesn't look good in all situations.  Changing to a more variable, opacity-driven color scheme.
