### PR TITLE
Minor manual installation documentation update.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -66,7 +66,7 @@ fork the project into your own account. Then get the source using::
 
     mkdir mdn # you probably want to do this, since you'll have to create
     cd mdn    # product_details_json/ as a sibling of kuma/ later.
-    git clone git://github.com/<your_account>/kuma.git
+    git clone git@github.com:<your_username>/kuma.git
     cd kuma
     git submodule update --init --recursive
 


### PR DESCRIPTION
You cannot push to git://github.com/`your_username`/kuma.git.
`your_account` is renamed to `your_username` for consistency with
installation-vagrant.rst
