### PR TITLE
Fix bug 934757: Update "Where is Mozilla" copy.

### DIFF
--- a/apps/devmo/templates/devmo/calendar.html
+++ b/apps/devmo/templates/devmo/calendar.html
@@ -16,9 +16,14 @@
       <h1 class="page-title">{{ _('Where is Mozilla?') }}</h1>
       <p>
         {% trans %}
-        Here you can see some of the developer events at which Mozilla will be participating, and the topics on which our Mozillians will be speaking. 
-If you are organizing an event and would like a Mozillian to participate, please <a href="https://bugzilla.mozilla.org/form.dev-engagement-event">file a bug</a>. If you are a Mozillian speaking at an event that's not listed here, <a href="mailto:dev-events@mozilla.com">let us know</a>!
-You can also check out the <a href="https://reps.mozilla.org/events/#/period/future/">Mozilla Reps events</a> page to find a Mozilla Reps event near you!
+        Here you can see some of the developer events at which Mozilla will be
+        participating, and the topics on which our Mozillians will be speaking.
+        If you are organizing an event and would like a Mozillian to
+        participate, please <a href="https://bugzilla.mozilla.org/form.dev-engagement-event">file a bug</a>.
+        If you are a Mozillian speaking at an event that's not listed here, or
+        if an existing event entry needs updating, <a href="mailto:dev-events@mozilla.com">let us know</a>!
+        You can also check out the <a href="https://reps.mozilla.org/events/#/period/future/">Mozilla Reps events</a>
+        page to find a Mozilla Reps event near you!
         {% endtrans %}
       </p>
     </header>


### PR DESCRIPTION
The only added copy is the phrase _or if an existing event entry needs updating_, but the diff looks more substantial because I also reformatted the content to a more consistent width.
