### PR TITLE
exclude noisy javascript: links from tracking

### DIFF
--- a/media/redesign/js/google-analytics.js
+++ b/media/redesign/js/google-analytics.js
@@ -64,7 +64,8 @@
   Track all outgoing links
   */
   $('body').on('click', 'a', function (e) {
-    if (this.hostname === window.location.hostname) {
+    if (this.hostname === window.location.hostname ||
+        this.protocol == 'javascript:') {
       return;
     }
     var newTab = (this.target === '_blank' || e.metaKey || e.ctrlKey);

--- a/settings.py
+++ b/settings.py
@@ -635,7 +635,6 @@ MINIFY_BUNDLES = {
             'redesign/js/components.js',
             'redesign/js/main.js',
             'redesign/js/badges.js',
-            'redesign/js/google-analytics.js',
         ),
         'jquery2': (
             'js/libs/jquery-2.1.0.js',


### PR DESCRIPTION
`javascript:` links make the outbound link metrics really noisy:

https://docs.google.com/a/mozilla.com/spreadsheet/ccc?key=0ApeHsuEebcoRdGwyeU5pWWdMODNsQ0xzOUxIQ0g2Mnc#gid=0
