### PR TITLE
fix bug 939383 - modify content min-height for zone nav

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -1,6 +1,7 @@
 (function($) {
 
   var focusClass = 'focused';
+  var noop = function(){};
 
   /*
     Plugin to create nav menus, show/hide delays, etc.
@@ -14,8 +15,8 @@
       submenu: null,
       focusOnOpen: false,
       brickOnClick: false,
-      onOpen: function(){},
-      onClose: function() {}
+      onOpen: noop,
+      onClose: noop
     }, options);
 
     var closeTimeout;
@@ -190,7 +191,9 @@
   */
   $.fn.mozTogglers = function(options) {
     var settings = $.extend({
-      items: null
+      onOpen: noop,
+      slideCallback: noop,
+      duration: 200 /* 400 is the default for jQuery */
     }, options);
 
     $(this).each(function() {
@@ -221,6 +224,7 @@
       $self.on('click', '.toggler', function(e) {
         e.preventDefault();
         e.stopPropagation();
+        settings.onOpen.call(this);
 
         // If I'm an accordion, close the other one
         var $parent = $self.closest('ol, ul');
@@ -246,12 +250,12 @@
         if(!getState($li) || forceClose) {
           $li.attr(closedAttribute, 'true').removeClass('current');
           pieces.$container.attr('aria-expanded', false);
-          pieces.$container.slideUp();
+          pieces.$container.slideUp(settings.duration, settings.slideCallback);
         }
         else {
           $li.attr(closedAttribute, '').addClass('current');
           pieces.$container.attr('aria-expanded', true);
-          pieces.$container.slideDown();
+          pieces.$container.slideDown(settings.duration, settings.slideCallback);
         }
         setIcon(pieces.$toggler, $li);
       }

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -1,7 +1,4 @@
-(function($) {
-
-  var doc = document;
-  var win = window;
+(function(win, doc, $) {
 
   /*
     Togglers within articles (i.e.)
@@ -69,15 +66,20 @@
   /*
     Set up the zone subnav accordion
   */
-  $('.zone-subnav-container').each(function() {
-    var $subnavList = $(this).find('.subnav > ol');
+  $('.zone-landing-header-preview-base').each(function() {
+    var $base = $(this);
+    var $subnav = $base.find('.subnav');
+    var $subnavList = $subnav.find(' > ol');
+
     if(!$subnavList.length) return; // Exit if the subnav isn't set up properly
 
     // Set the list items as togglers where needed
     setupTogglers($subnavList.find('li'));
 
     // Make them toggleable!
-    $subnavList.find('.toggleable').mozTogglers();
+    $subnavList.find('.toggleable').mozTogglers({
+      slideCallback: setMinHeight
+    });
 
     // Try to find the current page in the list, if found, open it
     // Need to keep track of the elements we've found so they aren't found twice
@@ -97,6 +99,15 @@
 
     // Mark this is an accordion so the togglers open/close properly
     $subnavList.addClass('accordion');
+
+    
+    function setMinHeight() {
+      if($base.css('position') == 'absolute') {
+        $('.wiki-main-content').css('min-height', $subnav.height());
+      }
+    }
+
+    setMinHeight();
   });
 
   /*
@@ -269,4 +280,4 @@
     };
   };
 
-})(jQuery);
+})(window, document, jQuery);

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -56,6 +56,7 @@ enable-toc-toggle() {
 
 .wiki-main-content {
   background: #fff;
+  min-height: 300px;
 
   .center {
     remove-center-spacing();


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=939383

This solution isn't perfect™ in that it relies on JavaScript but it's the first effort in ensuring there's no overlap in subnav and footer.  Upon opening a subnav item, we set the min-height of the content to the subnav height.

I'll be looking over the next few days at seeing if there's a way to make the subnav in normal flow with the page (not seeing a way now), but this will fix the issue in the interim.
