### PR TITLE
Move placement of tabzilla within base template

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -52,7 +52,6 @@
 
 {% macro site_js() %}
   {% block site_js %}
-      <script src="//mozorg.cdn.mozilla.net/{{ request.locale }}/tabzilla/tabzilla.js" async></script>
       <script src="https://login.persona.org/include.js" type="text/javascript"></script>
 
       {% if waffle.flag('redesign') %}
@@ -60,6 +59,8 @@
       {% endif %}
 
       {{ js('mdn') }}
+      <script src="//mozorg.cdn.mozilla.net/{{ request.locale }}/tabzilla/tabzilla.js?mdn" async></script>
+      
       {% for script in scripts %}
         {{ js(script) }}
       {% endfor %}


### PR DESCRIPTION
Moving Tabzilla to after MDN.  The reason is that Tabzilla does a jQuery check, and there could be a timing issue where jQuery isn't there yet, and thus Tabzilla may try to load jQuery again.  Boo.  This prevents that issue.
