### PR TITLE
Make the WYSIWYG toolbar scroll with the editor in all cases

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -103,15 +103,10 @@ CKEDITOR.editorConfig = function(config) {
     config.extraPlugins = 'definitionlist,mdn-buttons,mdn-link,mdn-syntaxhighlighter,mdn-keystrokes,mdn-attachments,mdn-image,mdn-enterkey,mdn-wrapstyle,mdn-table,tablesort,mdn-sampler,mdn-sample-finder,mdn-maximize,mdn-redirect,youtube';
     config.removePlugins = 'link,image,tab,enterkey,table,maximize';
     config.entities = false;
-
-    if(window.mdn.waffles.redesign_editor && !$('body').hasClass('translate')) {
-        config.height = (window.innerHeight - 150) + 'px';
-    }
-    else {
-        config.extraPlugins += ',autogrow';
-        var inlineHeight = CKEDITOR.inlineHeight;
-        config.autoGrow_minHeight = (!inlineHeight || inlineHeight < 150 ? 500 : inlineHeight);
-    }
+    config.extraPlugins += ',autogrow';
+  
+    var inlineHeight = CKEDITOR.inlineHeight;
+    config.autoGrow_minHeight = (!inlineHeight || inlineHeight < 150 ? 500 : inlineHeight);
     
     config.toolbar_MDN = [
         ['Source', 'mdnSave', 'mdnSaveExit', '-', 'PasteText', 'PasteFromWord', '-', 'SpellChecker', 'Scayt', '-', 'Find', 'Replace', '-', 'ShowBlocks'],

--- a/media/redesign/js/wiki-editor.js
+++ b/media/redesign/js/wiki-editor.js
@@ -2,14 +2,12 @@
 
   // CKEditor setup method
   var $body = $('body');
-  var setup = function() {};
-  
-  if($body.hasClass('translate')) {
-    setup = function() {
+  var setup = function() {
       var $appBoxes = $('.approved .boxed');
       var $tools = $('div.cke_toolbox');
       var $wikiArt = $('#cke_wikiArticle');
-      var contentTop = $('.ckeditor-container').offset().top;
+      var $container = $('.ckeditor-container');
+      var contentTop = $container.offset().top;
       var fixed = false;
 
       // Switch header and toolbar styles on scroll to keep them on screen
@@ -20,12 +18,12 @@
         if (scrollTop >= contentTop) {
 
           // Need to display or hide the toolbar depending on scroll position
-           if(scrollTop > $('.ckeditor-container').height() + 250) {
-            $tools.css("display", "none");
+           if(scrollTop > $container.height() + contentTop - 200 /* offset to ensure toolbar doesn't reach content bottom */) {
+            $tools.css('display', 'none');
             return; // Cut off at some point
            }
            else {
-            $tools.css("display", "");
+            $tools.css('display', '');
            }
 
            // Fixed position toolbar if scrolled down to the editor
@@ -61,9 +59,7 @@
           }); // Readjust toolbox to fit
         }
       });
-
    };
-  }
 
   // Renders the WYSIWYG editor
   $('#id_content').each(function () {


### PR DESCRIPTION
The latest bandaid for WYSIWYG, but sheppy likes it so we'll go with it.
