### PR TITLE
fix bug 970779 - Prevent ajax loading 404 gif

### DIFF
--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -335,6 +335,9 @@
   .owl-theme .owl-controls {
     margin-top: grid-spacing;
   }
+  .owl-item.loading {
+    background: url('/media/js/libs/owl.carousel/owl-carousel/AjaxLoader.gif') no-repeat center center
+  }
 
   .preview {
     text-transform: uppercase;


### PR DESCRIPTION
`compress_assets` moves the image path, I'm fixing it so we can save the request to owl by itself:

https://bugzilla.mozilla.org/show_bug.cgi?id=970779
