### PR TITLE
Ensure last child of soap messages doesn't have extra space

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -15,9 +15,9 @@
     compat-important(padding-top, 10px);
     compat-important(padding-bottom, 10px);
     compat-important(max-width, max-width-default);
-  }
 
-  prevent-last-child-spacing(p, margin-bottom);
+    prevent-last-child-spacing(p, margin-bottom);
+  }
 }
 
 /* header */


### PR DESCRIPTION
A recent change added padding to the bottom of the last message. :(
