### PR TITLE
Remove confusing aria properties

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -156,7 +156,7 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
 
     <a href="{{ url('home') }}" class="logo">{{ _('Mozilla Developer Network') }}</a>
 
-    <nav id="main-nav" role="navigation"><ul><li><a href="javascript:;" aria-haspopup="true" aria-owns="nav-zones-submenu" aria-expanded="false">{{ _('Zones') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+    <nav id="main-nav" role="navigation"><ul><li><a href="javascript:;">{{ _('Zones') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
         <div class="submenu submenu-single" id="nav-zones-submenu">
           <div class="submenu-column">
@@ -167,7 +167,7 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
             </ul>
           </div>
         </div>
-      </li><li><a href="{{ devmo_url('Web') }}" aria-haspopup="true" aria-owns="nav-platform-submenu" aria-expanded="false">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+      </li><li><a href="{{ devmo_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
         <div class="submenu" id="nav-platform-submenu">
           <div class="submenu-column">


### PR DESCRIPTION
icaaq says we don't need these since the menu opens upon focus.  He said they would only confuse screen readers.
