### PR TITLE
fix bug 915314: Use preformatted styling for code in script warning messages

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -255,7 +255,6 @@ div.bug > *:last-child, div.warning > *:last-child
   compat-only(color, text-color)
 
   pre
-    white-space normal !important
     padding (grid-spacing / 2) !important
     background none repeat scroll 0 0 rgba(255, 255, 255, 0.7) !important
 


### PR DESCRIPTION
This seems to do the trick in allowing the Kumascript errors to remain pre-formatted. Not sure if this breaks other styles though.
