### PR TITLE
Do not override "clear" property with custom mixin

### DIFF
--- a/media/redesign/stylus/grid.styl
+++ b/media/redesign/stylus/grid.styl
@@ -31,7 +31,7 @@
 
 /* this is a "helper" which automatically formats its column children, clears the floats afterward, removes margin from last item */
 .column-container {
-  clear();
+  clearfix();
 
   {grid-column-selector} {
     margin-right: grid-margin;

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -75,7 +75,7 @@
   }
 
   h3 {
-    clear();
+    clearfix();
     text-transform: uppercase;
 
     i {
@@ -307,7 +307,7 @@
   background: light-background-color;
 
   .home-demos-list {
-    clear();
+    clearfix();
     position: relative;
     height: 150px;
     overflow: hidden;

--- a/media/redesign/stylus/mixins.styl
+++ b/media/redesign/stylus/mixins.styl
@@ -269,7 +269,7 @@ offscreen() {
   width: 1px;
 }
 
-clear() {
+clearfix() {
   &:before, &:after {
     content: ' ';
     display: table;
@@ -309,7 +309,7 @@ title-header() {
    profile page and elsewhere) make them appear on the same line, with the
    checkbox to the left of the label. */
 $checkbox-label-container {
-    clear();
+    clearfix();
 
     input[type='checkbox'] {
         bidi-value(float, left, right);

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -121,7 +121,7 @@ p {
 }
 
 .search-results-more {
-  clear();
+  clearfix();
   padding: 0 grid-spacing;
 
   .with-view-all .view-all {

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -7,7 +7,7 @@
 }
 
 .clear { 
-  clear(); 
+  clearfix(); 
 }
 
 .title { 
@@ -53,7 +53,7 @@
 
 /* header */
 #main-header {
-  clear();
+  clearfix();
   border-color: transparent;
   border-bottom-width: 1px;
   border-bottom-style: solid;


### PR DESCRIPTION
Until now, we used a mixin named clear() to apply clear-fixes to
elements.

When Stylus encounters a property that shares a name with a mixin, it
assumes the property is a transparent call to the mixin [1]. Thus,
whenever we used the real CSS property "clear", Stylus assumed we were
calling the mixin of the same name, and we ended up applying clear-fixes
to elements accidentally.

To test this, inspect a Zone landing page title. Without this change,
the title should be incorrectly clear-fixed. With the change, the title
should correctly not be clear-fixed.

[1] http://pages.citebite.com/e2t7l2p4m9dig
