### PR TITLE
Create more accurate accordion opening and 'current' styling

### DIFF
--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -72,9 +72,19 @@
     $subnavList.find('.toggleable').mozTogglers();
 
     // Try to find the current page in the list, if found, open it
+    // Need to keep track of the elements we've found so they aren't found twice
+    var used = [];
     var $selected = $subnavList.find('a[href$="' + document.location.pathname + '"]');
     $selected.each(function() {
-      $(this).parents('.toggleable').find('.toggler').trigger('click');
+      var self = this;
+      var $togglers = $(this).parents('.toggleable').find('.toggler');
+
+      $togglers.each(function() {
+        if($.contains($(this).parent('li').get(0), self) && used.indexOf(this) === -1) {
+          $(this).trigger('click');
+          used.push(this);
+        }
+      });
     }).parent().addClass('current');
 
     // Mark this is an accordion so the togglers open/close properly

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -71,12 +71,11 @@
       }
     }
 
-    ol .current {
-      background-color: text-color;
-
-      a {
+    li.current {
+      > a:not(.toggler) {
         position: relative;
         color: #fff;
+        background-color: text-color;
 
         generate-arrow();
 


### PR DESCRIPTION
Subtogglers of togglers in the subnav appear to be opened incorrectly -- this ensures that the hierarchy is followed when opening subsubnav.
