### PR TITLE
Update docs to append to, not replace, /etc/hosts

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -69,7 +69,7 @@ Getting up and running
 
 #. Add some hostnames to the end of your hosts file with this shell command::
 
-       echo '192.168.10.55 developer-local.allizom.org mdn-local.mozillademos.org' | sudo tee /etc/hosts
+       echo '192.168.10.55 developer-local.allizom.org mdn-local.mozillademos.org' | sudo tee -a /etc/hosts
 
 #. Everything should be working now, from the host side::
 


### PR DESCRIPTION
The previous command (sudo tee /etc/hosts) completely replaces /etc/hosts with
standard input. The -a option (sudo tee -a /etc/hosts) ensures standard input is
only appended to /etc/hosts.
