### PR TITLE
Add maintenance README and fix minor download bug

### DIFF
--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -1,0 +1,11 @@
+These files are stored here only for revision control. Getting them served up will always require additional work.
+
+To use an asset that would normally be served from the CDN:
+
+1. Attach the asset to index.html relative to the CDN root. For example, to attach `https://developer.cdn.mozilla.net/media/css/mdn-min.css`, use
+
+   ```html
+   <link rel="stylesheet" media="screen,projection,tv" href="media/css/mdn-min.css" />
+   ```
+
+2. Run `download-assets.sh` in the VM

--- a/maintenance/download-assets.sh
+++ b/maintenance/download-assets.sh
@@ -21,7 +21,7 @@ function download {
 
 function download_referenced {
   # All additional assets referenced with url()
-  REFERENCED=`grep -Pro "url\(.*?\)" $LOCAL | sed -r "s/url\((\"|')?(.*?)(\?.*$|#.*$|\".*$|'.*$|\).*$)/\2/" | sort | uniq`
+  REFERENCED=`find . -name '*.css' | xargs grep -Pro "url\(.*?\)" | sed -r "s/url\((\"|')?(.*?)(\?.*$|#.*$|\".*$|'.*$|\).*$)/\2/" | sort | uniq`
 
   while read -r REFERENCE_INFO; do
     REFERENCED_FROM=`echo $REFERENCE_INFO | sed -r "s/(.*?\/?)+\/.*?:.*$/\1/"`


### PR DESCRIPTION
Neither of these changes requires that an existing maintenance page be
rebuilt.

The bug fix ensures that downloads are only attempted on strings found
within `url(...)` in _CSS_ files, so that downloads do not start (and
fail) when `url(...)` is encountered in JavaScript and SVG files.
