### PR TITLE
fix bug 921150 - Modify WYSIWYG scrolling behavior

### DIFF
--- a/apps/landing/templates/landing/waffles.js
+++ b/apps/landing/templates/landing/waffles.js
@@ -1,9 +1,12 @@
 (function($) {
+	var waffles = window.mdn.waffles = {};
 	$.each({{ flags|safe }}, function() {
+		waffles[this.name] = 1;
 		try {
 			var json = $.parseJSON(this.note);
-			if(json.selector) {
-				$(json.selector).
+			var selector = json.selector;
+			if(selector) {
+				$(selector).
 					attr('data-waffle-message', json.message || gettext('BETA: Only available to testers')).
 					addClass('waffle-beta');
 			}

--- a/apps/landing/views.py
+++ b/apps/landing/views.py
@@ -159,7 +159,7 @@ def waffles(request):
 
     flag_json = []
     for flag in flags:
-        if flag.note:
+        if flag_is_active(request, flag.name):
             flag_json.append({
                 'name': str(flag.name),
                 'note': str(flag.note)

--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -100,9 +100,18 @@ mdn.ckeditor.redirectPattern = '{{ redirect_pattern|safe }}';
 CKEDITOR.timestamp = '{{ BUILD_ID_JS }}';
 CKEDITOR.editorConfig = function(config) {
 
-    config.extraPlugins = 'autogrow,definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler,mdn-sample-finder,mdn-maximize,mdn-redirect,youtube';
+    config.extraPlugins = 'definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler,mdn-sample-finder,mdn-maximize,mdn-redirect,youtube';
     config.removePlugins = 'link,image,tab,enterkey,table,maximize';
     config.entities = false;
+
+    if(window.mdn.waffles.redesign_editor && !$('body').hasClass('translate')) {
+        config.height = (window.innerHeight - 150) + 'px';
+    }
+    else {
+        config.extraPlugins += ',autogrow';
+        var inlineHeight = CKEDITOR.inlineHeight;
+        config.autoGrow_minHeight = (!inlineHeight || inlineHeight < 150 ? 500 : inlineHeight);
+    }
     
     config.toolbar_MDN = [
         ['Source', 'mdnSave', 'mdnSaveExit', '-', 'PasteText', 'PasteFromWord', '-', 'SpellChecker', 'Scayt', '-', 'Find', 'Replace', '-', 'ShowBlocks'],
@@ -118,9 +127,6 @@ CKEDITOR.editorConfig = function(config) {
     config.startupFocus = true;
     config.toolbar = 'MDN';
     config.tabSpaces = 2;
-
-    var inlineHeight = CKEDITOR.inlineHeight;
-    config.autoGrow_minHeight = (!inlineHeight || inlineHeight < 150 ? 500 : inlineHeight);
     config.contentsCss = [
         mdn.mediaPath + 'css/wiki-screen.css', 
         mdn.mediaPath + 'css/wiki-edcontent.css', 

--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -1,3 +1,8 @@
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-<script src="{{ MEDIA_URL }}js/wiki_ckeditor.js?build={{ BUILD_ID_JS }}"></script>
+
+{% if waffle.flag('redesign_editor') %}
+ <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 
+{% else %}
+  <script src="{{ MEDIA_URL }}js/wiki_ckeditor.js?build={{ BUILD_ID_JS }}"></script>
+{% endif %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -163,7 +163,11 @@
   
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-  <script src="{{ MEDIA_URL }}js/wiki_ckeditor_translate.js?build={{ BUILD_ID_JS }}"></script>
+  {% if waffle.flag('redesign_editor') %}
+   <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 
+  {% else %}
+    <script src="{{ MEDIA_URL }}js/wiki_ckeditor_translate.js?build={{ BUILD_ID_JS }}"></script>
+  {% endif %}
 
   {{ js('wiki-edit') }}
 {% endblock %}

--- a/media/redesign/js/wiki-editor.js
+++ b/media/redesign/js/wiki-editor.js
@@ -1,0 +1,78 @@
+(function($) {
+
+  // CKEditor setup method
+  var $body = $('body');
+  var setup = function() {};
+  
+  if($body.hasClass('translate')) {
+    setup = function() {
+      var $appBoxes = $('.approved .boxed');
+      var $tools = $('div.cke_toolbox');
+      var $wikiArt = $('#cke_wikiArticle');
+      var contentTop = $('.ckeditor-container').offset().top;
+      var fixed = false;
+
+      // Switch header and toolbar styles on scroll to keep them on screen
+      $(document).scroll(function() {
+
+        // If top of the window is betwen top of #content and top of metadata (first .page-meta) blocks, the header is fixed
+        var scrollTop = $(this).scrollTop();
+        if (scrollTop >= contentTop) {
+
+          // Need to display or hide the toolbar depending on scroll position
+           if(scrollTop > $('.ckeditor-container').height() + 250) {
+            $tools.css("display", "none");
+            return; // Cut off at some point
+           }
+           else {
+            $tools.css("display", "");
+           }
+
+           // Fixed position toolbar if scrolled down to the editor
+           // Wrapped in IF to cut down on processing
+          if (!fixed) {
+            fixed = true;
+            $tools.css({
+              position: 'fixed',
+              top: 0,
+              width: $('#cke_id_content').width() - 11
+            });
+          }
+
+        } else { // If not, header is relative, put it back
+          if (fixed) {
+            fixed = false;
+            $tools.css({
+              position: 'relative',
+              top: 'auto',
+              width: 'auto'
+            });
+          }
+        }
+
+        // remove the id_content required attribute
+        $('#id_content').removeAttr('required');
+      });
+
+      $(window).resize(function() { // Recalculate box width on resize
+        if (fixed) {
+          $tools.css({
+            width: $wikiArt.width() - 10
+          }); // Readjust toolbox to fit
+        }
+      });
+
+   };
+  }
+
+  // Renders the WYSIWYG editor
+  $('#id_content').each(function () {
+    var $el = $(this);
+    if (!$body.is('.is-template')) {
+      $el.removeAttr('required').ckeditor(setup, {
+        customConfig : '/docs/ckeditor_config.js'
+      });
+    }
+  });
+
+})(jQuery);


### PR DESCRIPTION
So I mostly followed what was request in the ticket but we can't eliminate the scrolling behavior in the translation interface. Anyways, here's what this does:

On the "Edit" and "New" document pages, the editor is sized to the user's initial screen, so there's no scrolling behavior.

On the "Translate" interface, I've simplified the existing code. It brings a tear to my eye.

Waffled as @openjck requested.

Supercedes https://github.com/mozilla/kuma/pull/1449
