### PR TITLE
Make document/tag/file lists more readable

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -457,7 +457,8 @@ class BaseDocumentManager(models.Manager):
         docs = (self.filter(is_template=False, is_redirect=False)
                     .exclude(slug__startswith='User:')
                     .exclude(slug__startswith='Talk:')
-                    .order_by('title'))
+                    .exclude(slug__startswith='User_talk:')
+                    .order_by('slug'))
         if locale:
             docs = docs.filter(locale=locale)
         if category:

--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -39,11 +39,13 @@
       <div id="document-list" class="boxed">
         <h1>{{ title }}</h1>
         {% if documents.object_list %}
-          <ul class="documents cols-3">
+          <ul class="documents">
             {% for doc in documents.object_list %}
               <li>
-                <a href="{{ doc.get_absolute_url() }}">{{ doc.title }}</a> ({{ doc.locale }})<br/>
-                <small>{{ doc.get_absolute_url() }}</small>
+                <a href="{{ doc.get_absolute_url() }}">{{ doc.slug }}</a>
+                  {% if not is_templates %}
+                    <small>{{ doc.get_summary() | truncate(100) }}</small>
+                  {% endif %}
               </li>
             {% endfor %}
           </ul>

--- a/apps/wiki/templates/wiki/list_files.html
+++ b/apps/wiki/templates/wiki/list_files.html
@@ -20,8 +20,7 @@
           <ul class="documents cols-3">
             {% for file in files.object_list %}
               <li>
-                <a href="{{ file.get_absolute_url() }}">{{ file.title }}</a><br/>
-                <small>{{ file.get_absolute_url() }}</small>
+                <a href="{{ file.get_absolute_url() }}">{{ file.title }}</a>
               </li>
             {% endfor %}
           </ul>

--- a/apps/wiki/templates/wiki/list_tags.html
+++ b/apps/wiki/templates/wiki/list_tags.html
@@ -15,8 +15,7 @@
           <ul class="documents cols-3">
             {% for tag in tags.object_list %}
               <li>
-                <a href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a><br/>
-                <small>{{url('wiki.tag', tag.name)}}</small>
+                <a href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a>
               </li>
             {% endfor %}
           </ul>

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -1855,17 +1855,17 @@ class DocumentEditingTests(TestCaseBase):
                 eq_(0, page.find('.page-tags li a:contains("%s")' % t).length,
                     '%s should appear in document view tags' % t)
 
-            # Check for the document title in the tag listing
+            # Check for the document slug (title in feeds) in the tag listing
             for t in yes_tags:
                 response = client.get(reverse('wiki.tag', args=[t]))
-                ok_(doc.title in response.content.decode('utf-8'))
+                ok_(doc.slug in response.content.decode('utf-8'))
                 response = client.get(reverse('wiki.feeds.recent_documents',
                                       args=['atom', t]))
                 ok_(doc.title in response.content.decode('utf-8'))
 
             for t in no_tags:
                 response = client.get(reverse('wiki.tag', args=[t]))
-                ok_(doc.title not in response.content.decode('utf-8'))
+                ok_(doc.slug not in response.content.decode('utf-8'))
                 response = client.get(reverse('wiki.feeds.recent_documents',
                                       args=['atom', t]))
                 ok_(doc.title not in response.content.decode('utf-8'))

--- a/media/css/wiki.css
+++ b/media/css/wiki.css
@@ -650,19 +650,6 @@ article.main div.tags input.adder {
   position: relative;
 }
 
-/* Document list pages */
-#document-list ul.documents {
-    margin: 10px 0;
-}
-
-#document-list ul.documents li {
-    font-size: 14px;
-    list-style: none;
-    padding: 5px 0;
-    display: block;
-    overflow: hidden;
-}
-
 /* Revision history */
 #revision-history {
     color: #666;


### PR DESCRIPTION
Test pages: 
- https://developer.mozilla.org/en-US/docs/all
- https://developer.mozilla.org/en-US/docs/tags
- https://developer.mozilla.org/en-US/docs/tag/JavaScript
- https://developer.mozilla.org/en-US/docs/files
- https://developer.mozilla.org/en-US/docs/templates
- https://developer.mozilla.org/en-US/docs/needs-review/

Changes:

1) Pages with the slug "User_talk:" should be excluded as well (see https://developer.mozilla.org/en-US/docs/all?page=106). These are useless for us. 

2) Ordering is changed from "title" to "slug", which will allow us to better navigate through the doc structure.

3) Displaying the slug of docs/tags/files has been removed. For docs I added the truncated doc summary:

``` html
<small>{{ doc.get_summary() | truncate(100) }}</small>
```

4) Removed the CSS as it was imho just wasting space and things look OK without it (these pages haven't been styled for the redesign probably).

Hopefully this all is a good first step towards fixing [bug 803185](https://bugzilla.mozilla.org/show_bug.cgi?id=803185).
