### PR TITLE
[fix bug 915146] Fix Compatible Table tab styles

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -31,6 +31,14 @@ article
     &:hover, &:focus
       text-decoration none
 
+  .htab
+
+    a
+      text-decoration none
+
+      &:hover, &:focus
+        text-decoration underline
+
 .document-head
   position relative
   clear both


### PR DESCRIPTION
Change Compatible Table tab styles to have no underline normally and
have underline on hover.
