### PR TITLE
fix bug 938579 - Ensure two-line filters display properly

### DIFF
--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -143,47 +143,40 @@ p {
   reverse-link-decoration();
 
   h3 {
-    margin-bottom: (grid-spacing * 1.5);
+    margin-bottom: (grid-spacing / 2);
 
     i {
       margin-left: 0;
     }
   }
 
-  span {
+  li {
+    padding-bottom: (grid-spacing / 2);
+  }
 
-    &.inactive {
-      bidi-style(padding-right, (grid-spacing * 2), padding-left, 0);
-      display: block;
-      margin-top: grid-spacing;
-      position: relative;
-      color: lightgrey;
+  span, a {
+    bidi-value(padding-right, (grid-spacing * 2), grid-spacing);
+    bidi-value(padding-left, grid-spacing, (grid-spacing * 2));
 
-      {selector-icon} {
-        margin-left: 0;
-        bidi-style(margin-right, icon-margin, margin-left, 0);
-      }
+    display: block;
+    position: relative;
+
+    {selector-icon} {
+      position: absolute;
+      top: 4px;
+      bidi-style(left, -10px, right, auto);
     }
   }
 
-  a {
-    bidi-style(padding-right, (grid-spacing * 2), padding-left, 0);
-    display: block;
-    margin-top: grid-spacing;
-    position: relative;
-    color: #999;
+  span.inactive {
+    color: lightgrey;
+  }
 
-    {selector-icon} {
-      margin-left: 0;
-      bidi-style(margin-right, icon-margin, margin-left, 0);
-    }
+  a {
+    color: #999;
 
     &.checked {
       color: link-color;
-
-      {selector-icon} {
-
-      }
     }
 
     &:before {


### PR DESCRIPTION
Text no longer wraps around icons.
