### PR TITLE
Wiki column updates to better manage RTL and hidden columns

### DIFF
--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -33,21 +33,27 @@
     setupTogglers($quickLinks.find('> ul > li, > ol > li'));
     $quickLinks.find('.toggleable').mozTogglers();
     
-    var side = $('#quick-links-toggle').closest('.wiki-column').attr('id');
     var $columnContainer = $('#wiki-column-container');
     var $quickLinksControl = $('#wiki-controls .quick-links');
 
+    var child = $('#wiki-left').get(0);
+    if(child) {
+      var parent = child.parentNode;
+    }
+
     // Quick Link toggles
     $('#quick-links-toggle, #show-quick-links').on('click', function(e) {
-      var $side = $('#' + side);
-
       e.preventDefault();
-      $side.toggleClass('column-closed');
-      $columnContainer.toggleClass(side + '-closed');
+      $(child).toggleClass('column-closed');
+      $columnContainer.toggleClass('wiki-left-closed');
       $quickLinksControl.toggleClass('hidden');
 
-      if($side.hasClass('column-closed')) {
+      if($(child).hasClass('column-closed')) {
         $(window).trigger('resize');
+        parent.removeChild(child);
+      }
+      else {
+        parent.appendChild(child);
       }
     });
   })();

--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -23,13 +23,12 @@
     bidi-value(float, left, right);
 
     &:last-child {
-      margin-right: 0;
       bidi-value(margin-right, 0, grid-margin);
     }
   }
 
   &.column-container-reverse {
-    bidi-value(margin-left, -1%, 0);
+    bidi-style(margin-left, -1%, margin-right, 0);
 
     {grid-column-selector} {
       bidi-value(float, right, left);
@@ -39,7 +38,6 @@
       }
 
       &:last-child {
-        margin-right: grid-margin;
         bidi-value(margin-right, grid-margin, 0);
       }
     }

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -33,130 +33,6 @@
     padding: first-content-top-padding 0;
   }
 
