### PR TITLE
Moving some mixin classes to mixin functions to cut down on repeated CSS

### DIFF
--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -52,7 +52,7 @@
       padding: (grid-spacing * 2) 0;
 
       input {
-        @extend .big-search;
+        big-search();
         color: #fff;
 
         set-placeholder-style(color, #fff);

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -195,6 +195,33 @@ bidi-value(prop, ltr, rtl, make-important = false) {
   bidi-style(prop, ltr, prop, rtl, make-important);
 }
 
+/*
+  MIXINS LIKE CLASSES
+
+  These are not dynamic but serve as mixins so that styles wont be repeated throughout files
+*/
+heading-1() {
+  font-size: (content-block-margin * 2);
+  letter-spacing: -2px;
+}
+
+heading-2() {
+  font-size: 30px;
+  letter-spacing: -1px;
+}
+
+big-search() {
+  @extend .larger;
+  display: block;
+  margin: 0 auto;
+  background: rgba(255, 255, 255, 0.2);
+  border: 0;
+  border-radius: 3px;
+  font-family: 'Open Sans Light', sans-serif;
+  letter-spacing: -1px;
+  width: 60%;
+}
+
 
 /*
   CLASSES TO BE EXTENDED BY OTHER CLASSES
@@ -260,20 +287,6 @@ bidi-value(prop, ltr, rtl, make-important = false) {
   cursor: default;
 }
 
-.reset-font {
-  font-family: site-font-family;
-}
-
-.heading-1 {
-  font-size: (content-block-margin * 2);
-  letter-spacing: -2px;
-}
-
-.heading-2 {
-  font-size: 30px;
-  letter-spacing: -1px;
-}
-
 .button {
   text-decoration: none;
   display: inline-block;
@@ -322,16 +335,4 @@ bidi-value(prop, ltr, rtl, make-important = false) {
     vendorize(box-shadow, none);
     compat-important(background-color, transparent);
   }
-}
-
-.big-search {
-  @extend .larger;
-  display: block;
-  margin: 0 auto;
-  background: rgba(255, 255, 255, 0.2);
-  border: 0;
-  border-radius: 3px;
-  font-family: 'Open Sans Light', sans-serif;
-  letter-spacing: -1px;
-  width: 60%;
 }

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -37,7 +37,7 @@ p {
   margin-bottom: (grid-spacing * 2);
 
   input {
-    @extend .big-search;
+    big-search();
     background: rgba(255, 255, 255, 0.5);
   }
 }

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -38,12 +38,12 @@ h3, h4 {
 }
 
 h1 {
-  @extend .heading-1;
+  heading-1();
   margin-bottom: grid-spacing;
 }
 
 h2 {
-  @extend .heading-2;
+  heading-2();
   font-weight: 700;
 }
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -522,7 +522,7 @@ div.bug > *:last-child, div.warning > *:last-child {
   }
 
   h2 {
-    @extend .reset-font;
+    font-family: site-font-family;
     font-size: 28px; /* Change to h3 after redesign launched */
     compat-only(text-transform, none);
     margin-bottom: grid-spacing;

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -137,7 +137,7 @@
   overflow: hidden;
 
   .zone-title {
-    @extend .heading-2;
+    heading-2();
 
     a {
       font-family: heading-font-family;


### PR DESCRIPTION
Turned a few classes into mixin functions to cut down on repeated CSS -- the items I converted will never be used in an HTML template by themselves.
