### PR TITLE
Prevent zone margin and overlap issues per Holly's request

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -96,7 +96,6 @@
     p {
       @extend .larger;
       font-weight: light-font-weight;
-      margin-right: 220px;
     }
   }
 
@@ -108,6 +107,7 @@
     width: 468px;
     bottom: 0;
     background-repeat: no-repeat;
+    background-position: 95% 0;
   }
 
   a.button {
@@ -288,15 +288,6 @@
       .zone-image {
         opacity: 0.2;
       }
-  }
-
-  .zone-landing-header {
-
-    .masthead-text {
-      p {
-        margin-right: 0;
-      }
-    }
   }
 }
 


### PR DESCRIPTION
Updating the zone headers so that they don't require right margin and thus headers don't grow larger than they need to be.

You can test by going to the zone landing pages, executing `jQuery(".zone-landing-header .masthead-text p").css("margin-right", "0"); jQuery(".zone-image").css("background-position", "95% 0");`, and then resizing the browser smaller.

There will be overlap on this page (https://developer.mozilla.org/en-US/Apps) and this page (https://developer.mozilla.org/en-US/docs/Mozilla/Marketplace) but that's because the image has a massive amount of extra blank space in the image.  The images need to be updated.
