### PR TITLE
Fix masthead paragraph margin from overflowing

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -79,6 +79,7 @@
     p
       @extend .larger
       font-weight light-font-weight
+      margin-right 50px
 
   .zone-image
     position absolute
@@ -156,6 +157,12 @@
 
       .zone-image
         opacity 0.2
+
+  .zone-landing-header
+
+    .masthead-text
+      p
+        margin-right 0
     
 /* right to left */
 .html-rtl


### PR DESCRIPTION
Masthead paragraph was going under masthead image in
https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS. This patch
fixes the behaviour.

Before: http://i.imgur.com/p4AtXGu.png
After: http://i.imgur.com/XD0oMba.png

Signed-off-by: Kaustav Das Modak kaustav.dasmodak@yahoo.co.in
