### PR TITLE
Fix bug 931156: ensure breadcrumbs update during page move.

### DIFF
--- a/apps/wiki/admin.py
+++ b/apps/wiki/admin.py
@@ -230,7 +230,7 @@ class DocumentAdmin(admin.ModelAdmin):
                disable_deferred_rendering_for_documents,
                repair_breadcrumbs)
     change_list_template = 'admin/wiki/document/change_list.html'
-    fields = ('locale', 'slug', 'title', 'defer_rendering', 'parent',
+    fields = ('locale', 'title', 'defer_rendering', 'parent',
               'parent_topic', 'category',)
     list_display = ('id', 'locale', 'slug', 'title',
                     document_link,
@@ -253,7 +253,7 @@ class DocumentAdmin(admin.ModelAdmin):
 
 
 class RevisionAdmin(admin.ModelAdmin):
-    fields = ('title', 'slug', 'summary', 'content', 'keywords', 'tags',
+    fields = ('title', 'summary', 'content', 'keywords', 'tags',
               'reviewed', 'comment', 'is_approved')
     list_display = ('id', 'slug', 'title', 'is_approved', 'created',
                     'creator',)

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -2087,6 +2087,8 @@ class DocumentEditingTests(TestCaseBase):
         ok_(Document.objects.get(slug=d.slug, locale=d.locale).show_toc)
         data['form'] = 'rev'
         data['toc_depth'] = 0
+        data['slug'] = d.slug
+        data['title'] = d.title
         client.post(reverse('wiki.edit_document', args=[d.full_path]), data)
         eq_(0, Document.objects.get(slug=d.slug, locale=d.locale).current_revision.toc_depth)
 
@@ -2102,6 +2104,8 @@ class DocumentEditingTests(TestCaseBase):
         ok_(not Document.objects.get(slug=d.slug, locale=d.locale).show_toc)
         data = new_document_data()
         data['form'] = 'rev'
+        data['slug'] = d.slug
+        data['title'] = d.title
         client.post(reverse('wiki.edit_document', args=[d.full_path]), data)
         ok_(Document.objects.get(slug=d.slug, locale=d.locale).show_toc)
 


### PR DESCRIPTION
This does some significant refactoring, but not really changing, of
the page-moving code, breaking up the monolithic _move_tree() into
multiple shorter methods which each handle a smaller piece of the
puzzle (for easier debugging/editing).

The only genuine change is that Document.save() no longer attempts to
create redirects when a slug is edited; the redirect logic is now
called during page move, and the move() method, which existed only to
do that, is removed. This is considered safe because the only way to
edit a slug outside of page-move is through the Django admin, and this
commit also removes that ability.
