### PR TITLE
fix bug 957298 - Show navigation arrows persistently

### DIFF
--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -123,7 +123,7 @@
       }
 
       > a i {
-        display: none;
+        opacity: 0.85;
       }
 
       > a, .search-trigger {
@@ -429,7 +429,6 @@ footer {
         > a {
           i {
             @extend .larger;
-            display: inline-block;
           }
         }
       }


### PR DESCRIPTION
I've come around on this, to always showing arrows.  I think it's the right decision.

https://bugzilla.mozilla.org/show_bug.cgi?id=957298
