### PR TITLE
Make Demo Studio links appear over spotlight image

### DIFF
--- a/media/css/demos.css
+++ b/media/css/demos.css
@@ -366,7 +366,7 @@
 #page-head.gallery .author .edit .button { color: #fff; }
 
 /* @Gallery @Head *********/
-.gallery-head { clear: both; }
+.gallery-head { clear: both; position: relative; z-index: 11; }
 .gallery-head:after { content: "."; display: block; clear: both; height: 0; visibility: hidden; }
 .gallery-head .count { font-size: 1.428em; float: left; }
 .gallery-head .count .button { font-size: .636em; margin-left: 15px; position: relative; top: -2px; }

--- a/media/redesign/stylus/demo-studio.styl
+++ b/media/redesign/stylus/demo-studio.styl
@@ -62,6 +62,11 @@ html {
   .button, button {
     compat-important(box-shadow, none);
   }
+
+  .gallery-head {
+      position: relative;
+      z-index: 11;
+  }
 }
 
 #demostudio.landing, #demostudio.detail {


### PR DESCRIPTION
Fixes this bug:
https://twitter.com/johnkreitlow/status/380344466512437248

To reproduce on master:
1. Visit `/demos`
2. Try to click _Most Viewed_
