### PR TITLE
Move to 12-column, percentage based grid.  Much better for mobile.

### DIFF
--- a/apps/landing/templates/landing/homepage.html
+++ b/apps/landing/templates/landing/homepage.html
@@ -92,9 +92,43 @@
 <!-- hacks area -->
 <div class="home-hacks"><div class="column-container center">
   <div class="column-hacks">
-    <h2><i class="icon-star"></i> {{ _('Hacks Blog <a href="">read more at hacks.mozilla.org <i class="icon-arrow-right"></i></a>') }}</h2>
+    <h2><i class="icon-star"></i> {{ _('Hacks Blog <a href="http://hacks.mozilla.org">read more at hacks.mozilla.org <i class="icon-arrow-right"></i></a>') }}</h2>
     {{ newsfeed(updates, section_headers=True) }}
-      
+
+    <ul class="hfeed">
+          <li class="hentry">
+      <h2 class="entry-title"><a href="https://hacks.mozilla.org/2013/09/firefox-os-development-web-components-and-mozilla-brick/" rel="bookmark">Firefox OS Development: Web Components and Mozilla Brick</a></h2>
+      <p class="entry-summary">In this edition of “Firefox OS: The platform HTML5 deserves” (the previous six videos are published here), Mozilla’s Principal Evangelist Chris Heilmann (@codepo8) grilled Mozilla’s “Senior HTML5 Engineer Angle Bracket Coordinator” Matthew Claypotch (@potch) about the exciting new possibilities of Web Components for Web App developers and how Mozilla’s Brick ...</p>
+      <p class="entry-meta vcard">
+      Posted <time class="updated" datetime="2013-09-27" title="2013-09-27">September 27, 2013</time> by <cite class="author fn">Chris Heilmann</cite>            </p>
+    </li>
+              <li class="hentry">
+      <h2 class="entry-title"><a href="https://hacks.mozilla.org/2013/09/new-features-in-the-firefox-developer-tools-episode-26/" rel="bookmark">New Features in the Firefox Developer Tools: Episode 26</a></h2>
+      <p class="entry-summary">Firefox 26 was just uplifted to the Aurora release channel which means we are back to report on new features in Firefox Developer Tools. Here’s a summary of some of the most exciting new features. Inspector: pseudo element support To get more flexibility in the design of an element without ...</p>
+      <p class="entry-meta vcard">
+      Posted <time class="updated" datetime="2013-09-26" title="2013-09-26">September 26, 2013</time> by <cite class="author fn">Paul Rouget</cite>            </p>
+    </li>
+              <li class="hentry">
+      <h2 class="entry-title"><a href="https://hacks.mozilla.org/2013/09/reintroducing-the-firefox-developer-tools-part-1-the-web-console-and-the-javascript-debugger/" rel="bookmark">Reintroducing the Firefox Developer Tools, part 1: the Web Console and the JavaScript Debugger</a></h2>
+      <p class="entry-summary">This is part one, out of 5, focusing on the built-in Developer Tools in Firefox, their features and where we are now with them. The intention is to show you all the possibilities available, the progress and what we are aiming for. Firefox 4 saw the launch of the Web ...</p>
+      <p class="entry-meta vcard">
+      Posted <time class="updated" datetime="2013-09-24" title="2013-09-24">September 24, 2013</time> by <cite class="author fn">Jason Weathersby</cite>            </p>
+    </li>
+              <li class="hentry">
+      <h2 class="entry-title"><a href="https://hacks.mozilla.org/2013/09/firefox-24-for-android-gets-webrtc-support-by-default/" rel="bookmark">Firefox 24 for Android gets WebRTC support by default</a></h2>
+      <p class="entry-summary">WebRTC is now on Firefox for Android as well as Firefox Desktop! Firefox 24 for Android now supports mozGetUserMedia, mozRTCPeerConnection, and DataChannels by default. mozGetUserMedia has been in desktop releases since Firefox 20, and mozPeerConnection and DataChannels since Firefox 22, and we’re excited that Android is now joining Desktop releases ...</p>
+      <p class="entry-meta vcard">
+      Posted <time class="updated" datetime="2013-09-17" title="2013-09-17">September 17, 2013</time> by <cite class="author fn">Maire Reavy</cite>            </p>
+    </li>
+              <li class="hentry">
+      <h2 class="entry-title"><a href="https://hacks.mozilla.org/2013/09/user-agent-detection-history-and-checklist/" rel="bookmark">User-Agent detection, history and checklist</a></h2>
+      <p class="entry-summary">History User-Agent: &lt;something&gt; is a string of characters sent by HTTP clients (browsers, bots, calendar applications, etc.) for each individual HTTP request to a server. The HTTP Protocol as defined in 1991 didn’t have this field, but the next version defined in 1992 added User-Agent in the HTTP requests headers. ...</p>
+      <p class="entry-meta vcard">
+      Posted <time class="updated" datetime="2013-09-12" title="2013-09-12">September 12, 2013</time> by <cite class="author fn">Karl Dubost</cite>            </p>
+    </li>
+      </ul>
+
+    
   </div>
   <div class="column-involved">
     <div class="home-involved-card"><a href="{{ devmo_url('Project:MDN/Contributing') }}">
