### PR TITLE
Adding `bidi-style` and `bidi-value` mixins to aid with RTL styling.

### DIFF
--- a/media/redesign/stylus/classes.styl
+++ b/media/redesign/stylus/classes.styl
@@ -42,7 +42,7 @@
   }
 
   ul, ol {
-    padding-left: (grid-spacing * 2);
+    bidi-style(padding-left, (grid-spacing * 2), padding-right, 0);
     margin-bottom: content-block-margin;
   }
 
@@ -82,15 +82,5 @@
 
   caption {
     font-weight: bold;
-  }
-}
-
-/* right ot left */
-.html-rtl {
-  .text-content {
-    ul, ol {
-      padding-left: 0;
-      padding-right: (grid-spacing * 2);
-    }
   }
 }

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -6,8 +6,8 @@
   position: relative;
 
   i {
+    bidi-style(right, 10px, left, auto);
     position: absolute;
-    right: 10px;
     top: 3px;
     color: text-color;
   }
@@ -24,6 +24,7 @@
   compat-important(padding, grid-spacing (grid-spacing * .75));
 
   > ol {
+    bidi-style(padding-left, (grid-spacing * 1.5), padding-right, 0, true); /* compat-important */
     compat-important(padding-left, (grid-spacing * 1.5));
     compat-important(font-size, smaller-font-size);
   }
@@ -45,6 +46,9 @@
     padding-top: grid-spacing;
 
     &:before {
+      bidi-value(text-align, left, right);
+      bidi-style(left, -(grid-spacing * 1.5), right, auto);
+
       content: counters(toc, '.');
       text-align: right;
       position: absolute;
@@ -173,29 +177,5 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     border-bottom-color: arrow-border-color;
     position: absolute;
     z-index: 1;
-  }
-}
-
-
-/* rtl */
-.html-rtl {
-  .toggler {
-    i {
-      left: 10px;
-      right: auto;
-    }
-  }
-
-  #toc {
-    > ol {
-      compat-important(padding-left, 0);
-      compat-important(padding-right, (grid-spacing * 1.5));
-    }
-
-    li:before {
-      text-align: left;
-      right: -(grid-spacing * 1.5);
-      left: auto;
-    }
   }
 }

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -20,25 +20,27 @@
 
   {grid-column-selector} {
     margin-right: grid-margin;
-    float: left;
+    bidi-value(float, left, right);
 
     &:last-child {
       margin-right: 0;
+      bidi-value(margin-right, 0, grid-margin);
     }
   }
 
   &.column-container-reverse {
-    margin-left: -1%;
+    bidi-value(margin-left, -1%, 0);
 
     {grid-column-selector} {
-      float: right;
+      bidi-value(float, right, left);
 
       &:first-child {
-        margin-right: 0;
+        bidi-value(margin-right, 0, grid-margin);
       }
 
       &:last-child {
         margin-right: grid-margin;
+        bidi-value(margin-right, grid-margin, 0);
       }
     }
   }
@@ -46,32 +48,10 @@
 
 /* adjustments to reverse the column containers in RTL */
 .html-rtl .column-container {
-
   {grid-column-selector} {
-    float: right;
-
     &:first-child {
       margin-right: 0;
     } 
-    &:last-child {
-      margin-right: grid-margin;
-    }
-  }
-}
-
-.html-rtl .column-container-reverse {
-  margin-left: 0;
-
-  {grid-column-selector} {
-    float: left;
-
-    &:first-child {
-      margin-right: grid-margin;
-    }
-
-    &:last-child {
-      margin-right: 0;
-    }
   }
 }
 

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -43,7 +43,7 @@
       width: 60%;
 
       span {
-        padding-left: 20%;
+        bidi-style(padding-left, 20%, padding-right, 0);
         display: block;
       }
     }
