### PR TITLE
Adding 'small desktop' setting to keep left sidebar and push TOC above content

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -130,7 +130,7 @@
   {% endif %}
 
   <!-- start the main content container -->
-    <div id="wiki-column-container" class="{% if not show_right %}wiki-right-closed{% endif %} {% if not show_left %}wiki-left-closed{% endif %}">
+    <div id="wiki-column-container" class="{% if show_right %}wiki-right-present{% else %}wiki-right-closed wiki-right-none{% endif %} {% if show_left %}wiki-left-present{% else %}wiki-left-closed wiki-left-none{% endif %}">
 
       {% if show_left and not is_zone_root %}
       <!-- additional controls row; hidden unless needed -->
@@ -244,7 +244,7 @@
           
           {% if not is_zone_root %}
             
-            <a href="#quick-links" class="title" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide Sidebar') }}</a>
+            <a href="#quick-links" class="title smaller" id="quick-links-toggle"><i class="icon-caret-up"></i>{{ _('Hide Sidebar') }}</a>
             
             {% if zone_subnav_html %}
               <!-- zone subnav -->

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -5,7 +5,18 @@ document.documentElement.className += ' js';
 
 (function($) {
 
-  var isOldIE = $('#oldIE').length;
+  /*
+    Some quick feature testing up front
+  */
+  var isOldIE = $('#feature-test-old-ie').length;
+  (function() {
+    // This DIV will have a different z-index based on device width
+    // This is changed via media queries supported via MDN
+    var $div = $('<div id="feature-test-element"></div>').appendTo(document.body);
+    window.mdn.features.getDeviceState = function() {
+      return $div.css('z-index');
+    };
+  })();
 
   /*
     Main menu

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -34,12 +34,21 @@
     $quickLinks.find('.toggleable').mozTogglers();
     
     var side = $('#quick-links-toggle').closest('.wiki-column').attr('id');
+    var $columnContainer = $('#wiki-column-container');
+    var $quickLinksControl = $('#wiki-controls .quick-links');
+
     // Quick Link toggles
     $('#quick-links-toggle, #show-quick-links').on('click', function(e) {
+      var $side = $('#' + side);
+
       e.preventDefault();
-      $('#' + side).toggleClass('column-closed');
-      $('#wiki-column-container').toggleClass(side + '-closed');
-      $('#wiki-controls .quick-links').toggleClass('hidden');
+      $side.toggleClass('column-closed');
+      $columnContainer.toggleClass(side + '-closed');
+      $quickLinksControl.toggleClass('hidden');
+
+      if($side.hasClass('column-closed')) {
+        $(window).trigger('resize');
+      }
     });
   })();
   
@@ -124,7 +133,7 @@
         
         // Should the TOC be one-column (auto-closed) or sidebar'd
         if(!e || e.type == 'resize') {
-          if($wikiRight.css('float') == 'none') {
+          if($toggler.css('pointer-events') == 'auto'  || $toggler.find('i').css('display') != 'none') { /* icon check is for old IEs that don't support pointer-events */
             if(!$toc.attr('data-closed')) {
               $toggler.trigger('click');
             }

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -5,7 +5,7 @@
 .center {
   margin: 0 auto;
   position: relative;
-  max-width: 1220px;
+  max-width: max-width-default;
   add-center-spacing();
 }
 
@@ -70,7 +70,7 @@
   width: 65%;
 }
 .column-9, .column-main {
-  width: 73.5%;
+  width: grid-width-column-main;
 }
 .column-10 {
   width: 82%;

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -280,6 +280,21 @@ footer {
   }
 }
 
+/* feature testing */
+#feature-test-element {
+  position: absolute;
+  left: 0;
+  top: -999999px;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  z-index: 1;
+
+  @media media-query-small-desktop { z-index: 2; }
+  @media media-query-tablet { z-index: 3; }
+}
+
+
 
 /* tablet updates */
 @media media-query-tablet {

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -22,6 +22,12 @@ button-shadow-color = #bbbfc2;
 
 /* grid and site dimensions */
 grid-spacing = 20px;
+
+grid-width-column-main = 73.5%;
+
+max-width-default = 1400px;
+
+media-query-small-desktop = 'all and/*!YUI */(max-width: 1200px)';
 media-query-tablet = 'all and/*!YUI */(max-width: 1024px)';
 media-query-mobile = 'all and/*!YUI */(max-width: 768px)';
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -3,6 +3,15 @@
 @import 'grid'
 @import 'components'
 
+/* mixins applying only to the wiki */
+make-wiki-blocks-flat() {
+  #wiki-content, #wiki-right, #wiki-left {
+    margin-right: 0;
+    width: auto !important;
+    float: none;
+    padding-bottom: (grid-spacing * 2);
+  }
+}
 
 /* wiki classes to be extended */
 .wiki-block {
@@ -26,6 +35,10 @@
   .center {
     remove-center-spacing();
   }
+}
+
+#wiki-left {
+  position: relative;
 }
 
 /* wiki article display */
