### PR TITLE
Fixed Text overflowing in search input

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -208,7 +208,7 @@ a.persona-button {
     vendorize(transition-duration, default-animation-duration);
     position: absolute;
     left: 8px;
-    width: 100%;
+    width: 90%;
     z-index: 2;
     cursor: pointer;
 


### PR DESCRIPTION
Made in reference with #1525 after @darkwing asked me to make the change to structure.styl

When the user really types some thing really big the text typed will cover the search icon in the header making it look dirty and difficult to read, so reducing the width of the input box that the container this issue can be fixed.

Attached the screen shot
![screenshot2](https://f.cloud.github.com/assets/1151263/1344878/04231594-3687-11e3-913e-4b32acacfa2b.png)
![screenshot-1](https://f.cloud.github.com/assets/1151263/1344879/0459dfde-3687-11e3-986c-f8db77264c7a.png)
