### PR TITLE
vagrant: globally configure npm to ignore expired SSL certs

### DIFF
--- a/puppet/files/usr/share/npm/npmrc
+++ b/puppet/files/usr/share/npm/npmrc
@@ -1,0 +1,8 @@
+# DO NOT MODIFY THIS FILE - use /etc/npmrc instead.
+globalconfig=/etc/npmrc
+globalignorefile=/etc/npmignore
+prefix=/usr/local
+
+# HACK: Yeah, I know it said not to modify this file, but globalconfig seems
+# not to be working since /etc/npmrc is not used
+strict-ssl = false

--- a/puppet/manifests/classes/nodejs.pp
+++ b/puppet/manifests/classes/nodejs.pp
@@ -23,6 +23,12 @@ class nodejs {
         owner => "root", group => "root", mode => 0777,
         require => File["/root"];
     }
+    file { "/usr/share/npm/npmrc":
+        ensure => file,
+        owner => "root", group => "root", mode => 0755,
+        source => "/home/vagrant/src/puppet/files/usr/share/npm/npmrc",
+        require => Package["npm"]
+    }
     exec { 'npm-install':
         cwd => "/home/vagrant/src/kumascript",
         user => 'vagrant',
@@ -30,7 +36,8 @@ class nodejs {
         creates => "/home/vagrant/src/kumascript/node_modules/fibers",
         require => [
             Package["nodejs"], Package["nodejs-dev"], Package["npm"],
-            File["/usr/include/node"], File["/root/.npm"]
+            File["/usr/include/node"], File["/root/.npm"],
+            File["/usr/share/npm/npmrc"]
         ]
     }
 }

--- a/puppet/manifests/classes/stylus.pp
+++ b/puppet/manifests/classes/stylus.pp
@@ -5,6 +5,7 @@ class stylus {
         creates => "/usr/local/bin/stylus",
         require => [
             Package["nodejs"], Package["nodejs-dev"], Package["npm"],
+            File["/usr/share/npm/npmrc"]
         ]
     }
     file { "/usr/local/bin/stylus":


### PR DESCRIPTION
This is just a tad hacky - the long-term solution is to upgrade node & npm, and deal with the fallout from that (ie. upgrading ubuntu, reworking kumascript)

For now, this forces a global setting that ignores strict SSL cert validation, and seems to get the node dependencies installed.
