### PR TITLE
Prevents the page to move when persona is loaded. [no bug]

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -189,11 +189,12 @@
 a.persona-button {
   vendorize(border-radius, 3px);
   z-index: 2;
-  display: none;
+  display: inline-block;
+  visibility: hidden;
   font-weight: bold;
 
   &.persona-loaded {
-    display: inline-block;
+    visibility: visible;
   }
 
   &:focus{


### PR DESCRIPTION
In mobile view the page moves down when persona is loaded, this prevents this.
