### PR TITLE
[bug 881792] Add Mozillians field to user profile

### DIFF
--- a/apps/devmo/models.py
+++ b/apps/devmo/models.py
@@ -85,6 +85,11 @@ class UserProfile(ModelBase):
             prefix='http://www.linkedin.com/in/',
             regex='^https?://www.linkedin.com/in/',
         )),
+        ('mozillians', dict(
+            label=_(u'Mozillians'),
+            prefix='https://mozillians.org/u/',
+            regex='^https?://mozillians.org/u/',
+        ))
     ]
 
     class Meta:


### PR DESCRIPTION
Create a Mozillians profile field for adding link to user's Mozillians
page.

Need to add icon for Mozillians when displaying the link on user profile.

Signed-off-by: Kaustav Das Modak kaustav.dasmodak@yahoo.co.in
