### PR TITLE
Resolve djcelery migration error in Vagrant

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -852,6 +852,7 @@ SOUTH_MIGRATION_MODULES = {
     'taggit': 'migrations.south.taggit',
     # HACK: South treats "database" as the name of constance.backends.database
     'database': 'migrations.south.constance',
+    'djcelery': 'migrations.south.djcelery',
 }
 
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'


### PR DESCRIPTION
This reverts commit 368d9d74473a75844939494986ff4472d55d1ee1.

Run this like so, for most predictable results:

```
vagrant destroy
vagrant box remove kuma-ubuntu
vagrant up
```

So here's the problem:
- We have a Vagrant VM image with a partially populated database from Jan 2013
- The djcelery tables in that DB are currently in the state established by [_kuma_'s old 0001 migration](https://github.com/mozilla/kuma/blob/master/migrations/south/djcelery/0001_initial.py)
  - That is, **not** [djcelery's native 0001 migration](https://github.com/mozilla/kuma-lib/blob/master/packages/django-celery/djcelery/migrations/0001_initial.py). We started using South before djcelery did. 
  - Unfortunately, these migrations differ.
- So, attempts to apply [djcelery's own 0002 migration results in error](https://github.com/mozilla/kuma-lib/blob/master/packages/django-celery/djcelery/migrations/0002_v25_changes.py)
- Instead - at least until the Vagrant VM image is rebuilt - we need to apply [_kuma_'s old 0002 migration for djcelery](https://github.com/mozilla/kuma/blob/master/migrations/south/djcelery/0002_v25_changes.py), because it reconciles the differences.
- So, this should fix the immediate issue in Vagrant
  - A future task is to rebuild the downloadable VM image after this migrations and only _then_ return full migration control to djcelery
