### PR TITLE
Modify wiki CSS properties to save 40px height

### DIFF
--- a/media/redesign/stylus/vars.styl
+++ b/media/redesign/stylus/vars.styl
@@ -45,7 +45,7 @@ slide-timing-function = cubic-bezier(0, 1, 0.5, 1);
 
 /* dimensions */
 gutter-width = 24px;
-first-content-top-padding = (grid-spacing * 2);
+first-content-top-padding = (grid-spacing * 1.5);
 list-item-spacing = 8px;
 content-block-margin = gutter-width;
 icon-margin = 10px;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -254,7 +254,7 @@ article {
 /* wiki article cookie crumbs */
 .crumbs {
   @extend .smaller;
-  margin-bottom: (2 * grid-spacing);
+  margin-bottom: (grid-spacing / 2);
 
   li {
     bidi-style(margin-right, (grid-spacing / 2), margin-left, 0);


### PR DESCRIPTION
As provided to me by Sean Martell, this saves 40px height at the top of wiki articles, and 10px on every page of the site.
