### PR TITLE
Improve 'see also' text in quick links by making it look like a header bar

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -114,7 +114,7 @@
 
 {% macro get_document_quick_links(html) %}
   <div class="quick-links" id="quick-links">
-    <div class="title">{{ _('See Also') }}</div>
+    <div class="title see-also">{{ _('See Also') }}</div>
     {{ html|safe }}
   </div>
 {%- endmacro %}

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -412,6 +412,15 @@ div.bug > *:last-child, div.warning > *:last-child {
 
   .title {
     margin-bottom: 0;
+    display: inline-block;
+  }
+
+  .see-also {
+    background: light-background-color !important;
+    padding-left: 0;
+    margin-left: 0;
+    display: block;
+    padding: 4px 20px;
   }
 
   li {
@@ -432,10 +441,6 @@ div.bug > *:last-child, div.warning > *:last-child {
 
 .quick-links a, .quick-links .title {
   position: relative;
-}
-
-.quick-links .title {
-  display: inline-block;
 }
 
 #quick-links-toggle {


### PR DESCRIPTION
Just trying to make the quick links "See also" header better.  Now it's just floating crap; this gives it some semblance of a header.
