### PR TITLE
Use wider letter-spacing in name on profile

### DIFF
--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -24,4 +24,8 @@
   .submission .fm-submit button {
     box-shadow: inherit;
   }
+
+  h1 {
+      letter-spacing: -1px;
+  }
 }


### PR DESCRIPTION
A letter-spacing of -2px looks great on page titles, but makes profile
names look a bit too tight and somewhat out of place.
