### PR TITLE
Fixed typo on fonts that due to case sensitive server

### DIFF
--- a/media/css/fonts.css
+++ b/media/css/fonts.css
@@ -59,11 +59,11 @@
 }
 @font-face {
   font-family: 'MozTT';
-  src: url('../fonts/moztt-regular-webfont.eot');
-    src: url('../fonts/moztt-regular-webfont.eot?#iefix') format('embedded-opentype'),
-         url('../fonts/moztt-regular-webfont.woff') format('woff'),
-         url('../fonts/moztt-regular-webfont.ttf') format('truetype'),
-         url('../fonts/moztt-regular-webfont.svg#mozttregular') format('svg');
+  src: url('../fonts/MozTT-regular-webfont.eot');
+    src: url('../fonts/MozTT-regular-webfont.eot?#iefix') format('embedded-opentype'),
+         url('../fonts/MozTT-regular-webfont.woff') format('woff'),
+         url('../fonts/MozTT-regular-webfont.ttf') format('truetype'),
+         url('../fonts/MozTT-regular-webfont.svg#mozttregular') format('svg');
 }
 @font-face {
   font-family: 'MozTT';


### PR DESCRIPTION
IE8 gets a 404 on that font. http://www.webpagetest.org/result/131216_MC_EDG/1/details/

no bug, small fix :)
