### PR TITLE
Ensure correct email displays when editing another profile

### DIFF
--- a/apps/devmo/templates/devmo/profile_edit.html
+++ b/apps/devmo/templates/devmo/profile_edit.html
@@ -54,8 +54,8 @@
         <ul>
             <li id="field_email" class="field type_email required">
                 <label for="id_email">{{ _('Email') }}</label>
-                {{ user.email }} <a href="{{ url('users.change_email') }}">{{ _('Change') }}</a>
-                <input id="id_email" type="hidden" value="{{ user.email }}" name="email"/>
+                {{ profile.user.email }} <a href="{{ url('users.change_email') }}">{{ _('Change') }}</a>
+                <input id="id_email" type="hidden" value="{{ profile.user.email }}" name="email"/>
             </li>
           {{ li_field(form, 'beta') }}
           {{ li_field(form, 'fullname') }}


### PR DESCRIPTION
Can someone else check this out?  I can't create another user on my machine.  We just need to make sure nothing goes funky when saving someone else's profile.
