### PR TITLE
fix bug 927047 - Only include lang switcher if doc has multiple langs

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -59,7 +59,7 @@
 {% endblock %}
 
 {% block lang_switcher %}
-  {% if document.is_localizable or document.parent %}
+  {% if (document.is_localizable or document.parent) and document.other_translations|length %}
     <form class="languages go" method="get" action="{{ url('docs') }}">
       <label for="language">{{ _('Other languages:') }}</label>
       <select id="language" class="wiki-l10n" name="next" dir="ltr">


### PR DESCRIPTION
Only showing the footer translation dropdown if more than one language exists.
