### PR TITLE
Apply wordbreak only to code blocks in headings

### DIFF
--- a/media/redesign/stylus/tags.styl
+++ b/media/redesign/stylus/tags.styl
@@ -203,7 +203,9 @@ a {
 @media media-query-mobile {
 
   h1, h2, h3, h4, h5, h6 {
-    word-break: break-all;
+    code {
+      word-break: break-all;
+    }
   }
 }
 


### PR DESCRIPTION
I'm going to make this specific to the case that was pointed out in the original bug.  When we do a focused mobile sprint, I think we should clamp down on heading sizes.
