### PR TITLE
Vagrantfile compatibility fix with ruby v1.8

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant::VERSION >= "1.1.0" and Vagrant.configure("2") do |config|
     config.vm.box = CONF['box']
     config.vm.network :private_network, :ip => CONF['ip_address']
     config.package.name = CONF['package_name']
-    config.vm.synced_folder ".", "/vagrant", disabled: true
+    config.vm.synced_folder ".", "/vagrant", :disabled => true
 
     # nfs needs to be explicitly enabled to run.
     if CONF['nfs'] == false or RUBY_PLATFORM =~ /mswin(32|64)/


### PR DESCRIPTION
```
> vagrant up

There is a syntax error in the following Vagrantfile. The syntax error
message is reproduced below for convenience:

/path_to_kuma/Vagrantfile:58: syntax error, unexpected ':', expecting kEND
    config.vm.synced_folder ".", "/vagrant", disabled:  true
                                                  ^
```
