### PR TITLE
fix bug 937723 - correctly handle the difference between document tags and search filter tags.

### DIFF
--- a/apps/search/filters.py
+++ b/apps/search/filters.py
@@ -82,16 +82,16 @@ class DatabaseFilterBackend(BaseFilterBackend):
                 if len(filter_tags) > 1:
                     tag_filters = []
                     for filter_tag in filter_tags:
-                        tag_filters.append(F(tags=filter_tag.lower()))
+                        tag_filters.append(F(tags=filter_tag))
                     active_filters.append(reduce(filter_operator, tag_filters))
                 else:
-                    active_filters.append(F(tags=filter_tags[0].lower()))
+                    active_filters.append(F(tags=filter_tags[0]))
 
             if len(filter_tags) > 1:
                 facet_params = {
                     'or': {
                         'filters': [
-                            {'term': {'tags': tag.lower()}}
+                            {'term': {'tags': tag}}
                             for tag in filter_tags
                         ],
                         '_cache': True,
@@ -99,7 +99,7 @@ class DatabaseFilterBackend(BaseFilterBackend):
                 }
             else:
                 facet_params = {
-                    'term': {'tags': filter_tags[0].lower()}
+                    'term': {'tags': filter_tags[0]}
                 }
             active_facets.append((serialized_filter['slug'], facet_params))
 

--- a/apps/search/migrations/0005_slugify_tags.py
+++ b/apps/search/migrations/0005_slugify_tags.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from south.v2 import DataMigration
+from django.template.defaultfilters import slugify
+
+
+class Migration(DataMigration):
+
+    def get_tags(self, orm):
+        ContentType = orm['contenttypes.ContentType']
+        filter_ct = ContentType.objects.get(app_label='search', model='filter')
+        return orm['taggit.Tag'].objects.filter(
+            taggit_taggeditem_items__content_type=filter_ct.pk)
+
+    def forwards(self, orm):
+        for tag in self.get_tags(orm):
+            tag.slug = slugify(tag.slug)
+            tag.save()
+
+        # Fixing a mistake in the initial data of search filter tags, d'oh!
+        webdev_tag = orm['taggit.Tag'].objects.filter(name='"Web Development"')[0]
+        webdev_tag.name = "Web Development"
+        webdev_tag.save()
+
+    def backwards(self, orm):
+        for tag in self.get_tags(orm):
+            tag.slug = tag.name
+            tag.save()
+        webdev_tag = orm['taggit.Tag'].objects.filter(name='Web Development')[0]
+        webdev_tag.name = '"Web Development"'
+        webdev_tag.save()
+
+    models = {
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'search.filter': {
+            'Meta': {'unique_together': "(('name', 'slug'),)", 'object_name': 'Filter'},
+            'enabled': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'group': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'filters'", 'to': "orm['search.FilterGroup']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'operator': ('django.db.models.fields.CharField', [], {'default': "'OR'", 'max_length': '3'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'search.filtergroup': {
+            'Meta': {'ordering': "('-order', 'name')", 'object_name': 'FilterGroup'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'taggit.tag': {
+            'Meta': {'object_name': 'Tag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'taggit.taggeditem': {
+            'Meta': {'object_name': 'TaggedItem'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'taggit_taggeditem_tagged_items'", 'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'object_id': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "u'taggit_taggeditem_items'", 'to': "orm['taggit.Tag']"})
+        }
+    }
+
+    complete_apps = ['search']
+    symmetrical = True

--- a/apps/search/models.py
+++ b/apps/search/models.py
@@ -128,6 +128,10 @@ class DocumentType(SearchMappingType, Indexable):
                         'lowercase',
                         'snowball',
                     ],
+                },
+                'case_sensitive': {
+                    'type': 'custom',
+                    'tokenizer': 'keyword'
                 }
             },
         }
@@ -154,7 +158,7 @@ class DocumentType(SearchMappingType, Indexable):
                 # faster highlighting
                 'term_vector': 'with_positions_offsets',
             },
-            'tags': {'type': 'string', 'index': 'not_analyzed'},
+            'tags': {'type': 'string', 'analyzer': 'case_sensitive'},
             'title': {
                 'type': 'string',
                 'analyzer': 'kuma_title',
@@ -175,7 +179,7 @@ class DocumentType(SearchMappingType, Indexable):
             'locale': obj.locale,
             'modified': obj.modified,
             'content': strip_tags(obj.rendered_html),
-            'tags': [tag.slug for tag in obj.tags.all()]
+            'tags': list(obj.tags.values_list('name', flat=True))
         }
         # let's boost the main sections
         if obj.slug.split('/') == 1:

--- a/apps/search/serializers.py
+++ b/apps/search/serializers.py
@@ -52,8 +52,11 @@ class FilterGroupSerializer(serializers.Serializer):
 
 
 class FilterSerializer(serializers.ModelSerializer):
-    tags = serializers.ChoiceField(source='tags.all', read_only=True)
+    tags = serializers.SerializerMethodField('tag_names')
     group = FilterGroupSerializer(source='group', read_only=True)
+
+    def tag_names(self, obj):
+        return obj.tags.values_list('name', flat=True)
 
     class Meta:
         model = Filter


### PR DESCRIPTION
This also fixes an inconsistency in indexing the tags, they are now enforced
case sensitive. The “Web Developement” search filter had also a broken tag
(with quotes).
