### PR TITLE
Move error page rules, other error page cleanup

### DIFF
--- a/media/redesign/stylus/error-404.styl
+++ b/media/redesign/stylus/error-404.styl
@@ -67,8 +67,16 @@
     100% {left:231px; top:68px;}
 }
 
+/* Take grid-spacing away from the margin of .beast and (later) give it to the
+   padding #beastainer instead so that the eye positions can be relative to
+   .beast without accounting for the margin. */
+.beast {
+  margin: 0;
+}
+
 #beastainer {
     float: right;
+    padding: grid-spacing 0 grid-spacing grid-spacing;
     position: relative;
 }
 

--- a/media/redesign/stylus/error.styl
+++ b/media/redesign/stylus/error.styl
@@ -1,0 +1,11 @@
+@import 'vars'
+
+.beast {
+  float: right;
+  margin: grid-spacing 0 grid-spacing grid-spacing;
+}
+
+ul.prose {
+  list-style-type: disc;
+  margin: grid-spacing 0;
+}

--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -15,7 +15,7 @@ if [ ! -d "$CSSDIR" ]; then
   mkdir $CSSDIR
 fi
 
-FILENAMES=(main wiki demo-studio profile search zones home wiki-syntax users noscript err404 promote sphinx dashboards diff calendar newsletter)
+FILENAMES=(main wiki demo-studio profile search zones home wiki-syntax users noscript error error-404 promote sphinx dashboards diff calendar newsletter)
 STYLESHEETS=$(printf "$STYLUSDIR/%s.styl " "${FILENAMES[@]}")
 if [ $WATCH ]; then
   echo Watching and automatically compiling stylesheets

--- a/settings.py
+++ b/settings.py
@@ -576,9 +576,6 @@ MINIFY_BUNDLES = {
         'devderby': (
             'css/devderby.css',
         ),
-        'err404': (
-            'css/err404.css',
-        ),
         'home': (
             'redesign/css/home.css',
         ),
@@ -644,8 +641,12 @@ MINIFY_BUNDLES = {
         'redesign-demos': (
             'redesign/css/demo-studio.css',
         ),
-        'redesign-err404': (
-            'redesign/css/err404.css',
+        'error': (
+            'redesign/css/error.css',
+        ),
+        'error-404': (
+            'redesign/css/error.css',
+            'redesign/css/error-404.css',
         ),
         'calendar': (
             'redesign/css/calendar.css',

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,10 +1,6 @@
 {% extends "base.html" %}
 
-{% if waffle.flag('redesign') %}
-  {% set styles = ('redesign-err404',) %}
-{% else %}
-  {% set styles = ('err404',) %}
-{% endif %}
+{% set styles = ('error-404',) %}
 
 {% block bodyclass %}error{% endblock %}
 {% block title %}{{ page_title(_('Not Found')) }}{% endblock %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -4,6 +4,8 @@
 
 {% block title %}{{ page_title(_('Internal Server Error')) }}{% endblock %}
 
+{% set styles = ('error',) %}
+
 {% block content %}
 
 <section id="content">

--- a/templates/handlers/400.html
+++ b/templates/handlers/400.html
@@ -4,6 +4,8 @@
 
 {% block title %}{{ page_title(_('Permission Denied')) }}{% endblock %}
 
+{% set styles = ('error',) %}
+
 {% block content %}
 
 <section id="content">


### PR DESCRIPTION
Styles needed only by error pages are moved into their own stylesheets,
some stylesheets are renamed, and some old-design support is removed.
