### PR TITLE
fix newsletter process for emails never seen

### DIFF
--- a/apps/devmo/views.py
+++ b/apps/devmo/views.py
@@ -18,7 +18,8 @@ from teamwork.models import Team
 
 from . import INTEREST_SUGGESTIONS
 from .models import Calendar, Event, UserProfile
-from .forms import UserProfileEditForm, newsletter_subscribe
+from .forms import (UserProfileEditForm, newsletter_subscribe,
+                    get_subscription_details, subscribed_to_newsletter)
 
 
 DOCS_ACTIVITY_MAX_ITEMS = getattr(settings,
@@ -118,9 +119,8 @@ def profile_edit(request, username):
             initial[field] = ', '.join(t.name.replace(ns, '')
                                        for t in profile.tags.all_ns(ns))
 
-        subscription_details = basket.lookup_user(email=profile.user.email,
-                                          api_key=constance.config.BASKET_API_KEY)
-        if settings.BASKET_APPS_NEWSLETTER in subscription_details['newsletters']:
+        subscription_details = get_subscription_details(profile.user.email)
+        if subscribed_to_newsletter(subscription_details):
             initial['newsletter'] = True
             initial['agree'] = True
 


### PR DESCRIPTION
Spot-check (twice):
1. Sign in with an email you've never used before on any MDN server (e.g., '<real-email>+basket+local2@gmail.com')
2. Do **NOT** check the newsletter sign-up box
3. Should register fine
4. Edit your profile - check/un-check the newsletter box between edits and verify the page saves your state as expected
5. Sign in with an email you've never used before on any MDN server (e.g., '<real-email>+basket+local3@gmail.com')
6. **DO** check the newsletter sign-up box
7. Should register fine
8. Edit your profile - verify the newsletter box is initially checked. 
9. Check/un-check the newsletter box between edits and verify the page saves your state as expected
