### PR TITLE
Ensure long titles don't elongate demo widths on homepage

### DIFF
--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -275,6 +275,8 @@
     float left
     font-size smaller-font-size
     font-style italic
+    overflow hidden
+    width 194px
 
     img
       border 6px solid #fff


### PR DESCRIPTION
As of right now, the homepage has a really long demo title on it, making one item look way longer. This fixes said issue.