-  /* masthead */
-  .home-masthead {
-
-    h1 {
-      color: #fff;
-      margin-bottom: 0;
-      margin: 0 auto;
-      width: 60%;
-
-      span {
-        bidi-style(padding-left, 20%, padding-right, 0);
-        display: block;
-      }
-    }
-
-    .home-search-form {
-      padding: (grid-spacing * 2) 0;
-
-      input {
-        big-search();
-        color: #fff;
-
-        set-placeholder-style(color, #fff);
-      }
-    }
-  }
-
-  .home-features {
-    &, a {
-      color: #fff;
-    }
-
-    a {
-      text-decoration: underline;
-    }
-
-    h3 {
-      @extend .larger;
-      font-weight: bold;
-      font-family: 'Open Sans Extra Bold', sans-serif;
-    }
-
-    li {
-      padding: 4px 0;
-    }
-
-    .column-home-features {
-      @extend .column-strip;
-    }
-  }
-
-  /* callouts */
-
-  .column-callout  {
-    @extend .column-4;
-    position: relative;
-
-    i {
-      bidi-style(right, 5%, left, auto);
-      position: absolute;
-      top: 0;
-      display: block;
-    }
-
-    span {
-      padding-right: 20px;
-    }
-
-    a {
-      @extend .larger;
-      color: #fff;
-      display: block;
-      padding: 100px grid-spacing grid-spacing grid-spacing;
-      position: relative;
-      overflow-x: hidden;
-
-      &:before {
-        bidi-style(content, '\f061', content, '\f060');
-        bidi-style(right, grid-spacing, left, 0);
-        font-family: 'FontAwesome';
-        bottom: grid-spacing;
-        position: absolute;
-        font-size: 24px;
-        z-index: 4;
-      }
-    }
-
-    &.callout-apps {
-      background: #e66000;
-
-      i {
-        width: 200px;
-        height: 130px;
-        background: url(media-url-dir + 'HTML5_Logo.svg') center -70px no-repeat;
-      }
-    }
-
-    &.callout-android {
-      background: #97c03d;
-
-      i {
-        width: 260px;
-        height: 140px;
-        background: url(media-url-dir + 'promo-phone.png') center -190px no-repeat;
-      }
-    }
-
-    &.callout-firefoxos {
-      background-color: #0095dd;
-
-      i {
-        width: 320px;
-        height: 150px;
-        background: url(media-url-dir + 'promo-fox.png') center -60px no-repeat;
-      }
-    }
-    
-    &.callout-apps, &.callout-android, &.callout-firefoxos {
-      i {
-        background-size: cover;
-      }
-    }
-  }
-
   /* shared */
   h2, h3 {
     > i {
@@ -203,7 +79,7 @@
       width: 47px;
       height: 41px;
       color: #0095dd;
-      margin-right: 10px !important;
+      margin-left: 0 !important;
       float: left;
 
       &:before {
@@ -226,90 +102,212 @@
     @extend .smaller;
     font-style: italic;
   }
+}
 
-  /* hacks */
-  .home-hacks {
-    background: #fff;
+/* masthead */
+.home-masthead {
 
-    .column-hacks {
-      @extend .column-main;
+  h1 {
+    color: #fff;
+    margin: 0 auto;
+    width: 60%;
+
+    span {
+      bidi-style(padding-left, 20%, padding-right, 0);
+      display: block;
+    }
+  }
+
+  .home-search-form {
+    padding: (grid-spacing * 2) 0;
+
+    input {
+      big-search();
+      color: #fff;
+
+      set-placeholder-style(color, #fff);
+    }
+  }
+}
+
+.home-features {
+  &, a {
+    color: #fff !important;
+  }
+
+  a {
+    text-decoration: underline;
+  }
+
+  h3 {
+    @extend .larger;
+    font-weight: bold;
+    font-family: 'Open Sans Extra Bold', sans-serif;
+  }
+
+  li {
+    padding: 4px 0;
+  }
+
+  .column-home-features {
+    @extend .column-strip;
+  }
+}
+
+/* callouts */
+.column-callout  {
+  @extend .column-4;
+  position: relative;
+
+  i {
+    bidi-style(right, 5%, left, auto);
+    position: absolute;
+    top: 0;
+    display: block;
+  }
+
+  span {
+    padding-right: 20px;
+  }
+
+  a {
+    @extend .larger;
+    color: #fff !important;
+    display: block;
+    padding: 100px grid-spacing grid-spacing grid-spacing;
+    position: relative;
+    overflow-x: hidden;
+
+    &:before {
+      bidi-style(content, '\f061', content, '\f060');
+      bidi-style(right, grid-spacing, left, auto);
+      font-family: 'FontAwesome';
+      bottom: grid-spacing;
+      position: absolute;
+      font-size: 24px;
+      z-index: 4;
+    }
+  }
+
+  &.callout-apps {
+    background: #e66000;
+
+    i {
+      width: 200px;
+      height: 130px;
+      background: url(media-url-dir + 'HTML5_Logo.svg') center -70px no-repeat;
+    }
+  }
+
+  &.callout-android {
+    background: #97c03d;
+
+    i {
+      width: 260px;
+      height: 140px;
+      background: url(media-url-dir + 'promo-phone.png') center -190px no-repeat;
+    }
+  }
+
+  &.callout-firefoxos {
+    background-color: #0095dd;
+
+    i {
+      width: 320px;
+      height: 150px;
+      background: url(media-url-dir + 'promo-fox.png') center -60px no-repeat;
+    }
+  }
+  
+  &.callout-apps, &.callout-android, &.callout-firefoxos {
+    i {
+      background-size: cover;
+    }
+  }
+}
+
+/* hacks */
+.home-hacks {
+  background: #fff;
+
+  .column-hacks {
+    @extend .column-main;
+  }
+
+  .column-involved {
+    @extend .column-strip;
+  }
+
+  li {
+    padding-top: grid-spacing;
+    border-bottom: 1px solid #ececec;
+
+    &:last-child {
+      border-bottom: 0;
+    }
+  }
+
+  h2.entry-title {
+    letter-spacing: 0;
+    line-height: normal;
+    margin-bottom: 0;
+    font-size: base-font-size;
+
+    a {
+      text-decoration: underline;
+      compat-only(margin-left, 0);
+      compat-only(font-style, normal);
+    }
+  }
+
+  .hacks {
+    margin-bottom: (grid-spacing / 2);
+  }
+
+  .home-involved-card {
+    background: url(media-url-dir + 'home-globe.svg') -90px 40px no-repeat #f4f7f8;
+    background-size: 600px;
+
+    a {
+      color: #fff;
+      text-decoration: none;
+      padding: grid-spacing;
+      display: block;
     }
 
-    .column-involved {
-      @extend .column-strip;
-    }
+    .numbers {
+      padding-bottom: 40px;
+      line-height: 40px;
 
-    li {
-      padding-top: grid-spacing;
-      border-bottom: 1px solid #ececec;
-
-      &:last-child {
-        border-bottom: 0;
-      }
-    }
-
-    h2.entry-title {
-      letter-spacing: 0;
-      line-height: normal;
-      margin-bottom: 0;
-      font-size: base-font-size;
-
-      a {
-        text-decoration: underline;
-        compat-only(margin-left, 0);
-        compat-only(font-style, normal);
-      }
-    }
-
-    .hacks {
-      margin-bottom: (grid-spacing / 2);
-    }
-
-    .home-involved-card {
-      background: url(media-url-dir + 'home-globe.svg') -90px 40px no-repeat #f4f7f8;
-      background-size: 600px;
-
-      a {
-        color: #fff;
-        text-decoration: none;
-        padding: grid-spacing;
+      .row1, .row2, .row3 {
         display: block;
       }
+    }
 
-      .numbers {
-        padding-bottom: 40px;
-        line-height: 40px;
+    .number {
+      font-size: 30px;
+      font-weight: bold;
+    }
 
-        .row1, .row2, .row3 {
-          display: block;
-        }
-      }
+    h3 {
+      @extend .larger;
+      padding-bottom: (grid-spacing / 2);
+      border-bottom: 1px solid #e0e2e4;
+      margin-bottom: 110px;
+      bidi-style(margin-right, -(grid-spacing), margin-left, 0);
+      font-weight: bold;
+    }
 
-      .number {
-        font-size: 30px;
-        font-weight: bold;
-      }
+    p {
+      margin: 0;
+      padding: 0;
+      text-align: center;
+    }
 
-      h3 {
-        @extend .larger;
-        padding-bottom: (grid-spacing / 2);
-        border-bottom: 1px solid #e0e2e4;
-        margin-bottom: 110px;
-        bidi-style(margin-right, -(grid-spacing), margin-left, 0);
-        font-weight: bold;
-      }
-
-      p {
-        margin: 0;
-        padding: 0;
-        text-align: center;
-      }
-
-      .button {
-        background-color: #48ade4 !important;
-        font-size: smaller-font-size !important;
-        color: #fff !important;
-      }
+    .button {
+      background-color: #48ade4 !important;
+      font-size: smaller-font-size !important;
+      color: #fff !important;
     }
   }
 }
@@ -450,6 +448,12 @@
     > selector-icon:before {
       margin-right: 22px;
     }
+
+    a { /* this can be bidi-'d when we can accommodate for body */
+      margin-right: (grid-spacing * 2);
+      margin-left: 0;
+    }
+
   }
 
   h3 {

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -303,8 +303,9 @@ big-search() {
 
   &.only-icon {
     {selector-icon} {
-      margin-left: 0;
-      margin-top: -1px;
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      margin-top: -1px !important;
     }
 
     span {

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -480,14 +480,6 @@ div.bug > *:last-child, div.warning > *:last-child {
   }
 }
 
-#wiki-column-container.wiki-right-closed #wiki-content {
-  margin-right: 0;
-}
-
-#wiki-column-container.wiki-left-closed #wiki-content {
-  margin-left: 0;
-}
-
 /* wiki new and edit pages */
 .page-meta section, #article-head {
   compat-only(background, none);
@@ -687,22 +679,12 @@ span.cke_skin_kuma {
     }
   }
 
-  #wiki-column-container, #wiki-content, $wiki {
+  #wiki-column-container, #wiki-content {
     width: auto !important;
   }
 
   #quick-links-toggle,  #wiki-controls {
     display: none;
-  }
-}
-
-
-/* rtl */
-.html-rtl {
-  #settings-menu {
-    .icon-cog {
-      margin-right: 0 !important;
-    }
   }
 }
 


### PR DESCRIPTION
The PR dreams are made of.  I was tripping over wiki issues when in RTL mode when the subnav column was hidden.  Turns out, if I simply remove the column from the DOM when hidden, the column container's :last-child rules kick in and I can avoid all that.

This PR looks big but isn't.  I was wrapping all of the homepage stuff in #home but that just bloats the CSS so I moved most of it out.

Would love to get this PR merged by end of day so Jean-Yves doesn't needlessly open tickets for a few things tomorrow.
