### PR TITLE
Issue #1755: Remove pointer from compat tab hover

### DIFF
--- a/media/css/wiki-screen.css
+++ b/media/css/wiki-screen.css
@@ -577,8 +577,8 @@ pre[class*="language-"].twopartsyntaxbox, pre[class*="language-"].syntaxbox {
 
 /* HTabs - Compatibility Tables */
 .htab { margin: 0 auto 1em; display: inline-block; }
-.htab > ul > li { background-image: none; width:150px; height:30px; list-style-type:none; display:inline; padding-bottom:3px; border: 1px solid #ddd; padding-top:5px; text-align:left; font-size:13px; font-weight:bold; margin:auto; position:relative; padding-left:6px; padding-right:6px; border-bottom:none; opacity:.5; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50); cursor:pointer; }
-.htab > ul > li.selected { opacity:1; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100); border: 1px solid #ddd; border-bottom: none; z-index: 10; background-color: #f1f6f8 !important; position: relative; cursor:pointer; }
+.htab > ul > li { background-image: none; width:150px; height:30px; list-style-type:none; display:inline; padding-bottom:3px; border: 1px solid #ddd; padding-top:5px; text-align:left; font-size:13px; font-weight:bold; margin:auto; position:relative; padding-left:6px; padding-right:6px; border-bottom:none; opacity:.5; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=50)"; filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=50); }
+.htab > ul > li.selected { opacity:1; -ms-filter: "progid:DXImageTransform.Microsoft.Alpha(Opacity=100)"; filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=100); border: 1px solid #ddd; border-bottom: none; z-index: 10; background-color: #f1f6f8 !important; position: relative; }
 .htab > ul { width:150px; text-align:left; display:inline; padding:0; margin:0 auto; position:relative; top:1px; }
 .htab > div { background-color: #f1f6f8; margin-top: 0px; border: 1px solid #ddd; padding: 12px; position: relative; z-index: 9; word-wrap: break-word; }
 table.compat-table { border: 1px solid #bbb; border-collapse: collapse;}


### PR DESCRIPTION
This is one part of #1755. Many other changes were made on the
production Template:CustomCSS that also address this issue. The issue
has not been completely resolved (there are small areas near the edges
of each tab that cannot be clicked) but this is about as far as I can go
for now. If we ever clean up Template:CustomCSS, the rest will be easier
to fix.
