### PR TITLE
fix bug 940440 - Remove DevTools from dropdown

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -180,7 +180,6 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
               <li><a href="{{ devmo_url('Web/Guide/Graphics') }}?menu">Graphics</a></li>
               <li><a href="{{ devmo_url('Web/API') }}?menu">APIs / DOM</a></li>
               <li><a href="{{ devmo_url('Web/Apps') }}?menu">Apps</a></li>
-              <li><a href="{{ devmo_url('Tools') }}?menu">Dev Tools</a></li>
               <li><a href="{{ devmo_url('Web/MathML') }}?menu">MathML</a></li>
             </ul>
           </div><div class="submenu-column">


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=940440
