### PR TITLE
Made SENTRY_DSN optional to prevent it from raising misleading exceptions.

### DIFF
--- a/puppet/files/vagrant/settings_local.py
+++ b/puppet/files/vagrant/settings_local.py
@@ -154,4 +154,10 @@ ES_INDEX_PREFIX = 'mdn'
 ES_LIVE_INDEX = True
 ES_INDEXING_TIMEOUT = 30
 
-SENTRY_DSN = 'https://mana.mozilla.org/wiki/display/websites/Developer+Cluster#DeveloperCluster-Sentry'
+# See https://mana.mozilla.org/wiki/display/websites/Developer+Cluster#DeveloperCluster-Sentry
+SENTRY_DSN = ''
+
+if SENTRY_DSN:
+    INSTALLED_APPS = INSTALLED_APPS + (
+        'raven.contrib.django.raven_compat',
+    )

--- a/settings.py
+++ b/settings.py
@@ -459,7 +459,6 @@ INSTALLED_APPS = (
     'teamwork',
     'djcelery',
     'taggit',
-    'raven.contrib.django.raven_compat',
     'dbgettext',
 
     'dashboards',
@@ -1129,7 +1128,6 @@ LOGGING = {
 CSRF_COOKIE_SECURE = True
 X_FRAME_OPTIONS = 'DENY'
 
-SENTRY_DSN = 'set this in settings_local.py'
 TEAMWORK_BASE_POLICIES = {
     'anonymous': (
         'wiki.view_document',),


### PR DESCRIPTION
Fixes #1900.
