### PR TITLE
Add an arrow to main nav items to just show dropdown

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -27,9 +27,10 @@
       var initialized;
 
       // Brick on click?
-      if(settings.brickOnClick) {
+      var brick = settings.brickOnClick;
+      if(brick) {
         $self.on('click', function(e) {
-          e.preventDefault();
+          if(typeof brick != 'function' || brick(e)) e.preventDefault();
         });
       }
 

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -12,7 +12,11 @@ document.documentElement.className += ' js';
   */
   (function() {
     var $mainItems = $('#main-nav > ul > li');
-    $mainItems.find('> a').mozMenu();
+    $mainItems.find('> a').mozMenu({
+      brickOnClick: function(e) {
+        return e.target.tagName == 'I';
+      }
+    });
     $mainItems.find('.submenu').mozKeyboardNav();
   })();
 

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -32,6 +32,9 @@
       vendorize(transition-duration, default-animation-duration)
       vendorize(transition-delay, default-animation-duration)
 
+      > a i
+        display none
+
       > a, .search-trigger
         compat-important(color, menu-link-color)
         compat-important(text-decoration, none)
@@ -227,6 +230,16 @@ footer
   label
     padding-right 4px
 
+
+/* tablet updates */
+@media media-query-tablet
+  #main-nav
+    > ul
+      > li
+        > a
+          i
+            display inline-block
+            font-size larger-font-size
 
 
 /* mobile updates */

--- a/templates/base.html
+++ b/templates/base.html
@@ -138,7 +138,7 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
 
     <a href="{{ url('home') }}" class="logo">{{ _('Mozilla Developer Network') }}</a>
 
-    <nav id="main-nav"><ul><li><a href="javascript:;">{{ _('Zones') }}</a>
+    <nav id="main-nav"><ul><li><a href="javascript:;">{{ _('Zones') }}<i class="icon-caret-down"></i></a>
 
         <div class="submenu submenu-single">
           <div class="submenu-column">
@@ -149,7 +149,7 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
             </ul>
           </div>
         </div>
-      </li><li><a href="{{ devmo_url('Web') }}">{{ _('Web Platform') }}</a>
+      </li><li><a href="{{ devmo_url('Web') }}">{{ _('Web Platform') }}<i class="icon-caret-down"></i></a>
 
         <div class="submenu">
           <div class="submenu-column">


### PR DESCRIPTION
This is sweet.  If we're on tablet or mobile, a "v" arrow will display next to main menu items that have subnav.  If they click the link, they go to the link target.  If they click the "v" next to it, it shows the submenu.  Yay.
