### PR TITLE
Lazyload Prism, package ckeditor

### DIFF
--- a/apps/wiki/templates/wiki/confirm_revision_revert.html
+++ b/apps/wiki/templates/wiki/confirm_revision_revert.html
@@ -44,7 +44,3 @@
   </div>
 </section>
 {% endblock %}
-
-{% block js %}
-    {% include 'wiki/includes/highlighting_scripts.html' %}
-{% endblock %}

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -88,7 +88,3 @@
 {% block side %}
   {% include 'wiki/includes/support_for_selectors.html' %}
 {% endblock %}
-
-{% block js %}
-    {% include 'wiki/includes/highlighting_scripts.html' %}
-{% endblock %}

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -180,7 +180,7 @@
     {% if document.is_template %}
       {{ js('ace-editor') }}
     {% else %}
-      {% include 'wiki/includes/ckeditor_scripts.html' %}
+      {{ js('ckeditor') }}
     {% endif %}
 
     {{ js('wiki-edit') }}

--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -1,4 +1,0 @@
-<script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
-<script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-
-<script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script> 

--- a/apps/wiki/templates/wiki/includes/highlighting_scripts.html
+++ b/apps/wiki/templates/wiki/includes/highlighting_scripts.html
@@ -1,9 +1,0 @@
-<!-- include syntax highlighting scripts -->
-{{ css('syntax-prism') }}
-
-{% if waffle.flag('redesign') %}
-  {{ css('redesign-wiki-syntax') }}
-{% endif %}
-
-<script type="text/javascript" src="{{ MEDIA_URL }}js/libs/prism/prism.js" data-manual></script>
-{{ js('syntax-prism') }}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -95,7 +95,7 @@
     {% if is_template %}
       {{ js('ace-editor') }}
     {% else %}
-      {% include 'wiki/includes/ckeditor_scripts.html' %}
+      {{ js('ckeditor') }}
     {% endif %}
 
     {{ js('wiki-edit') }}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -164,10 +164,7 @@
 
 {% block js %}
   {% include 'wiki/includes/tag_suggestions.html' %}
-
-  <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
-  <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-  <script src="{{ MEDIA_URL }}redesign/js/wiki-editor.js?build={{ BUILD_ID_JS }}"></script>
-
+  
+  {{ js('ckeditor') }}
   {{ js('wiki-edit') }}
 {% endblock %}

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -1,5 +1,8 @@
 (function($) {
 
+  var doc = document;
+  var win = window;
+
   /*
     Create the settings and languages menu
   */
@@ -49,7 +52,7 @@
       $quickLinksControl.toggleClass('hidden');
 
       if($(child).hasClass('column-closed')) {
-        $(window).trigger('resize');
+        $(win).trigger('resize');
         parent.removeChild(child);
       }
       else {
@@ -74,7 +77,7 @@
     // Try to find the current page in the list, if found, open it
     // Need to keep track of the elements we've found so they aren't found twice
     var used = [];
-    var $selected = $subnavList.find('a[href$="' + document.location.pathname + '"]');
+    var $selected = $subnavList.find('a[href$="' + doc.location.pathname + '"]');
     $selected.each(function() {
       var self = this;
       var $togglers = $(this).parents('.toggleable').find('.toggler');
@@ -113,6 +116,23 @@
     });
   }
 
+  /* Syntax highlighting scripts */
+  $('pre').length && (function() {
+    var mediaPath = win.mdn.mediaPath;
+    $('<link />').attr({
+      type: 'text/css',
+      rel: 'stylesheet',
+      href: mediaPath + 'css/syntax-prism-min.css'
+    }).appendTo(doc.head);
+
+    var syntaxScript = doc.createElement('script');
+    syntaxScript.setAttribute('data-manual', '');
+    syntaxScript.async = 'true';
+    syntaxScript.src = mediaPath + 'js/syntax-prism-min.js';
+    doc.body.appendChild(syntaxScript);
+  })();
+
+
   /*
     Set up the scrolling TOC effect
   */
@@ -126,8 +146,8 @@
 
       var resizeFn = debounce(function(e) {
         // Set forth the pinned or static positioning of the table of contents
-        var scroll = window.scrollY;
-        var maxHeight = window.innerHeight - parseInt($toc.css('padding-top'), 10) - parseInt($toc.css('padding-bottom'), 10);
+        var scroll = win.scrollY;
+        var maxHeight = win.innerHeight - parseInt($toc.css('padding-top'), 10) - parseInt($toc.css('padding-bottom'), 10);
 
         if(scroll > tocOffset && $toggler.css('pointer-events') == 'none') {
           $toc.css({
@@ -162,7 +182,7 @@
 
       // Set it forth!
       resizeFn();
-      $(window).on('scroll resize', resizeFn);
+      $(win).on('scroll resize', resizeFn);
     }
   })();
 
@@ -178,7 +198,7 @@
     var value = $(this).find('#stack-search').val();
 
     if(value != '') {
-      window.location = 'http://stackoverflow.com/search?q=[firefox]+or+[firefox-os]+or+[html5-apps]+' + value;
+      win.location = 'http://stackoverflow.com/search?q=[firefox]+or+[firefox-os]+or+[html5-apps]+' + value;
     }
   });
 

--- a/settings.py
+++ b/settings.py
@@ -739,9 +739,15 @@ MINIFY_BUNDLES = {
             'js/framebuster.js',
         ),
         'syntax-prism': (
+            'js/libs/prism/prism.js',
             'js/prism-mdn/components/prism-json.js',
             'js/prism-mdn/plugins/line-numbering/prism-line-numbering.js',
             'js/syntax-prism.js',
+        ),
+        'ckeditor': (
+            'js/libs/ckeditor/ckeditor.js',
+            'js/libs/ckeditor/adapters/jquery.js',
+            'redesign/js/wiki-editor.js',
         ),
         'ace-editor': (
             'js/libs/ace/ace.js',

--- a/templates/includes/config.html
+++ b/templates/includes/config.html
@@ -9,7 +9,7 @@
     // Ensures gettext always returns something, is always set
     gettext: function(x) { return x; },
     // The path to media (images, CSS, JS) in MDN
-    mediaPath: '{{ MEDIA_URL }}',
+    mediaPath: ((window.location.host == 'developer.mozilla.org' ? '//developer.cdn.mozilla.net' : '') + '{{ MEDIA_URL }}'),
     // Wiki-specific settings will be placed here
     wiki: {
       autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'


### PR DESCRIPTION
OK, so here's what this does:
1.  Lazy-loads Prism -- only loads if the page has PRE elements.  Loads async.  Saves 2 requests on pages that don't have code samples.
2.  Packaging CKEditor so that we aren't repeating scripts, saves 2 requests on those pages.
