### PR TITLE
Remove ?mdn cache-buster on tabzilla.js

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -61,7 +61,7 @@
       {% endif %}
 
       {{ js('mdn') }}
-      <script src="//mozorg.cdn.mozilla.net/{{ request.locale }}/tabzilla/tabzilla.js?mdn" async></script>
+      <script src="//mozorg.cdn.mozilla.net/{{ request.locale }}/tabzilla/tabzilla.js" async></script>
       
       {% for script in scripts %}
         {{ js(script) }}


### PR DESCRIPTION
We were using this temporarily as we waited for some important updates
to hit the Tabzilla CDN. This has since happened, making the
cache-buster unnecessary.
