### PR TITLE
Update Zones to remain in alphabetical order

### DIFF
--- a/apps/landing/templates/landing/homepage.html
+++ b/apps/landing/templates/landing/homepage.html
@@ -49,11 +49,11 @@
       <div class="column-home-features">
         <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Zones') }}</span></h3>
         <ul>
+          <li><a href="{{ devmo_url('Mozilla/Add-ons') }}?menu">{{ _('Add-ons') }}</a></li>
           <li><a href="{{ devmo_url('Apps') }}">{{ _('App Center') }}</a></li>
           <li><a href="{{ devmo_url('Firefox') }}">{{ _('Firefox') }}</a></li>
-          <li><a href="{{ devmo_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
           <li><a href="{{ devmo_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
-          <li><a href="{{ devmo_url('Persona') }}">{{ _('Persona') }}</a></li>
+          <li><a href="{{ devmo_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
         </ul>
       </div>
       <div class="column-home-features">

--- a/templates/base.html
+++ b/templates/base.html
@@ -174,12 +174,12 @@ https://wiki.mozilla.org/MDN/Development/Redesign/Testing">Here\'s how you can h
         <div class="submenu submenu-single" id="nav-zones-submenu">
           <div class="submenu-column">
             <ul>
+              <li><a href="{{ devmo_url('Mozilla/Add-ons') }}?menu">{{ _('Add-ons') }}</a></li>
               <li><a href="{{ devmo_url('Apps') }}?menu">{{ _('App Center') }}</a></li>
               <li><a href="{{ devmo_url('Firefox') }}?menu">{{ _('Firefox') }}</a></li>
-              <li><a href="{{ devmo_url('Firefox_OS') }}?menu">{{ _('Firefox OS') }}</a></li>
               <li><a href="{{ devmo_url('Mozilla/Marketplace') }}?menu">{{ _('Firefox Marketplace') }}</a></li>
+              <li><a href="{{ devmo_url('Firefox_OS') }}?menu">{{ _('Firefox OS') }}</a></li>
               <li><a href="{{ devmo_url('Persona') }}?menu">{{ _('Persona') }}</a></li>
-              <li><a href="{{ devmo_url('Mozilla/Add-ons') }}?menu">{{ _('Add-ons') }}</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
We had been doing this until recently, but "Firefox Marketplace" and
"Add-ons" ended up out of order.

Dropping "Persona" from the homepage feels strange, but we have the
following bug open for solving this long term.

https://bugzilla.mozilla.org/show_bug.cgi?id=946777
