### PR TITLE
Update mixin / class structure to avoid unwanted duplication

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -109,7 +109,7 @@
   <!-- heading -->
   <div class="document-head{% if from_search %} from-search{% endif %}">
     {% if from_search %}
-      <a href="" class="from-search-previous only-icon"><i aria-hidden="true" class="icon-chevron-left"></i></a>
+      <a href="" class="button from-search-previous only-icon"><i aria-hidden="true" class="icon-chevron-left"></i></a>
       <a href="" class="from-search-navigate"><span class="from-search-navigate-up"><i aria-hidden="true" class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i aria-hidden="true" class="icon-double-angle-down"></i></span></a>
       <div class="from-search-toc hidden">
         <ol>
@@ -122,7 +122,7 @@
           <li><a href="">Blah blah blah</a></li>
         </ol>
       </div>
-      <a href="" class="from-search-next only-icon"><i aria-hidden="true" class="icon-chevron-right"></i></a>
+      <a href="" class="button from-search-next only-icon"><i aria-hidden="true" class="icon-chevron-right"></i></a>
     {% endif %}
 
     <h1>{{ document.title }}</h1>

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -267,10 +267,8 @@ big-search() {
 */
 .clear {
   &:before, &:after {
-    content: '\0020';
-    display: block;
-    height: 0;
-    overflow: hidden;
+    content: ' ';
+    display: table;
   }
 
   &:after {
@@ -289,11 +287,6 @@ big-search() {
   width: 1px;
 }
 
-.text-offscreen {
-  text-indent: -9999px;
-  overflow: hidden;
-}
-
 .title {
   font-weight: bold;
   text-transform: uppercase;
@@ -310,71 +303,11 @@ big-search() {
   font-size: larger-font-size;
 }
 
-.hidden {
-  display: none;
-}
-
 .grid-padding {
   padding: grid-spacing;
 }
 
-.disabled {
-  pointer-events: none;
-  cursor: default;
-}
-
-.button {
-  text-decoration: none;
-  display: inline-block;
-  compat-important(background-color, button-background);
-  compat-important(color, button-color);
-  compat-important(text-transform, uppercase);
-  compat-important(padding, 5px 11px);
-  compat-important(border-radius, 4px);
-  vendorize(box-shadow, inset 0 -1px button-shadow-color);
-  compat-only(background-image, none);
-  compat-only(font-family, site-font-family);
-  compat-only(font-size, base-font-size);
-  compat-only(letter-spacing, normal);
-
-  &.only-icon {
-    {selector-icon} {
-      margin-left: 0 !important;
-      margin-right: 0 !important;
-      margin-top: -1px !important;
-    }
-
-    span {
-      @extend .offscreen;
-    }
-  }
-
-  &.neutral, &.negative, &.positive {
-    compat-important(color, #fff);
-  }
-
-  &.neutral {
-    compat-important(background-color, #0095dd);
-    vendorize(box-shadow, inset 0 -1px #00539f);
-  }
-
-  &.negative {
-    compat-important(background-color, #ea3b28);
-    vendorize(box-shadow, inset 0 -1px #c13832);
-  }
-
-  &.positive {
-    compat-important(background-color, #70a300);
-    vendorize(box-shadow, inset 0 -1px #486900);
-  }
-
-  &.transparent {
-    vendorize(box-shadow, none);
-    compat-important(background-color, transparent);
-  }
-}
-
-.heading-link {
+.heading-link { /* used in wiki content as well as the homepage */
   font-style: italic;
   font-size: base-font-size;
   font-weight: normal;

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -34,7 +34,6 @@
   border-top: 2px solid #fff;
 
   .logo {
-    @extend .text-offscreen;
     bidi-value(float, left, right);
     width: 216px;
     height: 54px;
@@ -42,6 +41,8 @@
     background-position: -5px 0;
     background-repeat: no-repeat;
     display: block;
+    text-indent: -9999px;
+    overflow: hidden;
   }
 }
 
@@ -360,6 +361,23 @@ footer {
   @media media-query-mobile { z-index: 4; }
 }
 
+/* simple hiding of elements */
+.hidden {
+  display: none;
+}
+
+/* disabling of elements */
+.disabled {
+  pointer-events: none;
+  cursor: default;
+}
+
+/* redesign beta notice */
+.redesign-beta-notice {
+  @extend .smaller;
+  padding: 6px 0;
+}
+
 
 /* tablet updates */
 @media media-query-tablet {
@@ -487,13 +505,6 @@ footer {
       }
     }
   }
-}
-
-
-/* redesign beta notice */
-.redesign-beta-notice {
-  @extend .smaller;
-  padding: 6px 0;
 }
 
 

--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -138,8 +138,55 @@ a {
   }
 }
 
-button, input[type='submit'], input[type='button'] {
-  @extend .button;
+.button, button, input[type='submit'], input[type='button'] {
+  text-decoration: none;
+  display: inline-block;
+  compat-important(background-color, button-background);
+  compat-important(color, button-color);
+  compat-important(text-transform, uppercase);
+  compat-important(padding, 5px 11px);
+  compat-important(border-radius, 4px);
+  vendorize(box-shadow, inset 0 -1px button-shadow-color);
+  compat-only(background-image, none);
+  compat-only(font-family, site-font-family);
+  compat-only(font-size, base-font-size);
+  compat-only(letter-spacing, normal);
+
+  &.only-icon {
+    {selector-icon} {
+      margin-left: 0 !important;
+      margin-right: 0 !important;
+      margin-top: -1px !important;
+    }
+
+    span {
+      @extend .offscreen;
+    }
+  }
+
+  &.neutral, &.negative, &.positive {
+    compat-important(color, #fff);
+  }
+
+  &.neutral {
+    compat-important(background-color, #0095dd);
+    vendorize(box-shadow, inset 0 -1px #00539f);
+  }
+
+  &.negative {
+    compat-important(background-color, #ea3b28);
+    vendorize(box-shadow, inset 0 -1px #c13832);
+  }
+
+  &.positive {
+    compat-important(background-color, #70a300);
+    vendorize(box-shadow, inset 0 -1px #486900);
+  }
+
+  &.transparent {
+    vendorize(box-shadow, none);
+    compat-important(background-color, transparent);
+  }
 
   &::-moz-focus-inner {
     margin-top: -1px;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -177,7 +177,6 @@ article {
 }
 
 .from-search-previous, .from-search-next {
-  @extend .button;
   position: absolute;
   top: (grid-spacing * .75) + 2px;
   display: block;


### PR DESCRIPTION
This is the first step in avoiding CSS duplication due to @import.  More to come, but this is a good first step.  Cuts a few CSS files down by ~2k.
