### PR TITLE
Allow Stylus to control keyframes

### DIFF
--- a/media/redesign/stylus/error-404.styl
+++ b/media/redesign/stylus/error-404.styl
@@ -1,50 +1,6 @@
 @import 'mixins'
 
 /* 404 - Animate the tumbeast's eyes. Original animation by J Zeller. */
-@-moz-keyframes crazylefteye {
-    0%   {left:125px; top:65px;}
-    10%  {left:118px; top:56px;}
-    20%  {left:118px; top:56px;}
-    40%  {left:148px; top:62px;}
-    50%  {left:145px; top:72px;}
-    60%  {left:121px; top:70px;}
-    70%  {left:125px; top:65px;}
-    100% {left:125px; top:65px;}
-}
-
-@-moz-keyframes crazyrighteye {
-    0%   {left:231px; top:68px;}
-    10%  {left:212px; top:62px;}
-    20%  {left:212px; top:62px;}
-    40%  {left:239px; top:64px;}
-    50%  {left:240px; top:80px;}
-    60%  {left:215px; top:73px;}
-    70%  {left:231px; top:68px;}
-    100% {left:231px; top:68px;}
-}
-
-@-webkit-keyframes crazylefteye {
-    0%   {left:125px; top:65px;}
-    10%  {left:118px; top:56px;}
-    20%  {left:118px; top:56px;}
-    40%  {left:148px; top:62px;}
-    50%  {left:145px; top:72px;}
-    60%  {left:121px; top:70px;}
-    70%  {left:125px; top:65px;}
-    100% {left:125px; top:65px;}
-}
-
-@-webkit-keyframes crazyrighteye {
-    0%   {left:231px; top:68px;}
-    10%  {left:212px; top:62px;}
-    20%  {left:212px; top:62px;}
-    40%  {left:239px; top:64px;}
-    50%  {left:240px; top:80px;}
-    60%  {left:215px; top:73px;}
-    70%  {left:231px; top:68px;}
-    100% {left:231px; top:68px;}
-}
-
 @keyframes crazylefteye {
     0%   {left:125px; top:65px;}
     10%  {left:118px; top:56px;}


### PR DESCRIPTION
Stylus handles keyframes by itself at the moment.  It adds -webkit-, -moz-, -o-, and -ms- for us, so we don't need to do so ourselves.

I know -moz- and -o- are a bit legacy, but Stylus will update that with time and we should try to keep our code clean.