@@ -401,9 +414,20 @@ div.bug > *:last-child, div.warning > *:last-child {
 
 .quick-links a, .quick-links .title, #quick-links-toggle {
   display: block;
-  position: relative;
   padding-left: 20px;
   color: inherit;
+}
+
+.quick-links a, .quick-links .title {
+  position: relative;
+}
+
+.quick-links .title {
+  display: inline-block;
+}
+
+#quick-links-toggle {
+  height: 30px;
 }
 
 .quick-links {selector-icon}, #quick-links-toggle {selector-icon} {
@@ -591,9 +615,30 @@ span.cke_skin_kuma {
 }
 
 
+/*
+  Small desktop.  We go to a two-column layout 
+*/
+@media media-query-small-desktop {
+
+  /* when there's a left sidebar, we need to adjust the layout to look like:  |= */
+  .wiki-left-present:not(.wiki-left-closed) {
+    #wiki-right, #wiki-content {
+      width: grid-width-column-main;
+      margin-right: 0;
+    }
+    #wiki-right {
+      enable-toc-toggle();
+      padding-bottom: (grid-spacing * 2);
+    }
+    #wiki-left {
+      float: none;
+    }
+  }
+}
 
 
 @media media-query-tablet {
+  make-wiki-blocks-flat();
 
   .zone-landing-header-preview {
     .column-strip, masthead-text {
@@ -602,6 +647,8 @@ span.cke_skin_kuma {
   }
 
   #wiki-right {
+    enable-toc-toggle();
+
     .tag-attach-list {
       display: inline-block;
 
@@ -614,19 +661,10 @@ span.cke_skin_kuma {
         margin-left: 20px;
       }
     }
-
-    enable-toc-toggle();
   }
 
-  #wiki-column-container, #wiki-content {
+  #wiki-column-container, #wiki-content, $wiki {
     width: auto !important;
-  }
-
-  #wiki-content, #wiki-right, #wiki-left {
-    margin-right: 0;
-    width: auto;
-    float: none;
-    padding-bottom: (grid-spacing * 2);
   }
 
   #quick-links-toggle,  #wiki-controls {

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
       <script src="https://login.persona.org/include.js" type="text/javascript"></script>
 
       {% if waffle.flag('redesign') %}
-        <!--[if lte IE 8]><script src="/media/redesign/js/libs/selectivizr-1.0.2/selectivizr-build.js?build={{ BUILD_JS }}"></script><div id="oldIE"></div><![endif]-->
+        <!--[if lte IE 8]><script src="/media/redesign/js/libs/selectivizr-1.0.2/selectivizr-build.js?build={{ BUILD_JS }}"></script><div id="feature-test-old-ie"></div><![endif]-->
       {% endif %}
 
       {{ js('mdn') }}

--- a/templates/includes/config.html
+++ b/templates/includes/config.html
@@ -2,12 +2,17 @@
   // This represents the site configuration
   window.mdn = {
     build: '{{ BUILD_ID_JS }}',
+    // Properties and settings for CKEditor will go here
     ckeditor: {},
+    // Feature test results and methods will be placed here
+    features: {},
+    // Ensures gettext always returns something, is always set
+    gettext: function(x) { return x; },
+    // The path to media (images, CSS, JS) in MDN
     mediaPath: '{{ MEDIA_URL }}',
+    // Wiki-specific settings will be placed here
     wiki: {
       autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
     }
   };
-  // Ensures gettext always returns something, is always set
-  window.gettext = function(x) { return x; }
 </script>


### PR DESCRIPTION
Based on all of this:

https://etherpad.mozilla.org/23OCT13-MDN-Article-Update

Need to check this with (1) Only TOC, (2) Only subnav, (3) both at all supported widths.

Also need to check IE.