@@ -91,10 +91,10 @@
     position: relative;
 
     i {
+      bidi-style(right, 5%, left, auto);
       position: absolute;
       top: 0;
       display: block;
-      right: 5%;
     }
 
     span {
@@ -110,10 +110,10 @@
       overflow-x: hidden;
 
       &:before {
-        content: '\f061';
+        bidi-style(content, '\f061', content, '\f060');
+        bidi-style(right, grid-spacing, left, 0);
         font-family: 'FontAwesome';
         bottom: grid-spacing;
-        right: grid-spacing;
         position: absolute;
         font-size: 24px;
         z-index: 4;
@@ -295,7 +295,7 @@
         padding-bottom: (grid-spacing / 2);
         border-bottom: 1px solid #e0e2e4;
         margin-bottom: 110px;
-        margin-right: -(grid-spacing);
+        bidi-style(margin-right, -(grid-spacing), margin-left, 0);
         font-weight: bold;
       }
 
@@ -442,32 +442,9 @@
   }
 }
 
+
 /* right to left */
 #home.html-rtl {
-
-    .home-masthead {
-      h1 {
-        span {
-          padding-right: 20%;
-          padding-left: 0;
-        }
-      }
-    }
-
-  .column-callout {
-    a {
-      &:before {
-        content: '\f060';
-        right: auto;
-        left: grid-spacing;
-      }
-    }
-    
-    i {
-      right: auto;
-      left: 5%;
-    }
-  }
 
   h2 {
     > selector-icon:before {
@@ -488,10 +465,5 @@
 
   i.icon-arrow-right:before {
     content: '\f060';
-  }
-
-  .home-hacks .home-involved-card h3 {
-    margin-right: 0;
-    margin-left: -20px;
   }
 }

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -172,6 +172,29 @@ use-white-logo() {
   }
 }
 
+/* Allows setting of a property for LTR and RTL without having to deal with duplicating and maintaining selectors 
+
+    example:   bidi-style(left, 20px, right, auto)
+*/
+bidi-style(ltr-prop, value, inverse-prop, inverse-value, make-important = false) {
+  if make-important {
+    make-important = unquote('!important');
+  } else {
+    make-important = unquote(';');
+  }
+
+  {ltr-prop}: value make-important;
+
+  .html-rtl & {
+    {inverse-prop}: value make-important;
+    {ltr-prop}: inverse-value make-important;
+  }
+}
+
+bidi-value(prop, ltr, rtl, make-important = false) {
+  bidi-style(prop, ltr, prop, rtl, make-important);
+}
+
 
 /*
   CLASSES TO BE EXTENDED BY OTHER CLASSES

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -17,7 +17,7 @@ main {
 }
 
 h3 {selector-icon} {
-  compat-important(margin-right, (grid-spacing * .75));
+  bidi-style(margin-right, (grid-spacing * .75), margin-left, 0);
 }
 
 p {
@@ -52,7 +52,7 @@ p {
   padding-right: 0;
 
   h3 {
-    margin-left: grid-spacing;
+    bidi-style(margin-left, grid-spacing, margin-right, 0);
     margin-bottom: grid-spacing;
   }
 }
@@ -61,7 +61,7 @@ p {
   reverse-link-decoration();
 
   .column-1 {
-    text-align: right;
+    bidi-value(text-align, right, left);
     color: link-color;
   }
 
@@ -143,12 +143,13 @@ p {
   }
 
   a {
+    bidi-style(padding-right, (grid-spacing * 2), padding-left, 0);
     display: block;
     margin-top: grid-spacing;
-    padding-right: (grid-spacing * 2);
     position: relative;
 
     &:before {
+      bidi-style(right, 0, left, auto);
       position: absolute;
       right: 0;
       top: 0;
@@ -163,7 +164,6 @@ p {
   }
 }
 
-
 .search-results-no-demo {
   .result-list {
     .column-strip {
@@ -171,41 +171,6 @@ p {
     }
     .result-list-item {
       @extend .column-7;
-    }
-  }
-}
-
-
-
-/* right to left */
-.html-rtl {
-  h3 {selector-icon} {
-    compat-important(margin-right, 0);
-    compat-important(margin-left, (grid-spacing * .75));
-  }
-
-  .seach-results-container {
-    h3 {
-      margin-left: 0;
-      margin-right: grid-spacing;
-    }
-  }
-
-  .result-list {
-    .column-1 {
-      text-align: left;
-    }
-  }
-
-  .search-results-topics {
-    a {
-      padding-right: 0;
-      padding-left: (grid-spacing * 2);
-
-      &:before {
-        right: auto;
-        left: 0;
-      }
     }
   }
 }

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -8,14 +8,18 @@
 
   .logo {
     @extend .text-offscreen;
+    bidi-value(float, left, right);
     width: 216px;
     height: 54px;
     background-image: url(media-url-dir + 'mdn_logo-wordmark-full_color.svg');
     background-position: -5px 0;
     background-repeat: no-repeat;
     display: block;
-    float: left;
   }
