### PR TITLE
fix bug 928305 - Adding a box state for search filters when on and off

### DIFF
--- a/apps/search/templates/search/results-redesign.html
+++ b/apps/search/templates/search/results-redesign.html
@@ -114,13 +114,9 @@
         {% for facet in facet_counts %}
         <li>
         {% if facet.deselect_url %}
-          {#
-            if face.deselect_url is available that means the facet is applied and should somehow indicate that to the user.
-            here I'm using a blasphemous style attribute to make the font bold when a facet is select. PLEASE FIXME!
-          #}
-          <a href="{{ facet.deselect_url }}" data-count="{{ facet.count }}" class="checked">{{ facet.label }}<i class="icon-check"></i></a>
+          <a href="{{ facet.deselect_url }}" data-count="{{ facet.count }}" class="checked"><i class="icon-check"></i>{{ facet.label }}</a>
         {% else %}
-          <a href="{{ facet.select_url }}" data-count="{{ facet.count }}">{{ facet.label }}</a>
+          <a href="{{ facet.select_url }}" data-count="{{ facet.count }}"><i class="icon-check-empty"></i>{{ facet.label }}</a>
         {% endif %}
         </li>
         {% endfor %}

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -5,8 +5,8 @@
 .toggler {
   position: relative;
 
-  i {
-    bidi-style(right, 10px, left, auto);
+  {selector-icon} {
+    bidi-style(right, icon-margin, left, auto);
     position: absolute;
     top: 3px;
     color: text-color;

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -143,8 +143,8 @@
     font-weight: bold;
     font-family: 'Open Sans Extra Bold', sans-serif;
 
-    i {
-      bidi-style(margin-right, 10px, margin-left, 0);
+    {selector-icon} {
+      bidi-style(margin-right, icon-margin, margin-left, 0);
     }
   }
 
@@ -465,7 +465,7 @@
 
     {selector-icon} {
       compat-only(margin-right, 0);
-      compat-only(margin-left, 10px);
+      compat-only(margin-left, icon-margin);
     }
   }
 

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -150,6 +150,20 @@ p {
     display: block;
     margin-top: grid-spacing;
     position: relative;
+    color: #999;
+
+    {selector-icon} {
+      margin-left: 0;
+      bidi-style(margin-right, icon-margin, margin-left, 0);
+    }
+
+    &.checked {
+      color: link-color;
+
+      {selector-icon} {
+
+      }
+    }
 
     &:before {
       bidi-style(right, 0, left, auto);
@@ -159,10 +173,6 @@ p {
       content: attr(data-count);
       color: text-color;
       opacity: 0.6;
-    }
-
-    &.checked {
-      color: #999;
     }
   }
 }

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -59,8 +59,8 @@ h4 {
 
 /* basic text */
 {selector-icon} {
-  bidi-style(margin-left, (grid-spacing / 2), margin-right, 0); /* compat-only */
-  bidi-style(margin-right, 0, margin-left, (grid-spacing / 2)); /* compat-only */
+  bidi-style(margin-left, icon-margin, margin-right, 0); /* compat-only */
+  bidi-style(margin-right, 0, margin-left, icon-margin); /* compat-only */
   display: inline-block;
 
   &:before {

--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -44,7 +44,10 @@ gutter-width = 24px;
 first-content-top-padding = (grid-spacing * 2);
 list-item-spacing = 8px;
 content-block-margin = gutter-width;
+icon-margin = 10px;
 
 /* selectors */
 selector-icon = 'i[class^="icon-"]';
+
+/* paths */
 media-url-dir = '/media/redesign/img/';

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -355,7 +355,7 @@ div.bug > *:last-child, div.warning > *:last-child {
   position: relative;
 
   {selector-icon} {
-    left: (grid-spacing / 2);
+    bidi-style(left, icon-margin, right, auto);
     position: absolute;
   }
 


### PR DESCRIPTION
The real work is in "results-redesign.html".  This adds both a checked and unchecked state for filters.  Additionally, I've taken the liberty of creating a variable for icon margin spacing instead of repeating 10px everywhere.
