### PR TITLE
fix bug 926858 - Remove 'last reviewed' text from wiki pages

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -232,12 +232,6 @@
                   {{ _('Last updated by:') }}  
                   <a href="{{ url('devmo.views.profile_view', username=current_revision.creator) }}">{{ current_revision.creator }}</a>, 
                   {{ datetimeformat(current_revision.created, format='datetime') }}
-                  {% if current_revision.reviewer and current_revision.reviewed %}
-                    <br />
-                    {{ _('Last reviewed by:') }}  
-                    <a href="{{ url('devmo.views.profile_view', username=current_revision.reviewer) }}">{{ current_revision.reviewer }}</a>, 
-                    {{ datetimeformat(current_revision.reviewed, format='datetime') }}
-                  {% endif %}
                 {% endif %}
               </p>
             </div>


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=926858
