### PR TITLE
Update Stylus stylesheets with CSS-like syntax

### DIFF
--- a/media/redesign/stylus/classes.styl
+++ b/media/redesign/stylus/classes.styl
@@ -1,57 +1,71 @@
 /* real page content displays */
-.text-content
-  table
-    border-collapse collapse
-    border solid #e0e0dc
-    border-width 1px 0 0 1px
-    margin-bottom content-block-margin
+.text-content {
+  table {
+    border-collapse: collapse;
+    border: solid #e0e0dc;
+    border-width: 1px 0 0 1px;
+    margin-bottom: content-block-margin;
+  }
 
-  td, th
-    border solid #e0e0dc
-    border-width 0 1px 1px 0
-    padding 6px
-    text-align start
+  td, th {
+    border: solid #e0e0dc;
+    border-width: 0 1px 1px 0;
+    padding: 6px;
+    text-align: start;
+  }
 
-  thead th
-    background #f3f3ef
+  thead th {
+    background: #f3f3ef;
+  }
 
-  blockquote
-    padding 0 25px
-    border-left 5px solid #ccc
-    margin-bottom content-block-margin
+  blockquote {
+    padding: 0 25px;
+    border-left: 5px solid #ccc;
+    margin-bottom: content-block-margin;
+  }
 
-  ul
-    list-style disc
+  ul {
+    list-style: disc;
 
-    ul
-      list-style circle
+    ul {
+      list-style: circle;
+    }
+  }
 
-  ul, ol
-    padding-left (grid-spacing * 2)
-    margin-bottom content-block-margin
+  ul, ol {
+    padding-left: (grid-spacing * 2);
+    margin-bottom: content-block-margin;
+  }
 
-  ol
-    list-style-type decimal
+  ol {
+    list-style-type: decimal;
+  }
 
-  dt
-    font-style normal
-    font-weight bold
+  dt {
+    font-style: normal;
+    font-weight: bold;
+  }
 
-  dd
-    margin-bottom .5em
-    padding-left grid-spacing
+  dd {
+    margin-bottom: .5em;
+    padding-left: grid-spacing;
+  }
 
-  pre
-    border 0
-    background #f6f6f2
-    padding 15px
-    overflow auto
-    font 100% 'Courier New', 'Andale Mono', monospace
-    margin-bottom content-block-margin
+  pre {
+    border: 0;
+    background: #f6f6f2;
+    padding: 15px;
+    overflow: auto;
+    font: 100% 'Courier New', 'Andale Mono', monospace;
+    margin-bottom: content-block-margin;
+  }
 
-  code
-    font 100% 'Courier New', 'Andale Mono', monospace
-    font-weight inherit
+  code {
+    font: 100% 'Courier New', 'Andale Mono', monospace;
+    font-weight: inherit;
+  }
 
-  caption
-    font-weight bold
+  caption {
+    font-weight: bold;
+  }
+}

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -2,160 +2,194 @@
 @import 'mixins'
 
 /* togglers */
-.toggler
-  position relative
+.toggler {
+  position: relative;
 
-  i
-    position absolute
-    right 10px
-    top 3px
-    color #d4dde4
+  i {
+    position: absolute;
+    right: 10px;
+    top: 3px;
+    color: #d4dde4;
+  }
+}
 
-.toggle-container.closed
-  display none
+.toggle-container.closed {
+  display: none;
+}
 
 
 /* table of contents; uses toggler */
-#toc
-  background light-background-color
-  compat-important(padding, grid-spacing (grid-spacing * .75))
+#toc {
+  background: light-background-color;
+  compat-important(padding, grid-spacing (grid-spacing * .75));
 
-  > ol
-    compat-important(padding-left, (grid-spacing + (grid-spacing/2)))
-    compat-important(font-size, smaller-font-size)
+  > ol {
+    compat-important(padding-left, (grid-spacing + (grid-spacing/2)));
+    compat-important(font-size, smaller-font-size);
+  }
 
-  a.title
-    position relative
-    &.title
-      text-decoration none
+  a.title {
+    position: relative;
+    &.title {
+      text-decoration: none;
+    }
+  }
 
-  ol
-    counter-reset toc
+  ol {
+    counter-reset: toc;
+  }
 
-  li
-    position relative
-    counter-increment toc
-    padding-top grid-spacing
+  li {
+    position: relative;
+    counter-increment: toc;
+    padding-top: grid-spacing;
 
-    &:before
-      content counters(toc, '.')
-      text-align right
-      position absolute
-      left -(grid-spacing + (grid-spacing/2))
-      color #484848
+    &:before {
+      content: counters(toc, '.');
+      text-align: right;
+      position: absolute;
+      left: -(grid-spacing + (grid-spacing/2));
+      color: #484848;
+    }
+  }
 
-  reverse-link-decoration()
+  reverse-link-decoration();
+}
 
 /* subnav */
-.subnav
-  .toggler, > ol > li > a
-    padding grid-spacing (2 * grid-spacing) grid-spacing grid-spacing
-    border-bottom 1px dotted #d4dde4
-    text-transform uppercase
-    display block
-    
-  ol ol
-    display none /* prevents flash of unstyled content */
+.subnav {
+  .toggler, > ol > li > a {
+    padding: grid-spacing (2 * grid-spacing) grid-spacing grid-spacing;
+    border-bottom: 1px dotted #d4dde4;
+    text-transform: uppercase;
+    display: block;
+  }
 
-  .toggleable.current, > ol > li.current
-    background light-background-color
+  ol ol {
+    display: none; /* prevents flash of unstyled content */
+  }
 
-  i
-    top (grid-spacing + 3px)
-    right grid-spacing
+  .toggleable.current, > ol > li.current {
+    background: light-background-color;
+  }
 
-  .toggle-container
-    a
-      @extend .smaller
-      display block
-      padding list-item-spacing grid-spacing
+  i {
+    top: (grid-spacing + 3px);
+    right: grid-spacing;
+  }
 
-    .toggleable
-      background #e9eef1
+  .toggle-container {
+    a {
+      @extend .smaller;
+      display: block;
+      padding: list-item-spacing grid-spacing;
+    }
 
-      .toggler
-        @extend .title
-        font-weight normal
-        padding-top (grid-spacing / 2)
-        padding-bottom (grid-spacing / 2)
-        border 0
+    .toggleable {
+      background: #e9eef1;
 
-        i
-          top (grid-spacing / 2)
+      .toggler {
+        @extend .title;
+        font-weight: normal;
+        padding-top: (grid-spacing / 2);
+        padding-bottom: (grid-spacing / 2);
+        border: 0;
 
-      .toggle-container a
-        padding-left grid-spacing + (grid-spacing / 2)
+        i {
+          top: (grid-spacing / 2);
+        }
+      }
 
-    ol .current a
-      position relative
-      color text-color
+      .toggle-container a {
+        padding-left: grid-spacing + (grid-spacing / 2);
+      }
+    }
 
-      generate-arrow()
+    ol .current a {
+      position: relative;
+      color: text-color;
 
-      &:before
-        border-right-color #fff
-        position absolute
-        top 20%
-        right 0
+      generate-arrow();
 
-  reverse-link-decoration()
+      &:before {
+        border-right-color: #fff;
+        position: absolute;
+        top: 20%;
+        right: 0;
+      }
+    }
+  }
+
+  reverse-link-decoration();
+}
 
 /* Submenu's, like the main menu and settings menu */
-component-submenu-method(menu-width, num-columns, background-color, arrow-border-color)
-  position absolute
-  padding grid-spacing
-  background background-color
-  display none
-  width menu-width
+component-submenu-method(menu-width, num-columns, background-color, arrow-border-color) {
+  position: absolute;
+  padding: grid-spacing;
+  background: background-color;
+  display: none;
+  width: menu-width;
 
-  .submenu-column
-    col-width = ((menu-width - (num-columns * grid-spacing) - 1) / num-columns)
+  .submenu-column {
+    col-width = ((menu-width - (num-columns * grid-spacing) - 1) / num-columns);
 
-    padding-right grid-spacing
-    vertical-align text-top
-    margin-right grid-spacing
-    border-right 1px dotted #d4dde4
-    width col-width
+    padding-right: grid-spacing;
+    vertical-align: text-top;
+    margin-right: grid-spacing;
+    border-right: 1px dotted #d4dde4;
+    width: col-width;
 
-    &:last-child
-      margin-right 0
-      border-right 0
-      padding-right 0
+    &:last-child {
+      margin-right: 0;
+      border-right: 0;
+      padding-right: 0;
+    }
+  }
 
-  a
-    @extend .smaller
-    padding 5px 0
-    display block
+  a {
+    @extend .smaller;
+    padding: 5px 0;
+    display: block;
+  }
 
-  reverse-link-decoration()
+  reverse-link-decoration();
 
-  generate-arrow()
+  generate-arrow();
 
-  &:before
-    border-bottom-color background-color
-    position absolute
-    z-index 2
+  &:before {
+    border-bottom-color: background-color;
+    position: absolute;
+    z-index: 2;
+  }
 
-  &:after
-    border-bottom-color arrow-border-color
-    position absolute
-    z-index 1
-
+  &:after {
+    border-bottom-color: arrow-border-color;
+    position: absolute;
+    z-index: 1;
+  }
+}
 
 
 /* rtl */
-.html-rtl
-  .toggler
-    i
-      left 10px
-      right auto
+.html-rtl {
+  .toggler {
+    i {
+      left: 10px;
+      right: auto;
+    }
+  }
 
-  #toc
-    > ol
+  #toc {
+    > ol {
       compat-important(padding-left, 0);
-      compat-important(padding-right, (grid-spacing + (grid-spacing/2)))
+      compat-important(padding-right, (grid-spacing + (grid-spacing/2)));
+    }
 
-    li:before
-      text-align left
-      right -(grid-spacing + (grid-spacing/2))
-      left auto
+    li:before {
+      text-align: left;
+      right: -(grid-spacing + (grid-spacing/2));
+      left: auto;
+    }
+  }
+}

--- a/media/redesign/stylus/demo-studio.styl
+++ b/media/redesign/stylus/demo-studio.styl
@@ -2,55 +2,70 @@
 @import 'mixins'
 @import 'grid'
 
-html
-  background url('/media/img/bg-content.png') repeat fixed 0% 0% #f6f6f1
+html {
+  background: url('/media/img/bg-content.png') repeat fixed 0% 0% #f6f6f1;
+}
 
-.section-demos
-  background #c0c4c8
-  min-width 0
+.section-demos {
+  background: #c0c4c8;
+  min-width: 0;
 
-  use-white-logo()
+  use-white-logo();
 
-  main
-    background transparent
+  main {
+    background: transparent;
+  }
 
-  &:not(.devderby) 
-    override-main-nav-color(#fff)
+  &:not(.devderby) {
+    override-main-nav-color(#fff);
 
-    #main-header
+    #main-header {
 
-      .search-wrap
-        background-color rgba(255, 255, 255, 0.2)
+      .search-wrap {
+        background-color: rgba(255, 255, 255, 0.2);
 
-        &, input, .search-trigger
-          color #fff !important
+        &, input, .search-trigger {
+          color: #fff !important;
+        }
+      }
+    }
+  }
 
 
   /* dev derby landing - legacy offsets */
-  &.devderby.landing
+  &.devderby.landing {
 
-    main 
-      /* background #eaeff2 */
+    main {
+      /* background: #eaeff2; */
 
-      .center
-        max-width 980px
+      .center {
+        max-width: 980px;
+      }
+    }
 
-    .main, .sub
-      float left
+    .main, .sub {
+      float: left;
+    }
 
-    .main
-      @extend .column-main
+    .main {
+      @extend .column-main;
+    }
 
-    .sub
-      @extend .column-strip
+    .sub {
+      @extend .column-strip;
+    }
 
-    #challenge-prizes
-      padding 0
-      
+    #challenge-prizes {
+      padding: 0;
+    }
+  }
 
   /* remove ugly button styles */
-  .button, button
-    compat-important(box-shadow, none)
+  .button, button {
+    compat-important(box-shadow, none);
+  }
+}
 
-#demostudio.landing, #demostudio.detail
-  compat-important(background-position, center 0px)
+#demostudio.landing, #demostudio.detail {
+  compat-important(background-position, center 0px);
+}

--- a/media/redesign/stylus/fonts.styl
+++ b/media/redesign/stylus/fonts.styl
@@ -1,69 +1,76 @@
-@font-face
-  font-family 'Open Sans Light'
-  src url('/media/redesign/fonts/OpenSans-Light-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans Light';
+  src: url('/media/redesign/fonts/OpenSans-Light-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-Light-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-Light-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-Light-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg')
-  font-weight normal
-  font-style normal
+     url('/media/redesign/fonts/OpenSans-Light-webfont.svg#OpenSansLight') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
 
-@font-face
-  font-family 'Open Sans Light'
-  src url('/media/redesign/fonts/OpenSans-Regular-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans Light';
+  src: url('/media/redesign/fonts/OpenSans-Regular-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-Regular-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg')
-  font-weight bold
-  font-style normal
+     url('/media/redesign/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
+  font-weight: bold;
+  font-style: normal;
+}
 
-@font-face
-  font-family 'Open Sans Light'
-  src url('/media/redesign/fonts/OpenSans-LightItalic-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-LightItalic-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans Light';
+  src: url('/media/redesign/fonts/OpenSans-LightItalic-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-LightItalic-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-LightItalic-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-LightItalic-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-LightItalic-webfont.svg#OpenSansRegular') format('svg')
-  font-weight normal
-  font-style italic
+     url('/media/redesign/fonts/OpenSans-LightItalic-webfont.svg#OpenSansRegular') format('svg');
+  font-weight: normal;
+  font-style: italic;
+}
 
-@font-face
-  font-family 'Open Sans'
-  src url('/media/redesign/fonts/OpenSans-Regular-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans';
+  src: url('/media/redesign/fonts/OpenSans-Regular-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-Regular-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-Regular-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-Regular-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg')
-  font-weight normal
-  font-style normal
+     url('/media/redesign/fonts/OpenSans-Regular-webfont.svg#OpenSansRegular') format('svg');
+  font-weight: normal;
+  font-style: normal;
+}
 
-@font-face
-  font-family 'Open Sans'
-  src url('/media/redesign/fonts/OpenSans-Semibold-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans';
+  src: url('/media/redesign/fonts/OpenSans-Semibold-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-Semibold-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-Semibold-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-Semibold-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg')
-  font-weight bold
-  font-style normal
+     url('/media/redesign/fonts/OpenSans-Semibold-webfont.svg#OpenSansSemibold') format('svg');
+  font-weight: bold;
+  font-style: normal;
+}
 
-@font-face
-  font-family 'Open Sans'
-  src url('/media/redesign/fonts/OpenSans-Italic-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-Italic-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans';
+  src: url('/media/redesign/fonts/OpenSans-Italic-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-Italic-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-Italic-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-Italic-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-Italic-webfont.svg#OpenSansItalic') format('svg')
-  font-weight normal
-  font-style italic
+     url('/media/redesign/fonts/OpenSans-Italic-webfont.svg#OpenSansItalic') format('svg');
+  font-weight: normal;
+  font-style: italic;
+}
 
-@font-face
-  font-family 'Open Sans Extra Bold'
-  src url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.eot')
-  src url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.eot?#iefix') format('embedded-opentype'),
+@font-face {
+  font-family: 'Open Sans Extra Bold';
+  src: url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.eot');
+  src: url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.eot?#iefix') format('embedded-opentype'),
      url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.woff') format('woff'),
      url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.ttf') format('truetype'),
-     url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.svg#OpenSansSemibold') format('svg')
-  font-weight bold
-  font-style normal
+     url('/media/redesign/fonts/OpenSans-ExtraBold-webfont.svg#OpenSansSemibold') format('svg');
+  font-weight: bold;
+  font-style: normal;
+}

--- a/media/redesign/stylus/globals.styl
+++ b/media/redesign/stylus/globals.styl
@@ -1,9 +1,11 @@
 @import 'vars'
 
-html
-  background #fff
+html {
+  background: #fff;
+}
 
-body
-  font 14px/1.5 site-font-family
-  color text-color
-  create-gradient-background(header-background-color)
+body {
+  font: 14px/1.5 site-font-family;
+  color: text-color;
+  create-gradient-background(header-background-color);
+}

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -1,84 +1,110 @@
 @import 'vars'
 @import 'mixins'
 
-.center
-  margin 0 auto
-  position relative
-  max-width 1220px
-  padding-left 10px
-  padding-right 10px
+.center {
+  margin: 0 auto;
+  position: relative;
+  max-width: 1220px;
+  padding-left: 10px;
+  padding-right: 10px;
+}
 
 /* Column helpers for the grids to be generated */
-.column-closed
-  display none
-  
+.column-closed {
+  display: none;
+}
+
 /* This is a "helper" which automatically formats its column children, clears the floats afterward, removes margin from last item */
-.column-container
-  @extend .clear
+.column-container {
+  @extend .clear;
 
-  > [class^='column-']
-    margin-right 3%
-    float left
+  > [class^='column-'] {
+    margin-right: 3%;
+    float: left;
 
-    &:last-child
-      margin-right 0
+    &:last-child {
+      margin-right: 0;
+    }
+  }
 
-  &.column-container-reverse
+  &.column-container-reverse {
 
-    > [class^='column-']
-      float right
+    > [class^='column-'] {
+      float: right;
 
-      &:first-child
-        margin-right 0
+      &:first-child {
+        margin-right: 0;
+      }
 
-      &:last-child
-        margin-right 3%
-
+      &:last-child {
+        margin-right: 3%;
+      }
+    }
+  }
+}
 
 /*  Column definitions */
-.column-1
-  width 5.5%
-.column-2
-  width 14%
-.column-3, .column-strip, .column-quarter
-  width 22.5%
-.column-4, .column-third
-  width 31%
-.column-5
-  width 39.5%
-.column-6, .column-half
-  width 48%
-.column-7
-  width 56.5%
-.column-8
-  width 65%
-.column-9, .column-main
-  width 73.5%
-.column-10 
-  width 82%
-.column-11 
-  width 90.5%
-.column-12, .column-all
-  width 99%
-  margin 0
-  float none
+.column-1 {
+  width: 5.5%;
+}
+.column-2 {
+  width: 14%;
+}
+.column-3, .column-strip, .column-quarter {
+  width: 22.5%;
+}
+.column-4, .column-third {
+  width: 31%;
+}
+.column-5 {
+  width: 39.5%;
+}
+.column-6, .column-half {
+  width: 48%;
+}
+.column-7 {
+  width: 56.5%;
+}
+.column-8 {
+  width: 65%;
+}
+.column-9, .column-main {
+  width: 73.5%;
+}
+.column-10 {
+  width: 82%;
+}
+.column-11 {
+  width: 90.5%;
+}
+.column-12, .column-all {
+  width: 99%;
+  margin: 0;
+  float: none;
+}
 
 /*  Tablet grid width */
-@media media-query-tablet
-  
-  .column-container
-    &.column-container-reverse
-      margin-left 0
-  
-  .center
-    max-width 1000px
+@media media-query-tablet {
+
+  .column-container {
+    &.column-container-reverse {
+      margin-left: 0;
+    }
+  }
+
+  .center {
+    max-width: 1000px;
+  }
+}
 
 /* Mobile phone grid settings
      Disabled for now as not required for launch
- 
-@media media-query-mobile
 
-  .center, .column-1, .column-2, .column-3, .column-4, .column-5, .column-6, .column-7, .column-8, .column-9, .column-10, .column-11
-    float  none
-    width 99%
+@media media-query-mobile {
+
+  .center, .column-1, .column-2, .column-3, .column-4, .column-5, .column-6, .column-7, .column-8, .column-9, .column-10, .column-11 {
+    float:  none;
+    width: 99%;
+  }
+}
 */

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -2,385 +2,480 @@
 @import 'mixins'
 @import 'grid'
 
-#home
-  create-home-gradient-background(#00539f)
-  remove-main-spacing()
-  use-white-logo()
+#home {
+  create-home-gradient-background(#00539f);
+  remove-main-spacing();
+  use-white-logo();
 
   /* general structure adjustments */
-  #main-header
-    background none
-    border-bottom-color rgba(255, 255, 255, 0.2)
+  #main-header {
+    background: none;
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+  }
 
   /* update main nav menu color */
-  override-main-nav-color(#fff)
+  override-main-nav-color(#fff);
 
-  .main-nav-search
-    display none
+  .main-nav-search {
+    display: none;
+  }
 
-   .home-callouts
-    background #4d4e53
+  .home-callouts {
+    background: #4d4e53;
+  }
 
-  main
-    background transparent
+  main {
+    background: transparent;
+  }
 
   /* shared spacing in prominent block*/
-  .home-masthead, .home-hacks, .home-demos, .home-contribute
-    padding first-content-top-padding 0
+  .home-masthead, .home-hacks, .home-demos, .home-contribute {
+    padding: first-content-top-padding 0;
+  }
 
   /* masthead */
-  .home-masthead
+  .home-masthead {
 
-    h1
-      width 60%
+    h1 {
+      width: 60%;
+    }
 
-    h1
-      color #fff
-      margin-bottom 0 
-      margin 0 auto
+    h1 {
+      color: #fff;
+      margin-bottom: 0;
+      margin: 0 auto;
 
-      span
-        padding-left 20%
-        display block
+      span {
+        padding-left: 20%;
+        display: block;
+      }
+    }
 
-    .home-search-form
-      padding (grid-spacing * 2) 0
+    .home-search-form {
+      padding: (grid-spacing * 2) 0;
 
-      input
-        @extend .big-search
-        color #fff
-        set-placeholder-style(color, #fff)
+      input {
+        @extend .big-search;
+        color: #fff;
 
-  .home-features
-    &, a
-      color #fff
+        set-placeholder-style(color, #fff);
+      }
+    }
+  }
 
-    a
-      text-decoration underline
+  .home-features {
+    &, a {
+      color: #fff;
+    }
 
-    h3
-      @extend .larger
-      font-weight bold
-      font-family 'Open Sans Extra Bold', sans-serif
+    a {
+      text-decoration: underline;
+    }
 
-    li
-      padding 4px 0
+    h3 {
+      @extend .larger;
+      font-weight: bold;
+      font-family: 'Open Sans Extra Bold', sans-serif;
+    }
 
-    .column-home-features
-      @extend .column-strip
+    li {
+      padding: 4px 0;
+    }
+
+    .column-home-features {
+      @extend .column-strip;
+    }
+  }
 
   /* callouts */
 
-  .column-callout 
-    @extend .column-4
-    position relative
+  .column-callout  {
+    @extend .column-4;
+    position: relative;
 
-    i
-      position absolute
-      top 0
-      display block
-      right 5%
+    i {
+      position: absolute;
+      top: 0;
+      display: block;
+      right: 5%;
+    }
 
-    span
-      padding-right 20px
+    span {
+      padding-right: 20px;
+    }
 
-    a
-      @extend .larger
-      color #fff
-      display block
-      padding 100px grid-spacing grid-spacing grid-spacing
-      position relative
-      overflow-x hidden
+    a {
+      @extend .larger;
+      color: #fff;
+      display: block;
+      padding: 100px grid-spacing grid-spacing grid-spacing;
+      position: relative;
+      overflow-x: hidden;
 
-      &:before
-        content '\f061'
-        font-family 'FontAwesome'
-        bottom grid-spacing
-        right grid-spacing
-        position absolute
-        font-size 24px
-        z-index 4
+      &:before {
+        content: '\f061';
+        font-family: 'FontAwesome';
+        bottom: grid-spacing;
+        right: grid-spacing;
+        position: absolute;
+        font-size: 24px;
+        z-index: 4;
+      }
+    }
 
-    &.callout-apps
-      background #e66000
+    &.callout-apps {
+      background: #e66000;
 
-      i
-        width 200px
-        height 130px
-        background url(media-url-dir + 'HTML5_Logo.svg') center -70px no-repeat
-        background-size cover
+      i {
+        width: 200px;
+        height: 130px;
+        background: url(media-url-dir + 'HTML5_Logo.svg') center -70px no-repeat;
+        background-size: cover;
+      }
+    }
 
-    &.callout-android
-      background #97c03d
+    &.callout-android {
+      background: #97c03d;
 
-      i
-        width 260px
-        height 140px
-        background url(media-url-dir + 'promo-phone.png') center -190px no-repeat
-        background-size cover
+      i {
+        width: 260px;
+        height: 140px;
+        background: url(media-url-dir + 'promo-phone.png') center -190px no-repeat;
+        background-size: cover;
+      }
+    }
 
-    &.callout-firefoxos
-      background-color #0095dd
+    &.callout-firefoxos {
+      background-color: #0095dd;
 
-      i
-        width 320px
-        height 150px
-        background url(media-url-dir + 'promo-fox.png') center -60px no-repeat
-        background-size cover
+      i {
+        width: 320px;
+        height: 150px;
+        background: url(media-url-dir + 'promo-fox.png') center -60px no-repeat;
+        background-size: cover;
+      }
+    }
+  }
 
   /* shared */
-  h2, h3
-    > i
-      display inline-block
-      position relative
-      margin-left 0
-      background-image url(media-url-dir + 'mdn_blank-grey-document-color.svg') 
+  h2, h3 {
+    > i {
+      display: inline-block;
+      position: relative;
+      margin-left: 0;
+      background-image: url(media-url-dir + 'mdn_blank-grey-document-color.svg');
+    }
+  }
 
-  h2 
-    a
-      font-style italic
-      font-size base-font-size
-      font-weight normal
-      display inline-block
-      margin-left (grid-spacing * 2)
+  h2 {
+    a {
+      font-style: italic;
+      font-size: base-font-size;
+      font-weight: normal;
+      display: inline-block;
+      margin-left: (grid-spacing * 2);
+    }
 
-    > i
-      width 72px 
-      height 62px 
-      color #0095dd
-      
-      &.blue
-        background-image url(media-url-dir + 'mdn_blank-blue-document-color.svg') 
-        color #fff
+    > i {
+      width: 72px;
+      height: 62px;
+      color: #0095dd;
 
-      &[class^='icon-']:before
-        margin 16px 0 0 0
-        display block
-        text-align center
+      &.blue {
+        background-image: url(media-url-dir + 'mdn_blank-blue-document-color.svg');
+        color: #fff;
+      }
 
-  h3
-    @extend .clear
-    text-transform uppercase
+      &[class^='icon-']:before {
+        margin: 16px 0 0 0;
+        display: block;
+        text-align: center;
+      }
+    }
+  }
 
-    i
-      background-size cover
-      width 47px 
-      height 41px
-      color #0095dd
-      margin-right 10px !important
-      float left
+  h3 {
+    @extend .clear;
+    text-transform: uppercase;
 
-      &:before
-        margin 9px 0 0 0
-        display block
-        text-align center
+    i {
+      background-size: cover;
+      width: 47px;
+      height: 41px;
+      color: #0095dd;
+      margin-right: 10px !important;
+      float: left;
 
-    &.zones span
-      padding-top 10px
+      &:before {
+        margin: 9px 0 0 0;
+        display: block;
+        text-align: center;
+      }
+    }
 
-    span
-      float left
+    &.zones span {
+      padding-top: 10px;
+    }
 
-  .entry-meta
-    @extend .smaller
-    font-style italic
+    span {
+      float: left;
+    }
+  }
+
+  .entry-meta {
+    @extend .smaller;
+    font-style: italic;
+  }
 
   /* hacks */
-  .home-hacks
-    background #fff
+  .home-hacks {
+    background: #fff;
 
-    .column-hacks
-      @extend .column-main
+    .column-hacks {
+      @extend .column-main;
+    }
 
-    .column-involved
-      @extend .column-strip
+    .column-involved {
+      @extend .column-strip;
+    }
 
-    li
-      padding-top grid-spacing
-      border-bottom 1px solid #ececec
+    li {
+      padding-top: grid-spacing;
+      border-bottom: 1px solid #ececec;
 
-      &:last-child
-        border-bottom 0
+      &:last-child {
+        border-bottom: 0;
+      }
+    }
 
-    h2.entry-title
-      letter-spacing 0
-      line-height normal
-      margin-bottom 0
-      font-size base-font-size
+    h2.entry-title {
+      letter-spacing: 0;
+      line-height: normal;
+      margin-bottom: 0;
+      font-size: base-font-size;
 
-      a
-        text-decoration underline
-        compat-only(margin-left, 0)
-        compat-only(font-style, normal)
+      a {
+        text-decoration: underline;
+        compat-only(margin-left, 0);
+        compat-only(font-style, normal);
+      }
+    }
 
-    .hacks
-      margin-bottom (grid-spacing / 2)
+    .hacks {
+      margin-bottom: (grid-spacing / 2);
+    }
 
-    .home-involved-card
-      background url(media-url-dir + 'home-globe.svg') -90px 40px no-repeat #f4f7f8
-      background-size 600px
+    .home-involved-card {
+      background: url(media-url-dir + 'home-globe.svg') -90px 40px no-repeat #f4f7f8;
+      background-size: 600px;
 
-      a
-        color #fff
-        text-decoration none
-        padding grid-spacing
-        display block
+      a {
+        color: #fff;
+        text-decoration: none;
+        padding: grid-spacing;
+        display: block;
+      }
 
-      .numbers
-        padding-bottom 40px
-        line-height 40px
+      .numbers {
+        padding-bottom: 40px;
+        line-height: 40px;
 
-        .row1, .row2, .row3
-          display block
+        .row1, .row2, .row3 {
+          display: block;
+        }
+      }
 
-      .number
-        font-size 30px
-        font-weight bold
+      .number {
+        font-size: 30px;
+        font-weight: bold;
+      }
 
-      h3
-        @extend .larger
-        padding-bottom (grid-spacing / 2)
-        border-bottom 1px solid #e0e2e4
-        margin-bottom 110px
-        margin-right -(grid-spacing)
-        font-weight bold
+      h3 {
+        @extend .larger;
+        padding-bottom: (grid-spacing / 2);
+        border-bottom: 1px solid #e0e2e4;
+        margin-bottom: 110px;
+        margin-right: -(grid-spacing);
+        font-weight: bold;
+      }
 
-      p
-        margin 0
-        padding 0
-        text-align center
+      p {
+        margin: 0;
+        padding: 0;
+        text-align: center;
+      }
 
-      .button
-        background-color #48ade4 !important
-        font-size smaller-font-size !important
-        color #fff !important
-        
+      .button {
+        background-color: #48ade4 !important;
+        font-size: smaller-font-size !important;
+        color: #fff !important;
+      }
+    }
+  }
+}
+
 /* demos section */
-.home-demos
-  background light-background-color
+.home-demos {
+  background: light-background-color;
 
-  ul
-    @extend .clear
-    overflow-x auto
-    position relative
+  ul {
+    @extend .clear;
+    overflow-x: auto;
+    position: relative;
+  }
 
-  li
-    @extend .smaller
-    display block
-    text-align center
-    margin-right grid-spacing
-    float left
-    font-style italic
-    overflow hidden
-    width 194px
+  li {
+    @extend .smaller;
+    display: block;
+    text-align: center;
+    margin-right: grid-spacing;
+    float: left;
+    font-style: italic;
+    overflow: hidden;
+    width: 194px;
 
-    img
-      border 6px solid #fff
-      display block
-      vendorize(box-shadow, 2px 2px 1px rgba(0 , 0, 0, .1))
-      margin-bottom 6px
+    img {
+      border: 6px solid #fff;
+      display: block;
+      vendorize(box-shadow, 2px 2px 1px rgba(0 , 0, 0, .1));
+      margin-bottom: 6px;
+    }
+  }
 
-  .preview
-    text-transform uppercase
-    float right
-    margin-top -10px
+  .preview {
+    text-transform: uppercase;
+    float: right;
+    margin-top: -10px;
 
-    span
-      display block
+    span {
+      display: block;
+    }
+  }
+}
 
 
 /* contribute section */
-.home-contribute
-  background #fff
+.home-contribute {
+  background: #fff;
 
-  a
-    text-decoration underline
+  a {
+    text-decoration: underline;
+  }
 
-  h3
-    @extend .larger
-    font-weight bold
-    text-transform uppercase
+  h3 {
+    @extend .larger;
+    font-weight: bold;
+    text-transform: uppercase;
+  }
 
-  li
-    border-bottom 1px solid #ececec
-    padding list-item-spacing 0
+  li {
+    border-bottom: 1px solid #ececec;
+    padding: list-item-spacing 0;
 
-    &:last-child
-      border-bottom 0
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
 
-  .home-contribute-recent
-    margin-top (grid-spacing / 2)
-
+  .home-contribute-recent {
+    margin-top: (grid-spacing / 2);
+  }
+}
 
 /* tablet */
-@media media-query-tablet
-  #home
-
-    .home-masthead
-        h1, input
-          width 90%
-
+@media media-query-tablet {
+  #home {
+    .home-masthead {
+      h1, input {
+        width: 90%;
+      }
+    }
+  }
+}
 
 /* mobile */
-@media media-query-mobile
-  #home
+@media media-query-mobile {
+  #home {
 
-    .home-masthead
-      h1, input
-        width 90%
+    .home-masthead {
+      h1, input {
+        width: 90%;
 
-        span
-          padding-left 0
+        span {
+          padding-left: 0;
+        }
+      }
+    }
 
-    .column-callout, .column-home-features
-      width auto !important
-      float none
-      margin-bottom grid-spacing
-      margin-right 0
+    .column-callout, .column-home-features {
+      width: auto !important;
+      float: none;
+      margin-bottom: grid-spacing;
+      margin-right: 0;
+    }
 
-    .home-callouts
-      padding-top 20px
+    .home-callouts {
+      padding-top: 20px;
+    }
 
-    .column-home-features
-      li
-        display inline-block
-        padding-right grid-spacing
+    .column-home-features {
+      li {
+        display: inline-block;
+        padding-right: grid-spacing;
+      }
+    }
 
-    .home-hacks
-      .column-hacks, .column-involved
-        float none
-        width auto
+    .home-hacks {
+      .column-hacks, .column-involved {
+        float: none;
+        width: auto;
+      }
 
-      .column-involved
-        margin-top (grid-spacing * 2)
-      
-      .home-involved-card p
-        text-align left
+      .column-involved {
+        margin-top: (grid-spacing * 2);
+      }
 
+      .home-involved-card p {
+        text-align: left;
+      }
+    }
+  }
+}
 
 /* right to left */
-#home.html-rtl
-    .column-callout
-      a
-        &:before
-          content '\f060'
-          right auto
-          left grid-spacing
+#home.html-rtl {
+  .column-callout {
+    a {
+      &:before {
+        content: '\f060';
+        right: auto;
+        left: grid-spacing;
+      }
+    }
+  }
 
-    h2 
-      > selector-icon:before
-        margin-right 22px
+  h2 {
+    > selector-icon:before {
+      margin-right: 22px;
+    }
+  }
 
-    h3 
-      i, span
-        float right 
+  h3 {
+    i, span {
+      float: right;
+    }
 
-      selector-icon:before
-        margin-right 16px
+    selector-icon:before {
+      margin-right: 16px;
+    }
+  }
 
-    i.icon-arrow-right:before
-      content '\f060'
+  i.icon-arrow-right:before {
+    content: '\f060';
+  }
 
-    .home-hacks .home-involved-card h3
-      margin-right 0
-      margin-left -20px
+  .home-hacks .home-involved-card h3 {
+    margin-right: 0;
+    margin-left: -20px;
+  }
+}

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -7,143 +7,180 @@
 */
 
 /* vendorizes a propery */
-vendorize(property, value)
-  -webkit-{property} value
-  -moz-{property} value
-  -ms-{property} value
-  {property} value
+vendorize(property, value) {
+  -webkit-{property}: value;
+  -moz-{property}: value;
+  -ms-{property}: value;
+  {property}: value;
+}
 
-vendorize-value(property, value, more='')
-  {property} unquote('-webkit-'+value+more)
-  {property} unquote('-moz-'+value+more)
-  {property} unquote('-ms-'+value+more)
-  {property} value+more
+vendorize-value(property, value, more='') {
+  {property}: unquote('-webkit-'+value+more);
+  {property}: unquote('-moz-'+value+more);
+  {property}: unquote('-ms-'+value+more);
+  {property}: value+more;
+}
 
 /* prevents spacing of a given element if it's the last child */
-prevent-last-child-spacing(element='*', property='padding')
-  & {element}:last-child
-    {property} 0
+prevent-last-child-spacing(element='*', property='padding') {
+  & {element}:last-child {
+    {property}: 0;
+  }
+}
 
 /* text-decoration none, hover text-decoration underline */
-reverse-link-decoration()
-  a
-    text-decoration none
-    &:hover, &:active, &:focus
-      text-decoration underline
+reverse-link-decoration() {
+  a {
+    text-decoration: none;
+    &:hover, &:active, &:focus {
+      text-decoration: underline;
+    }
+  }
+}
 
 /* generates a background property for header and zones */
-create-gradient-background(color='', use-gradient=false)
-  if use-gradient
-    background-image url(media-url-dir + 'header-background.png'), url(media-url-dir + 'mdn-header-gradient.png')
-    background-repeat repeat, repeat-x
-  else
-    background-image url(media-url-dir + 'header-background.png')
-    background-repeat repeat
-  background-position 0 0, 0 0, 0 0
-  if color
-    background-color color
+create-gradient-background(color='', use-gradient=false) {
+  if use-gradient {
+    background-image: url(media-url-dir + 'header-background.png'), url(media-url-dir + 'mdn-header-gradient.png');
+    background-repeat: repeat, repeat-x;
+  } else {
+    background-image: url(media-url-dir + 'header-background.png');
+    background-repeat: repeat;
+  }
+  background-position: 0 0, 0 0, 0 0;
+  if color {
+    background-color: color;
+  }
+}
 
-create-home-gradient-background(color)
-  create-gradient-background(color)
-  background-image url(media-url-dir + 'header-background.png'), url(media-url-dir + 'blueprint.png'), url(media-url-dir + 'mdn-header-gradient.png')
-  background-repeat repeat, repeat, repeat-x
+create-home-gradient-background(color) {
+  create-gradient-background(color);
+  background-image: url(media-url-dir + 'header-background.png'), url(media-url-dir + 'blueprint.png'), url(media-url-dir + 'mdn-header-gradient.png');
+  background-repeat: repeat, repeat, repeat-x;
+}
 
 /* generates a cross-browser gradient */
-create-gradient(start-color, end-color, direction=false)
-  if direction
-    vendorize-value(background, linear-gradient, '(' + direction + ', ' + start-color + ', ' + end-color + ')')
-  else
-    vendorize-value(background, linear-gradient, '(' + start-color + ', ' + end-color + ')')
-  filter unquote("progid:DXImageTransform.Microsoft.gradient(startColorstr='" + start-color + "', endColorstr='" + end-color + "', GradientType=1)") /* IE6-9 */
+create-gradient(start-color, end-color, direction=false) {
+  if direction {
+    vendorize-value(background, linear-gradient, '(' + direction + ', ' + start-color + ', ' + end-color + ')');
+  } else {
+    vendorize-value(background, linear-gradient, '(' + start-color + ', ' + end-color + ')');
+  }
+  filter: unquote("progid:DXImageTransform.Microsoft.gradient(startColorstr='" + start-color + "', endColorstr='" + end-color + "', GradientType=1)"); /* IE6-9 */
+}
 
 /* generates the essential "before" and "after" code for pseudo-arrows */
-generate-arrow()
-  &:before, &:after
-    content ' '
-    height 0
-    position absolute
-    width 0
-    border 10px solid transparent
+generate-arrow() {
+  &:before, &:after {
+    content: ' ';
+    height: 0;
+    position: absolute;
+    width: 0;
+    border: 10px solid transparent;
+  }
+}
 
 /* use this in the case of having to override styles from old template :( */
-compat-important(prop, value)
-  {prop}: value !important
+compat-important(prop, value) {
+  {prop}: value !important;
+}
 
 /* Used for style which are only present to override other styles -- these will be deleted once legacy design is gone */
-compat-only(prop, value, more-selector='')
-  compat-important(prop, value)
+compat-only(prop, value, more-selector='') {
+  compat-important(prop, value);
 
-  if more-selector
-    & {more-selector}
-      compat-important(prop, value)
+  if more-selector {
+    & {more-selector} {
+      compat-important(prop, value);
+    }
+  }
+}
 
 /* Used to denote an old IE style */
-old-ie(prop, value, important=false)
-  {prop} value (important ? unquote('!important') : '')
+old-ie(prop, value, important=false) {
+  {prop}: value (important ? unquote('!important') : '');
+}
 
 /* Used to create sliding animations */
-slider(duration=default-animation-duration, maximum-height=10000px)
-  overflow-y hidden
-  max-height maximum-height
-  vendorize(transition-property, all)
-  vendorize(transition-duration, duration)
-  vendorize(transition-timing-function, slide-timing-function)
+slider(duration=default-animation-duration, maximum-height=10000px) {
+  overflow-y: hidden;
+  max-height: maximum-height;
+  vendorize(transition-property, all);
+  vendorize(transition-duration, duration);
+  vendorize(transition-timing-function, slide-timing-function);
 
-  &.closed
-    max-height 0
+  &.closed {
+    max-height: 0;
+  }
+}
 
 /* Sets the base styles for messages (review, warning, error, notice, etc.) */
-set-message-base()
-  compat-only(border-width, 5px)
-  compat-only(border-style, solid)
-  padding (grid-spacing / 2)
-  margin-bottom grid-spacing
-  font-size smaller-font-size
+set-message-base() {
+  compat-only(border-width, 5px);
+  compat-only(border-style, solid);
+  padding: (grid-spacing / 2);
+  margin-bottom: grid-spacing;
+  font-size: smaller-font-size;
 
-  & *:last-child
-    margin-bottom 0
-    padding-bottom 0
+  & *:last-child {
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}
 
 /* Enables the TOC toggle for small screens */
-enable-toc-toggle()
-  #toc
-    padding (grid-spacing / 2) grid-spacing
+enable-toc-toggle() {
+  #toc {
+    padding: (grid-spacing / 2) grid-spacing;
 
-    .toggler
-      pointer-events auto
-      color link-color
+    .toggler {
+      pointer-events: auto;
+      color: link-color;
 
-      i
-        display inline-block
+      i {
+        display: inline-block;
+      }
+    }
+  }
+}
 
 /* removes the implied "<main>" spacing so page is more customizable */
-remove-main-spacing()
-  main > .center
-    width auto
-    padding 0
-    margin 0
-    max-width none
+remove-main-spacing() {
+  main > .center {
+    width: auto;
+    padding: 0;
+    margin: 0;
+    max-width: none;
+  }
+}
 
-add-main-space()
-  @extend .center
-  
+add-main-space() {
+  @extend .center;
+}
 
 /* Overrides the navigation menu color - zones and homepage */
-override-main-nav-color(hex)
-  #main-nav > ul > li > a, .user-state a
-    compat-important(color, hex)
+override-main-nav-color(hex) {
+  #main-nav > ul > li > a, .user-state a {
+    compat-important(color, hex);
+  }
+}
 
 /* Sets an input tag's placeholder styles */
-set-placeholder-style(prop, value)
-  &::-webkit-input-placeholder
-    {prop} value
-  &::-moz-input-placeholder
-    {prop} value
+set-placeholder-style(prop, value) {
+  &::-webkit-input-placeholder {
+    {prop}: value;
+  }
+  &::-moz-input-placeholder {
+    {prop}: value;
+  }
+}
 
 /* Uses the white logo instead of color logo */
-use-white-logo()
-  #main-header .logo
-      background url(media-url-dir + 'mdn_logo-wordmark-full_white.svg') 0 0 no-repeat
+use-white-logo() {
+  #main-header .logo {
+      background: url(media-url-dir + 'mdn_logo-wordmark-full_white.svg') 0 0 no-repeat;
+  }
+}
 
 
 /*
@@ -152,103 +189,125 @@ use-white-logo()
   These are very "general" and non-specific on purpose
   There's a good chance these classes wont be used directly in HTML
 */
-.clear
-  &:before, &:after
-    content "\0020"
-    display block
-    height 0
-    overflow hidden
+.clear {
+  &:before, &:after {
+    content: "\0020";
+    display: block;
+    height: 0;
+    overflow: hidden;
+  }
 
-  &:after
-    clear both
+  &:after {
+    clear: both;
+  }
+}
 
-.offscreen
-  position absolute
-  left -99999px
-  
-.text-offscreen
-  text-indent -9999px
-  overflow hidden
+.offscreen {
+  position: absolute;
+  left: -99999px;
+}
 
-.title
-  font-weight bold
-  text-transform uppercase
-  color text-color
-  text-decoration none
-  display block
+.text-offscreen {
+  text-indent: -9999px;
+  overflow: hidden;
+}
 
-.smaller
-  font-size smaller-font-size
+.title {
+  font-weight: bold;
+  text-transform: uppercase;
+  color: text-color;
+  text-decoration: none;
+  display: block;
+}
 
-.larger
-  font-size larger-font-size
+.smaller {
+  font-size: smaller-font-size;
+}
 
-.hidden
-  display none
+.larger {
+  font-size: larger-font-size;
+}
 
-.grid-padding
-  padding grid-spacing
+.hidden {
+  display: none;
+}
 
-.disabled
-  pointer-events none
-  cursor default
+.grid-padding {
+  padding: grid-spacing;
+}
 
-.reset-font
-  font-family site-font-family
+.disabled {
+  pointer-events: none;
+  cursor: default;
+}
 
-.heading-1
-  font-size 48px
-  letter-spacing -2px
+.reset-font {
+  font-family: site-font-family;
+}
 
-.heading-2
-  font-size 32px
-  letter-spacing -1px
+.heading-1 {
+  font-size: 48px;
+  letter-spacing: -2px;
+}
 
-.button
-  text-decoration none
-  display inline-block
-  compat-important(background-color, button-background)
-  compat-important(color, button-color)
-  compat-important(text-transform, uppercase)
-  compat-important(padding, 5px 11px)
-  compat-important(border-radius, 4px)
-  vendorize(box-shadow, inset 0 -1px button-shadow-color)
-  compat-only(background-image, none)
-  compat-only(font-family, site-font-family)
-  compat-only(font-size, base-font-size)
-  compat-only(letter-spacing, normal)
+.heading-2 {
+  font-size: 32px;
+  letter-spacing: -1px;
+}
 
-  &.only-icon
-    {selector-icon}
-      margin-left 0
-      margin-top -1px
+.button {
+  text-decoration: none;
+  display: inline-block;
+  compat-important(background-color, button-background);
+  compat-important(color, button-color);
+  compat-important(text-transform, uppercase);
+  compat-important(padding, 5px 11px);
+  compat-important(border-radius, 4px);
+  vendorize(box-shadow, inset 0 -1px button-shadow-color);
+  compat-only(background-image, none);
+  compat-only(font-family, site-font-family);
+  compat-only(font-size, base-font-size);
+  compat-only(letter-spacing, normal);
 
-    span
-      @extend .offscreen
+  &.only-icon {
+    {selector-icon} {
+      margin-left: 0;
+      margin-top: -1px;
+    }
 
-  &.neutral, &.negative, &.positive
-    compat-important(color, #fff)
+    span {
+      @extend .offscreen;
+    }
+  }
 
-  &.neutral
-    compat-important(background-color, #0095dd)
-    vendorize(box-shadow, inset 0 -1px #00539f)
+  &.neutral, &.negative, &.positive {
+    compat-important(color, #fff);
+  }
 
-  &.negative
-    compat-important(background-color, #ea3b28)
-    vendorize(box-shadow, inset 0 -1px #c13832)
+  &.neutral {
+    compat-important(background-color, #0095dd);
+    vendorize(box-shadow, inset 0 -1px #00539f);
+  }
 
-  &.positive
-    compat-important(background-color, #70a300)
-    vendorize(box-shadow, inset 0 -1px #486900)
+  &.negative {
+    compat-important(background-color, #ea3b28);
+    vendorize(box-shadow, inset 0 -1px #c13832);
+  }
 
-.big-search
-  @extend .larger
-  display block
-  margin 0 auto
-  background rgba(255, 255, 255, 0.2)
-  border 0
-  border-radius 3px
-  font-family 'Open Sans Light', sans-serif
-  letter-spacing -1px
-  width 60%
-  
+  &.positive {
+    compat-important(background-color, #70a300);
+    vendorize(box-shadow, inset 0 -1px #486900);
+  }
+}
+
+.big-search {
+  @extend .larger;
+  display: block;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.2);
+  border: 0;
+  border-radius: 3px;
+  font-family: 'Open Sans Light', sans-serif;
+  letter-spacing: -1px;
+  width: 60%;
+}

--- a/media/redesign/stylus/print.styl
+++ b/media/redesign/stylus/print.styl
@@ -1,8 +1,11 @@
-@media print
+@media print {
 
-  header, footer
-    display none
+  header, footer {
+    display: none;
+  }
 
   /* wiki section */
-  #wiki-left, #wiki-right, #wiki-controls, .crumbs, .page-buttons, #page-attachments
-    display none
+  #wiki-left, #wiki-right, #wiki-controls, .crumbs, .page-buttons, #page-attachments {
+    display: none;
+  }
+}

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -1,21 +1,27 @@
 @import 'vars'
 @import 'mixins'
 
-.profile
+.profile {
 
   /* off-settings some old styles for now */
-  #profile-head
-    background light-background-color
-    border-color header-background-color
+  #profile-head {
+    background: light-background-color;
+    border-color: header-background-color;
+  }
 
-  table.activity thead, table.activity tfoot
-    background header-background-color
+  table.activity thead, table.activity tfoot {
+    background: header-background-color;
+  }
 
-  table.activity tr:nth-child(2n), .gallery-foot
-    background light-background-color
+  table.activity tr:nth-child(2n), .gallery-foot {
+    background: light-background-color;
+  }
 
-  table.activity th h3
-    @extend .larger
+  table.activity th h3 {
+    @extend .larger;
+  }
 
-  .submission .fm-submit button
-    box-shadow inherit
+  .submission .fm-submit button {
+    box-shadow: inherit;
+  }
+}

--- a/media/redesign/stylus/reset.styl
+++ b/media/redesign/stylus/reset.styl
@@ -3,16 +3,20 @@ h1, h2, h3, h4, h5, h6, p, blockquote, pre,
 a, abbr, address, cite, code, del, dfn, em, img, ins, kbd, q, samp,
 small, strong, sub, sup, var, b, i, hr, dl, dt, dd, ol, ul, li,
 fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figure, figcaption, hgroup, menu, footer, header, nav, section, summary, time, mark, audio, video
-    margin 0
-    padding 0
-    border 0
+table, caption, tbody, tfoot, thead, tr, th, td, article, aside, canvas, details, figure, figcaption, hgroup, menu, footer, header, nav, section, summary, time, mark, audio, video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+}
 
-article, main, aside, canvas, figure, figure img, figcaption, hgroup, footer, header, nav, section, audio, video
-    display block
+article, main, aside, canvas, figure, figure img, figcaption, hgroup, footer, header, nav, section, audio, video {
+    display: block;
+}
 
-a img 
-  border 0
+a img {
+  border: 0;
+}
 
-ul, ol
-  list-style-type none
+ul, ol {
+  list-style-type: none;
+}

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -2,137 +2,175 @@
 @import 'mixins'
 @import 'grid'
 
-body.search-results
-  create-gradient-background(header-background-color)
+body.search-results {
+  create-gradient-background(header-background-color);
+}
 
-main
-  background transparent
+main {
+  background: transparent;
+}
 
-.search-pane
-  @extend .grid-padding
-  background #fff
-  margin-bottom (grid-spacing / 2)
+.search-pane {
+  @extend .grid-padding;
+  background: #fff;
+  margin-bottom: (grid-spacing / 2);
+}
 
-h3 {selector-icon}
-  compat-important(margin-right, (grid-spacing * .75))
+h3 {selector-icon} {
+  compat-important(margin-right, (grid-spacing * .75));
+}
 
-p
-  compat-only(padding-left, 0)
+p {
+  compat-only(padding-left, 0);
+}
 
-.search-results-explanation
-  position relative
+.search-results-explanation {
+  position: relative;
 
-  p
-    font-style italic
-    margin-bottom 0
+  p {
+    font-style: italic;
+    margin-bottom: 0;
+  }
+}
 
-.results-search-form
-  margin-bottom (grid-spacing * 2)
+.results-search-form {
+  margin-bottom: (grid-spacing * 2);
 
-  input
-    @extend .big-search
-    background rgba(255, 255, 255, 0.5)
+  input {
+    @extend .big-search;
+    background: rgba(255, 255, 255, 0.5);
+  }
+}
 
-#search-results-close-container
-  slider()
+#search-results-close-container {
+  slider();
+}
 
-.seach-results-container
-  @extend .grid-padding
-  padding-left 0
-  padding-right 0
+.seach-results-container {
+  @extend .grid-padding;
+  padding-left: 0;
+  padding-right: 0;
 
-  h3
-    margin-left grid-spacing
-    margin-bottom grid-spacing
+  h3 {
+    margin-left: grid-spacing;
+    margin-bottom: grid-spacing;
+  }
+}
 
-.result-list
-  reverse-link-decoration()
+.result-list {
+  reverse-link-decoration();
 
-  .column-1
-    text-align right
-    color link-color
+  .column-1 {
+    text-align: right;
+    color: link-color;
+  }
 
-  p
-    margin-bottom 0
-    font-style italic
+  p {
+    margin-bottom: 0;
+    font-style: italic;
+  }
 
-  li
-    slider()
-    margin-bottom (grid-spacing + (grid-spacing / 2))
+  li {
+    slider();
+    margin-bottom: (grid-spacing + (grid-spacing / 2));
 
-    &.closed
-      margin-bottom 0
-
-
-.search-meta
-  margin-top (grid-spacing / 2)
-  a
-    color #6a7b86
-    opacity .5
-
-.result-list-link
-  @extend .smaller
-  font-style italic
-
-  {selector-icon}
-    margin-right 6px !important
-    margin-left 0
-
-  a
-    color text-color
-    display inline-block
-    margin-right (grid-spacing / 2)
-
-  prevent-last-child-spacing(a, margin-right)
-
-.search-results-more
-  @extend .clear
-  padding 0 grid-spacing
-
-  .with-view-all .view-all
-    display block
-
-.view-all
-  reverse-link-decoration()
-  float right
-  display none
-
-.search-results-more.with-view-all
-  .view-all
-    display block
-  .pager
-    display none
-
-.search-results-topics
-  reverse-link-decoration()
-
-  h3
-    margin-bottom (grid-spacing * 1.5)
-    
-    i
-      margin-left 0
-
-  a
-    display block
-    margin-top grid-spacing
-    padding-right (grid-spacing * 2)
-    position relative
-
-    &:before
-      position absolute
-      right 0
-      top 0
-      content attr(data-count)
-      color text-color
-      opacity 0.6
-
-    &.checked
-      color #999
+    &.closed {
+      margin-bottom: 0;
+    }
+  }
+}
 
 
-.search-results-no-demo
-  .result-list
-    .column-strip
-      display none
-    .result-list-item
-      @extend .column-7
+.search-meta {
+  margin-top: (grid-spacing / 2);
+  a {
+    color: #6a7b86;
+    opacity: .5;
+  }
+}
+
+.result-list-link {
+  @extend .smaller;
+  font-style: italic;
+
+  {selector-icon} {
+    margin-right: 6px !important;
+    margin-left: 0;
+  }
+
+  a {
+    color: text-color;
+    display: inline-block;
+    margin-right: (grid-spacing / 2);
+  }
+
+  prevent-last-child-spacing(a, margin-right);
+}
+
+.search-results-more {
+  @extend .clear;
+  padding: 0 grid-spacing;
+
+  .with-view-all .view-all {
+    display: block;
+  }
+}
+
+.view-all {
+  reverse-link-decoration();
+  float: right;
+  display: none;
+}
+
+.search-results-more.with-view-all {
+  .view-all {
+    display: block;
+  }
+  .pager {
+    display: none;
+  }
+}
+
+.search-results-topics {
+  reverse-link-decoration();
+
+  h3 {
+    margin-bottom: (grid-spacing * 1.5);
+
+    i {
+      margin-left: 0;
+    }
+  }
+
+  a {
+    display: block;
+    margin-top: grid-spacing;
+    padding-right: (grid-spacing * 2);
+    position: relative;
+
+    &:before {
+      position: absolute;
+      right: 0;
+      top: 0;
+      content: attr(data-count);
+      color: text-color;
+      opacity: 0.6;
+    }
+
+    &.checked {
+      color: #999;
+    }
+  }
+}
+
+
+.search-results-no-demo {
+  .result-list {
+    .column-strip {
+      display: none;
+    }
+    .result-list-item {
+      @extend .column-7;
+    }
+  }
+}

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -1,343 +1,421 @@
 /* header */
-#main-header
-  @extend .clear
-  
-  border-color transparent
-  border-bottom-width 1px
-  border-bottom-style solid
+#main-header {
+  @extend .clear;
 
-  .logo
-    @extend .text-offscreen
-    width 216px
-    height 54px
-    background-image url(media-url-dir + 'mdn_logo-wordmark-full_color.svg')
-    background-position 0 0
-    background-repeat no-repeat
-    display block
-    float left
+  border-color: transparent;
+  border-bottom-width: 1px;
+  border-bottom-style: solid;
 
-#main-nav
-  > ul
-    float right
-    margin-top 20px
-    margin-bottom grid-spacing
+  .logo {
+    @extend .text-offscreen;
+    width: 216px;
+    height: 54px;
+    background-image: url(media-url-dir + 'mdn_logo-wordmark-full_color.svg');
+    background-position: 0 0;
+    background-repeat: no-repeat;
+    display: block;
+    float: left;
+  }
+}
 
-    > li
-      padding-left 31px
-      position relative
-      opacity 1
-      max-width 1000px
-      display inline-block
-      vendorize(transition-property, width)
-      vendorize(transition-duration, default-animation-duration)
-      vendorize(transition-delay, default-animation-duration)
+#main-nav {
+  > ul {
+    float: right;
+    margin-top: 20px;
+    margin-bottom: grid-spacing;
 
-      > a i
-        display none
+    > li {
+      padding-left: 31px;
+      position: relative;
+      opacity: 1;
+      max-width: 1000px;
+      display: inline-block;
+      vendorize(transition-property, width);
+      vendorize(transition-duration, default-animation-duration);
+      vendorize(transition-delay, default-animation-duration);
 
-      > a, .search-trigger
-        compat-important(color, menu-link-color)
-        compat-important(text-decoration, none)
-        compat-important(text-transform, uppercase)
-        compat-important(font-weight, bold)
+      > a i {
+        display: none;
+      }
 
-      > a, .search-wrap
-        padding 4px 8px
+      > a, .search-trigger {
+        compat-important(color, menu-link-color);
+        compat-important(text-decoration, none);
+        compat-important(text-transform, uppercase);
+        compat-important(font-weight, bold);
+      }
 
-  button[type='submit']
-    display none
+      > a, .search-wrap {
+        padding: 4px 8px;
+      }
+    }
+  }
 
-  .submenu
-    menu-border-width = 5px
-    menu-arrow-top = -19px
-    component-submenu-method(520px, 2, #fff, #333)
+  button[type='submit'] {
+    display: none;
+  }
 
-    top 40px
-    left -200px
-    border-top menu-border-width solid #404040
-    z-index 9999
+  .submenu {
+    menu-border-width = 5px;
+    menu-arrow-top = -19px;
+    component-submenu-method(520px, 2, #fff, #333);
 
-    .submenu-column
-      min-height 90px
-      display inline-block
+    top: 40px;
+    left: -200px;
+    border-top: menu-border-width solid #404040;
+    z-index: 9999;
 
-    &:before, &:after
-      top menu-arrow-top
-      left 269px
+    .submenu-column {
+      min-height: 90px;
+      display: inline-block;
+    }
 
-    &:after
-      top (menu-arrow-top - menu-border-width)
+    &:before, &:after {
+      top: menu-arrow-top;
+      left: 269px;
+    }
 
-  .submenu-single
-    width 180px
-    left -30px
+    &:after {
+      top: (menu-arrow-top - menu-border-width);
+    }
+  }
 
-    .submenu-column
-      width 100%
+  .submenu-single {
+    width: 180px;
+    left: -30px;
 
-    &:before, &:after
-      top menu-arrow-top
-      left 84px
+    .submenu-column {
+      width: 100%;
+    }
+
+    &:before, &:after {
+      top: menu-arrow-top;
+      left: 84px;
+    }
+  }
 
 
-  &.expand
-    .search-wrap
-      width 500px
+  &.expand {
+    .search-wrap {
+      width: 500px;
+    }
 
-    > ul > li:not(:last-child)
-      opacity 0
-      width 0
-      max-width 0
-      overflow hidden
-      padding 0
-      vendorize(transition-delay, 0)
+    > ul > li:not(:last-child) {
+      opacity: 0;
+      width: 0;
+      max-width: 0;
+      overflow: hidden;
+      padding: 0;
+      vendorize(transition-delay, 0);
+    }
+  }
+}
 
-.user-state
-  @extend .smaller
-  position absolute
-  right 200px
-  top 12px
-  compat-only(width, auto)
+.user-state {
+  @extend .smaller;
+  position: absolute;
+  right: 200px;
+  top: 12px;
+  compat-only(width, auto);
 
-  li + li
-    border-left 1px solid #bbb
+  li + li {
+    border-left: 1px solid #bbb;
+  }
 
-  a, a:hover, a:focus, a:visited
-    color link-color
+  a, a:hover, a:focus, a:visited {
+    color: link-color;
+  }
+}
 
-a.persona-button
-  vendorize(border-radius, 3px)
+a.persona-button {
+  vendorize(border-radius, 3px);
 
-  span
-    text-decoration none
-    outline none
-    display block
-    float left
-    font-size 14px
-    line-height 24px
-    color white
-    font-weight bold
-    padding 0 10px 0 20px
-    position relative
+  span {
+    text-decoration: none;
+    outline: none;
+    display: block;
+    float: left;
+    font-size: 14px;
+    line-height: 24px;
+    color: white;
+    font-weight: bold;
+    padding: 0 10px 0 20px;
+    position: relative;
 
-    &:after
-      content:''
-      position absolute
-      top 0
-      right -12px
-      width 24px
-      height 24px
-      z-index 1
-      vendorize(transform, scale(0.707) rotate(45deg))
-      vendorize(border-radius, 0 3px 0 50px)
+    &:after {
+      content:'';
+      position: absolute;
+      top: 0;
+      right: -12px;
+      width: 24px;
+      height: 24px;
+      z-index: 1;
+      vendorize(transform, scale(0.707) rotate(45deg));
+      vendorize(border-radius, 0 3px 0 50px);
+    }
 
-    &.persona-icon
-      padding-left 3px
-      vendorize(border-radius, 3px 0 0 3px)
-      create-gradient(#43a6e2, #287cc2)
+    &.persona-icon {
+      padding-left: 3px;
+      vendorize(border-radius, 3px 0 0 3px);
+      create-gradient(#43a6e2, #287cc2);
 
-      &:after
-        create-gradient(#43a6e2, #287cc2, left top)
+      &:after {
+        create-gradient(#43a6e2, #287cc2, left top);
+      }
 
-      img
-        position relative
-        top 2px
-        left 5px
-        width 14px
-        height 15px
+      img {
+        position: relative;
+        top: 2px;
+        left: 5px;
+        width: 14px;
+        height: 15px;
+      }
+    }
 
-    &.signin
-      create-gradient(#56565a, #3a3a3a)
-      text-shadow 0px 1.5px 1px rgba(0, 0, 0, 0.35)
-      &:after
-        create-gradient(#56565a, #3a3a3a)
-        z-index -1
+    &.signin {
+      create-gradient(#56565a, #3a3a3a);
+      text-shadow: 0px 1.5px 1px rgba(0, 0, 0, 0.35);
+      &:after {
+        create-gradient(#56565a, #3a3a3a);
+        z-index: -1;
+      }
+    }
+  }
+}
 
-.search-wrap
-  background transparent
-  padding 4px 8px
-  border-radius 3px
-  position relative
-  vendorize(transition-property, width)
-  vendorize(transition-duration, default-animation-duration)
-  width 20px
+.search-wrap {
+  background: transparent;
+  padding: 4px 8px;
+  border-radius: 3px;
+  position: relative;
+  vendorize(transition-property, width);
+  vendorize(transition-duration, default-animation-duration);
+  width: 20px;
 
-  &.expanded
-    background #fff
+  &.expanded {
+    background: #fff;
+  }
 
-  input
-    background transparent
-    border 0
-    color menu-link-color
-    font-weight bold
-    width 20px
-    overflow hidden
-    compat-only(padding, 0)
-    vendorize(transition-property, width)
-    vendorize(transition-duration, default-animation-duration)
-    position absolute
-    left 8px
-    width 100%
-    z-index 2
-    cursor pointer
+  input {
+    background: transparent;
+    border: 0;
+    color: menu-link-color;
+    font-weight: bold;
+    width: 20px;
+    overflow: hidden;
+    compat-only(padding, 0);
+    vendorize(transition-property, width);
+    vendorize(transition-duration, default-animation-duration);
+    position: absolute;
+    left: 8px;
+    width: 100%;
+    z-index: 2;
+    cursor: pointer;
 
-    set-placeholder-style(color, text-color)
-    set-placeholder-style(text-transform, uppercase)
+    set-placeholder-style(color, text-color);
+    set-placeholder-style(text-transform, uppercase);
+  }
 
-  .search-trigger
-    position absolute
-    right 12px
-    z-index 1
+  .search-trigger {
+    position: absolute;
+    right: 12px;
+    z-index: 1;
+  }
+}
 
 /* main content area */
-.wrap
-  compat-only(max-width, none)
-  compat-only(min-width, 0)
-  compat-only(width, auto)
-  compat-only(padding, 0)
+.wrap {
+  compat-only(max-width, none);
+  compat-only(min-width, 0);
+  compat-only(width, auto);
+  compat-only(padding, 0);
+}
 
-main
-  background #fff
-  
-  > .center 
-    padding-top first-content-top-padding
+main {
+  background: #fff;
+
+  > .center {
+    padding-top: first-content-top-padding;
+  }
+}
 
 
-.boxed
-  compat-only(border, 0)
-  compat-only(box-shadow, none)
-  compat-only(padding, 0)
-  compat-only(margin, 0)
+.boxed {
+  compat-only(border, 0);
+  compat-only(box-shadow, none);
+  compat-only(padding, 0);
+  compat-only(margin, 0);
+}
 
 
 /* footer */
-footer
-  @extend .smaller
-  background #fff
-  padding  (2 * first-content-top-padding 0)
+footer {
+  @extend .smaller;
+  background: #fff;
+  padding:  (2 * first-content-top-padding 0);
 
-  p, label
-    font-style italic
+  p, label {
+    font-style: italic;
+  }
 
-  p
-    background url(media-url-dir + 'mdn_logo-only_color.svg') 0 0 no-repeat
-    compat-important(padding, 10px 0 0 92px)
-    min-height 62px
+  p {
+    background: url(media-url-dir + 'mdn_logo-only_color.svg') 0 0 no-repeat;
+    compat-important(padding, 10px 0 0 92px);
+    min-height: 62px;
+  }
 
-  .column-strip
-    padding-top 10px
+  .column-strip {
+    padding-top: 10px;
+  }
 
-  label
-    padding-right 4px
+  label {
+    padding-right: 4px;
+  }
+}
 
 
 /* tablet updates */
-@media media-query-tablet
-  #main-nav
-    > ul
-      > li
-        > a
-          i
-            @extend .larger
-            display inline-block
+@media media-query-tablet {
+  #main-nav {
+    > ul {
+      > li {
+        > a {
+          i {
+            @extend .larger;
+            display: inline-block;
+          }
+        }
+      }
+    }
+  }
+}
 
 
 /* mobile updates */
-@media media-query-mobile
+@media media-query-mobile {
 
-  #main-header
-    #tabzilla
-      display none
+  #main-header {
+    #tabzilla {
+      display: none;
+    }
 
-    .user-state
-      right grid-spacing
-      top grid-spacing
+    .user-state {
+      right: grid-spacing;
+      top: grid-spacing;
+    }
+  }
 
-  #main-nav
-    > ul
-      text-align right
-      width 100%
-      clear both
+  #main-nav {
+    > ul {
+      text-align: right;
+      width: 100%;
+      clear: both;
       
-      > li
-        vendorize(transition-property, none)
+      > li {
+        vendorize(transition-property, none);
+      }
       
-      > li:first-child
-          padding-left 0
+      > li:first-child {
+          padding-left: 0;
+      }
+    }
 
-    &.expand
-      ul
-        > li:not(:last-child)
-          width auto
-          max-width none
-          vendorize(transition-property, none)
-          overflow visible
+    &.expand {
+      ul {
+        > li:not(:last-child) {
+          width: auto;
+          max-width: none;
+          vendorize(transition-property, none);
+          overflow: visible;
+        }
+      }
+    }
+  }
+}
 
 
 /* redesign beta notice */
-.redesign-beta-notice
-  @extend .smaller
-  padding 6px 0
+.redesign-beta-notice {
+  @extend .smaller;
+  padding: 6px 0;
+}
 
 
 /* rtl */
-.html-rtl
-  #main-header
-    .logo
-      float right
+.html-rtl {
+  #main-header {
+    .logo {
+      float: right;
+    }
+  }
 
-  #main-nav
-    > ul
-      float left
+  #main-nav {
+    > ul {
+      float: left;
+    }
+  }
 
-  .user-state
-    left 200px
-    right auto
+  .user-state {
+    left: 200px;
+    right: auto;
 
-    li + li
-      border-left 1px solid #bbb
-      border-right 0
-      compat-only(padding-left, 10px)
-      compat-only(padding-right, 0)
-      compat-only(margin-left, 8px)
-      compat-only(margin-right, 0)
-      
+    li + li {
+      border-left: 1px solid #bbb;
+      border-right: 0;
+      compat-only(padding-left, 10px);
+      compat-only(padding-right, 0);
+      compat-only(margin-left, 8px);
+      compat-only(margin-right, 0);
+    }
+  }
+}
+
 
 
 
 
 
 /* legacy crap for the docs page to get rid of when possible */
-#docs
+#docs {
 
-  #content-main
-    @extend .column-main
+  #content-main {
+    @extend .column-main;
 
-    #doc-search #q-docs
-      width 80%
+    #doc-search #q-docs {
+      width: 80%;
+    }
+  }
 
-  #content-sub
-    compat-only(float, left)
-    compat-only(border, 0)
-    compat-only(margin-left, 0)
-    compat-only(margin-bottom, 0)
-    compat-only(border, 0)
-    compat-only(background, transparent)
+  #content-sub {
+    compat-only(float, left);
+    compat-only(border, 0);
+    compat-only(margin-left, 0);
+    compat-only(margin-bottom, 0);
+    compat-only(border, 0);
+    compat-only(background, transparent);
 
-    @extend .column-strip
+    @extend .column-strip;
 
-    .module 
-      .mod-title
-        compat-only(font, inherit)
+    .module  {
+      .mod-title {
+        compat-only(font, inherit);
+      }
 
-      .hfeed h4
-        compat-only(font-size, base-font-size)
+      .hfeed h4 {
+        compat-only(font-size, base-font-size);
+      }
+    }
+  }
 
-  #other-sections
-    compat-only(margin-top, grid-spacing)
+  #other-sections {
+    compat-only(margin-top, grid-spacing);
+  }
 
-  .section h4 a
-    compat-only(font, inherit)
+  .section h4 a {
+    compat-only(font, inherit);
+  }
 
-  .wrap.sidebar
-    compat-only(background, none)
+  .wrap.sidebar {
+    compat-only(background, none);
+  }
+}

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -2,100 +2,123 @@
 @import 'mixins'
 @import 'grid'
 
-aside
-  @extend .column-half
-  float right
-  border 1px solid header-background-color
-  background light-background-color
-  padding grid-spacing
-  margin-left grid-spacing
-  margin-bottom grid-spacing
+aside {
+  @extend .column-half;
+  float: right;
+  border: 1px solid header-background-color;
+  background: light-background-color;
+  padding: grid-spacing;
+  margin-left: grid-spacing;
+  margin-bottom: grid-spacing;
 
-  *:last-child
-    padding-bottom 0
-    margin-bottom 0
+  *:last-child {
+    padding-bottom: 0;
+    margin-bottom: 0;
+  }
+}
 
 
 /* headings */
-h1, h2, h3, h4
-  font-weight light-font-weight
-  margin-bottom (grid-spacing / 2)
-  font-family heading-font-family
+h1, h2, h3, h4 {
+  font-weight: light-font-weight;
+  margin-bottom: (grid-spacing / 2);
+  font-family: heading-font-family;
+}
 
-h1
-  @extend .heading-1
-  margin-bottom grid-spacing
+h1 {
+  @extend .heading-1;
+  margin-bottom: grid-spacing;
+}
 
-h2
-  @extend .heading-2
-  line-height 100%
+h2 {
+  @extend .heading-2;
+  line-height: 100%;
+}
 
-h3
-  font-size 28px
-  letter-spacing -0.5px
-  line-height 100%
+h3 {
+  font-size: 28px;
+  letter-spacing: -0.5px;
+  line-height: 100%;
+}
 
-h4
-  font-size 24px
-  letter-spacing -0.25px
-  line-height 100%
+h4 {
+  font-size: 24px;
+  letter-spacing: -0.25px;
+  line-height: 100%;
+}
 
 /* basic text */
-{selector-icon}
-  display inline-block
-  margin-left (grid-spacing / 2)
-  compat-only(margin-right, 0)
+{selector-icon} {
+  display: inline-block;
+  margin-left: (grid-spacing / 2);
+  compat-only(margin-right, 0);
 
-  &:before
-    display inline-block
-    text-decoration none
+  &:before {
+    display: inline-block;
+    text-decoration: none;
+  }
+}
 
-img
-  max-width 100%
+img {
+  max-width: 100%;
+}
 
-p, dl
-  margin-bottom content-block-margin
-  
-pre
-  compat-only(line-height, 19px)
+p, dl {
+  margin-bottom: content-block-margin;
+}
 
+pre {
+  compat-only(line-height, 19px);
+}
 
 /* forms */
-input[type='search']
-  vendorize(appearance, textfield)
+input[type='search'] {
+  vendorize(appearance, textfield);
 
-  &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration
-    display none
+  &::-webkit-search-decoration, &::-webkit-search-cancel-button, &::-webkit-search-results-button, &::-webkit-search-results-decoration {
+    display: none;
+  }
+}
 
-label
-  cursor pointer
+label {
+  cursor: pointer;
+}
 
 
 /* links */
-a
-  &:link, &:visited, &:focus, &:active
-    color link-color
+a {
+  &:link, &:visited, &:focus, &:active {
+    color: link-color;
+  }
 
-  &:visited:hover, &:visited:focus, &:visited:active
-    color link-color
+  &:visited:hover, &:visited:focus, &:visited:active {
+    color: link-color;
+  }
 
-  {selector-icon}:before
-    cursor pointer
+  {selector-icon}:before {
+    cursor: pointer;
+  }
 
-  &[name]
-    color inherit
-    text-decoration none
+  &[name] {
+    color: inherit;
+    text-decoration: none;
+  }
+}
 
-button, input[type='submit'], input[type='button']
-  @extend .button
+button, input[type='submit'], input[type='button'] {
+  @extend .button;
 
-  &::-moz-focus-inner
-    margin-top -1px
-    margin-bottom -1px
+  &::-moz-focus-inner {
+    margin-top: -1px;
+    margin-bottom: -1px;
+  }
+}
 
 
 /* rtl */
-.html-rtl
-  {selector-icon}
-    compat-only(margin-right, (grid-spacing / 2))
-    compat-only(margin-left, 0)
+.html-rtl {
+  {selector-icon} {
+    compat-only(margin-right, (grid-spacing / 2));
+    compat-only(margin-left, 0);
+  }
+}

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -1,40 +1,40 @@
 /* colors */
-text-color = #4d4e53
-link-color = #0095dd
-menu-link-color = text-color
-header-background-color = #eaeff2
-light-background-color = #f4f7f8
+text-color = #4d4e53;
+link-color = #0095dd;
+menu-link-color = text-color;
+header-background-color = #eaeff2;
+light-background-color = #f4f7f8;
 
 /* typography */
-light-font-weight = 200
-site-font-family = 'Open Sans', sans-serif
-heading-font-family = 'Open Sans Light', sans-serif
+light-font-weight = 200;
+site-font-family = 'Open Sans', sans-serif;
+heading-font-family = 'Open Sans Light', sans-serif;
 
 /* sizes */
-base-font-size = 14px
-smaller-font-size = 12px
-larger-font-size = 20px
+base-font-size = 14px;
+smaller-font-size = 12px;
+larger-font-size = 20px;
 
 /* buttons */
-button-background = #eaeff2
-button-color = menu-link-color
-button-shadow-color = #bbbfc2
+button-background = #eaeff2;
+button-color = menu-link-color;
+button-shadow-color = #bbbfc2;
 
 /* grid and site dimensions */
-grid-spacing = 20px
-media-query-tablet = 'all and/*!YUI */(max-width: 1024px)'
-media-query-mobile = 'all and/*!YUI */(max-width: 768px)'
+grid-spacing = 20px;
+media-query-tablet = 'all and/*!YUI */(max-width: 1024px)';
+media-query-mobile = 'all and/*!YUI */(max-width: 768px)';
 
 /* animation */
-default-animation-duration = .5s
-slide-timing-function = cubic-bezier(0, 1, 0.5, 1)
+default-animation-duration = .5s;
+slide-timing-function = cubic-bezier(0, 1, 0.5, 1);
 
 /* dimensions */
-gutter-width = 30px
-first-content-top-padding = (grid-spacing * 2)
-list-item-spacing = 8px
-content-block-margin = grid-spacing
+gutter-width = 30px;
+first-content-top-padding = (grid-spacing * 2);
+list-item-spacing = 8px;
+content-block-margin = grid-spacing;
 
 /* selectors */
-selector-icon = 'i[class^="icon-"]'
-media-url-dir = '/media/redesign/img/'
+selector-icon = 'i[class^="icon-"]';
+media-url-dir = '/media/redesign/img/';

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -5,516 +5,640 @@
 
 
 /* wiki classes to be extended */
-.wiki-block
-  padding-top (grid-spacing * 2)
-  margin-top (grid-spacing * 2)
-  border-top 1px solid button-background
-  padding-left 0
-  padding-right 0
+.wiki-block {
+  padding-top: (grid-spacing * 2);
+  margin-top: (grid-spacing * 2);
+  border-top: 1px solid button-background;
+  padding-left: 0;
+  padding-right: 0;
+}
 
 
 /* general wiki section */
-#content-main
-  compat-only(padding, 0)
-  compat-only(width, auto)
+#content-main {
+  compat-only(padding, 0);
+  compat-only(width, auto);
+}
 
-.wiki-main-content
-  background #fff
+.wiki-main-content {
+  background: #fff;
+}
 
 /* wiki article display */
-article
-  position relative
-  
-  a
-    text-decoration underline
+article {
+  position: relative;
 
-    &:hover, &:focus
-      text-decoration none
+  a {
+    text-decoration: underline;
 
-.document-head
-  position relative
-  clear both
+    &:hover, &:focus {
+      text-decoration: none;
+    }
+  }
+}
 
-.redirected-from
-  @extend .smaller
-  margin-top -(grid-spacing)
-  font-style italic
-  opacity 0.7
+.document-head {
+  position: relative;
+  clear: both;
+}
 
-.crumbs
-  @extend .smaller
-  margin-bottom (2 * grid-spacing)
-  float left
-  width 70%
+.redirected-from {
+  @extend .smaller;
+  margin-top: -(grid-spacing);
+  font-style: italic;
+  opacity: 0.7;
+}
 
-  li
-    display inline-block
-    margin-right (grid-spacing / 2)
+.crumbs {
+  @extend .smaller;
+  margin-bottom: (2 * grid-spacing);
+  float: left;
+  width: 70%;
 
-  a
-    display block
+  li {
+    display: inline-block;
+    margin-right: (grid-spacing / 2);
+  }
 
-    &:after
-      display inline-block
-      font-family FontAwesome
-      text-decoration none
-      content "\f054"
-      color #c1c2c4
-      margin-left 4px
-      font-size 70%
+  a {
+    display: block;
 
-  reverse-link-decoration()
+    &:after {
+      display: inline-block;
+      font-family: FontAwesome;
+      text-decoration: none;
+      content: "\f054";
+      color: #c1c2c4;
+      margin-left: 4px;
+      font-size: 70%;
+    }
+  }
 
-.page-buttons, #page-buttons
-  float right
-  text-align right
-  compat-only(width, auto)
-  compat-only(top, auto)
+  reverse-link-decoration();
+}
 
-  > li
-    margin-left (grid-spacing / 2)
-    display inline-block
+.page-buttons, #page-buttons {
+  float: right;
+  text-align: right;
+  compat-only(width, auto);
+  compat-only(top, auto);
 
-    a, button, input[type='submit'], input[type='button']
-      compat-important(font-size, smaller-font-size)
-      compat-only(font-family, site-font-family)
-      compat-only(letter-spacing, normal)
+  > li {
+    margin-left: (grid-spacing / 2);
+    display: inline-block;
 
-      &.disabled
-        opacity 0.8
+    a, button, input[type='submit'], input[type='button'] {
+      compat-important(font-size, smaller-font-size);
+      compat-only(font-family, site-font-family);
+      compat-only(letter-spacing, normal);
 
-    {selector-icon}
-      font-size 16px
+      &.disabled {
+        opacity: 0.8;
+      }
+    }
 
-  .submenu
-    component-submenu-method(400px, 2, button-background, button-shadow-color)
-    top 40px
-    right 0
-    z-index 3
-    border-top 1px solid button-shadow-color
+    {selector-icon} {
+      font-size: 16px;
+    }
+  }
 
-    .submenu-column
-      float left
+  .submenu {
+    component-submenu-method(400px, 2, button-background, button-shadow-color);
+    top: 40px;
+    right: 0;
+    z-index: 3;
+    border-top: 1px solid button-shadow-color;
 
-    &:before
-      top -18px
-      right 10px
+    .submenu-column {
+      float: left;
+    }
 
-    &:after
-      top -20px
-      right 10px
+    &:before {
+      top: -18px;
+      right: 10px;
+    }
+
+    &:after {
+      top: -20px;
+      right: 10px;
+    }
+  }
+}
 
 
-.summary
-  background light-background-color
-  font-weight bold
-  padding grid-spacing
-  margin-bottom grid-spacing
+.summary {
+  background: light-background-color;
+  font-weight: bold;
+  padding: grid-spacing;
+  margin-bottom: grid-spacing;
 
-  prevent-last-child-spacing(p, margin-bottom)
+  prevent-last-child-spacing(p, margin-bottom);
+}
 
-#page-attachments
-  @extend .wiki-block
-  compat-only(background, #fff)
+#page-attachments {
+  @extend .wiki-block;
+  compat-only(background, #fff);
+}
 
-#page-attachments-button
-  compat-only(font-size, smaller-font-size)
-  compat-only(font-family, site-font-family)
-  compat-only(letter-spacing, normal)
-  
-.contributors
-  @extend .smaller
-  color #777
+#page-attachments-button {
+  compat-only(font-size, smaller-font-size);
+  compat-only(font-family, site-font-family);
+  compat-only(letter-spacing, normal);
+}
 
-#wiki-right
-  min-height 1px /* ensures that when TOC becomes fixed, the column has width */
+.contributors {
+  @extend .smaller;
+  color: #777;
+}
 
-#toc
-  compat-only(margin-left, 0)
-  compat-only(font-size, base-font-size)
-  compat-only(margin-left, 0, 'ol ol, ul ul')
+#wiki-right {
+  min-height: 1px; /* ensures that when TOC becomes fixed, the column has width */
+}
 
-  &.fixed
-    position fixed
-    top 0
-    z-index 2
-    overflow-y auto
+#toc {
+  compat-only(margin-left, 0);
+  compat-only(font-size, base-font-size);
+  compat-only(margin-left, 0, 'ol ol, ul ul');
 
-  .toggler
-    pointer-events none
-    color inherit
+  &.fixed {
+    position: fixed;
+    top: 0;
+    z-index: 2;
+    overflow-y: auto;
+  }
 
-    i
-      display none
+  .toggler {
+    pointer-events: none;
+    color: inherit;
 
-  li
-    compat-important(padding-top, (grid-spacing / 2))
+    i {
+      display: none;
+    }
+  }
 
-  .title
-    compat-only(margin-bottom, 0)
+  li {
+    compat-important(padding-top, (grid-spacing / 2));
+  }
 
-#kumascript-errors
-  ul
-    list-style-type none
-    padding-left 0 !important
+  .title {
+    compat-only(margin-bottom, 0);
+  }
+}
+
+#kumascript-errors {
+  ul {
+    list-style-type: none;
+    padding-left: 0 !important;
+  }
+}
 
 
 /* coming from a search - heading links */
-.from-search
-  padding-left (grid-spacing * 2)
+.from-search {
+  padding-left: (grid-spacing * 2);
 
-  h1
-    display inline-block
+  h1 {
+    display: inline-block;
+  }
+}
 
-.from-search-previous, .from-search-next
-  @extend .button
-  position absolute
-  top (grid-spacing * .75) + 2px
-  display block
-  compat-only(font-size, 24px)
+.from-search-previous, .from-search-next {
+  @extend .button;
+  position: absolute;
+  top: (grid-spacing * .75) + 2px;
+  display: block;
+  compat-only(font-size, 24px);
+}
 
-.from-search-previous
-  left 0
+.from-search-previous {
+  left: 0;
+}
 
-.from-search-next
-  right 0
+.from-search-next {
+  right: 0;
+}
 
-.from-search-navigate
-  @extend .larger
-  position relative
-  color #ced1d2
-  display inline-block
-  height 38px
-  width grid-spacing
-  top 4px
+.from-search-navigate {
+  @extend .larger;
+  position: relative;
+  color: #ced1d2;
+  display: inline-block;
+  height: 38px;
+  width: grid-spacing;
+  top: 4px;
+}
 
-.from-search-navigate-up, .from-search-navigate-down
-  @extend .smaller
-  position absolute
-  left 0
+.from-search-navigate-up, .from-search-navigate-down {
+  @extend .smaller;
+  position: absolute;
+  left: 0;
+}
 
-.from-search-navigate-up
-  top 0
+.from-search-navigate-up {
+  top: 0;
+}
 
-.from-search-navigate-down
-  bottom 0
+.from-search-navigate-down {
+  bottom: 0;
+}
 
-.from-search-toc
-  @extend .smaller
-  border 1px solid button-shadow-color
-  width 200px
-  position absolute
-  left 66px
-  top 0
-  z-index 2
-  background button-background
-  padding (grid-spacing / 2)
-  color #888
+.from-search-toc {
+  @extend .smaller;
+  border: 1px solid button-shadow-color;
+  width: 200px;
+  position: absolute;
+  left: 66px;
+  top: 0;
+  z-index: 2;
+  background: button-background;
+  padding: (grid-spacing / 2);
+  color: #888;
 
-  ol
-    list-style-type decimal
-    padding-left grid-spacing
+  ol {
+    list-style-type: decimal;
+    padding-left: grid-spacing;
+  }
 
-  li
-    padding 4px 0
+  li {
+    padding: 4px 0;
+  }
 
-  a.current
-    color #888
-    pointer-events none
-    cursor default
+  a.current {
+    color: #888;
+    pointer-events: none;
+    cursor: default;
+  }
+}
 
 
 /* notices */
-.notice
-  set-message-base()
+.notice {
+  set-message-base();
 
-  compat-important(border-width, 2px)
+  compat-important(border-width, 2px);
+}
 
-.reviews
-  set-message-base()
-  @extend .smaller
+.reviews {
+  set-message-base();
+  @extend .smaller;
 
-  background #fbf8e9
-  border-color #f9f3d9
+  background: #fbf8e9;
+  border-color: #f9f3d9;
 
-  p
-    margin 0
+  p {
+    margin: 0;
+  }
 
-  li
-    padding-top list-item-spacing
+  li {
+    padding-top: list-item-spacing;
+  }
 
-  button
-    compat-important(font-size, smaller-font-size)
+  button {
+    compat-important(font-size, smaller-font-size);
+  }
+}
 
-div.bug > *:last-child, div.warning > *:last-child
-  compat-important(padding-left, inherit)
+div.bug > *:last-child, div.warning > *:last-child {
+  compat-important(padding-left, inherit);
+}
 
-.warning
-  set-message-base()
-  @extend .smaller
+.warning {
+  set-message-base();
+  @extend .smaller;
 
-  background rgba(193, 56, 50, 0.3)
-  compat-important(border-color, rgba(193, 56, 50, 0.1))
-  compat-only(color, text-color)
+  background: rgba(193, 56, 50, 0.3);
+  compat-important(border-color, rgba(193, 56, 50, 0.1));
+  compat-only(color, text-color);
 
-  pre
-    padding (grid-spacing / 2) !important
-    background none repeat scroll 0 0 rgba(255, 255, 255, 0.7) !important
+  pre {
+    padding: (grid-spacing / 2) !important;
+    background: none repeat scroll 0 0 rgba(255, 255, 255, 0.7) !important;
+  }
+}
 
 /* tag and file icons under the TOC */
-.tag-attach-list
-  margin-top grid-spacing
-  position relative
+.tag-attach-list {
+  margin-top: grid-spacing;
+  position: relative;
 
-  {selector-icon}
-    left (grid-spacing / 2)
-    position absolute
-    font-weight bold
+  {selector-icon} {
+    left: (grid-spacing / 2);
+    position: absolute;
+    font-weight: bold;
+  }
 
-  ul, > a
-    @extend .smaller
-    margin-left 40px
-    display block
+  ul, > a {
+    @extend .smaller;
+    margin-left: 40px;
+    display: block;
+  }
 
-  > a
-    text-decoration none
-    &:hover
-      text-decoration underline
+  > a {
+    text-decoration: none;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
 
-.tags
-  li
-    display inline-block
-    margin-bottom 7px
+.tags {
+  li {
+    display: inline-block;
+    margin-bottom: 7px;
+  }
+}
 
-.tags a, .tagit li
-  @extend .smaller
-  padding 1px 4px
-  border 1px solid #cee9f9 !important /* overrides plugin selector */
-  text-decoration none
-  border-radius 4px
-  background light-background-color !important /* overrides plugin selector */
+.tags a, .tagit li {
+  @extend .smaller;
+  padding: 1px 4px;
+  border: 1px solid #cee9f9 !important; /* overrides plugin selector */
+  text-decoration: none;
+  border-radius: 4px;
+  background: light-background-color !important; /* overrides plugin selector */
 
-  .close
-    color #cee9f9 !important /* overrides plugin selector */
+  .close {
+    color: #cee9f9 !important; /* overrides plugin selector */
+  }
+}
 
-.tag-list li
-  margin-right 6px
-  compat-only(margin-right, 6px)
+.tag-list li {
+  margin-right: 6px;
+  compat-only(margin-right, 6px);
+}
 
-.tagit li
-  font-size base-font-size
+.tagit li {
+  font-size: base-font-size;
+}
 
-.tagit, .tagit-new
-  border 0 !important /* overrides plugin selector */
+.tagit, .tagit-new {
+  border: 0 !important; /* overrides plugin selector */
+}
 
 /* quick links */
-.quick-links
-  @extend .smaller
-  position relative
-  margin-bottom grid-spacing
+.quick-links {
+  @extend .smaller;
+  position: relative;
+  margin-bottom: grid-spacing;
 
-  li
-    position relative
-    padding-top list-item-spacing
+  li {
+    position: relative;
+    padding-top: list-item-spacing;
+  }
 
-  li li
-    padding-left 20px
+  li li {
+    padding-left: 20px;
+  }
+}
 
-.quick-links a, #quick-links-toggle
-  display block
-  position relative
-  padding-left 20px
-  color inherit
+.quick-links a, #quick-links-toggle {
+  display: block;
+  position: relative;
+  padding-left: 20px;
+  color: inherit;
+}
 
-.quick-links {selector-icon}, #quick-links-toggle {selector-icon}
-  font-size 14px
-  position absolute
-  left -6px
-  top 1px
-    
-  p, div /* don't allow empty paragraphs by CKEditor */
-    display none
+.quick-links {selector-icon}, #quick-links-toggle {selector-icon} {
+  font-size: 14px;
+  position: absolute;
+  left: -6px;
+  top: 1px;
 
-  reverse-link-decoration()
+  /* don't allow empty paragraphs by CKEditor */
+  p, div {
+    display: none;
+  }
+
+  reverse-link-decoration();
+}
 
 /* adjustments to columns based on show/hide and media query */
-#wiki-column-container.wiki-right-closed #wiki-content, #wiki-column-container.wiki-left-closed #wiki-content
-  @extend .column-9
+#wiki-column-container.wiki-right-closed #wiki-content, #wiki-column-container.wiki-left-closed #wiki-content {
+  @extend .column-9;
+}
 
-#wiki-column-container.wiki-right-closed.wiki-left-closed  #wiki-content
-  @extend .column-all
-  float none
+#wiki-column-container.wiki-right-closed.wiki-left-closed  #wiki-content {
+  @extend .column-all;
+  float: none;
+}
 
-#wiki-column-container.wiki-right-closed #wiki-content
-  margin-right 0
+#wiki-column-container.wiki-right-closed #wiki-content {
+  margin-right: 0;
+}
 
-#wiki-column-container.wiki-left-closed #wiki-content
-  margin-left 0
+#wiki-column-container.wiki-left-closed #wiki-content {
+  margin-left: 0;
+}
 
 /* wiki new and edit pages */
-.page-meta section, #article-head
-  compat-only(background, none)
+.page-meta section, #article-head {
+  compat-only(background, none);
+}
 
-#page-tags, #page-comment
-  @extend .wiki-block
+#page-tags, #page-comment {
+  @extend .wiki-block;
+}
 
-.right-icons
-  margin-left 0 !important
-  margin-right 10px !important;
+.right-icons {
+  margin-left: 0 !important;
+  margin-right: 10px !important;
+}
 
-#edit-document, #wiki-page-translate, #wiki-page-edit
-  h1
-    compat-only(letter-spacing, normal)
-    compat-only(padding-left, 0)
-    line-height 40px
-    margin-top (grid-spacing * 1.5)
+#edit-document, #wiki-page-translate, #wiki-page-edit {
+  h1 {
+    compat-only(letter-spacing, normal);
+    compat-only(padding-left, 0);
+    line-height: 40px;
+    margin-top: (grid-spacing * 1.5);
 
-    .action
-      @extend .larger
-      display block
-      line-height 20px
+    .action {
+      @extend .larger;
+      display: block;
+      line-height: 20px;
+    }
 
-    em
-      compat-only(margin-left, -3px)
-      text-transform none
+    em {
+      compat-only(margin-left, -3px);
+      text-transform: none;
+    }
+  }
 
-  .save-state
-    compat-only(padding-left, 0)
+  .save-state {
+    compat-only(padding-left, 0);
+  }
 
-  h2
+  h2 {
     @extend .reset-font;
-    font-size 28px /* Change to h3 after redesign launched */
-    compat-only(text-transform, none)
-    margin-bottom grid-spacing
+    font-size: 28px; /* Change to h3 after redesign launched */
+    compat-only(text-transform, none);
+    margin-bottom: grid-spacing;
+  }
 
-  h2 {selector-icon}, h3 {selector-icon}
-    @extend .right-icons
+  h2 {selector-icon}, h3 {selector-icon} {
+    @extend .right-icons;
+  }
+}
 
 /* ckeditor / content area styles */
-.ckeditor-container
-  padding 6px
-  border 1px solid #eaeff2
+.ckeditor-container {
+  padding: 6px;
+  border: 1px solid #eaeff2;
+}
 
-span.cke_skin_kuma
-  padding 0 !important
+span.cke_skin_kuma {
+  padding: 0 !important;
+}
 
-.cke_skin_kuma .cke_toolbox
-  border-width 0 !important
-  margin 0 !important
+.cke_skin_kuma .cke_toolbox {
+  border-width: 0 !important;
+  margin: 0 !important;
+}
 
-#content-fields .approved header:after
-  compat-only(background, none)
-  compat-only(width, auto)
-  compat-only(height, 0)
+#content-fields .approved header:after {
+  compat-only(background, none);
+  compat-only(width, auto);
+  compat-only(height, 0);
+}
 
-#content-fields header
-  compat-only(background, none)
-  margin-bottom (grid-spacing / 2)
+#content-fields header {
+  compat-only(background, none);
+  margin-bottom: (grid-spacing / 2);
+}
 
 
-#page-attachments
-  h2 {selector-icon}, h3 {selector-icon}
-    @extend .right-icons
+#page-attachments {
+  h2 {selector-icon}, h3 {selector-icon} {
+    @extend .right-icons;
+  }
+}
 
-#wiki-page-translate
-  #page-buttons
-    right 0
+#wiki-page-translate {
+  #page-buttons {
+    right: 0;
+  }
 
-  .description .approved dt
-    compat-only(padding-top, 0)
+  .description .approved dt {
+    compat-only(padding-top, 0);
+  }
 
-  .change-locale
-    margin-top (grid-spacing / 2)
+  .change-locale {
+    margin-top: (grid-spacing / 2);
+  }
+}
 
-#article-head
-  compat-only(margin-top, 0)
-  compat-only(max-width, none)
-  compat-only(padding-top, 0)
+#article-head {
+  compat-only(margin-top, 0);
+  compat-only(max-width, none);
+  compat-only(padding-top, 0);
 
