### PR TITLE
fix bug 935897 - Remove unneeded class from ckeditor content body

### DIFF
--- a/apps/wiki/templates/wiki/ckeditor_config.js
+++ b/apps/wiki/templates/wiki/ckeditor_config.js
@@ -131,7 +131,7 @@ CKEDITOR.editorConfig = function(config) {
   config.dialog_backgroundCoverColor = 'black';
   config.dialog_backgroundCoverOpacity = 0.3;
   config.docType = '<!DOCTYPE html>';
-  config.bodyClass = 'page-content text-content redesign';
+  config.bodyClass = 'text-content redesign';
 
   if(!CKEDITOR.stylesSet.registered['default']) {
           CKEDITOR.stylesSet.add('default', [


### PR DESCRIPTION
We no longer need this class on the iframe body, it's causing heading issues.
