### PR TITLE
fix bug 938552 - Prevent too much spacing at the bottom of overheadIndicator boxes

### DIFF
--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -23,7 +23,11 @@ vendorize-value(property, value, more = '') {
 
 /* prevents spacing of a given element if it's the last child */
 prevent-last-child-spacing(element = '*', property = 'padding') {
-  & unquote(element):last-child {
+  if (element is '*') {
+    element = unquote(element);
+  }
+
+  & > {element}:last-child {
     {property}: 0;
   }
 }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -331,8 +331,13 @@ article {
   }
 }
 
-div.bug > *:last-child, div.warning > *:last-child {
-  compat-important(padding-left, inherit);
+div.bug, div.warning, div.overheadIndicator {
+  prevent-last-child-spacing('*', margin-bottom);
+  prevent-last-child-spacing('*', padding-bottom);
+
+  & > *:last-child {
+    compat-important(padding-left, inherit);
+  }
 }
 
 .warning {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=938552

You'll also need to grab Template:CustomCSS from prod -- I made an adjustment there too.
