### PR TITLE
Prevent the need for 'last' class on only-child elements, more efficiently uses width of container

### DIFF
--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -110,10 +110,12 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     border-right: 1px dotted #d4dde4;
     width: col-width;
 
-    &.last {
+    &.last, &:only-child {
       margin-right: 0;
       border-right: 0;
       padding-right: 0;
+      width: auto;
+      float: none;
     }
   }
   

--- a/templates/base.html
+++ b/templates/base.html
@@ -84,7 +84,7 @@
     <nav id="main-nav" role="navigation"><ul><li><a href="{{ devmo_url('Zones') }}">{{ _('Zones') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
         <div class="submenu submenu-single" id="nav-zones-submenu">
-          <div class="submenu-column last">
+          <div class="submenu-column">
             <ul>
               <li><a href="{{ devmo_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
               <li><a href="{{ devmo_url('Apps') }}">{{ _('App Center') }}</a></li>


### PR DESCRIPTION
Now there's no excess padding to the right of only-child submenu's and no need to add 'last' to them.
