### PR TITLE
Ensure search term is in user's desired case

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -34,8 +34,8 @@
 
       > a, .search-trigger
         compat-important(color, menu-link-color)
-        compat-important(text-transform, uppercase)
         compat-important(text-decoration, none)
+        compat-important(text-transform, uppercase)
         compat-important(font-weight, bold)
 
       > a, .search-wrap
@@ -163,7 +163,6 @@ a.persona-button
     background transparent
     border 0
     color menu-link-color
-    text-transform uppercase
     font-weight bold
     width 20px
     overflow hidden
@@ -177,6 +176,7 @@ a.persona-button
     cursor pointer
 
     set-placeholder-style(color, text-color)
+    set-placeholder-style(text-transform, uppercase)
 
   .search-trigger
     position absolute


### PR DESCRIPTION
We should simply make the placeholder uppercase like the nav items, not the search values.
