### PR TITLE
fix bug 932847 - Remove redesign_editor flag references

### DIFF
--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -1,8 +1,4 @@
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
 
-{% if waffle.flag('redesign_editor') %}
- <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 
-{% else %}
-  <script src="{{ MEDIA_URL }}js/wiki_ckeditor.js?build={{ BUILD_ID_JS }}"></script>
-{% endif %}
+<script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -167,11 +167,7 @@
   
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
   <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-  {% if waffle.flag('redesign_editor') %}
-   <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 
-  {% else %}
-    <script src="{{ MEDIA_URL }}js/wiki_ckeditor_translate.js?build={{ BUILD_ID_JS }}"></script>
-  {% endif %}
-
+  <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 
+  
   {{ js('wiki-edit') }}
 {% endblock %}


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=932847
