### PR TITLE
Misc profile page cleanups and fluid demos blocks

### DIFF
--- a/apps/devmo/templates/devmo/profile.html
+++ b/apps/devmo/templates/devmo/profile.html
@@ -47,6 +47,19 @@
 
       <div class="main">
         <h1 class="page-title"><span class="nickname">{{ profile.user.username }}</span> {% if profile.fullname %}<b>(<span class="fn">{{ profile.fullname }}</span>)</b>{% endif %}</h1>
+
+        <div class="edit">
+          {% if show_manage_roles_button %}
+              {# TODO: Need a method to detect whether the logged in user can manage any roles, here #}
+              <a href="{{ url('teamwork.views.user_roles', profile.user.username) }}" class="button neutral">{{_("Manage Roles")}}<i aria-hidden="true" class="icon-users"></i></a>
+          {% endif %}
+          <!-- Only shown for the user and admins -->
+          {% if profile.allows_editing_by(request.user) %}
+              <a href="{{ url('authkeys.list') }}" class="button neutral">{{_("Manage API Keys")}}<i aria-hidden="true" class="icon-key"></i></a>
+              <a id="edit-profile" href="{{ url('devmo.views.profile_edit', username=profile.user.username) }}" class="button neutral">{{_("Edit Profile")}}<i aria-hidden="true" class="icon-pencil"></i></a>
+          {% endif %}
+          {{ ban_link(profile.user, request.user) }}
+      </div>
   
       {% if profile.title or profile.organization or profile.location or profile.irc_nickname %}
       <ul class="info">
@@ -89,19 +102,6 @@
 
         <div class="memberSince">{{ _('Member since {date}') | f(date=profile.user.date_joined.strftime('%B %d, %Y')) }}</div>
       </div>
-
-      <p class="edit">
-          {% if show_manage_roles_button %}
-              {# TODO: Need a method to detect whether the logged in user can manage any roles, here #}
-              <a href="{{ url('teamwork.views.user_roles', profile.user.username) }}" class="button">{{_("Manage Roles")}}</a>
-          {% endif %}
-          <!-- Only shown for the user and admins -->
-          {% if profile.allows_editing_by(request.user) %}
-              <a href="{{ url('authkeys.list') }}" class="button">{{_("Manage API Keys")}}</a>
-              <a id="edit-profile" href="{{ url('devmo.views.profile_edit', username=profile.user.username) }}" class="button">{{_("Edit Profile")}}</a>
-          {% endif %}
-          {{ ban_link(profile.user, request.user) }}
-      </p>
     </section>
 
     {% if waffle.flag('badger') and award_list %}

--- a/media/redesign/stylus/demo-studio.styl
+++ b/media/redesign/stylus/demo-studio.styl
@@ -69,6 +69,16 @@ html {
   }
 }
 
+/* allow demo blocks for flow freely with site width */
+.gallery {
+  .demo {
+    display: inline-block;
+    vertical-align: text-top;
+    float: none;
+    margin: 20px 20px 0 0;
+  }
+}
+
 #demostudio.landing, #demostudio.detail {
   compat-important(background-position, center 0px);
 }

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -138,3 +138,23 @@ beta-spacing = (grid-spacing * 2.5);
         compat-only(padding-left, 0);
     }
 }
+
+
+@media media-query-tablet {
+  #profile-head {
+    .edit {
+      position: relative;
+      top: auto;
+      right: auto;
+      text-align: left;
+      margin: 0 0 grid-spacing 0;
+
+      a {
+        float: none;
+        display: inline-block;
+        margin: 0 10px 0 0;
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This:
-  Moves the profile edit/ban/keys buttons below the username at tablet width
-  Makes the buttons more pronounced with color
-  Ensures demo items can wide or thing as the screen -- no more breaking on the 4th item.  Better for large and small screens.
