### PR TITLE
U - fix cut-offed persona icon and aligned the text verticaly.

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -242,7 +242,7 @@ a.persona-button {
         position: relative;
         top: 2px;
         left: 5px;
-        width: 14px;
+        width: 15px;
         height: 15px;
         display: inline-block;
       }
@@ -250,6 +250,8 @@ a.persona-button {
 
     &.signin {
       text-shadow: 0px 1.5px 1px rgba(0, 0, 0, 0.35);
+      line-height: 23px;
+      padding-bottom 1px;
 
       &:after {
         z-index: 2;


### PR DESCRIPTION
The persona icon way cut off. aligned the text a bit as well to make it look more centered against the arrows.
![screen shot 2014-02-03 at 01 45 59](https://f.cloud.github.com/assets/74497/2061824/e91007a8-8c6c-11e3-8e1b-ab0d9de6debe.png)
