### PR TITLE
Fix left margin on tablet and remove sidebar controls

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -66,7 +66,11 @@
 
 /*  Tablet grid width */
 @media media-query-tablet
-
+  
+  .column-container
+    &.column-container-reverse
+      margin-left 0
+  
   .center
     max-width 1000px
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -487,12 +487,6 @@ span.cke_skin_kuma
     float none
     padding-bottom (grid-spacing * 2)
 
-
-
-
-
-@media media-query-mobile
-  
   #quick-links-toggle,  #wiki-controls
     display none
 


### PR DESCRIPTION
So my margin fix looks crap on tablet, so I fix it.  Also, no reason to show the "show sidebar/hide sidebar" stuff on tablets as they're in different places in the design on that platform.
