### PR TITLE
Remove zone.css from main/homepage

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -264,10 +264,6 @@
   }
 }
 
-.dev-program-resources {
-
-}
-
 
 
 

--- a/settings.py
+++ b/settings.py
@@ -627,10 +627,10 @@ MINIFY_BUNDLES = {
         ),
         'redesign-main': (
             'redesign/css/main.css',
-            'redesign/css/zones.css',
         ),
         'redesign-wiki': (
             'redesign/css/wiki.css',
+            'redesign/css/zones.css',
             #'js/libs/jquery-ui-1.10.3.custom/css/ui-lightness/jquery-ui-1.10.3.custom.min.css',
             #'css/jqueryui/moz-jquery-plugins.css',
             'redesign/css/diff.css',


### PR DESCRIPTION
No reason to use zone.css on every page -- only needed in the wiki.
