### PR TITLE
fix bug 949042 - Ensure only the 'specific slug' is proposed for page move

### DIFF
--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -54,17 +54,17 @@
           </li>
           <li>
             <dl>
-              <dt><label for="moveSlug">{{ _('New Slug:') }}</label> </dt>
+              <dt><label for="move-slug">{{ _('New Slug:') }}</label> </dt>
               <dd>
-                <input type="text" name="slug" id="moveSlug" value="" required="required" data-validator="{{ SLUG_CLEANSING_REGEX }}" />
-                <input type="hidden" value="{{ document.slug }}" id="currentSlug" />
+                <input type="text" name="slug" id="move-slug" value="" required="required" data-validator="{{ SLUG_CLEANSING_REGEX }}" />
+                <input type="hidden" value="{{ specific_slug }}" id="current-slug" />
                 <input type="hidden" value="{{ document.locale }}" id="locale" name="locale"/>
               </dd>
-              <dd class="parentSuggestContainer">
-                <a href="javascript:;" class="moveLookupLink">{{ _('Lookup by Document Title') }}</a>
+              <dd class="parent-suggest-container">
+                <a href="javascript:;" class="move-lookup-link">{{ _('Lookup by Document Title') }}</a>
 
-                <div id="parentSuggestionInputContainer">
-                    <input type="text" placeholder="{{ _('Parent Title') }}" id="parentSuggestion" disabled />
+                <div id="parent-suggest-input-container">
+                    <input type="text" placeholder="{{ _('Parent Title') }}" id="parent-suggestion" disabled />
                 </div>
               </dd>
             </dl>

--- a/apps/wiki/templates/wiki/move_requested.html
+++ b/apps/wiki/templates/wiki/move_requested.html
@@ -8,6 +8,7 @@
 {% set old_slug=document.slug %}
 {% set new_slug=form.slug.value() %}
 {% trans new_url=url('wiki.document', new_slug, locale=document.locale) %}
+<h1>Page Move Scheduled</h1>
 <p>Moving {{ old_slug }} to <a href="{{ new_url }}">{{ new_slug }}</a></p>
 <p> You'll receive an email when it finishes, or if any errors occur during the move.</p>
 {% endtrans %}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1230,6 +1230,7 @@ def move(request, document_slug, document_locale):
         Document, locale=document_locale, slug=document_slug)
 
     descendants = doc.get_descendants()
+    slug_split = _split_slug(doc.slug)
 
     if request.method == 'POST':
         form = TreeMoveForm(initial=request.GET, data=request.POST)
@@ -1260,6 +1261,7 @@ def move(request, document_slug, document_locale):
         'descendants':  descendants,
         'descendants_count': len(descendants),
         'SLUG_CLEANSING_REGEX': SLUG_CLEANSING_REGEX,
+        'specific_slug': slug_split['specific']
     })
 
 

--- a/media/css/wiki.css
+++ b/media/css/wiki.css
@@ -559,15 +559,15 @@ article.main div.tags input.adder {
   width: 400px;
 }
 
-.parentSuggestContainer {
+.parent-suggest-container {
   position: relative;
 }
 
-  .parentSuggestContainer.show .moveLookupLink {
+  .parent-suggest-container.show .move-lookup-link {
     display: none;
   }
 
-  .parentSuggestContainer.show #parentSuggestionInputContainer {
+  .parent-suggest-container.show #parent-suggest-input-container {
     display: block;
     opacity: 1;
     top: -22px;
@@ -580,12 +580,12 @@ article.main div.tags input.adder {
     -moz-transition-duration: .4s;
   }
 
-.moveLookupLink {
+.move-lookup-link {
   display: inline-block; 
   margin-left: 40px; 
   font-size: 0.8em;
 }
-#parentSuggestionInputContainer {
+#parent-suggest-input-container {
   padding: 10px;
   background: #eaeff2;
   background: linear-gradient(top, #eaeff2, #d4dde4);
@@ -599,7 +599,7 @@ article.main div.tags input.adder {
   top: -10px;
   left: -90000px;
 }
-#parentSuggestionInputContainer:before {
+#parent-suggest-input-container:before {
   position: absolute;
   display: inline-block;
   border-top: 7px solid transparent;
@@ -609,7 +609,7 @@ article.main div.tags input.adder {
   top: 20px;
   content: '';
 }
-#parentSuggestionInputContainer:after {
+#parent-suggest-input-container:after {
   position: absolute;
   display: inline-block;
   border-top: 6px solid transparent;
@@ -619,7 +619,7 @@ article.main div.tags input.adder {
   top: 21px;
   content: '';
 }
-#parentSuggestion  {
+#parent-suggestion  {
   width: 300px;
 }
 .moveDescendants {

--- a/media/js/wiki-move.js
+++ b/media/js/wiki-move.js
@@ -1,11 +1,11 @@
 (function($) {
      // Retrieve request and move information
-     var $moveSlug = $('#moveSlug'),
-         $suggestionInput = $('#parentSuggestion'),
-         $suggestionContainer= $('.parentSuggestContainer'),
-         $lookupLink = $('.moveLookupLink'),
-         specific_slug = $('#currentSlug').val(),
-         moveLocale = $('#moveLocale').val(),
+     var $moveSlug = $('#move-slug'),
+         $suggestionInput = $('#parent-suggestion'),
+         $suggestionContainer= $('.parent-suggest-container'),
+         $lookupLink = $('.move-lookup-link'),
+         specific_slug = $('#current-slug').val(),
+         moveLocale = $('#locale').val(),
          onHide = function() {
              $suggestionContainer.removeClass('show');
              $moveSlug[0].focus();

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -350,6 +350,7 @@ a.persona-button {
 
 main {
   background: #fff;
+  min-height: 200px;
 
   > .center {
     padding-top: first-content-top-padding;


### PR DESCRIPTION
To test, try to move a nested document (more than one level deep) to another and ensure only the specific slug is proposed from the original.
