### PR TITLE
Ensure accessibility links don't display in Tabzilla block

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -20,6 +20,9 @@
 
 #nav-access {
   width: 0;
+  height: 0;
+  left: -20em;
+  overflow: hidden;
 }
 
 #main-nav {


### PR DESCRIPTION
For some reason, the accessibility block displays in the Tabzilla fold-down block.  This prevents that.
