### PR TITLE
fix bug 943387, 943381 - Make 'skip to' links more accessible

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -51,6 +51,27 @@
 
 #nav-access {
   width: 0;
+  position: absolute;
+  top: -20em;
+  width: 100%;
+  z-index: 999;
+
+  a {
+    compat-important(color, #fff);
+    compat-important(background, text-color);
+    width: 200px;
+    padding: 4px 10px;
+    outline: 0; 
+    display: inline-block;
+    position: absolute;
+    box-shadow: 2px 2px 3px rgba(0,0,0,.5);
+
+    &:hover, &:focus {
+      top: 19em;
+      compat-important(background, text-color);
+      text-decoration: none;
+    }
+  }
 }
 
 #main-nav {

--- a/templates/base.html
+++ b/templates/base.html
@@ -142,12 +142,12 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
   <!-- Header -->
   <header id="main-header"><div class="center">
 
-    <ul class="offscreen">
+    <ul id="nav-access">
+      <li><a href="#content">{{ _('Skip to main content') }}</a></li>
       <li><a href="#language">{{ _('Select language') }}</a></li>
       {% if not is_sphinx %}
         <li><a href="#q" id="skip-search">{{ _('Skip to search') }}</a></li>
       {% endif %}
-      <li><a href="#content">{{ _('Skip to main content') }}</a></li>
     </ul>
 
     <div class="clear header-login">


### PR DESCRIPTION
Now visible when focused \o/
