### PR TITLE
Search in all locales for macro usage

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content_redesign.html
+++ b/apps/wiki/templates/wiki/includes/document_content_redesign.html
@@ -27,7 +27,7 @@
 
 {% if document.is_template %}
   {% set macro_name = document.slug|replace('Template:','', 1) %}
-  {% set template_search_link = url('search', locale=document.locale)|urlparams(locale=request.locale, kumascript_macros=macro_name) %}
+  {% set template_search_link = url('search', locale=document.locale)|urlparams(locale='*', kumascript_macros=macro_name) %}
 {% endif %}
 
 {% set zone_stack = document.find_zone_stack() %}


### PR DESCRIPTION
In order cleanup our usage of macros, we need to look into all locales rather than just English. Macros are written to be used in all locales.
