### PR TITLE
Fix bug 929373 - Stop indexing even more documents.

### DIFF
--- a/apps/search/tests/test_types.py
+++ b/apps/search/tests/test_types.py
@@ -3,6 +3,8 @@ from nose.tools import ok_, eq_
 from search.models import DocumentType
 from search.tests import ElasticTestCase
 
+from wiki.models import Document
+
 
 class DocumentTypeTests(ElasticTestCase):
     fixtures = ['test_users.json', 'wiki/documents.json']
@@ -47,3 +49,12 @@ class DocumentTypeTests(ElasticTestCase):
             excerpt = doc.get_excerpt()
             ok_('the word for tough things' in excerpt)
             ok_('extra content' not in excerpt)
+
+    def test_hidden_slugs_get_indexable(self):
+        self.refresh()
+        title_list = DocumentType.get_indexable().values_list('title', flat=True)
+        ok_('User:jezdez' not in title_list)
+
+    def test_hidden_slugs_should_update(self):
+        jezdez_doc = Document.objects.get(slug='User:jezdez')
+        eq_(DocumentType.should_update(jezdez_doc), False)

--- a/apps/wiki/fixtures/wiki/documents.json
+++ b/apps/wiki/fixtures/wiki/documents.json
@@ -84,6 +84,19 @@
         }
     },
     {
+        "pk": 7,
+        "model": "wiki.document",
+        "fields": {
+            "category": 10,
+            "title": "User:jezdez",
+            "locale": "en-US",
+            "is_template": false,
+            "modified": "2014-01-27 18:12:10",
+            "html": "",
+            "slug": "User:jezdez"
+        }
+    },
+    {
         "pk": 19,
         "model": "wiki.revision",
         "fields": {

--- a/apps/wiki/tests/test_cron.py
+++ b/apps/wiki/tests/test_cron.py
@@ -28,7 +28,9 @@ class SitemapsTestCase(TestCase):
                                 (settings.MEDIA_ROOT, locale),
                                'r').read()
 
-            docs = Document.objects.filter(locale=locale)
+            docs = (Document.objects.filter(locale=locale)
+                                    .exclude(title__startswith='User:')
+                                    .exclude(slug__icontains='Talk:'))
 
             ok_(docs[0].modified.strftime('%Y-%m-%d') in sitemap_xml)
             for doc in docs:


### PR DESCRIPTION
We now exclude documents whose slug starts with any of the following strings:
Talk:, User:, User_talk:, Template_talk:, Project_talk:
