### PR TITLE
DO NOT MERGE: Ensure using 100% of real estate within article view

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -24,6 +24,7 @@
       margin-right 0
 
   &.column-container-reverse
+    margin-left -1%
 
     > [class^='column-']
       float right

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -341,9 +341,16 @@ div.bug > *:last-child, div.warning > *:last-child
 #wiki-column-container.wiki-right-closed #wiki-content, #wiki-column-container.wiki-left-closed #wiki-content
   @extend .column-9
 
-#wiki-column-container.wiki-right-closed.wiki-left-closed  #wiki-content
-  @extend .column-all
-  float none
+#wiki-column-container.wiki-right-closed.wiki-left-closed
+
+  #wiki-content
+    @extend .column-all
+    float none
+    width auto
+  
+  .column-container-reverse
+    margin-left 0
+
 
 #wiki-column-container.wiki-right-closed #wiki-content
   margin-right 0
@@ -464,8 +471,6 @@ span.cke_skin_kuma
 .topicpage-table .Documentation, .topicpage-table .Community, .topicpage-table .Tools, .topicpage-table .Related_Topics
   font-family site-font-family
   text-transform none
-
-
 
 
 @media media-query-tablet


### PR DESCRIPTION
This places back the -1% margin for documents.  The issue is that "missing" space on the left is due to right floated elements (basically the reverse of every other page).  Needs to be reverse because we want TOC to semantically display first for screen readers.

Anywho, marking as DNM until we get John's stuff in.
