### PR TITLE
fix bug 926616 - Move overflow prevention to only place it's used, zone

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -198,7 +198,6 @@ a.persona-button
 
 main
   background #fff
-  overflow-x hidden
   
   > .center 
     padding-top first-content-top-padding

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -32,6 +32,9 @@
 
 .zone-landing
 
+  main
+    overflow-x hidden
+
   h1
     color #fff
     @extend .column-6


### PR DESCRIPTION
Prevents a scrollbar duplication on the localization dashboard. I originally placed that property on `main` for all to prevent issues of overflow on the site, but since it had this side effect, I moved it into the zone stylesheet since it only exists there now.
