### PR TITLE
Use 100% content space within the wiki

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -28,6 +28,7 @@
   }
 
   &.column-container-reverse {
+    margin-left: -1%;
 
     > [class^='column-'] {
       float: right;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -416,9 +416,16 @@ div.bug > *:last-child, div.warning > *:last-child {
   @extend .column-9;
 }
 
-#wiki-column-container.wiki-right-closed.wiki-left-closed  #wiki-content {
-  @extend .column-all;
-  float: none;
+#wiki-column-container.wiki-right-closed.wiki-left-closed {
+  #wiki-content {
+    @extend .column-all;
+    float: none;
+    width: auto;
+  }
+  
+  .column-container-reverse {
+    margin-left: 0;
+  }
 }
 
 #wiki-column-container.wiki-right-closed #wiki-content {


### PR DESCRIPTION
The content within the wiki is floated right so that the TOC is in the HTML first but is presented last.  That leaves 1% of space not used on the left.  This ensures 100% of the content space is used.
