### PR TITLE
DO NOT MERGE - fix bug 921150 - Modify WYSIWYG scrolling behavior

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -100,9 +100,16 @@ mdn.ckeditor.redirectPattern = '{{ redirect_pattern|safe }}';
 CKEDITOR.timestamp = '{{ BUILD_ID_JS }}';
 CKEDITOR.editorConfig = function(config) {
 
-    config.extraPlugins = 'autogrow,definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler,mdn-sample-finder,mdn-maximize,mdn-redirect,youtube';
+    config.extraPlugins = 'definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler,mdn-sample-finder,mdn-maximize,mdn-redirect,youtube';
     config.removePlugins = 'link,image,tab,enterkey,table,maximize';
     config.entities = false;
+
+    if(!$('body').hasClass('translate')) {
+        config.height = (window.innerHeight - 150) + 'px';
+    }
+    else {
+        config.extraPlugins += ',autogrow';
+    }
     
     config.toolbar_MDN = [
         ['Source', 'mdnSave', 'mdnSaveExit', '-', 'PasteText', 'PasteFromWord', '-', 'SpellChecker', 'Scayt', '-', 'Find', 'Replace', '-', 'ShowBlocks'],
@@ -118,9 +125,6 @@ CKEDITOR.editorConfig = function(config) {
     config.startupFocus = true;
     config.toolbar = 'MDN';
     config.tabSpaces = 2;
-
-    var inlineHeight = CKEDITOR.inlineHeight;
-    config.autoGrow_minHeight = (!inlineHeight || inlineHeight < 150 ? 500 : inlineHeight);
     config.contentsCss = [
         mdn.mediaPath + 'css/wiki-screen.css', 
         mdn.mediaPath + 'css/wiki-edcontent.css', 

--- a/media/js/wiki_ckeditor.js
+++ b/media/js/wiki_ckeditor.js
@@ -1,59 +1,12 @@
-(function () {
-
-  // Callback functions after CKE is ready
-  var setup_ckeditor = function () {
-
-    var $head      = $('#article-head');
-    var $tools     = $('.cke_toolbox');
-    var contentTop = $('#content').offset();
-    var headHeight = $head.height();
-    var toolHeight = $tools.height();
-    var fixed = false;
-
-    // Switch header and toolbar styles on scroll to keep them on screen
-    $(document).scroll(function() {
-        var contentBottom = $('.page-meta').first().offset().top - 300; //Position of the first metadata at 300px of the top
-        if( $(this).scrollTop() >= contentTop.top  &&  $(this).scrollTop() < contentBottom )  { // If top of the window is betwen top of #content and top of metadata (first .page-meta) blocks, the header is fixed
-            if( !fixed ) {
-                fixed = true;
-                $head.css({position:'fixed', top:19, width:'95%'});
-                $tools.css({position:'fixed', top:headHeight+28, width:$('#cke_id_content').width()-11});
-                $('td.cke_top').css({ height: toolHeight+28 });
-                $('#cke_id_content').css({ marginTop: headHeight });
-            }
-        } else { // If not, header is relative
-            if( fixed ) { 
-                fixed = false;
-                $head.css({position:'relative', top:'auto', width:'auto'});
-                $tools.css({position:'relative', top:'auto', width:'auto'});
-                $('td.cke_top').css({ height: 'auto' });
-                $('#cke_id_content').css({ marginTop: 0 });
-            }
-        }
-    });
-
-    $(window).resize(function() { // Recalculate box width on resize
-      if ( fixed ) {
-        $tools.css({width:$('#cke_id_content').width()-10}); // Readjust toolbox to fit
-      }
-    });
-
-    // remove the id_content required attribute
-    $('#id_content').removeAttr('required');
-
-  };
-
-  jQuery('#id_content').each(function () {
-
-      var el = jQuery(this),
-          doc_slug = $('#id_slug').val();
-
+(function($) {
+  $('#id_content').each(function () {
+      var $el = $(this);
       if (!$('body').is('.is-template')) {
-          el.ckeditor(setup_ckeditor, {
-              customConfig : '/docs/ckeditor_config.js'
-          });
+        $el.ckeditor(function(){
+            $el.removeAttr('required');
+          }, {
+                customConfig : '/docs/ckeditor_config.js'
+        });
       }
-
   });
-
-})();
+})(jQuery);

--- a/media/js/wiki_ckeditor_translate.js
+++ b/media/js/wiki_ckeditor_translate.js
@@ -4,66 +4,45 @@
   var setup_ckeditor = function() {
 
     var $appBoxes = $('.approved .boxed'),
-      $head = $('#article-head'),
-      $transdesc = $('#trans-description'),
-      $transcont = $('#content-fields'),
       $tools = $('div.cke_toolbox'),
       $wikiArt = $('#cke_wikiArticle'),
-      contentTop = $('#content').offset(),
-      transTop = $transcont.offset(),
-      headHeight = $head.height(),
-      toolHeight = $tools.height(),
-      contentBottom = $('.page-meta').first().offset().top - 300,
+      contentTop = $('.ckeditor-container').offset().top,
       fixed = false;
-
-    $('#content-fields .approved .boxed').css({
-      paddingTop: toolHeight + 50
-    });
 
     // Switch header and toolbar styles on scroll to keep them on screen
     $(document).scroll(function() {
-      if ($(this).scrollTop() >= contentTop.top && $(this).scrollTop() < contentBottom) { // If top of the window is betwen top of #content and top of metadata (first .page-meta) blocks, the header is fixed
+
+      // If top of the window is betwen top of #content and top of metadata (first .page-meta) blocks, the header is fixed
+      var scrollTop = $(this).scrollTop();
+      if (scrollTop >= contentTop) {
+
+      	// Need to display or hide the toolbar depending on scroll position
+      	 if(scrollTop > $('.ckeditor-container').height() + 250) {
+      	 	$tools.css("display", "none");
+      	 	return; // Cut off at some point
+      	 }
+      	 else {
+      	 	$tools.css("display", "");
+      	 }
+
+      	 // Fixed position toolbar if scrolled down to the editor
+      	 // Wrapped in IF to cut down on processing
         if (!fixed) {
           fixed = true;
-          $head.css({
-            position: 'fixed',
-            top: 19,
-            width: '95%'
-          });
           $tools.css({
             position: 'fixed',
-            top: headHeight + 28,
+            top: 0,
             width: $('#cke_id_content').width() - 11
           });
-          $('#cke_id_content').css({
-            marginTop: headHeight
-          });
-          $('.approved header').hide();
-          $('.localized header').hide();
-          $('#content-fields .approved .boxed').css({
-            paddingTop: toolHeight - 40
-          });
         }
-      } else { // If not, header is relative
+
+      } else { // If not, header is relative, put it back
         if (fixed) {
           fixed = false;
-          $head.css({
-            position: 'relative',
-            top: 'auto',
-            width: 'auto'
-          });
           $tools.css({
             position: 'relative',
             top: 'auto',
             width: 'auto'
-          });
-          $('#cke_id_content').css({
-            marginTop: 0
-          });
-          $('.approved header').show();
-          $('.localized header').show();
-          $('#content-fields .approved .boxed').css({
-            paddingTop: toolHeight + 50
           });
         }
       }


### PR DESCRIPTION
So I mostly followed what was request in the ticket but we can't eliminate the scrolling behavior in the translation interface.  Anyways, here's what this does:
1.  On the "Edit" and "New" document pages, the editor is sized to the user's initial screen, so there's no scrolling behavior.
2.  On the "Translate" interface, I've simplified the existing code.  It brings a tear to my eye.
