### PR TITLE
Fix reverse column 1% offset within wiki article pages

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -24,6 +24,8 @@
       margin-right 0
 
   &.column-container-reverse
+    margin-left -1%
+
     > [class^='column-']
       float right
 


### PR DESCRIPTION
Since we work on a 99% grid system, if we reverse that with right floats, there's 1% left over on the right, which looks weird.  This fixes that.
