### PR TITLE
 Fix iPad/WebKit overflow on zone landing pages

### DIFF
--- a/media/redesign/stylus/globals.styl
+++ b/media/redesign/stylus/globals.styl
@@ -1,7 +1,6 @@
 @import 'vars'
 
 html
-  overflow-x hidden
   background #fff
 
 body

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -195,6 +195,7 @@ a.persona-button
 
 main
   background #fff
+  overflow-x hidden
   
   > .center 
     padding-top first-content-top-padding


### PR DESCRIPTION
Found this problem on iPad, and can be reproduced in Chrome.  Go here (https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS) and squeeze the page a bit.  Scroll to the right... :(  .  Adding overflow-x:hidden on the main element fixes it all.
