### PR TITLE
Remove italics from the zone subpage headers

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -133,8 +133,8 @@
     @extend .heading-2;
 
     a {
+      font-family: heading-font-family;
       color: #fff;
-      font-style: italic;
     }
   }
 


### PR DESCRIPTION
No more italics, say the creative weirdos.