@@ -143,14 +177,14 @@
     </div>
     <div class="column-half">
       <div class="column-container">
-        <div class="column-strip">
+        <div class="column-half">
           <ul>
           <li><a href="{{ devmo_url('needs-review/editorial') }}">{{ _('Editorial review') }}</a></li>
                 <li><a href="{{ devmo_url('needs-review/technical') }}">{{ _('Technical review') }}</a></li>
                 <li><a href="{{ devmo_url('Project:Getting_started') }}#Create_a_new_page">{{ _('Creating new docs') }}</a></li>
           </ul>
         </div>
-        <div class="column-strip">
+        <div class="column-half">
           <ul>
           <li><a href="{{ devmo_url('Project:Localization_Projects') }}">{{ _('Translating (L10N)') }}</a></li>
                 <li><a href="{{ url('promote') }}">{{ _('Promoting MDN') }}</a></li>

--- a/media/redesign/stylus/classes.styl
+++ b/media/redesign/stylus/classes.styl
@@ -42,7 +42,7 @@
     padding-left grid-spacing
 
   pre
-    border 1px dotted #cbc8b9
+    border 0
     background #f6f6f2
     padding 15px
     overflow auto

--- a/media/redesign/stylus/demo-studio.styl
+++ b/media/redesign/stylus/demo-studio.styl
@@ -3,6 +3,9 @@
 
 .section-demos
   background #c0c4c8
+  min-width 0
+
+  use-white-logo()
 
   main
     background transparent
