### PR TITLE
fix bug 964664 - Remove ace editor bundle, move scripts to own resource

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -175,9 +175,10 @@
     {% include 'wiki/includes/tag_suggestions.html' %}
 
     {% if document.is_template %}
-      {{ js('ace-editor') }}
+      {% include 'wiki/includes/ace_scripts.html' %}
     {% else %}
       {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
+    {{ js('wiki-edit') }}
 
 {% endblock %}

--- a/apps/wiki/templates/wiki/includes/ace_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ace_scripts.html
@@ -1,0 +1,4 @@
+<script type="text/javascript" src="/media/js/libs/ace/ace.js"></script>
+<script type="text/javascript" src="/media/js/libs/ace/mode-javascript.js"></script>
+<script type="text/javascript" src="/media/js/libs/ace/theme-dreamweaver.js"></script>
+<script type="text/javascript" src="/media/js/libs/ace/worker-javascript.js"></script>

--- a/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
+++ b/apps/wiki/templates/wiki/includes/ckeditor_scripts.html
@@ -1,3 +1,2 @@
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/ckeditor.js?build={{ BUILD_ID_JS }}"></script>
 <script src="{{ MEDIA_URL }}js/libs/ckeditor/adapters/jquery.js?build={{ BUILD_ID_JS }}"></script>
-{{ js('wiki-edit') }}

--- a/apps/wiki/templates/wiki/new_document.html
+++ b/apps/wiki/templates/wiki/new_document.html
@@ -93,9 +93,10 @@
     {% include 'wiki/includes/tag_suggestions.html' %}
 
     {% if is_template %}
-      {{ js('ace-editor') }}
+      {% include 'wiki/includes/ace_scripts.html' %}
     {% else %}
       {% include 'wiki/includes/ckeditor_scripts.html' %}
     {% endif %}
+    {{ js('wiki-edit') }}
 
 {% endblock %}

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -158,5 +158,6 @@
 
   {% include 'wiki/includes/tag_suggestions.html' %}
   {% include 'wiki/includes/ckeditor_scripts.html' %}
+  {{ js('wiki-edit') }}
   
 {% endblock %}

--- a/settings.py
+++ b/settings.py
@@ -703,12 +703,6 @@ MINIFY_BUNDLES = {
             'js/libs/prism/plugins/line-highlight/prism-line-highlight.js',
             'js/syntax-prism.js',
         ),
-        'ace-editor': (
-            'js/libs/ace/ace.js',
-            'js/libs/ace/mode-javascript.js',
-            'js/libs/ace/theme-dreamweaver.js',
-            'js/libs/ace/worker-javascript.js',
-        ),
         'wiki': (
             'redesign/js/wiki.js',
         ),


### PR DESCRIPTION
Ace editor bundle causing an error, prevents initialization. Fixed here.
