### PR TITLE
Use slug instead of title for macro search link

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -26,7 +26,7 @@
 {% endif %}
 
 {% if document.is_template %}
-  {% set macro_name = document.title|replace('Template:','', 1) %}
+  {% set macro_name = document.slug|replace('Template:','', 1) %}
   {% set template_search_link = url('search', locale=document.locale)|urlparams(locale=request.locale, kumascript_macros=macro_name) %}
 {% endif %}
 


### PR DESCRIPTION
Fails: search?locale=en-US&kumascript_macros=obsolete+inline
Works: search?locale=en-US&kumascript_macros=obsolete_inline

Shouldn't use the title as it can be totally different from the slug and the search accepts macro slugs without "Template:".
