### PR TITLE
fix bug 937832 - Change outline color for a11y

### DIFF
--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -136,6 +136,7 @@
 
   a {
     text-decoration: underline;
+    outline-color: #fff;
   }
 
   h3 {


### PR DESCRIPTION
The home features outline should be white for the sake of a11y
