### PR TITLE
[fix bug 927638] Prevent overlap of Edit page h1

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -449,6 +449,7 @@ div.bug > *:last-child, div.warning > *:last-child {
     compat-only(padding-left, 0);
     line-height: 40px;
     margin-top: (grid-spacing * 1.5);
+    margin-bottom: (grid-spacing);
 
     .action {
       @extend .larger;


### PR DESCRIPTION
Introduce margin-bottom for Edit page and Translate page h1
