### PR TITLE
fix bug 935351 - Don't allow IFRAME's or videos to be more than 100%

### DIFF
--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -68,7 +68,7 @@ h4 {
   }
 }
 
-img {
+img, iframe, video {
   max-width: 100%;
 }
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=935351
