### PR TITLE
Change DocHub to Zeal

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content.html
+++ b/apps/wiki/templates/wiki/includes/document_content.html
@@ -101,7 +101,7 @@
               <a href="http://kapeli.com/dash?ref=mdn" class="offline-dialog-mac" data-title="Dash App">
                 <img src="{{ request.build_absolute_uri('/media/img/dash-app.png') }}" alt="Dash App" />
               </a>
-              <a href="https://github.com/rgarcia/dochub#runnning-locally" target="_blank" class="offline-dialog-others" data-title="DocHub">
+              <a href="http://zealdocs.org" target="_blank" class="offline-dialog-others" data-title="Zeal">
                 <i class="icon-book" style="font-size: 160px;"></i>
               </a>
             </div>


### PR DESCRIPTION
DocHub is rather abandoned and isn't that easy to setup for offline use.

This changes the link from DocHub to [Zeal](http://zealdocs.org), which should be a better alternative for Linux & Windows users.
