### PR TITLE
Bug 951775 - Add a list of pages with errors to the wiki

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -455,11 +455,13 @@ class BaseDocumentManager(models.Manager):
         return True
 
     def filter_for_list(self, locale=None, category=None, tag=None,
-                        tag_name=None):
+                        tag_name=None, errors=None):
         docs = (self.filter(is_template=False, is_redirect=False)
                     .exclude(slug__startswith='User:')
                     .exclude(slug__startswith='Talk:')
                     .exclude(slug__startswith='User_talk:')
+                    .exclude(slug__startswith='Template_talk:')
+                    .exclude(slug__startswith='Project_talk:')
                     .order_by('slug'))
         if locale:
             docs = docs.filter(locale=locale)
@@ -472,6 +474,9 @@ class BaseDocumentManager(models.Manager):
             docs = docs.filter(tags__in=[tag])
         if tag_name:
             docs = docs.filter(tags__name=tag_name)
+        if errors:
+            docs = (docs.exclude(rendered_errors__isnull=True)
+                        .exclude(rendered_errors__exact='[]'))
         # Leave out the html, since that leads to huge cache objects and we
         # never use the content in lists.
         docs = docs.defer('html')

--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -1,13 +1,16 @@
-{# vim: set ts=2 et sts=2 sw=2: #}
 {% extends "wiki/base.html" %}
+{% set counter = _('Found {0} documents.')|f(count) %}
 {% if category %}
   {% set title = category %}
 {% elif tag %}
   {% set title = _('Articles tagged: {tag}')|f(tag=tag) %}
 {% elif is_templates %}
-  {% set title = _('All Templates') %}
+  {% set title = _('All templates') %}
+  {% set counter = _('Found {0} templates.')|f(count) %}
+{% elif errors %}
+  {% set title = _('Documents with errors') %}
 {% else %}
-  {% set title = _('All Articles') %}
+  {% set title = _('All documents') %}
 {% endif %}
 {% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(None, title)] %}
@@ -36,11 +39,12 @@
     <div id="document-list" class="boxed">
       <h1>{{ title }}</h1>
       {% if documents.object_list %}
+        <p>{{ counter }}</p>
         <ul class="documents">
           {% for doc in documents.object_list %}
             <li>
               <a href="{{ doc.get_absolute_url() }}">{{ doc.slug }}</a>
-                {% if not is_templates %}
+                {% if not is_templates and not errors %}
                   <small>{{ doc.get_summary() | truncate(100) }}</small>
                 {% endif %}
             </li>

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -74,6 +74,7 @@ urlpatterns = patterns('wiki.views',
     url(r'^/new$', 'new_document', name='wiki.new_document'),
     url(r'^/all$', 'list_documents', name='wiki.all_documents'),
     url(r'^/preview-wiki-content$', 'preview_revision', name='wiki.preview'),
+    url(r'^/with-errors$', 'list_documents_with_errors', name='wiki.errors'),
 
     url(r'^/move-requested$',
         TemplateView.as_view(template_name='wiki/move_requested.html'),

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -756,9 +756,10 @@ def list_documents(request, category=None, tag=None):
     docs = Document.objects.filter_for_list(locale=request.locale,
                                              category=category_id,
                                              tag=tag_obj)
-    docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents.html',
-                        {'documents': docs,
+                        {'documents': paginated_docs,
+                         'count': docs.count(),
                          'category': category,
                          'tag': tag})
 
@@ -767,9 +768,10 @@ def list_documents(request, category=None, tag=None):
 def list_templates(request):
     """Returns listing of all templates"""
     docs = Document.objects.filter(is_template=True).order_by('title')
-    docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents.html',
-                        {'documents': docs,
+                        {'documents': paginated_docs,
+                         'count': docs.count(),
                          'is_templates': True})
 
 
@@ -802,6 +804,16 @@ def list_documents_for_review(request, tag=None):
                         {'documents': docs,
                          'tag': tag_obj,
                          'tag_name': tag})
+
+@require_GET
+def list_documents_with_errors(request):
+    """Lists wiki documents with (KumaScript) errors"""
+    docs = Document.objects.filter_for_list(errors=True)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
+    return render(request, 'wiki/list_documents.html',
+                         {'documents': paginated_docs,
+                          'count': docs.count(),
+                          'errors': True})
 
 
 @login_required


### PR DESCRIPTION
This is an attempt to make the black box of KumaScript errors visible to us.
What this PR does:
- A new view is introduced here: https://developer-local.allizom.org/en-US/docs/with-errors
- A document counter has been added to the document lists:
  - https://developer-local.allizom.org/en-US/docs/all
  - https://developer-local.allizom.org/en-US/docs/templates
  - https://developer-local.allizom.org/en-US/docs/tag/test
- The exclude rules have been updated to match with the search https://github.com/mozilla/kuma/pull/1923.
