### PR TITLE
Additional instructions for manual installation

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -210,6 +210,17 @@ What’s next?
 
 See :doc:`development <development>` for further instructions.
 
+Some site funcationaly require waffle flags.  Waffle flags include:
+
+-  ``kumaediting``:  Allows creation, editing, and translating of documents
+-  ``page_move``:  Allows moving of documents
+-  ``revision-dashboard-newusers``:  Allows searching of new users through the revision dashboard
+-  ``events_map``:  Allows display of map on the events page
+-  ``elasticsearch``:  Enables elastic search for site search
+-  ``redesign``:  Enables the latest MDN redesign styles and layouts (run ``./scripts/compile-stylesheets`` to compile stylesheets)
+
+To create or modify waffle flags, visit "/admin/" and click the "Waffle" link.
+
 Last Steps
 ==========
 


### PR DESCRIPTION
Manual installation instructions do not mention anything about waffle flags, this commit fixes that and adds instructions for compiling stylesheets.
