### PR TITLE
Add last_edit for translations to json

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -911,6 +911,7 @@ class Document(NotificationsMixin, models.Model):
         if self.pk:
             for translation in self.other_translations:
                 translations.append({
+                    'last_edit': translation.current_revision.created.isoformat(),
                     'locale': translation.locale,
                     'title': translation.title,
                     'url': reverse('wiki.document',


### PR DESCRIPTION
Same as in pull #1914 but this time for translations.

See e.g. https://developer.mozilla.org/en-US/docs/Web/CSS/color$json?expand=1 
There is an array of translations available and it would be really useful to have the last_edit information here, too. Would allow us to test with a single call if
a) a translation is available and,
b) whether the translation is older than the English document.
