### PR TITLE
Show edit profile checkboxes to left of labels

### DIFF
--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -104,3 +104,18 @@
     }
   }
 }
+
+#profile-edit {
+    #field_beta, #field_newsletter {
+        @extend .clear;
+
+        input[type="checkbox"] {
+            bidi-value(float, left, right);
+        }
+
+        label {
+            position: absolute;
+            bidi-style(margin-left, 25px, margin-right, 0);
+        }
+    }
+}


### PR DESCRIPTION
Would have preferred not to match #field_beta and #field_newsletter
directly, given that we will add new checkboxes in the future, but I
cannot think of another way to match only the needed elements without
adjusting `templates/includes/common_macros.py`.
