### PR TITLE
Refactor the submenu system

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -40,19 +40,26 @@
 
       // Add a mouseenter / focus event to get the showing of the submenu in motion
       $self.on('mouseenter focus', function() {
+
         // If this is a fake focus set by us, ignore this
         if($submenu.ignoreFocus) return;
 
         // If no submenu, go
         if(!$submenu.length) {
           clear(showTimeout);
-          $.fn.mozMenu.$openMenu && closeSubmenu($.fn.mozMenu.$openMenu.parent().find('.submenu'));
+          $.fn.mozMenu.$openMenu && closeSubmenu(getOpenParent());
           return;
         }
 
         // Lazy-initialize events that aren't needed until an item is entered.
         if(!initialized) {
           initialized = 1;
+
+          // Add the close
+          var $closeButton = $('<button class="submenu-close transparent">\
+            <span class="offscreen">' + gettext('Close submenu') + '</span>\
+            <i aria-hidden="true" class="icon-remove-sign"></i>\
+          </button>').appendTo($submenu);
 
           // Hide the submenu when the main menu is blurred for hideDelay
           $self.on('mouseleave focusout', function() {
@@ -81,7 +88,7 @@
             }
           });
           
-          $submenu.find('.submenu-close').on('click', function(){
+          $closeButton.on('click', function(){
             closeSubmenu($(this).parent());
           });
         }
@@ -89,7 +96,7 @@
         // Used for tab navigation from submenu to the next menu item
         if($.fn.mozMenu.$openMenu && $.fn.mozMenu.$openMenu != $self) {
           clear(showTimeout);
-          closeSubmenu($.fn.mozMenu.$openMenu.parent().find('.submenu'));
+          closeSubmenu(getOpenParent());
         }
         else if($.fn.mozMenu.$openMenu == $self) {
           clear(closeTimeout);
@@ -120,6 +127,11 @@
         }, settings.showDelay);
       });
     });
+
+    // Gets the open parent
+    function getOpenParent() {
+      return $.fn.mozMenu.$openMenu.parent().find('.submenu');
+    }
 
     // Clears the current timeout, interrupting fade-ins and outs as necessary
     function clear(timeout) {

--- a/media/redesign/stylus/components.styl
+++ b/media/redesign/stylus/components.styl
@@ -105,22 +105,30 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
   width: menu-width;
   box-shadow: 3px 3px 5px #aaa;
 
+  .submenu-close {
+    display: none;
+    position: absolute;
+    top: 20px;
+    bidi-style(right, 0, left, auto);
+
+    i {
+      margin-left: 0;
+    }
+  }
+
   .submenu-column {
-    col-width = ((menu-width - (num-columns * grid-spacing) - 1) / num-columns);
-
-    padding-right: grid-spacing;
+    if num-columns is 1 {
+      col-width = 100%;
+    } else {
+      col-width = ((menu-width - (num-columns * grid-spacing) - 1) / num-columns) + (grid-spacing / 2);
+    }
     vertical-align: text-top;
-    margin-right: grid-spacing;
-    border-right: 1px dotted #d4dde4;
     width: col-width;
+    display: inline-block;
 
-    &.last, &:only-child {
-      margin-right: 0;
-      border-right: 0;
-      padding-right: 0;
-      width: auto;
-      float: none;
-      border-right: none;
+    &:nth-child(even) {
+      bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
+      bidi-style(padding-left, grid-spacing, padding-right, 0);
     }
   }
   
@@ -149,30 +157,28 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     position: absolute;
     z-index: 1;
   }
-}
 
-.submission .section > legend {
-    margin: 0;
-}
-
-.submenu {
-  component-submenu-method(160px, 1, button-background, button-shadow-color);
-  bidi-style(right, 0, left, auto);
-  top: 40px;
-  z-index: 3;
-  border-top: 1px solid button-shadow-color;
-
-  .submenu-column {
-    float: left;
+  @media media-query-tablet {
+    .submenu-close {
+      display: block;
+    }
   }
 
-  &:before {
-    bidi-style(right, 10px, left, auto);
-    top: -18px;
+  @media media-query-mobile {
+    .submenu-column, .submenu-column:nth-child(even) {
+      bidi-style(border-left, 0, border-right, 0);
+      bidi-style(padding-left, 0, padding-right, 0);
+    }
   }
 
-  &:after {
-    bidi-style(right, 10px, left, auto);
-    top: -20px;
+  @media media-query-small-mobile {
+    & {
+      width: auto;
+
+      .submenu-column {
+        width: auto;
+        display: block;
+      }
+    }
   }
 }

--- a/media/redesign/stylus/structure.styl
+++ b/media/redesign/stylus/structure.styl
@@ -109,7 +109,7 @@
     margin-bottom: grid-spacing;
 
     > li {
-      bidi-style(padding-left, 31px, padding-right, 0);
+      bidi-style(margin-left, 31px, margin-right, 0);
       position: relative;
       opacity: 1;
       max-width: 1000px;
@@ -117,9 +117,10 @@
       vendorize(transition-property, width);
       vendorize(transition-duration, default-animation-duration);
       vendorize(transition-delay, default-animation-duration);
+      text-align: initial;
 
       &:first-child {
-        padding-left: 0;
+        margin-left: 0;
       }
 
       > a i {
@@ -145,24 +146,19 @@
   .submenu {
     menu-border-width = 5px;
     menu-arrow-top = -19px;
-    component-submenu-method(520px, 2, #fff, #333);
+    component-submenu-method(400px, 2, #fff, #333);
 
     top: 40px;
-    left: -186px;
+    left: -136px;
     border-top: menu-border-width solid #404040;
 
     .submenu-column {
       min-height: 90px;
-      display: inline-block;
-    }
-
-    .submenu-close{
-      display:none;
     }
 
     &:before, &:after {
       top: menu-arrow-top;
-      left: 269px;
+      bidi-style(left, 190px, right, auto);
     }
 
     &:after {
@@ -174,13 +170,8 @@
     width: 180px;
     left: -74px;
 
-    .submenu-column {
-      width: 100%;
-    }
-
     &:before, &:after {
-      top: menu-arrow-top;
-      left: 98px;
+      bidi-style(left, 98px, right, auto);
     }
   }
 
@@ -385,7 +376,7 @@ footer {
 
     &:after {
       bidi-style(left, 0, right, 0);
-      content: "";
+      content: '';
       display: block;
       width: 65px;
       height: 60px
@@ -433,13 +424,25 @@ footer {
   cursor: default;
 }
 
-
 /* tablet updates */
 @media media-query-tablet {
+
+  /* make submenus full width */
+  #main-nav {
+    .submenu {
+      left: 0;
+      right: 0;
+
+      &:before, &:after {
+        bidi-style(left, 10px, right, auto);
+      }
+    }
+  }
+
   #main-nav {
     > ul {
       > li {
-        bidi-style(padding-left, 21px, padding-right, 0);
+        bidi-style(margin-left, 21px, margin-right, 0);
 
         > a {
           i {
@@ -470,7 +473,7 @@ footer {
         vendorize(transition-property, none);
 
         &:first-child {
-          padding-left: 0;
+          margin-left: 0;
         }
       }
     }
@@ -479,6 +482,7 @@ footer {
 
 /* break nav into blocks (own line) */
 @media media-query-navigation-block {
+
   #main-nav {
     > ul {
       float: none;
@@ -487,7 +491,7 @@ footer {
       > li {
         display: block;
         width: auto;
-        padding-left: 0;
+        margin-left: 0;
         margin: 10px 0;
       }
     }
@@ -540,35 +544,6 @@ footer {
       }
     }
   }
-
-  /* make submenus full width */
-  #main-nav {
-    .submenu {
-      left: 0;
-      right: 0;
-      width: auto;
-      min-width: 255px;
-      text-align: left;
-
-      &:before, &:after {
-        left: 10px;
-      }
-      .submenu-column {
-        width: 40%;
-        border-right: 0;
-      }
-
-      .submenu-close{
-        display: block;
-        position: absolute;
-        top: 20px;
-        right: 20px;
-        i{
-          margin-left: 0;
-        }
-      }
-    }
-  }
 }
 
 
@@ -589,4 +564,9 @@ p.field-explanation {
 label {selector-icon} {
     margin-left: 0;
     margin-right: 10px;
+}
+
+
+.submission .section > legend {
+    margin: 0;
 }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -317,7 +317,6 @@ article {
   float: right;
   margin-top: -5px;
 
-  text-align: right;
   compat-only(width, auto);
   compat-only(top, auto);
 
@@ -338,6 +337,29 @@ article {
 
     {selector-icon} {
       font-size: 16px;
+    }
+  }
+
+  .submenu {
+    component-submenu-method(160px, 1, button-background, button-shadow-color);
+    bidi-style(right, 0, left, auto);
+    top: 40px;
+    z-index: 3;
+    border-top: 1px solid button-shadow-color;
+    width: 160px !important; /* needs this due to overriding media query rule of component */
+
+    bdi {
+      bidi-value(text-align, left, right);
+    }
+
+    &:before {
+      bidi-style(right, 10px, left, auto);
+      top: -18px;
+    }
+
+    &:after {
+      bidi-style(right, 10px, left, auto);
+      top: -20px;
     }
   }
 }
@@ -521,7 +543,6 @@ div.bug, div.warning, div.overheadIndicator {
       bidi-value(text-align, left, right);
       bidi-style(left, -(grid-spacing * 1.5), right, auto);
 
-      text-align: right;
       position: absolute;
       left: -(grid-spacing + (grid-spacing/2));
       color: #484848;

--- a/templates/base.html
+++ b/templates/base.html
@@ -99,10 +99,6 @@
               <li><a href="{{ devmo_url('Persona') }}">{{ _('Persona') }}</a></li>
             </ul>
           </div>
-          <button class="submenu-close transparent">
-            <span class="offscreen">Close submenu</span>
-            <i aria-hidden="true" class="icon-remove-sign"></i>
-          </button>
         </div>
       </li><li><a href="{{ devmo_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
@@ -129,10 +125,6 @@
               <li><a href="{{ devmo_url('Web') }}">{{ _('...more docs') }}</a></li>
             </ul>
           </div>
-          <button class="submenu-close transparent">
-            <span class="offscreen">Close submenu</span>
-            <i aria-hidden="true" class="icon-remove-sign"></i>
-          </button>
         </div>
       </li><li><a href="{{ devmo_url('Mozilla/Developer_Program') }}">{{ _('Developer Program') }}</a></li><li><a href="{{ devmo_url('Tools') }}">{{ _('Tools') }}</a></li><li><a href="{{ url('demos') }}">{{ _('Demos') }}</a></li>{#<li><a href="">{{ _('Developer Program') }}</a></li>#}{% if not is_sphinx %}<li class="main-nav-search"><form action="{{ url('search') }}" method="get" role="search">
         <div class="search-wrap">


### PR DESCRIPTION
Our submenu stuff started getting dirty and separated into different `styl` files, so I've taken the time to do some cleanup.  This will:
1.  Automatically inject close buttons into submenus (using JS)
2.  Cut down on wasted space inside submenus, and makes the "Web Platform" submenu slimmer
3.  Ensures arrows and menus display properly on tablet/mobile and RTL
