### PR TITLE
Remove legacy redesign search artifacts

### DIFF
--- a/apps/search/templates/search/results.html
+++ b/apps/search/templates/search/results.html
@@ -123,7 +123,7 @@
           {% endfor %}
         </ul>
 
-        <div class="search-results-more {% if show_expander %}with-view-all{% endif %}">
+        <div class="search-results-more">
 
           <div class="pager">
             {% if previous %}

--- a/media/redesign/js/search.js
+++ b/media/redesign/js/search.js
@@ -9,12 +9,6 @@
     }
   };
 
-  var parentSelector = '.search-pane';
-  $(parentSelector + ' .close').on('click', function(e) {
-    e.preventDefault();
-    $('#search-results-close-container').addClass('closed');
-  });
-
   /*
     Set up the "from search" buttons if user came from search
   */
@@ -38,16 +32,6 @@
     });
     fromSearchList.find('ol').mozKeyboardNav();
   }
-
-  var more = $('.search-results-more');
-  more.find('.view-all').on('click', function(e) {
-    e.preventDefault();
-    var hiddenClass = 'closed';
-    var parent = $(this).closest(parentSelector);
-    parent.find('.' + hiddenClass).removeClass(hiddenClass);
-    parent.find('.pager').removeClass('hidden');
-    more.removeClass('with-view-all');
-  });
 
   // a small wrapper around store.js to be able to set an expiration
   var searchStore = {

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -48,11 +48,6 @@ p {
   }
 }
 
-/* search results container and child elements */
-#search-results-close-container {
-  slider();
-}
-
 .search-results-container {
   padding: grid-spacing;
   
@@ -123,25 +118,6 @@ p {
 .search-results-more {
   clearfix();
   padding: 0 grid-spacing;
-
-  .with-view-all .view-all {
-    display: block;
-  }
-}
-
-.view-all {
-  reverse-link-decoration();
-  float: right;
-  display: none;
-}
-
-.search-results-more.with-view-all {
-  .view-all {
-    display: block;
-  }
-  .pager {
-    display: none;
-  }
 }
 
 /* sidebar topic listings */


### PR DESCRIPTION
We originally had a "close" button and animations on the search page.  Writers complained about it.  It wont be coming back.
