### PR TITLE
bug 950231: Schedule document rendering after a revision is reverted

### DIFF
--- a/apps/wiki/management/commands/render_document.py
+++ b/apps/wiki/management/commands/render_document.py
@@ -109,7 +109,7 @@ class Command(BaseCommand):
         if self.options['defer']:
             logging.info(u"Queuing deferred render for %s (%s)" %
                           (doc, doc.get_absolute_url()))
-            render_document.delay(doc, cc, self.base_url)
+            render_document.delay(doc.pk, cc, self.base_url)
             logging.debug(u"Queued.")
 
         else:

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -440,7 +440,7 @@ class BaseDocumentManager(models.Manager):
                 if log:
                     log.info("Rendered stale %s" % doc)
             else:
-                tasks.render_document.delay(doc, 'no-cache', settings.SITE_URL)
+                tasks.render_document.delay(doc.pk, 'no-cache', settings.SITE_URL)
                 if log:
                     log.info("Deferred rendering for stale %s" % doc)
 
@@ -835,7 +835,7 @@ class Document(NotificationsMixin, models.Model):
             # Attempt to queue a rendering. If celery.conf.ALWAYS_EAGER is
             # True, this is also an immediate rendering.
             from . import tasks
-            tasks.render_document.delay(self, cache_control, base_url)
+            tasks.render_document.delay(self.pk, cache_control, base_url)
 
     def render(self, cache_control=None, base_url=None, timeout=None):
         """Render content using kumascript and any other services necessary."""
@@ -1122,6 +1122,7 @@ class Document(NotificationsMixin, models.Model):
         if old_review_tags:
             revision.review_tags.set(*old_review_tags)
         revision.make_current()
+        self.schedule_rendering('max-age=0')
         return revision
 
     def revise(self, user, data, section_id=None):

--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -109,9 +109,10 @@ def _rebuild_kb_chunk(data, **kwargs):
 
 
 @task(rate_limit='10/m')
-def render_document(doc, cache_control, base_url):
+def render_document(pk, cache_control, base_url):
     """Simple task wrapper for the render() method of the Document model"""
-    doc.render(cache_control, base_url)
+    document = Document.objects.get(pk=pk)
+    document.render(cache_control, base_url)
 
 
 @task

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1978,6 +1978,7 @@ def helpful_vote(request, document_slug, document_locale):
 
 @login_required
 @check_readonly
+@transaction.autocommit
 def revert_document(request, document_path, revision_id):
     """Revert document to a specific revision."""
     document_locale, document_slug, needs_redirect = (Document


### PR DESCRIPTION
This should ensure that a document gets re-rendered after a revision revert.
