### PR TITLE
fix bug 938552 - Prevent too much spacing at the bottom of overheadIndicator boxes

### DIFF
--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -21,9 +21,18 @@ vendorize-value(property, value, more = '') {
 
 /* prevents spacing of a given element if it's the last child */
 prevent-last-child-spacing(element = '*', property = 'padding') {
-  & unquote(element):last-child {
+  if (element is '*') {
+    element = unquote(element);
+  }
+
+  & > {element}:last-child {
     {property}: 0;
   }
+}
+
+prevent-last-child-bottom-spacing(element = '*') {
+  prevent-last-child-spacing(element, margin-bottom);
+  prevent-last-child-spacing(element, padding-bottom);
 }
 
 /* text-decoration none, hover text-decoration underline */

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -4,18 +4,18 @@
 
 aside {
   @extend .column-half;
+  prevent-last-child-bottom-spacing();
+
   float: right;
   border: 1px solid header-background-color;
   background: light-background-color;
   padding: grid-spacing;
   margin-left: grid-spacing;
   margin-bottom: grid-spacing;
-
-  prevent-last-child-spacing('*', padding-bottom);
-  prevent-last-child-spacing('*', margin-bottom);
 }
 
 blockquote {
+  prevent-last-child-bottom-spacing();
   padding: 0 25px;
   border-left: 5px solid #ccc;
   margin-bottom: content-block-margin;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -355,8 +355,8 @@ article {
 }
 
 /* document warnings, bugs, etc. */
-div.bug > *:last-child, div.warning > *:last-child {
-  compat-important(padding-left, inherit);
+div.bug, div.warning, div.overheadIndicator {
+  prevent-last-child-bottom-spacing();
 }
 
 /* page attachments block at the bottom of the article */


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=938552

You'll also need to grab Template:CustomCSS from prod -- I made an adjustment there too.
