### PR TITLE
Bug 958238 - The X-UA-Compatible meta element is placed to late in the document

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,10 +2,12 @@
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" id="developer-mozilla-org" class="redesign">
 <head prefix="og: http://ogp.me/ns#">
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   {% if not is_sphinx %}
     {{ optimizely_script() }}
   {% endif %}
-  <meta charset="utf-8">
+
   <title>{% block title %}{{ _('Mozilla Developer Network') }}{% endblock %}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -44,7 +46,6 @@
 
   <!--[if IE]>
   <meta http-equiv="imagetoolbar" content="no">
-  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script src="{{ MEDIA_URL }}js/libs/html5.js"></script>
   <![endif]-->
 


### PR DESCRIPTION
also the element containing the character encoding declaration must be serialized completely within the first 1024 bytes of the document so i did that as well.
