### PR TITLE
Text overflowing in search input Pull #2

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -17,7 +17,6 @@
     input, i
       color #fff
       set-placeholder-style(color, #fff)
-      width:90%;
 
   .user-state
     a, a:hover, a:focus, a:visited


### PR DESCRIPTION
Made in reference with #1525 after @darkwing asked me to make the change to structure.styl

When the user really types some thing really big the text typed will cover the search icon in the header making it look dirty and difficult to read, so reducing the width of the input box that the container this issue can be fixed.

Attached the screen shot
![screenshot2](https://f.cloud.github.com/assets/1151263/1344878/04231594-3687-11e3-913e-4b32acacfa2b.png)
![screenshot-1](https://f.cloud.github.com/assets/1151263/1344879/0459dfde-3687-11e3-986c-f8db77264c7a.png)