-  .metadata
-    padding-top (grid-spacing * 2)
-    width auto
-    float none
+  .metadata {
+    padding-top: (grid-spacing * 2);
+    width: auto;
+    float: none;
 
-    li label
-      width auto
+    li label {
+      width: auto;
+    }
+  }
+}
 
-.metadata-choose-parent
-  compat-important(background, light-background-color)
-  compat-important(border, 0)
-  compat-important(padding, grid-spacing)
-  compat-important(margin-top, 20px)
-  compat-only(border-radius, 0)
+.metadata-choose-parent {
+  compat-important(background, light-background-color);
+  compat-important(border, 0);
+  compat-important(padding, grid-spacing);
+  compat-important(margin-top, 20px);
+  compat-only(border-radius, 0);
+}
 
 /* compare page */
-.compare, #revision-list
-  ul
-    @extend .smaller
-    compat-only(min-width, 0)
+.compare, #revision-list {
+  ul {
+    @extend .smaller;
+    compat-only(min-width, 0);
+  }
 
-  input[type='submit'], a.button
-    compat-only(font-size, smaller-font-size)
+  input[type='submit'], a.button {
+    compat-only(font-size, smaller-font-size);
+  }
+}
 
 /* move page */
-.move-page #page-buttons
-  float none
+.move-page #page-buttons {
+  float: none;
+}
 
 
 /* legacy overrides */
