### PR TITLE
Add last_edit to document json

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -932,6 +932,10 @@ class Document(NotificationsMixin, models.Model):
         else:
             modified = datetime.now().isoformat()
 
+        last_edit = ''
+        if self.current_revision:
+            last_edit = self.current_revision.created.isoformat()
+
         return {
             'title': self.title,
             'label': self.title,
@@ -945,7 +949,8 @@ class Document(NotificationsMixin, models.Model):
             'summary': summary,
             'translations': translations,
             'modified': modified,
-            'json_modified': datetime.now().isoformat()
+            'json_modified': datetime.now().isoformat(),
+            'last_edit': last_edit
         }
 
     def get_json_data(self, stale=True):


### PR DESCRIPTION
Having the last edit date of a document helps us to find old/outdated pages. The document json gets called from [KumaScript macros](https://developer.mozilla.org/en-US/docs/Template:NeedsUpdateInSection) and the "modified" field only tells us when the page was last rebuilt (which was last year at least). This PR now adds the real last edit date from a human who created the last revision to the document.

I guess adding a new field will need a rebuild of all the documents. Curious what @lmorchard thinks.
