### PR TITLE
Put advanced profile features behind gear submenu

### DIFF
--- a/apps/devmo/templates/devmo/profile.html
+++ b/apps/devmo/templates/devmo/profile.html
@@ -53,12 +53,21 @@
               {# TODO: Need a method to detect whether the logged in user can manage any roles, here #}
               <a href="{{ url('teamwork.views.user_roles', profile.user.username) }}" class="button neutral">{{_("Manage Roles")}}<i aria-hidden="true" class="icon-users"></i></a>
           {% endif %}
+          {{ ban_link(profile.user, request.user) }}
           <!-- Only shown for the user and admins -->
           {% if profile.allows_editing_by(request.user) %}
-              <a href="{{ url('authkeys.list') }}" class="button neutral">{{_("Manage API Keys")}}<i aria-hidden="true" class="icon-key"></i></a>
-              <a id="edit-profile" href="{{ url('devmo.views.profile_edit', username=profile.user.username) }}" class="button neutral">{{_("Edit Profile")}}<i aria-hidden="true" class="icon-pencil"></i></a>
+              <a id="edit-profile" href="{{ url('devmo.views.profile_edit', username=profile.user.username) }}" class="button neutral">{{_("Edit")}}<i aria-hidden="true" class="icon-pencil"></i></a>
+              <a href="javascript:;" id="advanced-menu" class="button neutral only-icon" {{ disabled_attr }} aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false"><span>{{ _('Advanced') }}</span><i aria-hidden="true" class="icon-cog"></i></a>
+              <div class="submenu" id="advanced-menu-submenu">
+                <!-- this page -->
+                <div class="submenu-column">
+                  <div class="title">{{ _('Advanced') }}</div>
+                  <ul>
+                    <li><a href="{{ url('authkeys.list') }}" class="neutral">{{ _("Manage API keys") }}</a></li>
+                  </ul>
+                </div>
+              </div>
           {% endif %}
-          {{ ban_link(profile.user, request.user) }}
       </div>
   
       {% if profile.title or profile.organization or profile.location or profile.irc_nickname %}

--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -51,12 +51,12 @@
               {% endif %}
             </ul>
           </div>
-        </div></li>{% endif %}<li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><a href="javascript:;" id="settings-menu" class="button only-icon" {{ disabled_attr }} aria-haspopup="true" aria-owns="settings-menu-submenu" aria-expanded="false"><span>{{ _('Settings') }}</span><i aria-hidden="true" class="icon-cog"></i></a>
+        </div></li>{% endif %}<li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button {{ disabled_class }}" {{ disabled_attr }}>{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><a href="javascript:;" id="advanced-menu" class="button only-icon" {{ disabled_attr }} aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false"><span>{{ _('Advanced') }}</span><i aria-hidden="true" class="icon-cog"></i></a>
 
-        <div class="submenu" id="settings-menu-submenu">
+        <div class="submenu" id="advanced-menu-submenu">
           <!-- this page -->
           <div class="submenu-column">
-            <div class="title">{{ _('This Page') }}</div>
+            <div class="title">{{ _('Advanced') }}</div>
             <ul>
                 <li><a href="{{ url('wiki.document_revisions', document.full_path) }}">{{_('History')}}</a></li>
                 {% if user.is_authenticated() and document %}

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -195,4 +195,13 @@
     $('#language').get(0).focus();
   });
 
+  /*
+    Create advanced and language menus
+  */
+  (function() {
+    var $menus = $('#advanced-menu, #languages-menu');
+    $menus.mozMenu();
+    $menus.parent().find('.submenu').mozKeyboardNav();
+  })();
+
 })(jQuery);

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -6,15 +6,6 @@
   $('.toggleable').mozTogglers();
 
   /*
-    Create the settings and languages menu
-  */
-  (function() {
-    var $menus = $('#settings-menu, #languages-menu');
-    $menus.mozMenu();
-    $menus.parent().find('.submenu').mozKeyboardNav();
-  })();
-
-  /*
     Toggle for quick links show/hide
   */
   (function() {

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -154,3 +154,25 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
 .submission .section > legend {
     margin: 0;
 }
+
+.submenu {
+  component-submenu-method(160px, 1, button-background, button-shadow-color);
+  bidi-style(right, 0, left, auto);
+  top: 40px;
+  z-index: 3;
+  border-top: 1px solid button-shadow-color;
+
+  .submenu-column {
+    float: left;
+  }
+
+  &:before {
+    bidi-style(right, 10px, left, auto);
+    top: -18px;
+  }
+
+  &:after {
+    bidi-style(right, 10px, left, auto);
+    top: -20px;
+  }
+}

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -72,6 +72,19 @@ beta-spacing = (grid-spacing * 2.5);
         padding: 0;
       }
     }
+
+    .edit {
+      & > a {
+        compat-only(margin, 0 5px 0 0);
+      }
+    }
+
+    .submenu {
+      a {
+       compat-only(float, none);
+       compat-only(margin, 0);
+     }
+   }
   }
 }
 
@@ -138,6 +151,7 @@ beta-spacing = (grid-spacing * 2.5);
     width: 80%;
   }
 }
+
 #field_beta {
     @extend $checkbox-label-container;
 }
@@ -146,10 +160,10 @@ beta-spacing = (grid-spacing * 2.5);
 @media media-query-tablet {
   #profile-head {
     .edit {
+      display: inline-block;
       position: relative;
       top: auto;
       right: auto;
-      text-align: left;
       margin: 0 0 grid-spacing 0;
 
       a {
@@ -166,6 +180,26 @@ beta-spacing = (grid-spacing * 2.5);
 
     .fm-submit {
       display: none;
+    }
+  }
+}
+
+@media media-query-small-mobile {
+  .profile-display #profile-head .edit {
+    margin: 0;
+
+    & > a {
+      display: block;
+      text-align: center;
+      override-compat-important(margin, (grid-spacing / 2) 0);
+    }
+
+    #edit-profile i {
+      display: none;
+    }
+
+    .submenu {
+      top: 90px;
     }
   }
 }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -340,28 +340,6 @@ article {
       font-size: 16px;
     }
   }
-
-  .submenu {
-    component-submenu-method(160px, 1, button-background, button-shadow-color);
-    bidi-style(right, 0, left, auto);
-    top: 40px;
-    z-index: 3;
-    border-top: 1px solid button-shadow-color;
-
-    .submenu-column {
-      float: left;
-    }
-
-    &:before {
-      bidi-style(right, 10px, left, auto);
-      top: -18px;
-    }
-
-    &:after {
-      bidi-style(right, 10px, left, auto);
-      top: -20px;
-    }
-  }
 }
 
 /* kumascript errors block at the top of an article */


### PR DESCRIPTION
My hope was to A/B test this change with Optimizely, but we are
currently unable to run tests on page elements that only logged-in users
see.

When we made a similar change to article pages (moving the history
feature behind a gear icon) the edit button saw a statistically
significant increase in click rate, so we can be moderately confident
that the same thing will happen here.
