### PR TITLE
fix bug 926896 - Prevent header misalignment in the wiki

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -24,7 +24,6 @@
       margin-right 0
 
   &.column-container-reverse
-    margin-left -1%
 
     > [class^='column-']
       float right


### PR DESCRIPTION
This margin offset is causing a side-effect of header misalignment, so I'll remove and try to find a better solution for the other niggle it causes.
