### PR TITLE
Change edit button label to simply "Edit"

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -51,7 +51,7 @@
               {% endif %}
             </ul>
           </div>
-        </div></li>{% endif %}<li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit Page') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }} aria-haspopup="true" aria-owns="settings-menu-submenu" aria-expanded="false"><span>{{ _('Settings') }}</span><i aria-hidden="true" class="icon-cog"></i></a>
+        </div></li>{% endif %}<li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }} aria-haspopup="true" aria-owns="settings-menu-submenu" aria-expanded="false"><span>{{ _('Settings') }}</span><i aria-hidden="true" class="icon-cog"></i></a>
 
         <div class="submenu" id="settings-menu-submenu">
           <!-- this page -->


### PR DESCRIPTION
Based on the following A/B test results:
http://optimize.ly/~VoAkCt?token=20ca22118554616e752d

The label "Edit Page" is used elsewhere (like on profile pages and in
the revision dashboard) but these instances are intentionally left
unchanged. Only on article pages is "Page" clear from context.