+}
+
+#tabzilla {
+  bidi-value(float, right, left);
 }
 
 #nav-access {
@@ -24,7 +28,7 @@
 
 #main-nav {
   > ul {
-    float: right;
+    bidi-value(float, right, left);
     margin-top: 20px;
     margin-bottom: grid-spacing;
 
@@ -117,12 +121,16 @@
 
 .user-state {
   @extend .smaller;
+  bidi-style(right, 200px, left, auto);
   position: absolute;
   right: 200px;
   top: 12px;
   compat-only(width, auto);
 
   li + li {
+    bidi-style(border-left, 1px solid #bbb, border-right, 0);
+    bidi-style(padding-right, 10px, padding-left, 10px, true); /* compat-important */
+    bidi-style(margin-right, 8px, margin-left, 0, true); /* compat-important */
     border-left: 1px solid #bbb;
   }
 
@@ -259,15 +267,21 @@ main {
 footer {
   @extend .smaller;
   background: #fff;
-  padding:  (2 * first-content-top-padding 0);
+  padding:  (2 * first-content-top-padding) 0;
 
   p, label {
     font-style: italic;
   }
 
   p {
-    background: url(media-url-dir + 'mdn_logo-only_color.svg') -5px 0 no-repeat;
-    compat-important(padding, 10px 0 0 92px);
+    bidi-style(padding-left, 92px, padding-right, 0, true);
+    bidi-style(background-position, -5px 0, background-position, right 0);
+    background-image: url(media-url-dir + 'mdn_logo-only_color.svg');
+    background-position: -5px 0;
+    background-repeat: no-repeat;
+    compat-important(padding-top, 10px);
+    padding-bottom: 0;
+
     min-height: 62px;
   }
 
@@ -365,45 +379,7 @@ footer {
 }
 
 
-/* rtl */
-.html-rtl {
-  #main-header {
-    .logo {
-      float: right;
-    }
 
-    #tabzilla {
-      float: left;
-    }
-  }
-
-  #main-nav {
-    > ul {
-      float: left;
-    }
-  }
-
-  .user-state {
-    left: 200px;
-    right: auto;
-
-    li + li {
-      border-left: 1px solid #bbb;
-      border-right: 0;
-      compat-only(padding-left, 10px);
-      compat-only(padding-right, 0);
-      compat-only(margin-left, 8px);
-      compat-only(margin-right, 0);
-    }
-  }
-
-  footer {
-    p {
-      background: url(media-url-dir + 'mdn_logo-only_color.svg') right 0 no-repeat;
-      compat-important(padding, 10px 92px 0 0);
-    }
-  }
-}
 
 
 /* print styling */

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -59,9 +59,8 @@ h4 {
 
 /* basic text */
 {selector-icon} {
+  bidi-style(margin-left, (grid-spacing / 2), margin-right, 0, true); /* compat-only */
   display: inline-block;
-  margin-left: (grid-spacing / 2);
-  compat-only(margin-right, 0);
 
   &:before {
     display: inline-block;
@@ -126,10 +125,4 @@ button, input[type='submit'], input[type='button'] {
 }
 
 
-/* rtl */
-.html-rtl {
-  {selector-icon} {
-    compat-only(margin-right, (grid-spacing / 2));
-    compat-only(margin-left, 0);
-  }
-}
+

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -86,20 +86,20 @@ article {
   margin-bottom: (2 * grid-spacing);
 
   li {
+    bidi-style(margin-right, (grid-spacing / 2), margin-left, 0);
     display: inline-block;
-    margin-right: (grid-spacing / 2);
   }
 
   a {
     display: block;
 
     &:after {
+      bidi-style(margin-left, 4px, margin-right, 0, true);
+      bidi-style(content, '\f054', content, '\f053');
       display: inline-block;
       font-family: FontAwesome;
       text-decoration: none;
-      content: '\f054';
       color: #c1c2c4;
-      margin-left: 4px;
       font-size: 70%;
     }
   }
@@ -108,7 +108,9 @@ article {
 }
 
 .page-buttons, #page-buttons {
+  bidi-value(float, right, left);
   float: right;
+
   text-align: right;
   compat-only(width, auto);
   compat-only(top, auto);
@@ -135,8 +137,8 @@ article {
 
   .submenu {
     component-submenu-method(160px, 1, button-background, button-shadow-color);
+    bidi-style(right, 0, left, auto);
     top: 40px;
-    right: 0;
     z-index: 3;
     border-top: 1px solid button-shadow-color;
 
@@ -145,13 +147,13 @@ article {
     }
 
     &:before {
+      bidi-style(right, 10px, left, auto);
       top: -18px;
-      right: 10px;
     }
 
     &:after {
+      bidi-style(right, 10px, left, auto);
       top: -20px;
-      right: 10px;
     }
   }
 }
@@ -420,13 +422,13 @@ div.bug > *:last-child, div.warning > *:last-child {
   }
 
   li li {
-    padding-left: 20px;
+    bidi-style(padding-left, 20px, padding-right, 0);
   }
 }
 
 .quick-links a, .quick-links .title, #quick-links-toggle {
+  bidi-style(padding-left, 20px, padding-right, 0);
   display: block;
-  padding-left: 20px;
   color: inherit;
 }
 
@@ -443,9 +445,9 @@ div.bug > *:last-child, div.warning > *:last-child {
 }
 
 .quick-links {selector-icon}, #quick-links-toggle {selector-icon} {
+  bidi-style(left, -6px, right, auto);
   font-size: 14px;
   position: absolute;
-  left: -6px;
   top: 1px;
 
   /* don't allow empty paragraphs by CKEditor */
@@ -690,49 +692,11 @@ span.cke_skin_kuma {
 }
 
 
-
-
 /* rtl */
 .html-rtl {
-
-  .page-buttons, #page-buttons {
-    float: left;
-    
-    .submenu {
-      right: auto;
-      left: 0;
-      
-      &:before {
-        right: auto;
-        left: 10px
-      }
-  
-      &:after {
-        right: auto;
-        left: 10px;
-      }
-    }
-  }
-  
   #settings-menu {
     .icon-cog {
       margin-right: 0 !important;
-    }
-  }
-
-  .crumbs {
-    float: right;
-    
-    li {
-      margin-right: 0;
-      margin-left: (grid-spacing / 2);
-    }
-    a {
-      &:after {
-        content: '\f053';
-        margin-left: 0;
-        margin-right: 4px;
-      }
     }
   }
 }

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -146,8 +146,8 @@
   }
 
   .zone-image {
+    bidi-style(right, 0, left, auto);
     position: absolute;
-    right: 0;
     top: 0;
     display: block;
     width: 200px;
@@ -212,15 +212,3 @@
     }
   }
 }
-
-/* right to left */
-.html-rtl {
-
-  .zone-article-header {
-    .zone-image {
-      right: auto;
-      left: 0;
-    }
-  }
-}
-


### PR DESCRIPTION
This is sweet.  So basically instead of repeating the nested structure of selectors, instead I created two mixins so I could set the value for ltr and rtl at the same time.

So:  

`bidi-style(left, 20px, right, auto)` becomes:

`.something { left: 20px; }  .html-rtl .something { right: 20px; left: auto; }`

Super helpful shortcut.  Much more maintainable.
