### PR TITLE
Adding magical RTL updates, including reversing wiki/zone + search + homepage columns

### DIFF
--- a/media/redesign/stylus/classes.styl
+++ b/media/redesign/stylus/classes.styl
@@ -84,3 +84,13 @@
     font-weight: bold;
   }
 }
+
+/* right ot left */
+.html-rtl {
+  .text-content {
+    ul, ol {
+      padding-left: 0;
+      padding-right: (grid-spacing * 2);
+    }
+  }
+}

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -18,8 +18,8 @@
 .column-container {
   @extend .clear;
 
-  > [class^='column-'] {
-    margin-right: 3%;
+  {grid-column-selector} {
+    margin-right: grid-margin;
     float: left;
 
     &:last-child {
@@ -30,7 +30,7 @@
   &.column-container-reverse {
     margin-left: -1%;
 
-    > [class^='column-'] {
+    {grid-column-selector} {
       float: right;
 
       &:first-child {
@@ -38,13 +38,44 @@
       }
 
       &:last-child {
-        margin-right: 3%;
+        margin-right: grid-margin;
       }
     }
   }
 }
 
-/*  Column definitions */
+/* adjustments to reverse the column containers in RTL */
+.html-rtl .column-container {
+
+  {grid-column-selector} {
+    float: right;
+
+    &:first-child {
+      margin-right: 0;
+    } 
+    &:last-child {
+      margin-right: grid-margin;
+    }
+  }
+}
+
+.html-rtl .column-container-reverse {
+  margin-left: 0;
+
+  {grid-column-selector} {
+    float: left;
+
+    &:first-child {
+      margin-right: grid-margin;
+    }
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+}
+
+/*  Column width definitions */
 .column-1 {
   width: 5.5%;
 }
@@ -97,15 +128,3 @@
     max-width: 1000px;
   }
 }
-
-/* Mobile phone grid settings
-     Disabled for now as not required for launch
-
-@media media-query-mobile {
-
-  .center, .column-1, .column-2, .column-3, .column-4, .column-5, .column-6, .column-7, .column-8, .column-9, .column-10, .column-11 {
-    float:  none;
-    width: 99%;
-  }
-}
-*/

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -444,6 +444,16 @@
 
 /* right to left */
 #home.html-rtl {
+
+    .home-masthead {
+      h1 {
+        span {
+          padding-right: 20%;
+          padding-left: 0;
+        }
+      }
+    }
+
   .column-callout {
     a {
       &:before {

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -174,3 +174,38 @@ p {
     }
   }
 }
+
+
+
+/* right to left */
+.html-rtl {
+  h3 {selector-icon} {
+    compat-important(margin-right, 0);
+    compat-important(margin-left, (grid-spacing * .75));
+  }
+
+  .seach-results-container {
+    h3 {
+      margin-left: 0;
+      margin-right: grid-spacing;
+    }
+  }
+
+  .result-list {
+    .column-1 {
+      text-align: left;
+    }
+  }
+
+  .search-results-topics {
+    a {
+      padding-right: 0;
+      padding-left: (grid-spacing * 2);
+
+      &:before {
+        right: auto;
+        left: 0;
+      }
+    }
+  }
+}

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -371,6 +371,10 @@ footer {
     .logo {
       float: right;
     }
+
+    #tabzilla {
+      float: left;
+    }
   }
 
   #main-nav {
@@ -390,6 +394,13 @@ footer {
       compat-only(padding-right, 0);
       compat-only(margin-left, 8px);
       compat-only(margin-right, 0);
+    }
+  }
+
+  footer {
+    p {
+      background: url(media-url-dir + 'mdn_logo-only_color.svg') right 0 no-repeat;
+      compat-important(padding, 10px 92px 0 0);
     }
   }
 }

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -23,7 +23,8 @@ button-shadow-color = #bbbfc2;
 
 /* grid and site dimensions */
 grid-spacing = 20px;
-
+grid-margin = 3%;
+grid-column-selector = '> [class^="column-"]';
 grid-width-column-main = 73.5%;
 
 max-width-default = 1400px;
@@ -40,7 +41,7 @@ slide-timing-function = cubic-bezier(0, 1, 0.5, 1);
 gutter-width = 24px;
 first-content-top-padding = (grid-spacing * 2);
 list-item-spacing = 8px;
-content-block-margin = 24px;
+content-block-margin = gutter-width;
 
 /* selectors */
 selector-icon = 'i[class^="icon-"]';

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -215,6 +215,7 @@
 
 /* right to left */
 .html-rtl {
+
   .zone-article-header {
     .zone-image {
       right: auto;


### PR DESCRIPTION
To switch to RTL mode, do this in the console:

`jQuery("html").attr("dir", "rtl"); jQuery("body").removeClass("html-ltr").addClass("html-rtl");`

This swaps the column positions (reverses them) in RTL, as well as reverses basic padding/text-align stuff throughout the wiki, search results page, and homepage.
