### PR TITLE
Improve L10n dashboard filters

### DIFF
--- a/apps/dashboards/__init__.py
+++ b/apps/dashboards/__init__.py
@@ -1,11 +1,16 @@
 from django.conf import settings
 
 ORDERS = (
-    ('last-update', 'Last update'),
+    ('-modified', 'Recent locale document'),
+    ('modified', 'Oldest locale document'),
+    ('-parent__modified', 'Recent En document'),
+    ('parent__modified', 'Oldest En document'),
 )
 
 LOCALIZATION_FLAGS = (
-    ('inprogress', 'Localization in Progress'),
+    ('update-needed', 'Update needed'),
+    ('missing-parent', 'Missing parent'),
+    ('inprogress', 'Localization in progress'),
 )
 
 # TODO: fix this

--- a/apps/dashboards/templates/dashboards/localization.html
+++ b/apps/dashboards/templates/dashboards/localization.html
@@ -32,10 +32,11 @@
           <label for="l10n-dashboard-topic">{{ _('Topic') }}:</label>
           <input name="topic" id="l10n-dashboard-topic" value="{{ request.GET.topic }}" />
           
-          <label for="localization-flags">{{ _("Localization Flags") }}:</label>
+          <label for="localization-flags">{{ _("Filter mode") }}:</label>
           <select name="localization_flags" id="localization-flags">
-            <option value=""></option>
-            <option value="inprogress"{{ selected('inprogress', filters['localization_flags']) }}>Localization in Progress</option>
+            {% for flags in filter_data.flag_list %}
+                <option value="{{ flags[0] }}"{{ selected(flags[0], filters['localization_flags']) }}>{{ flags[1] }}</option>
+            {% endfor %}
           </select>
           
           <label for="orderby">{{ _("Order by") }}:</label>


### PR DESCRIPTION
Improvements to filters and order options of the l10n dashboard.
- Fix order by and allow more orderings by locale and by English documents
- Make "update needed" the default view. There is no reason to show all locale docs. We just want the outdated ones here.
- Introduce a "missing parent" filter where locale teams are able to find missing associations to the English documents.

(The third filter is the "in progress" filter, which does not seem to work how it should be. Needs more review - a new bug probably)
