### PR TITLE
Performance: Build LANGUAGE_URL_MAP once on startup, rather than lazily

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -175,19 +175,10 @@ except OSError:
 
 PROD_LANGUAGES = MDN_LANGUAGES
 
-def lazy_lang_url_map():
-    # for bug 664330
-    # from django.conf import settings
-    # langs = DEV_LANGUAGES if (getattr(settings, 'DEV', False) or getattr(settings, 'STAGE', False)) else PROD_LANGUAGES
-    langs = PROD_LANGUAGES
-    lang_url_map = dict([(i.lower(), i) for i in langs])
-    for requested_lang in LOCALE_ALIASES:
-        delivered_lang = LOCALE_ALIASES[requested_lang]
-        if delivered_lang in langs:
-            lang_url_map[requested_lang.lower()] = delivered_lang
-    return lang_url_map
-
-LANGUAGE_URL_MAP = lazy(lazy_lang_url_map, dict)()
+LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in PROD_LANGUAGES])
+for requested_lang, delivered_lang in LOCALE_ALIASES.items():
+    if delivered_lang in PROD_LANGUAGES:
+        LANGUAGE_URL_MAP[requested_lang.lower()] = delivered_lang
 
 # Override Django's built-in with our native names
 def lazy_langs():


### PR DESCRIPTION
Got [a stupid-simple profiler middleware](https://djangosnippets.org/snippets/727/) working, and found something simple at the top of the list. 

Here's the profiler output before:

```
         525450 function calls (513252 primitive calls) in 5.618 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1334    0.311    0.000    0.534    0.000 settings.py:178(lazy_lang_url_map)
    57579    0.230    0.000    0.230    0.000 {method 'lower' of 'str' objects}
     5803    0.226    0.000    1.253    0.000 tokenizer.py:59(__iter__)
```

And, here's the profiler output after:

```
         463496 function calls (451409 primitive calls) in 4.857 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     5803    0.202    0.000    1.173    0.000 tokenizer.py:59(__iter__)
 6190/749    0.185    0.000    0.571    0.001 copy.py:145(deepcopy)
     6616    0.170    0.000    0.760    0.000 _base.py:107(__iter__)
```
