### PR TITLE
Change column hider text

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -137,7 +137,7 @@
         &nbsp;
       </div>
       <div class="column-strip quick-links hidden">
-        <a href="#show-quick-links" class="title smaller" id="show-quick-links"><i class="icon-caret-down"></i>{{ _('Show QuickLinks') }}</a>
+        <a href="#show-quick-links" class="title smaller" id="show-quick-links"><i class="icon-caret-down"></i>{{ _('Show Column') }}</a>
       </div>
     </div>
     {% endif %}
@@ -229,7 +229,7 @@
         <div id="wiki-left" class="column-strip wiki-column">
           
         {% if not is_zone_root and (zone_subnav_html or quick_links_html) %}
-          <a href="#quick-links" class="title" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide Quick Links') }}</a>
+          <a href="#quick-links" class="title" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide Column') }}</a>
         {% endif %}
 
           {% if not is_zone_root and zone_subnav_html %}


### PR DESCRIPTION
I don't think our users care that it's called "Quick Links", and sometimes it just hides the subnav.  I think we should change the text, as I've done here.
