### PR TITLE
Prevent last child spacing empty space side effect

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -137,7 +137,7 @@
   </div></header>
 
   <!-- Content will go here -->
-  <main id="content" role="main"><div class="center">
+  <main id="content" role="main"><div class="center clear">
   {% block content %}{% endblock %}
   </div></main>
 


### PR DESCRIPTION
Clearing the main content area so there's no bleeding into the footer.

For example, if the last element in the main area is a `<p></p>`, empty grey space from the `<html>` element appears.  This prevents said issue.
