### PR TITLE
Rename StackOverflow on Learn JavaScript page

### DIFF
--- a/apps/landing/templates/landing/learn_javascript.html
+++ b/apps/landing/templates/landing/learn_javascript.html
@@ -115,7 +115,7 @@
         </li>
         <li>  
           <h3 class="title"><a href="http://stackoverflow.com/questions/394601/which-javascript-framework-jquery-vs-dojo-vs" rel="external">{{ _('Which JavaScript Framework?') }}</a></h3>
-          <h4 class="source">StackOverflow</h4>
+          <h4 class="source">Stack Overflow</h4>
           <p>{{ _('Advice on choosing a JavaScript framework.') }}</p>
         </li>
         <li>


### PR DESCRIPTION
> Stack Overflow is a programmer Q&A site on the Stack Exchange Network.
> As a name, Stack Overflow, is always written "Stack Overflow" (two
> words, capital letters).

http://stackexchange.com/legal/trademark-guidance
