### PR TITLE
Update Dev Derby page with generic hiatus notice.

### DIFF
--- a/apps/demos/templates/demos/devderby_landing.html
+++ b/apps/demos/templates/demos/devderby_landing.html
@@ -44,7 +44,7 @@
         <p class="submit">{% trans %}<a href="{{ submit_url }}"><b>Submit</b> Your Demo</a>{% endtrans %}</p>
       {% else %}
         <h2>{{ _('Dev Derby on Hiatus') }}</h2>
-        <p>{{ _('The Dev Derby will be on hiatus from August to October 2013.  It will return in November.') }}</p>
+        <p>{{ _('The Dev Derby is on hiatus, but will return soon.') }}</p>
       {% endif %}
     </header>
     
@@ -222,11 +222,9 @@
       {% trans %}
         <div style="padding-right: 20px;">
           <h2>Dev Derby on Hiatus</h2>
-          <p>The Dev Derby will be on hiatus from August to October while we work on revamping the contest series. The winners of all monthly contests through August 2013 will be announced on <a href="https://hacks.mozilla.org/">Mozilla Hacks</a> and rewarded per the contest rules, but a new monthly contest will not begin until November. When it returns, you may see some changes in the contest format. However, the Dev Derby mission remains unchanged: to provide a platform that helps web developers learn, share, and push the web forward.</p>
+          <p>The Dev Derby is on hiatus while we work on revamping the contest series. When it returns, you may see some changes in the contest format. However, the Dev Derby mission remains unchanged: to provide a platform that helps web developers learn, share, and push the web forward.</p>
 
-          <p>For more information, see <a href="https://hacks.mozilla.org/2013/06/announcing-an-administrative-change-to-the-dev-derby/">Announcing an administrative change to the Dev Derby</a>. If you have suggestions or feedback about Dev Derby, please leave them in the comments on that posting.</p>
-
-          <p>See you in November!</p>
+          <p>See you soon!</p>
         </div>
       {% endtrans %}
 


### PR DESCRIPTION
The volunteer Dev Derby contributors will not be holding a contest in November,
and have asked that we use more generic timeframes on the landing page instead.
