### PR TITLE
Add non-default -q option to compile-stylesheets

### DIFF
--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -7,6 +7,7 @@ STYLUSDIR=$BASEDIR/../media/redesign/stylus
 for opt in "$@"; do
   case $opt in
     --watch|-w) WATCH=true;;
+    --quiet|-q) QUIET=true;;
   esac
 done
 
@@ -14,14 +15,21 @@ if [ ! -d "$CSSDIR" ]; then
   mkdir $CSSDIR
 fi
 
-STYLESHEETS=(main wiki demo-studio profile search zones home wiki-syntax users no-js)
+FILENAMES=(main wiki demo-studio profile search zones home wiki-syntax users no-js)
+STYLESHEETS=$(printf "$STYLUSDIR/%s.styl " "${FILENAMES[@]}")
 if [ $WATCH ]; then
-  for ss in ${STYLESHEETS[@]}; do
-    (stylus $STYLUSDIR/$ss.styl --out $CSSDIR --compress --watch &) &> /dev/null
-  done
   echo Watching and automatically compiling stylesheets
+
+  # Using $STYLESHEETS directly so that stylus only watches each stylesheet
+  # once, even if it is @included multiple times.
+  if [ $QUIET ]; then
+    (stylus $STYLESHEETS --out $CSSDIR --compress --watch &) &> /dev/null
+  else
+    stylus $STYLESHEETS --out $CSSDIR --compress --watch
+  fi
 else
+  # Iterating through stylesheets so that shell output is immediate.
   for ss in ${STYLESHEETS[@]}; do
-    stylus $STYLUSDIR/$ss.styl --out $CSSDIR --compress
+    stylus $ss --out $CSSDIR --compress
   done
 fi


### PR DESCRIPTION
This makes compile-stylesheets report on what it is watching (and more
importantly, what errors it runs into) by default. The old, quiet
behavior can be used with -q or --quiet.
