### PR TITLE
fix bug 931156 - save document parent during move

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1281,6 +1281,7 @@ class Document(NotificationsMixin, models.Model):
             new_parent = Document.objects.get(locale=self.locale,
                                               slug='/'.join(new_slug_bits))
             self.parent_topic = new_parent
+            self.save()
         except Document.DoesNotExist:
             pass
 


### PR DESCRIPTION
Do Not Merge (Yet): This fixes the bug, but should we add a test that reproduces the original behavior first?
