### PR TITLE
fix bug 927569 - Ensure right column has width when TOC becomes fixed

### DIFF
--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -101,7 +101,6 @@
         var scroll = window.scrollY;
         var maxHeight = window.innerHeight - parseInt($toc.css('padding-top'), 10) - parseInt($toc.css('padding-bottom'), 10);
         
-        console.log($toc.css('pointer-events'));
         if(scroll > tocOffset && $toggler.css('pointer-events') == 'none') {
           $toc.css({
             width: $toc.css('width'),

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -126,6 +126,9 @@ article
   @extend .smaller
   color #777
 
+#wiki-right
+  min-height 1px /* ensures that when TOC becomes fixed, the column has width */
+
 #toc
   compat-only(margin-left, 0)
   compat-only(font-size, base-font-size)


### PR DESCRIPTION
If the TOC is the only item in the sidebar, and the element becomes fixed, the sidebar loses width.  This prevents that.
