### PR TITLE
bug 773522: Fix djcelery tables with a local migration

### DIFF
--- a/migrations/south/djcelery/0002_v25_changes.py
+++ b/migrations/south/djcelery/0002_v25_changes.py
@@ -1,0 +1,147 @@
+# encoding: utf-8
+
+
+# NOTE: This migration is an attempt to correct a mistake in Kuma.
+#
+# At one point, we had a version of djcelery that did not use South. Then, we
+# upgraded to a version that *does* use South, but we had already shoehorned
+# migrations into djcelery using SOUTH_MIGRATION_MODULES locally.
+#
+# That put us out of sync with djcelery's migrations. So, this migration
+# attempts to put us back into sync, so that we can eventually take djcelery
+# out of SOUTH_MIGRATION_MODULES in settings.py
+
+
+from __future__ import absolute_import
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+
+        # Adding model 'TaskMeta'
+        db.create_table('celery_taskmeta', (
+                ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+                ('task_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+                ('hidden', self.gf('django.db.models.fields.BooleanField')(default=False)),
+                ('status', self.gf('django.db.models.fields.CharField')(default='PENDING', max_length=50)),
+                ('result', self.gf('picklefield.fields.PickledObjectField')(default=None, null=True)),
+                ('date_done', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),
+                ('traceback', self.gf('django.db.models.fields.TextField')(null=True, blank=True)),))
+        db.send_create_signal('djcelery', ['TaskMeta'])
+
+        # Adding model 'TaskSetMeta'
+        db.create_table('celery_tasksetmeta', (
+                ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+                ('taskset_id', self.gf('django.db.models.fields.CharField')(unique=True, max_length=255)),
+                ('hidden', self.gf('django.db.models.fields.BooleanField')(default=False)),
+                ('result', self.gf('picklefield.fields.PickledObjectField')()),
+                ('date_done', self.gf('django.db.models.fields.DateTimeField')(auto_now=True, blank=True)),))
+        db.send_create_signal('djcelery', ['TaskSetMeta'])
+        
+        # Adding field 'PeriodicTask.description'
+        db.add_column('djcelery_periodictask', 'description', self.gf('django.db.models.fields.TextField')(default='', blank=True), keep_default=False)
+
+        db.add_column('djcelery_taskstate', 'retries', self.gf('django.db.models.fields.IntegerField')(default=0), keep_default=False)
+
+
+    def backwards(self, orm):
+
+        # Deleting model 'TaskMeta'
+        db.delete_table('celery_taskmeta')
+
+        # Deleting model 'TaskSetMeta'
+        db.delete_table('celery_tasksetmeta')
+
+        # Deleting field 'PeriodicTask.description'
+        db.delete_column('djcelery_periodictask', 'description')
+
+        db.delete_column('djcelery_taskstate', 'retries')
+
+
+    models = {
+        'djcelery.crontabschedule': {
+            'Meta': {'object_name': 'CrontabSchedule'},
+            'day_of_week': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'hour': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'minute': ('django.db.models.fields.CharField', [], {'default': "'*'", 'max_length': '64'})
+        },
+        'djcelery.intervalschedule': {
+            'Meta': {'object_name': 'IntervalSchedule'},
+            'every': ('django.db.models.fields.IntegerField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'period': ('django.db.models.fields.CharField', [], {'max_length': '24'})
+        },
+        'djcelery.periodictask': {
+            'Meta': {'object_name': 'PeriodicTask'},
+            'args': ('django.db.models.fields.TextField', [], {'default': "'[]'", 'blank': 'True'}),
+            'crontab': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.CrontabSchedule']", 'null': 'True', 'blank': 'True'}),
+            'date_changed': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'exchange': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'expires': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'interval': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.IntervalSchedule']", 'null': 'True', 'blank': 'True'}),
+            'kwargs': ('django.db.models.fields.TextField', [], {'default': "'{}'", 'blank': 'True'}),
+            'last_run_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '200'}),
+            'queue': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'routing_key': ('django.db.models.fields.CharField', [], {'default': 'None', 'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'task': ('django.db.models.fields.CharField', [], {'max_length': '200'}),
+            'total_run_count': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        'djcelery.periodictasks': {
+            'Meta': {'object_name': 'PeriodicTasks'},
+            'ident': ('django.db.models.fields.SmallIntegerField', [], {'default': '1', 'unique': 'True', 'primary_key': 'True'}),
+            'last_update': ('django.db.models.fields.DateTimeField', [], {})
+        },
+        'djcelery.taskmeta': {
+            'Meta': {'object_name': 'TaskMeta', 'db_table': "'celery_taskmeta'"},
+            'date_done': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('picklefield.fields.PickledObjectField', [], {'default': 'None', 'null': 'True'}),
+            'status': ('django.db.models.fields.CharField', [], {'default': "'PENDING'", 'max_length': '50'}),
+            'task_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'traceback': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'djcelery.tasksetmeta': {
+            'Meta': {'object_name': 'TaskSetMeta', 'db_table': "'celery_tasksetmeta'"},
+            'date_done': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'result': ('picklefield.fields.PickledObjectField', [], {}),
+            'taskset_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'})
+        },
+        'djcelery.taskstate': {
+            'Meta': {'ordering': "['-tstamp']", 'object_name': 'TaskState'},
+            'args': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'eta': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'expires': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'hidden': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'kwargs': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'db_index': 'True'}),
+            'result': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'retries': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'runtime': ('django.db.models.fields.FloatField', [], {'null': 'True'}),
+            'state': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'task_id': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '36'}),
+            'traceback': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'tstamp': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True'}),
+            'worker': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['djcelery.WorkerState']", 'null': 'True'})
+        },
+        'djcelery.workerstate': {
+            'Meta': {'ordering': "['-last_heartbeat']", 'object_name': 'WorkerState'},
+            'hostname': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '255'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_heartbeat': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'})
+        }
+    }
+
+    complete_apps = ['djcelery']

--- a/settings.py
+++ b/settings.py
@@ -872,6 +872,8 @@ CELERY_ANNOTATIONS = {
     }
 }
 
+CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
+
 # Wiki rebuild settings
 WIKI_REBUILD_TOKEN = 'sumo:wiki:full-rebuild'
 WIKI_REBUILD_ON_DEMAND = False


### PR DESCRIPTION
djcelery has South migrations, now. But, we already slapped South migrations on it in our own local directory. This means some things are broken and DB columns missing, though I don't think anyone noticed until now.

Oh yeah, and spot-checking this might be odd. Basically:
- Visit djcelery sections in the admin, expect errors in a few of the sections.
- Run `mysql -uroot kuma`
  - These tables should not exist: `celery_taskmeta`, `celery_tasksetmeta`
  - These columns should not exist: `djcelery_periodictask.description`, `djcelery_taskstate.retries`
- Run `./manage.py migrate` and expect no errors.
- Visit djcelery sections in the admin, expect that the previous errors are now fixed.
- Run `mysql -uroot kuma`
  - Check that these tables now exist: `celery_taskmeta`, `celery_tasksetmeta`
  - Check that these columns exist on the respective tables: `djcelery_periodictask.description`, `djcelery_taskstate.retries`

This PR is step 1, which brings our custom migrations back in line with djcelery's official migrations. Step 2 will be to delete our local migrations, once they've been applied, and to let djcelery manage itself going forward.
