### PR TITLE
Fix bug 923631 - Faster moz menu

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -9,8 +9,8 @@
   $.fn.mozMenu = function(options) {
 
     var settings = $.extend({
-      showDelay: 500,
-      hideDelay: 500,
+      showDelay: 200,
+      hideDelay: 200,
       submenu: null,
       focusOnOpen: true,
       brickOnClick: false,


### PR DESCRIPTION
IMHO, the delay for the pop-up menu appearance is misleadingly long.

Would fix https://bugzilla.mozilla.org/show_bug.cgi?id=923631
