### PR TITLE
mime_types now behaves as wrapper for mimetypes.

### DIFF
--- a/lib/mime_types.py
+++ b/lib/mime_types.py
@@ -1,10 +1,8 @@
+import mimetypes
+
 # Mime types used on MDN
 MIME_TYPES = {
-    'image/gif': '.gif',
     'image/jpeg': '.jpeg, .jpg, .jpe',
-    'image/png': '.png',
-    'image/svg+xml': '.svg',
-    'text/html': '.xml',
     'image/vnd.adobe.photoshop': '.psd',
 }
 
@@ -12,4 +10,4 @@ def guess_extension(mime_type):
   if mime_type in MIME_TYPES:
     return MIME_TYPES[mime_type]
   else:
-    return None
+    return mimetypes.guess_extension(mime_type)


### PR DESCRIPTION
mimetypes does not allow overwriting stored values (stored in
mimetypes.knownfiles). This wrapper allows us to define our own mappings and
fallback on mimetypes if mime type is not found.