@@ -11,8 +14,6 @@
     override-main-nav-color(#fff)
 
     #main-header
-      .logo
-        background url('/media/redesign/img/mdn_logo-wordmark-full_white.svg') 0 0 no-repeat
 
       .search-wrap
         background-color rgba(255, 255, 255, 0.2)

--- a/media/redesign/stylus/globals.styl
+++ b/media/redesign/stylus/globals.styl
@@ -1,7 +1,5 @@
 @import 'vars'
 
-*  
-
 html
   overflow-x hidden
   background #fff

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -1,23 +1,23 @@
 @import 'vars'
 @import 'mixins'
 
+.center
+  margin 0 auto
+  position relative
+  max-width 1220px
+  padding-left 10px
+  padding-right 10px
 
 /* Column helpers for the grids to be generated */
 .column-closed
   display none
-
-.column-all
-  width auto
-  float none
-  margin-right 0
   
-
 /* This is a "helper" which automatically formats its column children, clears the floats afterward, removes margin from last item */
 .column-container
   @extend .clear
 
   > [class^='column-']
-    margin-right grid-spacing
+    margin-right 3%
     float left
 
     &:last-child
@@ -31,134 +31,53 @@
         margin-right 0
 
       &:last-child
-        margin-right grid-spacing
+        margin-right 3%
 
 
-/* Desktop Layout (default)
-  *
-  * The Sandstone layout is based on a 12 column grid where each column is 60px wide with 20px gutters.
-  * The gutters are achieved with 10px left and right margins on each column.
-  * Blocks can span multiple columns in any number of configurations.
-  *
-  * There are 30px outer page gutters for a total page width of 1000px.
-  *
-  * width = (60px * columns) + (20px * (columns - 1))
-  *
-  * 1 column span - width: 60px;
-  * 2 column span - width: 140px;
-  * 3 column span - width: 220px;
-  * 4 column span - width: 300px;
-  * 5 column span - width: 380px;
-  * 6 column span - width: 460px;
-  * 7 column span - width: 540px;
-  * 8 column span - width: 620px;
-  * 9 column span - width: 700px;
-  * 10 column span - width: 780px;
-  * 11 column span - width: 860px;
-  * 12 column span - width: 940px;
-*/
-generate-grid(grid-increment-desktop, grid-start-desktop, grid-end-desktop)
-.center
-  position relative
-  margin 0 auto
-generate-center(site-width-desktop)
+/* *********************************************************************************************************************
+ * Common columns definitions
+ */
+.column-1
+  width 5.5%
+.column-2
+  width 14%
+.column-3, .column-strip
+  width 22.5%
+.column-4
+  width 31%
+.column-5
+  width 39.5%
+.column-6, .column-half
+  width 48%
+.column-7
+  width 56.5%
+.column-8
+  width 65%
+.column-9, .column-main
+  width 73.5%
+.column-10 
+  width 82%
+.column-11 
+  width 90.5%
+.column-12, .column-all
+  width 99%
+  margin 0
+  float none
 
-
-/* Desktop Large - 1224px */
-@media media-query-desktop-large
-  grid-spacing = grid-spacing-wide
-  generate-center(site-width-desktop-large)
-  generate-grid(grid-increment-desktop-large, grid-start-desktop-large, grid-end-desktop-large)
-
-  .column-container
-    > [class^='column-']
-      margin-right grid-spacing-wide
-
-/* Desktop Large - 1824px */
-@media media-query-desktop-large
-  grid-spacing = grid-spacing-wide
-  generate-center(site-width-desktop-large)
-  generate-grid(grid-increment-desktop-large, grid-start-desktop-large, grid-end-desktop-large)
-
-  .column-container
-    > [class^='column-']
-      margin-right grid-spacing-wide
-
-
-/* Tablet Layout - 760px
-  *
-  * For smaller viewports, the column width drops to 40px with the
-  * same 20px column gutter and 30px page gutters.
-  *
-  * width = (40px * columns) + (20px * (columns - 1))
-  *
-  * 1 column span - width: 40px;
-  * 2 column span - width: 100px;
-  * 3 column span - width: 160px;
-  * 4 column span - width: 220px;
-  * 5 column span - width: 280px;
-  * 6 column span - width: 340px;
-  * 7 column span - width: 400px;
-  * 8 column span - width: 460px;
-  * 9 column span - width: 520px;
-  * 10 column span - width: 580px;
-  * 11 column span - width: 640px;
-  * 12 column span - width: 700px;
-*/
+/* *********************************************************************************************************************
+ * Disable padding left/right 10px if I'm 1024 or gibber - correct percentage math
+ */
 @media media-query-tablet
 
-  generate-center(site-width-tablet)
-  generate-grid(grid-increment-tablet, grid-start-tablet, grid-end-tablet)
+  .center
+    max-width 1000px
 
-/* Mobile Layout - 320px
- *
- * For very small viewports, we switch to a 5 column grid
- * at 40px per column, still with a 20px gutter.
- *
- * The outer page gutter goes from 30px to 20px.
- *
- * width = (40px * columns) + (20px * (columns - 1))
- *
- * 1 column span - width: 40px;
- * 2 column span - width: 100px;
- * 3 column span - width: 160px;
- * 4 column span - width: 220px;
- * 5 column span - width: 280px;
- */
+/* *********************************************************************************************************************
+ * Small devices
+ 
 @media media-query-mobile
 
-  generate-center(site-width-mobile)
-  generate-grid(grid-increment-mobile, grid-start-mobile, grid-end-mobile)
-
-  .column-container
-    @extend .clear
-
-    > [class^='column-'], &.column-container-reverse
-      margin-right 0 !important
-      float none
-      margin-bottom grid-spacing
-      width 100%
-
-
- /* Wide Mobile Layout - 480px
- *
- * For slightly wider viewports (e.g. smartphones in landscape mode),
- * we keep the 40px column but gain two more columns, for a total of 7.
- *
- * The outer page gutter is still 20px for a total page width of 440px.
- *
- * width = (40px * columns) + (20px * (columns - 1))
- *
- * 1 column span - width: 40px;
- * 2 column span - width: 100px;
- * 3 column span - width: 160px;
- * 4 column span - width: 220px;
- * 5 column span - width: 280px;
- * 6 column span - width: 340px;
- * 7 column span - width: 400px;
- */
-
-@media media-query-mobile-wide
-
-  generate-center(site-width-mobile-wide)
-  generate-grid(grid-increment-mobile, grid-start-mobile, grid-end-mobile-wide)
+  .center, .column-1, .column-2, .column-3, .column-4, .column-5, .column-6, .column-7, .column-8, .column-9, .column-10, .column-11
+    float  none
+    width 99%
+*/

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -4,14 +4,13 @@
 
 #home
   create-home-gradient-background(#00539f)
+  remove-main-spacing()
+  use-white-logo()
 
   /* general structure adjustments */
   #main-header
     background none
     border-bottom-color rgba(255, 255, 255, 0.2)
-    
-    .logo
-      background url('/media/redesign/img/mdn_logo-wordmark-full_white.svg') 0 0 no-repeat
 
   /* update main nav menu color */
   override-main-nav-color(#fff)
@@ -21,8 +20,6 @@
 
    .home-callouts
     background #4d4e53
-
-   remove-main-spacing()
 
   main
     background transparent
@@ -90,7 +87,7 @@
       position absolute
       top 0
       display block
-      right 10%
+      right 5%
 
     span
       padding-right 20px
@@ -118,7 +115,7 @@
       i
         width 200px
         height 130px
-        background url('/media/redesign/img/HTML5_Logo.svg') center -70px no-repeat
+        background url(media-url-dir + 'HTML5_Logo.svg') center -70px no-repeat
         background-size cover
 
     &.callout-android
@@ -127,7 +124,7 @@
       i
         width 260px
         height 140px
-        background url('/media/redesign/img/promo-phone.png') center -190px no-repeat
+        background url(media-url-dir + 'promo-phone.png') center -190px no-repeat
         background-size cover
 
     &.callout-firefoxos
@@ -136,7 +133,7 @@
       i
         width 320px
         height 150px
-        background url('/media/redesign/img/promo-fox.png') center -60px no-repeat
+        background url(media-url-dir + 'promo-fox.png') center -60px no-repeat
         background-size cover
 
   /* shared */
@@ -145,7 +142,7 @@
       display inline-block
       position relative
       margin-left 0
-      background-image url('/media/redesign/img/mdn_blank-grey-document-color.svg') 
+      background-image url(media-url-dir + 'mdn_blank-grey-document-color.svg') 
 
   h2 
     a
@@ -161,7 +158,7 @@
       color #0095dd
       
       &.blue
-        background-image url('/media/redesign/img/mdn_blank-blue-document-color.svg') 
+        background-image url(media-url-dir + 'mdn_blank-blue-document-color.svg') 
         color #fff
 
       &[class^="icon-"]:before
@@ -214,6 +211,9 @@
       margin-bottom 4px
 
     h2.entry-title
+      letter-spacing 0
+      line-height normal
+
       a
         text-decoration underline
         compat-only(margin-left, 0)
@@ -224,7 +224,7 @@
       margin-bottom (grid-spacing / 2)
 
     .home-involved-card
-      background url('/media/redesign/img/home-globe.svg') -90px 40px no-repeat #f4f7f8
+      background url(media-url-dir + 'home-globe.svg') -90px 40px no-repeat #f4f7f8
       background-size 600px
 
       a
@@ -308,7 +308,7 @@
 
   li
     border-bottom 1px solid #ececec
-    padding 8px 0
+    padding list-item-spacing 0
 
     &:last-child
       border-bottom 0
@@ -323,18 +323,7 @@
 
     .home-masthead
         h1, input
-          width 80%
-
-    h3 i
-      display none
-
-    .column-callout
-      a
-        font-size base-font-size
-
-      &.callout-android, &.callout-apps
-          i
-            right auto
+          width 90%
 
 
 /* mobile */
@@ -343,15 +332,36 @@
 
     .home-masthead
       h1, input
-        width 100%
+        width 90%
 
         span
           padding-left 0
 
-    .column-callout, .column-involved, .column-home-features
+    .column-callout, .column-home-features
       width auto !important
       float none
       margin-bottom grid-spacing
+      margin-right 0
+
+    .home-callouts
+      padding-top 20px
+
+    .column-home-features
+      li
+        display inline-block
+        padding-right grid-spacing
+
+    .home-hacks
+      .column-hacks, .column-involved
+        float none
+        width auto
+
+      .column-involved
+        margin-top (grid-spacing * 2)
+      
+      .home-involved-card p
+        text-align left
+
 
 /* right to left */
 #home.html-rtl
@@ -363,15 +373,19 @@
           left grid-spacing
 
     h2 
-      > i[class^="icon-"]:before
+      > selector-icon:before
         margin-right 22px
 
     h3 
       i, span
         float right 
 
-      i[class^="icon-"]:before
+      selector-icon:before
         margin-right 16px
 
     i.icon-arrow-right:before
       content "\f060"
+
+    .home-hacks .home-involved-card h3
+      margin-right 0
+      margin-left -20px

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -6,33 +6,6 @@
 
 */
 
-/* generates a grid based on min/max and increment */
-generate-grid(increment, start, end, desired-column=false)
-  total = start
-  for n, x in 0..((end - start) / increment)
-    if desired-column
-      if x+1 is desired-column
-        return total
-    else
-      .column-{x+1}
-        width total
-
-    total = total + increment
-
-  /* now add a few meaningful names */
-  .column-strip
-    @extend .column-3
-  .column-main
-    @extend .column-9
-  .column-half
-    @extend .column-6
-  .column-all
-    width auto
-
-get-grid-dimension(media-query, column-num)
-  if media-query is media-query-tablet
-    return generate-grid(grid-increment-tablet, grid-start-tablet, grid-end-tablet, column-num)
-
 /* vendorizes a propery */
 vendorize(property, value)
   -webkit-{property} value
@@ -61,10 +34,10 @@ reverse-link-decoration()
 /* generates a background property for header and zones */
 create-gradient-background(color='', use-gradient=false)
   if use-gradient
-    background-image url('/media/redesign/img/header-background.png'), url('/media/redesign/img/mdn-header-gradient.png')
+    background-image url(media-url-dir + 'header-background.png'), url(media-url-dir + 'mdn-header-gradient.png')
     background-repeat repeat, repeat-x
   else
-    background-image url('/media/redesign/img/header-background.png')
+    background-image url(media-url-dir + 'header-background.png')
     background-repeat repeat
   background-position 0 0, 0 0, 0 0
   if color
@@ -72,7 +45,7 @@ create-gradient-background(color='', use-gradient=false)
 
 create-home-gradient-background(color)
   create-gradient-background(color)
-  background-image url('/media/redesign/img/header-background.png'), url('/media/redesign/img/blueprint.png'), url('/media/redesign/img/mdn-header-gradient.png')
+  background-image url(media-url-dir + 'header-background.png'), url(media-url-dir + 'blueprint.png'), url(media-url-dir + 'mdn-header-gradient.png')
   background-repeat repeat, repeat, repeat-x
 
 /* generates a cross-browser gradient */
@@ -115,7 +88,7 @@ old-ie(prop, value, important=false)
   {prop} value (important ? unquote('!important') : '')
 
 /* Used to create sliding animations */
-slider(duration=animation-duration, maximum-height=10000px)
+slider(duration=default-animation-duration, maximum-height=10000px)
   overflow-y hidden
   max-height maximum-height
   vendorize(transition-property, all)
@@ -154,6 +127,12 @@ remove-main-spacing()
   main > .center
     width auto
     padding 0
+    margin 0
+    max-width none
+
+add-main-space()
+  @extend .center
+  
 
 /* Overrides the navigation menu color - zones and homepage */
 override-main-nav-color(hex)
@@ -166,6 +145,11 @@ set-placeholder-style(prop, value)
     {prop} value
   &::-moz-input-placeholder
     {prop} value
+
+/* Uses the white logo instead of color logo */
+use-white-logo()
+  #main-header .logo
+      background url(media-url-dir + 'mdn_logo-wordmark-full_white.svg') 0 0 no-repeat
 
 
 /*

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -8,6 +8,9 @@ body.search-results
   p
     padding inherit
 
+main
+  background transparent
+
 .search-pane
   background #fff
   margin-bottom (grid-spacing / 2)

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -10,7 +10,9 @@
     @extend .text-offscreen
     width 216px
     height 54px
-    background url('/media/redesign/img/mdn_logo-wordmark-full_color.svg') 0 0 no-repeat
+    background-image url(media-url-dir + 'mdn_logo-wordmark-full_color.svg')
+    background-position 0 0
+    background-repeat no-repeat
     display block
     float left
 
@@ -20,10 +22,6 @@
     margin-top 20px
     margin-bottom grid-spacing
 
-    @media media-query-mobile
-      width 100%
-      clear both
-
     > li
       padding-left 31px
       position relative
@@ -31,19 +29,8 @@
       max-width 1000px
       display inline-block
       vendorize(transition-property, width)
-      vendorize(transition-duration, animation-duration)
-      vendorize(transition-delay, animation-duration)
-
-      @media media-query-tablet
-        &:first-child, &:last-child
-          padding-left 0
-
-        padding-left 12px
-
-      @media media-query-mobile
-        display block
-        padding-left 0
-        padding 5px 0
+      vendorize(transition-duration, default-animation-duration)
+      vendorize(transition-delay, default-animation-duration)
 
       > a, .search-trigger
         compat-important(color, menu-link-color)
@@ -98,12 +85,6 @@
       overflow hidden
       padding 0
       vendorize(transition-delay, 0)
-
-  @media media-query-tablet
-
-    &.expand
-      input
-        width 400px
 
 .user-state
   position absolute
@@ -172,14 +153,11 @@ a.persona-button
   border-radius 3px
   position relative
   vendorize(transition-property, width)
-  vendorize(transition-duration, animation-duration)
+  vendorize(transition-duration, default-animation-duration)
   width 20px
 
   &.expanded
     background #fff
-
-  @media media-query-mobile
-        background #fff
 
   input
     background transparent
@@ -191,7 +169,7 @@ a.persona-button
     overflow hidden
     compat-only(padding, 0)
     vendorize(transition-property, width)
-    vendorize(transition-duration, animation-duration)
+    vendorize(transition-duration, default-animation-duration)
     position absolute
     left 8px
     width 100%
@@ -236,7 +214,7 @@ footer
     font-style italic
 
   p
-    background url('/media/redesign/img/mdn_logo-only_color.svg') 0 0 no-repeat
+    background url(media-url-dir + 'mdn_logo-only_color.svg') 0 0 no-repeat
     compat-important(padding, 10px 0 0 92px)
     min-height 62px
 
@@ -261,21 +239,15 @@ footer
 
   #main-nav
     > ul
-    
+      text-align right
+      width 100%
+      clear both
+      
       > li
         vendorize(transition-property, none)
       
-      > li:first-child, .main-nav-search
+      > li:first-child
           padding-left 0
-      
-      .main-nav-search
-        width 100%
-        margin-bottom grid-spacing
-        margin-top grid-spacing
-
-      .search-wrap
-        input
-          width 90%
 
     &.expand
       ul

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -22,49 +22,19 @@ button-shadow-color = #bbbfc2
 
 /* grid and site dimensions */
 grid-spacing = 20px
-grid-spacing-wide = 24px
-
-grid-increment-desktop = 80px
-grid-increment-desktop-large = 99px
-grid-increment-desktop-wide = 125px
-grid-increment-tablet = 60px
-grid-increment-mobile = grid-increment-tablet
-
-grid-start-desktop = 60px
-grid-start-desktop-large = 75px
-grid-start-desktop-wide = 125px
-grid-start-tablet = 40px
-grid-start-mobile = grid-start-tablet
-
-grid-end-desktop = 940px
-grid-end-desktop-large = 1164px
-grid-end-desktop-wide = 1764px
-grid-end-tablet = 700px
-grid-end-mobile = 280px
-grid-end-mobile-wide = 400px
-
-site-width-desktop = 1000px
-site-width-desktop-large = 1224px
-site-width-desktop-wide = 1824px
-site-width-tablet = 760px
-site-width-mobile = 320px
-site-width-mobile-wide = 480px
-
-media-query-desktop-large = 'only screen and/*!YUI Compressor */(min-width: 1224px)'
-media-query-desktop-wide = 'only screen and/*!YUI Compressor */(min-width: 1824px)'
-media-query-tablet = 'only screen and/*!YUI Compressor */(min-width: 760px) and/*!YUI Compressor */(max-width: 1000px)'
-media-query-mobile = 'only screen and/*!YUI Compressor */(max-width: 760px)'
-media-query-mobile-wide = 'only screen and/*!YUI Compressor */(min-width: 480px) and/*!YUI Compressor */(max-width: 760px)'
+media-query-tablet = 'all and/*!YUI */(max-width: 1024px)'
+media-query-mobile = 'all and/*!YUI */(max-width: 768px)'
 
 /* animation */
-animation-duration = .5s
+default-animation-duration = .5s
 slide-timing-function = cubic-bezier(0, 1, 0.5, 1)
 
 /* dimensions */
 gutter-width = 30px
-first-content-top-padding = (grid-spacing * 2) /*grid-spacing*/
+first-content-top-padding = (grid-spacing * 2)
 list-item-spacing = 8px
 content-block-margin = grid-spacing
 
 /* selectors */
 selector-icon = 'i[class^="icon-"]'
+media-url-dir = '/media/redesign/img/'

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -11,9 +11,6 @@
   border-top 1px solid button-background
   padding-left 0
   padding-right 0
-  
-  h2, h3
-    font-family 'Open Sans Light'
 
 
 /* general wiki section */
@@ -34,15 +31,9 @@ article
     &:hover, &:focus
       text-decoration none
 
-  h1, h2, h3, h4, h5, h6
-    font-family 'Open Sans Light'
-
 .document-head
   position relative
   clear both
-
-  h1
-    font-family 'Open Sans Light'
 
 .redirected-from
   margin-top -(grid-spacing)
@@ -304,11 +295,8 @@ div.bug > *:last-child, div.warning > *:last-child
 .tagit li
   font-size base-font-size
 
-.tagit
+.tagit, .tagit-new
   border 0 !important /* overrides plugin selector */
-
-.tagit-new
-  border 0
 
 /* quick links */
 .quick-links
@@ -470,13 +458,21 @@ span.cke_skin_kuma
 
 
 
-/* tablet article layout updates */
+
 @media media-query-tablet
+  
+  .zone-landing-header-preview
+    .column-strip, masthead-text
+      width 48%
+
   #wiki-right
     .tag-attach-list
       display inline-block
 
     enable-toc-toggle()
+
+  #wiki-column-container, #wiki-content
+    width auto !important
 
   #wiki-content, #wiki-right, #wiki-left
     margin-right 0
@@ -485,14 +481,14 @@ span.cke_skin_kuma
     margin-bottom (grid-spacing * 2)
 
 
-/* mobile */
-@media media-query-mobile
 
-  #wiki-controls
+
+
+@media media-query-mobile
+  
+  #quick-links-toggle,  #wiki-controls
     display none
 
-  #wiki-right
-    enable-toc-toggle()
 
 
 

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -4,12 +4,10 @@
 
 .zone
   create-gradient-background('', true)
+  use-white-logo()
 
   #main-header
     border-bottom-color rgba(255, 255, 255, 0.2)
-
-    .logo
-      background url('/media/redesign/img/mdn_logo-wordmark-full_white.svg') 0 0 no-repeat
 
   override-main-nav-color(#fff)
 
@@ -137,44 +135,22 @@
   td
     vertical-align bottom
     padding-right grid-spacing
-    
+ 
 
-/* tablets */
+    
 @media media-query-tablet
   .zone-landing
-    .zone-subnav-container
-      margin-top 0
+      .zone-subnav-container
+        margin-top 0
 
-    .zone-landing-header-preview .column-strip, .zone-landing-header-preview .masthead-text
-      width get-grid-dimension(media-query-tablet, 6)
+      .zone-landing-header-preview .column-strip, .zone-landing-header-preview .masthead-text
+        width get-grid-dimension(media-query-tablet, 6)
 
-      .zone-landing-header-preview-base
-        position static
+        .zone-landing-header-preview-base
+          position static
 
-    .zone-image
-      opacity 0.2
-
-/* mobile */
-@media media-query-mobile
-      
-  .zone-landing
-    .zone-landing-header-preview .column-strip, .zone-landing-header-preview .masthead-text
-      width auto
-      float none
-
-      .zone-landing-header-preview-base
-        position static
-
-  .zone-image
-    opacity 0.2
-    
-  .zone-landing-header
-    .masthead-text p
-      margin-top 0
-
-  #wiki-content
-    width auto
-    float none
+      .zone-image
+        opacity 0.2
     
 /* right to left */
 .html-rtl


### PR DESCRIPTION
I'm abandoning Mozilla's 12-column, fixed pixel grid.  It wont work for us, it's too rigid and outdated.  This percentage-based grid is a million times better for mobile and just as flexible.

Stuff to look at:
-  Homepage:  look at large, look at small
-  Zone Landing:  look at large, look at small
-  Zone Page:  look at large, look at small
-  Search:  look at large, look at small
-  Wiki Page:  look at large, look at small

look at small == squeeze your window width.  #ftw
