### PR TITLE
Stop loading CKEditor on basic document pages

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -90,7 +90,6 @@
 {% endblock %}
 
 {% block js %}
-    {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% include 'wiki/includes/highlighting_scripts.html' %}
 
     {% if waffle.flag('offline_notice') %}


### PR DESCRIPTION
Since section editing doesn't work, we don't need CKEditor anymore.
