### PR TITLE
Add --watch option to compile-stylesheets

### DIFF
--- a/puppet/manifests/classes/site-config.pp
+++ b/puppet/manifests/classes/site-config.pp
@@ -155,11 +155,6 @@ class kuma_config {
             command => "/usr/bin/python ./manage.py update_feeds",
             onlyif => "/usr/bin/mysql -B -uroot kuma -e'select count(*) from feeder_entry' | grep '0'",
             require => [ Exec["kuma_south_migrate"] ];
-        "kuma_stylus_watch":
-            user => "vagrant",
-            cwd => "/home/vagrant/src",
-            command => "/usr/local/bin/stylus -w media/redesign/stylus -o media/redesign/css &",
-            require => File["/usr/local/bin/stylus"];
     }
 }
 

--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -1,13 +1,27 @@
-#! /bin/sh
+#!/bin/bash
 
 BASEDIR=$(dirname $0)
-CSSDIR=$BASEDIR/../media/redesign/css/
+CSSDIR=$BASEDIR/../media/redesign/css
+STYLUSDIR=$BASEDIR/../media/redesign/stylus
+
+for opt in "$@"; do
+  case $opt in
+    --watch|-w) WATCH=true;;
+  esac
+done
 
 if [ ! -d "$CSSDIR" ]; then
-	mkdir $BASEDIR/../media/redesign/css/
+  mkdir $CSSDIR
 fi
 
-for file in main wiki demo-studio profile search zones home wiki-syntax
-do
-	stylus $BASEDIR/../media/redesign/stylus/$file.styl --out $BASEDIR/../media/redesign/css --compress
-done
+STYLESHEETS=(main wiki demo-studio profile search zones home wiki-syntax)
+if [ $WATCH ]; then
+  for ss in ${STYLESHEETS[@]}; do
+    (stylus $STYLUSDIR/$ss.styl --out $CSSDIR --compress --watch &) &> /dev/null
+  done
+  echo Watching and automatically compiling stylesheets
+else
+  for ss in ${STYLESHEETS[@]}; do
+    stylus $STYLUSDIR/$ss.styl --out $CSSDIR --compress
+  done
+fi


### PR DESCRIPTION
Would be good for someone using a Mac to test this.

Note that `compile-stylesheets --watch` should only be run once (calling this from a Git hook would not be a good idea) but I don't know of an easy, cross-platform way of enforcing this. Thoughts welcome.
