### PR TITLE
Prevent horizontal overflow on zone landing pages

### DIFF
--- a/media/redesign/stylus/globals.styl
+++ b/media/redesign/stylus/globals.styl
@@ -2,6 +2,9 @@
 
 *  
 
+html
+  overflow-x hidden
+
 html, body
   background #fff
 


### PR DESCRIPTION
The image on zone landing pages can slightly overflow the right side of the page (this is by design, adds depth).  This prevents the left to right scrolling from appearing.
