### PR TITLE
Fix bug 949988 - Close button for navigation submenus on Mobile devices

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -80,8 +80,11 @@
               $self[0].focus();
             }
           });
+          
+          $submenu.find('.submenu-close').on('click', function(){
+            closeSubmenu($(this).parent());
+          });
         }
-
         // If there's an open submenu and it's not this one, close it
         // Used for tab navigation from submenu to the next menu item
         if($.fn.mozMenu.$openMenu && $.fn.mozMenu.$openMenu != $self) {

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -110,7 +110,7 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     border-right: 1px dotted #d4dde4;
     width: col-width;
 
-    &:last-child {
+    &.last {
       margin-right: 0;
       border-right: 0;
       padding-right: 0;

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -156,6 +156,10 @@
       display: inline-block;
     }
 
+    .submenu-close{
+      display:none;
+    }
+
     &:before, &:after {
       top: menu-arrow-top;
       left: 269px;
@@ -542,6 +546,16 @@ footer {
       .submenu-column {
         width: 40%;
         border-right: 0;
+      }
+
+      .submenu-close{
+        display: block;
+        position: absolute;
+        top: 20px;
+        right: 20px;
+        i{
+          margin-left: 0;
+        }
       }
     }
   }

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,7 +84,7 @@
     <nav id="main-nav" role="navigation"><ul><li><a href="{{ devmo_url('Zones') }}">{{ _('Zones') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
         <div class="submenu submenu-single" id="nav-zones-submenu">
-          <div class="submenu-column">
+          <div class="submenu-column last">
             <ul>
               <li><a href="{{ devmo_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
               <li><a href="{{ devmo_url('Apps') }}">{{ _('App Center') }}</a></li>
@@ -94,6 +94,10 @@
               <li><a href="{{ devmo_url('Persona') }}">{{ _('Persona') }}</a></li>
             </ul>
           </div>
+          <button class="submenu-close transparent">
+            <span class="offscreen">Close submenu</span>
+            <i aria-hidden="true" class="icon-remove-sign"></i>
+          </button>
         </div>
       </li><li><a href="{{ devmo_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
@@ -109,7 +113,7 @@
               <li><a href="{{ devmo_url('Web/Apps') }}">{{ _('Apps') }}</a></li>
               <li><a href="{{ devmo_url('Web/MathML') }}">{{ _('MathML') }}</a></li>
             </ul>
-          </div><div class="submenu-column">
+          </div><div class="submenu-column last">
             <div class="title">{{ _('References & Guides') }}</div>
             <ul>
               <li><a href="{{ devmo_url('Web/Tutorials') }}">{{ _('Tutorials') }}</a></li>
@@ -120,6 +124,10 @@
               <li><a href="{{ devmo_url('Web') }}">{{ _('...more docs') }}</a></li>
             </ul>
           </div>
+          <button class="submenu-close transparent">
+            <span class="offscreen">Close submenu</span>
+            <i aria-hidden="true" class="icon-remove-sign"></i>
+          </button>
         </div>
       </li><li><a href="{{ devmo_url('Mozilla/Developer_Program') }}">{{ _('Developer Program') }}</a></li><li><a href="{{ devmo_url('Tools') }}">{{ _('Tools') }}</a></li><li><a href="{{ url('demos') }}">{{ _('Demos') }}</a></li>{#<li><a href="">{{ _('Developer Program') }}</a></li>#}{% if not is_sphinx %}<li class="main-nav-search"><form action="{{ url('search') }}" method="get" role="search">
         <div class="search-wrap">


### PR DESCRIPTION
Adding close button on submenus for mobile devices.

I tried to implement click outside (.submenu) for closing submenu, but that would prevent event propagation to close button. So couldn't get both working together. Any suggestions to improve this would be great!