-.topicpage-table .Documentation, .topicpage-table .Community, .topicpage-table .Tools, .topicpage-table .Related_Topics
-  font-family site-font-family
-  text-transform none
+.topicpage-table .Documentation, .topicpage-table .Community, .topicpage-table .Tools, .topicpage-table .Related_Topics {
+  font-family: site-font-family;
+  text-transform: none;
+}
 
 
 
 
-@media media-query-tablet
-  
-  .zone-landing-header-preview
-    .column-strip, masthead-text
-      width 48%
+@media media-query-tablet {
 
-  #wiki-right
-    .tag-attach-list
-      display inline-block
-      
-      {selector-icon}
-        left 0
-        margin-left 0
+  .zone-landing-header-preview {
+    .column-strip, masthead-text {
+      width: 48%;
+    }
+  }
 
-      ul
-        margin-left 20px
+  #wiki-right {
+    .tag-attach-list {
+      display: inline-block;
 
-    enable-toc-toggle()
+      {selector-icon} {
+        left: 0;
+        margin-left: 0;
+      }
 
-  #wiki-column-container, #wiki-content
-    width auto !important
+      ul {
+        margin-left: 20px;
+      }
+    }
 
-  #wiki-content, #wiki-right, #wiki-left
-    margin-right 0
-    width auto
-    float none
-    padding-bottom (grid-spacing * 2)
+    enable-toc-toggle();
+  }
 
