### PR TITLE
use custom GA var to segment beta testers

### DIFF
--- a/templates/includes/google_analytics.html
+++ b/templates/includes/google_analytics.html
@@ -3,6 +3,9 @@
 
   var _gaq = _gaq || [];
   _gaq.push(['_setAccount', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}']);
+  {% if waffle.flag('redesign') %}
+  _gaq.push(['_setCustomVar', 6, 'Redesign', 'Yes', 1]);
+  {% endif %}
   _gaq.push(['_trackPageview']);
 
   (function(a, d) {


### PR DESCRIPTION
Adding a custom 'Redesign' = 'Yes' variable to all Google Analytics requests so we can measure engagement impact.
