### PR TITLE
Implement microdata for breadcrumbs for Google Search results.

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -17,12 +17,12 @@
 {%- endmacro %}
 
 {% macro build_document_crumbs(document) %}
-  <nav class="crumbs" role="navigation"><ol>
-    <li><a href="/{{ request.locale }}">MDN</a></li>
+  <nav class="crumbs" role="navigation"><ol xmlns:v="http://rdf.data-vocabulary.org/#" aria-label="{{ _('breadcrumbs') }}">
+    <li typeof="v:Breadcrumb"><a href="/{{ request.locale }}" rel="v:url" property="v:title">MDN</a></li>
     {% for doc in document.parents %}
-      <li class="crumb"><a href="{{ url('wiki.document', doc.full_path) }}">{{ doc.title }}</a></li>
+      <li class="crumb" typeof="v:Breadcrumb"><a href="{{ url('wiki.document', doc.full_path) }}" rel="v:url" property="v:title">{{ doc.title }}</a></li>
     {% endfor %}
-    <li class="crumb">{{ document.title }}</li>
+    <li class="crumb" typeof="v:Breadcrumb" property="v:title">{{ document.title }}</li>
   </ol></nav>
 {%- endmacro %}
 


### PR DESCRIPTION
To test:

Create a 3-level deep document, then paste the crumb contents here:

http://www.google.com/webmasters/tools/richsnippets

You'll see the correct breadcrumb structure below it.