-  #quick-links-toggle,  #wiki-controls
-    display none
+  #wiki-column-container, #wiki-content {
+    width: auto !important;
+  }
+
+  #wiki-content, #wiki-right, #wiki-left {
+    margin-right: 0;
+    width: auto;
+    float: none;
+    padding-bottom: (grid-spacing * 2);
+  }
+
+  #quick-links-toggle,  #wiki-controls {
+    display: none;
+  }
+}
 
 
 
 
 /* rtl */
-.html-rtl
+.html-rtl {
 
-  .page-buttons, #page-buttons
-    left gutter-width
-    right auto
+  .page-buttons, #page-buttons {
+    left: gutter-width;
+    right: auto;
+  }
 
-  .crumbs
-    li
-      margin-right 0
-      margin-left (grid-spacing / 2)
-    a
-      &:after
-        content "\f053"
-        margin-left 0
-        margin-right 4px
+  .crumbs {
+    li {
+      margin-right: 0;
+      margin-left: (grid-spacing / 2);
+    }
+    a {
+      &:after {
+        content: "\f053";
+        margin-left: 0;
+        margin-right: 4px;
+      }
+    }
+  }
+}

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -2,174 +2,223 @@
 @import 'mixins'
 @import 'grid'
 
-.zone
-  create-gradient-background('', true)
-  use-white-logo()
+.zone {
+  create-gradient-background('', true);
+  use-white-logo();
 
-  #main-header
-    border-bottom-color rgba(255, 255, 255, 0.2)
+  #main-header {
+    border-bottom-color: rgba(255, 255, 255, 0.2);
+  }
 
-  override-main-nav-color(#fff)
+  override-main-nav-color(#fff);
 
-  .search-wrap
-    background-color rgba(255, 255, 255, 0.2)
+  .search-wrap {
+    background-color: rgba(255, 255, 255, 0.2);
 
-    input, i
-      color #fff
-      set-placeholder-style(color, #fff)
+    input, i {
+      color: #fff;
+      set-placeholder-style(color, #fff);
+    }
+  }
 
-  .user-state
-    a, a:hover, a:focus, a:visited
-      color #fff
+  .user-state {
+    a, a:hover, a:focus, a:visited {
+      color: #fff;
+    }
+  }
 
   /* zone content area needs to be adjusted for zone pages */
-  remove-main-spacing()
-  main
-    background transparent
+  remove-main-spacing();
+  main {
+    background: transparent;
+  }
 
-  .wiki-main-content
-    padding-top first-content-top-padding !important
+  .wiki-main-content {
+    padding-top: first-content-top-padding !important;
+  }
+}
 
-.zone-landing
+.zone-landing {
 
-  main
-    overflow-x hidden
+  main {
+    overflow-x: hidden;
+  }
 
-  h1
-    color #fff
-    @extend .column-6
+  h1 {
+    color: #fff;
+    @extend .column-6;
+  }
 
-  .zone-landing-header-preview
-    margin-top grid-spacing
+  .zone-landing-header-preview {
+    margin-top: grid-spacing;
 
-    .column-strip
-      position relative
+    .column-strip {
+      position: relative;
 
-      .zone-landing-header-preview-base
-        position absolute
-        width 100%
-        z-index 2
+      .zone-landing-header-preview-base {
+        position: absolute;
+        width: 100%;
+        z-index: 2;
+      }
 
-      .zone-landing-header-spacing
-        float left
+      .zone-landing-header-spacing {
+        float: left;
+      }
+    }
+  }
 
-  .crumbs
-    color #fff
+  .crumbs {
+    color: #fff;
 
-    a
-      old-ie(color, #fff)
-      color rgba(255, 255, 255, 0.7)
+    a {
+      old-ie(color, #fff);
+      color: rgba(255, 255, 255, 0.7);
+    }
+  }
 
-  .zone-subnav-container
+  .zone-subnav-container {
     /* nada */
+  }
 
-  .summary
-    display none
+  .summary {
+    display: none;
+  }
 
-  h3.title
-    font-size base-font-size
-    margin 6px 0 0 0
+  h3.title {
+    font-size: base-font-size;
+    margin: 6px 0 0 0;
+  }
+}
 
-.zone-landing-header
+.zone-landing-header {
   /* create-gradient-background(#0095dd) */
-  color #fff
-  position relative
-  
-  > .center
-    padding-top first-content-top-padding
+  color: #fff;
+  position: relative;
 
-  .masthead-text
-    p
-      @extend .larger
-      font-weight light-font-weight
-      margin-right 50px
+  > .center {
+    padding-top: first-content-top-padding;
+  }
 
-  .zone-image
-    position absolute
-    right -140px
-    top 100px
-    display block
-    width 468px
-    bottom 0
+  .masthead-text {
+    p {
+      @extend .larger;
+      font-weight: light-font-weight;
+      margin-right: 50px;
+    }
+  }
 
-  a.button
-    compat-important(color, #fff)
-    old-ie(background-color, #0095dd, true) /* old ie */
-    compat-important(background-color, rgba(0, 0, 0, 0.1))
-    vendorize(box-shadow, inset 0 -1px rgba(0, 0, 0, .1))
+  .zone-image {
+    position: absolute;
+    right: -140px;
+    top: 100px;
+    display: block;
+    width: 468px;
+    bottom: 0;
+  }
 
-.zone-landing-lists li
-  padding list-item-spacing 0
-  prevent-last-child-spacing(padding-bottom)
+  a.button {
+    compat-important(color, #fff);
+    old-ie(background-color, #0095dd, true); /* old ie */
+    compat-important(background-color, rgba(0, 0, 0, 0.1));
+    vendorize(box-shadow, inset 0 -1px rgba(0, 0, 0, .1));
+  }
+}
+
+.zone-landing-lists li {
+  padding: list-item-spacing 0;
+  prevent-last-child-spacing(padding-bottom);
+}
 
 
 
 /*  Basic zone article pages */
-.zone-article-header
-  padding grid-spacing 0
-  overflow hidden
+.zone-article-header {
+  padding: grid-spacing 0;
+  overflow: hidden;
 
-  .zone-title
-    @extend .heading-2
+  .zone-title {
+    @extend .heading-2;
 
-    a
-      color #fff
-      font-style italic
+    a {
+      color: #fff;
+      font-style: italic;
+    }
+  }
 
-  .zone-image
-    position absolute
-    right 0
-    top 0
-    display block
-    width 200px
-    height 400px
-    background-size contain
+  .zone-image {
+    position: absolute;
+    right: 0;
+    top: 0;
+    display: block;
+    width: 200px;
+    height: 400px;
+    background-size: contain;
+  }
+}
 
-.zone-content
-  padding-top 38px
+.zone-content {
+  padding-top: 38px;
   reverse-link-decoration()
+}
 
-.zone-subnav-container
-  background #fff
-  margin-bottom grid-spacing
+.zone-subnav-container {
+  background: #fff;
+  margin-bottom: grid-spacing;
+}
 
-.zone-callout
-  position relative
-  padding grid-spacing
-  background #f4f7f8
-  margin (grid-spacing + (grid-spacing / 2)) 0
+.zone-callout {
+  position: relative;
+  padding: grid-spacing;
+  background: #f4f7f8;
+  margin: (grid-spacing + (grid-spacing / 2)) 0;
 
-  table
-    width 100%
-  td
-    vertical-align bottom
-    padding-right grid-spacing
- 
+  table {
+    width: 100%;
+  }
+  td {
+    vertical-align: bottom;
+    padding-right: grid-spacing;
+  }
+}
 
-    
-@media media-query-tablet
-  .zone-landing
-      .zone-subnav-container
+
+
+@media media-query-tablet {
+  .zone-landing {
+      .zone-subnav-container {
         margin-top 0
+      }
 
-      .zone-landing-header-preview .column-strip, .zone-landing-header-preview .masthead-text
-        width get-grid-dimension(media-query-tablet, 6)
+      .zone-landing-header-preview .column-strip, .zone-landing-header-preview .masthead-text {
+        width: get-grid-dimension(media-query-tablet, 6);
 
-        .zone-landing-header-preview-base
-          position static
+        .zone-landing-header-preview-base {
+          position: static;
+        }
+      }
 
-      .zone-image
-        opacity 0.2
+      .zone-image {
+        opacity: 0.2;
+      }
+  }
 
-  .zone-landing-header
+  .zone-landing-header {
 
-    .masthead-text
-      p
-        margin-right 0
-    
+    .masthead-text {
+      p {
+        margin-right: 0;
+      }
+    }
+  }
+}
+
 /* right to left */
-.html-rtl
-  .zone-article-header
-    .zone-image
-      right auto
-      left 0
+.html-rtl {
+  .zone-article-header {
+    .zone-image {
+      right: auto;
+      left: 0;
+    }
+  }
+}
+


### PR DESCRIPTION
Braces, colons, and semicolons are added. Other refactoring is intentionally
omitted to keep the diff as straightforward as possible.

Testing is easy.
1. Verify that the formatting looks good
2. Verify that the old Stylus files and the new Stylus files compile to identical CSS (`diff -r` makes this easy)
