### PR TITLE
Update icon name to avoid CustomCSS conflict

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -133,7 +133,7 @@ a.persona-button
       vendorize(transform, scale(0.707) rotate(45deg))
       vendorize(border-radius, 0 3px 0 50px)
 
-    &.icon
+    &.persona-icon
       padding-left 3px
       vendorize(border-radius, 3px 0 0 3px)
       create-gradient(#43a6e2, #287cc2)

--- a/templates/includes/login.html
+++ b/templates/includes/login.html
@@ -17,7 +17,7 @@
 
         {% if waffle.flag('redesign') %}
           <a href="#" id="create_profile" class="persona-button persona-login" title="{{ _('Sign in with Persona') }}" data-next="{{ next_url }}">
-            <span class="icon"><img src="{{ MEDIA_URL }}redesign/img/persona-person-white.png" alt="persona icon"></span>
+            <span class="persona-icon"><img src="{{ MEDIA_URL }}redesign/img/persona-person-white.png" alt="persona icon"></span>
             <span class="signin">{{ _('Sign in with Persona') }}</span>
           </a>
         {% else %}


### PR DESCRIPTION
Apparently our writers are styling the global "icon" class.  :(  Updating an element in the redesign sign in button so it doesn't get the CustomCSS styling.
