### PR TITLE
Vertically center subnav icon

### DIFF
--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -77,7 +77,7 @@
     background: light-background-color;
   }
 
-  i {
+  {selector-icon} {
     top: (grid-spacing + 3px);
     right: grid-spacing;
   }


### PR DESCRIPTION
Created a specificity issue during my cleanup :/  This vertically centers the subnav arrow icon again.
