### PR TITLE
hack-fix django.db.backends test log level

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -1,2 +1,6 @@
+import logging
+
 CELERY_ALWAYS_EAGER = True
 ES_LIVE_INDEX = False
+
+logging.getLogger('django.db.backends').setLevel(logging.ERROR)


### PR DESCRIPTION
So annoying. This isn't the most elegant solution but it does fix the problem of all the DEBUG messages from django.db.backends module.
