### PR TITLE
fix bug 919065 - Allow attribute for auto-opening a quicklink menu

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -115,6 +115,7 @@ ALLOWED_ATTRIBUTES.update(dict((x, ['style', 'class', 'id', 'lang', 'dir', 'titl
 ALLOWED_ATTRIBUTES.update(dict((x, ['cite']) for x in (
     'blockquote', 'del', 'ins', 'q'
 )))
+ALLOWED_ATTRIBUTES['li'] += ['data-default-state']
 ALLOWED_ATTRIBUTES['time'] += ['datetime']
 ALLOWED_ATTRIBUTES['ins'] = ['datetime']
 ALLOWED_ATTRIBUTES['del'] = ['datetime']

--- a/media/css/wiki-edcontent.css
+++ b/media/css/wiki-edcontent.css
@@ -92,3 +92,13 @@ pre[class^="brush:sql"]:before, pre[class^="brush: sql"]:before {
 pre[class^="brush:xml"]:before, pre[class^="brush: xml"]:before {
 	content: "XML";
 }
+
+li[data-default-state="open"] > a:after {
+	content: "(defaults to 'open')";
+	color: #666;
+	font-size: 12px;
+	font-family: arial, sans-serif;
+	font-style: italic;
+	display: inline-block;
+	padding-left: 6px;
+}

--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -233,9 +233,14 @@
           }
         }
 
-        // Handle me
+        // Open or close the item, set the icon, etc.
         toggle($self);
       });
+
+      // The toggler can be initially opened via a data- attribute
+      if($self.attr('data-default-state') == 'open') {
+        toggle($self);
+      }
 
       function toggle($li, forceClose) {
         var pieces = getTogglerComponents($li);


### PR DESCRIPTION
Add "data-default-state='open'" to the top-level LI in a quicklinks list and it will now auto-open upon page load.

https://bugzilla.mozilla.org/show_bug.cgi?id=919065
