### PR TITLE
Add margin-bottom to all content tables

### DIFF
--- a/media/redesign/stylus/classes.styl
+++ b/media/redesign/stylus/classes.styl
@@ -4,7 +4,6 @@
     border-collapse: collapse;
     border: solid #e0e0dc;
     border-width: 1px 0 0 1px;
-    margin-bottom: content-block-margin;
   }
 
   td, th {

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -184,3 +184,9 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     z-index: 1;
   }
 }
+
+#content {
+    table {
+        margin-bottom: content-block-margin;
+    }
+}


### PR DESCRIPTION
Some tables, such as the one appearing on the "Where is Mozilla" page,
were not getting margin-bottoms because the property was only applied to
.text-content (wiki) tables.
