### PR TITLE
vagrant: Disable broken migration that prevents tidings migration from executing

### DIFF
--- a/migrations/14-unique-hash-indexes.sql
+++ b/migrations/14-unique-hash-indexes.sql
@@ -1,3 +1,7 @@
+-- HACK: This migration is commented out, because it's turned out to be
+-- trouble. But, removing it from the sequence entirely also causes trouble.
+-- So, this is a no-op.
+
 --
 -- The unique constraint got left out of an earlier actioncounters migration,
 -- so this schematic migration forcibly cleans up the few duplicates and adds
@@ -5,18 +9,18 @@
 --
 -- There should only be about 50 duplicates in 180000 or so production records.
 --
-CREATE TEMPORARY TABLE dup_actioncounter_hashes
-    SELECT unique_hash
-    FROM actioncounters_actioncounterunique
-    GROUP BY unique_hash 
-    HAVING count(unique_hash) > 1;
-
-DELETE FROM actioncounters_actioncounterunique 
-    WHERE unique_hash IN
-        (SELECT unique_hash FROM dup_actioncounter_hashes);
-
-DROP INDEX actioncounters_actioncounterunique_unique
-    ON actioncounters_actioncounterunique;
-
-ALTER TABLE actioncounters_actioncounterunique 
-    ADD UNIQUE actioncounters_actioncounterunique_unique (unique_hash);
+-- CREATE TEMPORARY TABLE dup_actioncounter_hashes
+--     SELECT unique_hash
+--     FROM actioncounters_actioncounterunique
+--     GROUP BY unique_hash 
+--     HAVING count(unique_hash) > 1;
+-- 
+-- DELETE FROM actioncounters_actioncounterunique 
+--     WHERE unique_hash IN
+--         (SELECT unique_hash FROM dup_actioncounter_hashes);
+-- 
+-- DROP INDEX actioncounters_actioncounterunique_unique
+--     ON actioncounters_actioncounterunique;
+-- 
+-- ALTER TABLE actioncounters_actioncounterunique 
+--     ADD UNIQUE actioncounters_actioncounterunique_unique (unique_hash);


### PR DESCRIPTION
This is a hack, commenting out all the SQL. But, it's an expedient fix until we resolve #1910 to remove schematic entirely
