### PR TITLE
refactor to KUMA_CUSTOM_CSS_DOC for inline style

### DIFF
--- a/apps/wiki/context_processors.py
+++ b/apps/wiki/context_processors.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+
+from constance import config
+
+from .models import Document
+
+
+def custom_css(request):
+    custom_css = ''
+    try:
+        custom_css_doc = Document.objects.get(slug=config.KUMA_CUSTOM_CSS_DOC,
+                                      locale=settings.WIKI_DEFAULT_LANGUAGE)
+        custom_css = custom_css_doc.html
+    except Document.DoesNotExist:
+        # If it doesn't exist, return ''
+        pass
+    return {'KUMA_CUSTOM_CSS': custom_css}

--- a/apps/wiki/templates/wiki/base.html
+++ b/apps/wiki/templates/wiki/base.html
@@ -6,9 +6,10 @@
     {% if waffle.flag('redesign') %}
       {{ css('redesign-wiki', 'all') }}
     {% endif %}
-    {% if config.KUMA_CUSTOM_CSS_PATH %}
-      <link rel="stylesheet" type="text/css"
-            href="{{ config.KUMA_CUSTOM_CSS_PATH }}?raw=1" />
+    {% if KUMA_CUSTOM_CSS %}
+      <style type="text/css">
+        {{ KUMA_CUSTOM_CSS }}
+      </style>
     {% endif %}
 {% endblock %}
 

--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -121,7 +121,7 @@ CKEDITOR.editorConfig = function(config) {
     config.startupFocus = true;
     config.toolbar = 'MDN';
     config.tabSpaces = 2;
-    config.contentsCss = [ mdn.mediaPath + 'css/wiki-screen.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'redesign/css/main.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'css/wiki-edcontent.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'css/libs/font-awesome/css/font-awesome.min.css?{{ BUILD_ID_JS }}', '/en-US/docs/Template:CustomCSS?raw=1'];
+    config.contentsCss = [ mdn.mediaPath + 'css/wiki-screen.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'redesign/css/main.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'css/wiki-edcontent.css?{{ BUILD_ID_JS }}', mdn.mediaPath + 'css/libs/font-awesome/css/font-awesome.min.css?{{ BUILD_ID_JS }}'];
     
     config.toolbarCanCollapse = false;
     config.resize_enabled = false;

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -538,8 +538,7 @@ def document(request, document_slug, document_locale):
         response['X-Frame-Options'] = 'Allow'
         response['X-Robots-Tag'] = 'noindex'
         absolute_url = doc.get_absolute_url()
-        if (constance.config.KUMA_CUSTOM_CSS_PATH == absolute_url or
-            constance.config.KUMA_CUSTOM_SAMPLE_CSS_PATH == absolute_url):
+        if constance.config.KUMA_CUSTOM_SAMPLE_CSS_PATH == absolute_url:
             response['Content-Type'] = 'text/css; charset=utf-8'
         elif doc.is_template:
             # Treat raw, un-bleached template source as plain text, not HTML.

--- a/settings.py
+++ b/settings.py
@@ -349,6 +349,8 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     'devmo.context_processors.i18n',
     'devmo.context_processors.next_url',
 
+    'wiki.context_processors.custom_css',
+
     'jingo_minify.helpers.build_ids',
 
     'constance.context_processors.config',
@@ -1040,12 +1042,11 @@ CONSTANCE_CONFIG = dict(
         'which tells kumascript whether or not to serve up a cached response.'
     ),
 
-    KUMA_CUSTOM_CSS_PATH = (
-        '/en-US/docs/Template:CustomCSS',
-        'Path to a wiki document whose raw content will be loaded as a CSS '
-        'stylesheet for the wiki base template. Will also cause the ?raw '
-        'parameter for this path to send a Content-Type: text/css header. Empty '
-        'value disables the feature altogether.',
+    KUMA_CUSTOM_CSS_DOC = (
+        'Template:CustomCSS',
+        'Slug of a wiki document whose raw content will be loaded as a CSS '
+        'style block for the wiki base template. Empty value disables the '
+        'feature altogether.',
     ),
 
     KUMA_CUSTOM_SAMPLE_CSS_PATH = (


### PR DESCRIPTION
**DNM** Want to get feedback from @lmorchard and @darkwing on this approach before I refactor `KUMA_CUSTOM_SAMPLE_CSS_PATH` to `KUMA_CUSTOM_SAMPLE_CSS_DOC`
