### PR TITLE
Issue #1964: Another attempt at DB fields for generated content - quick links, zone nav, and body HTML

### DIFF
--- a/apps/wiki/helpers.py
+++ b/apps/wiki/helpers.py
@@ -206,15 +206,6 @@ def wiki_bleach(val):
 
 
 @register.filter
-def section_extract(val, section_id):
-    """
-    Extract a section from the given markup, ignoring the heading (if any)
-    """
-    return (wiki.content.parse(val)
-                        .extractSection(section_id, ignore_heading=True)
-                        .serialize())
-
-@register.filter
 def selector_content_find(document, selector):
     """
     Provided a selector, returns the relevant content from the document
@@ -226,34 +217,6 @@ def selector_content_find(document, selector):
     except:
       pass
     return summary
-
-@register.filter
-def zone_section_extract(document, section_id):
-    """
-    Attempt to extract the given section from the current document, or from one
-    of its parent DocumentZones (if any)
-    """
-    html = section_extract(document.rendered_html, section_id)
-    if html:
-        return html
-
-    for zone in document.find_zone_stack():
-        html = section_extract(zone.document.rendered_html, section_id)
-        if html:
-            return html
-
-    return None
-
-
-@register.filter
-def section_hide(val, *section_ids):
-    """
-    Hide the given section(s) by replacing with an HTML comment
-    """
-    doc = wiki.content.parse(val)
-    for sid in section_ids:
-        doc = doc.replaceSection(sid, '<!-- -->')
-    return doc.serialize()
 
 
 @register.function

--- a/apps/wiki/migrations/0040_auto__add_fields_for_cached_content.py
+++ b/apps/wiki/migrations/0040_auto__add_fields_for_cached_content.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Document.body_html'
+        db.add_column('wiki_document', 'body_html',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Document.quick_links_html'
+        db.add_column('wiki_document', 'quick_links_html',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Document.zone_subnav_local_html'
+        db.add_column('wiki_document', 'zone_subnav_local_html',
+                      self.gf('django.db.models.fields.TextField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Document.body_html'
+        db.delete_column('wiki_document', 'body_html')
+
+        # Deleting field 'Document.quick_links_html'
+        db.delete_column('wiki_document', 'quick_links_html')
+
+        # Deleting field 'Document.zone_subnav_local_html'
+        db.delete_column('wiki_document', 'zone_subnav_local_html')
+
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'teamwork.team': {
+            'Meta': {'object_name': 'Team'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'founder': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '128', 'db_index': 'True'})
+        },
+        'tidings.watch': {
+            'Meta': {'object_name': 'Watch'},
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']", 'null': 'True', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'db_index': 'True', 'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'event_type': ('django.db.models.fields.CharField', [], {'max_length': '30', 'db_index': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'secret': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        'wiki.attachment': {
+            'Meta': {'object_name': 'Attachment'},
+            'current_revision': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'current_rev'", 'null': 'True', 'to': "orm['wiki.AttachmentRevision']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mindtouch_attachment_id': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'db_index': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'})
+        },
+        'wiki.attachmentrevision': {
+            'Meta': {'object_name': 'AttachmentRevision'},
+            'attachment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': "orm['wiki.Attachment']"}),
+            'comment': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_attachment_revisions'", 'to': "orm['auth.User']"}),
+            'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '500'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'is_mindtouch_migration': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'mime_type': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'mindtouch_old_id': ('django.db.models.fields.IntegerField', [], {'unique': 'True', 'null': 'True', 'db_index': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'})
+        },
+        'wiki.document': {
+            'Meta': {'unique_together': "(('parent', 'locale'), ('slug', 'locale'))", 'object_name': 'Document'},
+            'body_html': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'category': ('django.db.models.fields.IntegerField', [], {'db_index': 'True'}),
+            'current_revision': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'current_for+'", 'null': 'True', 'to': "orm['wiki.Revision']"}),
+            'defer_rendering': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'deleted': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'files': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['wiki.Attachment']", 'through': "orm['wiki.DocumentAttachment']", 'symmetrical': 'False'}),
+            'html': ('django.db.models.fields.TextField', [], {}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_localizable': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'is_redirect': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'is_template': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'json': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'last_rendered_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'locale': ('sumo.models.LocaleField', [], {'default': "'en-US'", 'max_length': '7', 'db_index': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'null': 'True', 'db_index': 'True', 'blank': 'True'}),
+            'parent': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'translations'", 'null': 'True', 'to': "orm['wiki.Document']"}),
+            'parent_topic': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'children'", 'null': 'True', 'to': "orm['wiki.Document']"}),
+            'quick_links_html': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'related_documents': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['wiki.Document']", 'through': "orm['wiki.RelatedDocument']", 'symmetrical': 'False'}),
+            'render_expires': ('django.db.models.fields.DateTimeField', [], {'db_index': 'True', 'null': 'True', 'blank': 'True'}),
+            'render_max_age': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'render_scheduled_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'render_started_at': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'db_index': 'True'}),
+            'rendered_errors': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'rendered_html': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'team': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['teamwork.Team']", 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'zone_subnav_local_html': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        'wiki.documentattachment': {
+            'Meta': {'object_name': 'DocumentAttachment'},
+            'attached_by': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']", 'null': 'True'}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Document']"}),
+            'file': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Attachment']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.TextField', [], {})
+        },
+        'wiki.documentdeletionlog': {
+            'Meta': {'object_name': 'DocumentDeletionLog'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('sumo.models.LocaleField', [], {'default': "'en-US'", 'max_length': '7', 'db_index': 'True'}),
+            'reason': ('django.db.models.fields.TextField', [], {}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'db_index': 'True'}),
+            'timestamp': ('django.db.models.fields.DateTimeField', [], {'auto_now': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'wiki.documenttag': {
+            'Meta': {'object_name': 'DocumentTag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'wiki.documentzone': {
+            'Meta': {'object_name': 'DocumentZone'},
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'zones'", 'unique': 'True', 'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'styles': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'url_root': ('django.db.models.fields.CharField', [], {'db_index': 'True', 'max_length': '255', 'null': 'True', 'blank': 'True'})
+        },
+        'wiki.editortoolbar': {
+            'Meta': {'object_name': 'EditorToolbar'},
+            'code': ('django.db.models.fields.TextField', [], {'max_length': '2000'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_toolbars'", 'to': "orm['auth.User']"}),
+            'default': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        'wiki.firefoxversion': {
+            'Meta': {'unique_together': "(('item_id', 'document'),)", 'object_name': 'FirefoxVersion'},
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'firefox_version_set'", 'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'wiki.helpfulvote': {
+            'Meta': {'object_name': 'HelpfulVote'},
+            'anonymous_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'to': "orm['wiki.Document']"}),
+            'helpful': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'user_agent': ('django.db.models.fields.CharField', [], {'max_length': '1000'})
+        },
+        'wiki.localizationtag': {
+            'Meta': {'object_name': 'LocalizationTag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'wiki.localizationtaggedrevision': {
+            'Meta': {'object_name': 'LocalizationTaggedRevision'},
+            'content_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Revision']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.LocalizationTag']"})
+        },
+        'wiki.operatingsystem': {
+            'Meta': {'unique_together': "(('item_id', 'document'),)", 'object_name': 'OperatingSystem'},
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'operating_system_set'", 'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'item_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        'wiki.relateddocument': {
+            'Meta': {'ordering': "['-in_common']", 'object_name': 'RelatedDocument'},
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_from'", 'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'in_common': ('django.db.models.fields.IntegerField', [], {}),
+            'related': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'related_to'", 'to': "orm['wiki.Document']"})
+        },
+        'wiki.reviewtag': {
+            'Meta': {'object_name': 'ReviewTag'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '100'})
+        },
+        'wiki.reviewtaggedrevision': {
+            'Meta': {'object_name': 'ReviewTaggedRevision'},
+            'content_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Revision']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.ReviewTag']"})
+        },
+        'wiki.revision': {
+            'Meta': {'object_name': 'Revision'},
+            'based_on': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Revision']", 'null': 'True', 'blank': 'True'}),
+            'comment': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'content': ('django.db.models.fields.TextField', [], {}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_revisions'", 'to': "orm['auth.User']"}),
+            'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_approved': ('django.db.models.fields.BooleanField', [], {'default': 'True', 'db_index': 'True'}),
+            'is_mindtouch_migration': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'keywords': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'render_max_age': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'reviewed': ('django.db.models.fields.DateTimeField', [], {'null': 'True'}),
+            'reviewer': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'reviewed_revisions'", 'null': 'True', 'to': "orm['auth.User']"}),
+            'significance': ('django.db.models.fields.IntegerField', [], {'null': 'True'}),
+            'slug': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'summary': ('django.db.models.fields.TextField', [], {}),
+            'tags': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '255', 'null': 'True', 'db_index': 'True'}),
+            'toc_depth': ('django.db.models.fields.IntegerField', [], {'default': '1'})
+        },
+        'wiki.taggeddocument': {
+            'Meta': {'object_name': 'TaggedDocument'},
+            'content_object': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Document']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'tag': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.DocumentTag']"})
+        }
+    }
+
+    complete_apps = ['wiki']

--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -23,6 +23,13 @@ from django.db.models import signals
 from django.http import Http404
 from django.utils.functional import cached_property
 
+from django.utils.decorators import available_attrs
+
+try:
+    from functools import wraps
+except ImportError:
+    from django.utils.functional import wraps
+
 from south.modelsinspector import add_introspection_rules
 import constance.config
 
@@ -358,6 +365,33 @@ SECONDARY_CACHE_ALIAS = getattr(settings,
                                 'SECONDARY_CACHE_ALIAS',
                                 'secondary')
 URL_REMAPS_CACHE_KEY_TMPL = 'DocumentZoneUrlRemaps:%s'
+
+
+def cache_with_field(field_name):
+    """Decorator for generated content methods.
+    
+    If the backing model field is null, or kwarg force_fresh is True, call the
+    decorated method to generate and return the content.
+
+    Otherwise, just return the value in the backing model field.
+    """
+    def decorator(fn):
+        @wraps(fn, assigned=available_attrs(fn))
+        def wrapper(self, *args, **kwargs):
+            force_fresh = kwargs.pop('force_fresh', False)
+
+            # Try getting the value using the DB field.
+            field_val = getattr(self, field_name)
+            if not field_val is None and not force_fresh:
+                return field_val
+
+            # DB field is blank, or we're forced to generate it fresh.
+            field_val = fn(self, force_fresh=force_fresh)
+            setattr(self, field_name, field_val)
+            return field_val
+
+        return wrapper
+    return decorator
 
 
 def _inherited(parent_attr, direct_attr):
@@ -732,6 +766,56 @@ class Document(NotificationsMixin, models.Model):
     # the current revision's created field
     modified = models.DateTimeField(auto_now=True, null=True, db_index=True)
 
+    body_html = models.TextField(editable=False, blank=True, null=True)
+    
+    quick_links_html = models.TextField(editable=False, blank=True, null=True)
+
+    zone_subnav_local_html = models.TextField(editable=False,
+                                              blank=True, null=True)
+
+    @cache_with_field('body_html')
+    def get_body_html(self, *args, **kwargs):
+        html = self.rendered_html and self.rendered_html or self.html
+        sections_to_hide = ('Quick_Links', 'Subnav')
+        doc = parse_content(html)
+        for sid in sections_to_hide:
+            doc = doc.replaceSection(sid, '<!-- -->')
+        doc.injectSectionIDs()
+        doc.annotateLinks(base_url=settings.SITE_URL)
+        return doc.serialize()
+
+    @cache_with_field('quick_links_html')
+    def get_quick_links_html(self, *args, **kwargs):
+        return self.get_section_content('Quick_Links')
+
+    @cache_with_field('zone_subnav_local_html')
+    def get_zone_subnav_local_html(self, *args, **kwargs):
+        return self.get_section_content('Subnav')
+
+    def regenerate_cache_with_fields(self):
+        """Regenerate fresh content for all the cached fields"""
+        # TODO: Maybe @cache_with_field can build a registry over which this
+        # method can iterate?
+        self.get_body_html(force_fresh=True)
+        self.get_quick_links_html(force_fresh=True)
+        self.get_zone_subnav_local_html(force_fresh=True)
+
+    def get_zone_subnav_html(self):
+        """Search from self up through DocumentZone stack, returning the first
+        zone nav HTML found."""
+        src = self.get_zone_subnav_local_html()
+        if src:
+            return src
+        for zone in self.find_zone_stack():
+            src = zone.document.get_zone_subnav_local_html()
+            if src:
+                return src
+
+    def get_section_content(self, section_id):
+        """Convenience method to extract the rendered content for a single section"""
+        html = self.rendered_html and self.rendered_html or self.html
+        return parse_content(html).extractSection(section_id).serialize()
+
     def calculate_etag(self, section_id=None):
         """Calculate an etag-suitable hash for document content or a section"""
         if not section_id:
@@ -844,6 +928,9 @@ class Document(NotificationsMixin, models.Model):
 
     def render(self, cache_control=None, base_url=None, timeout=None):
         """Render content using kumascript and any other services necessary."""
+        if not base_url:
+            base_url = settings.SITE_URL
+
         # Disallow rendering while another is in progress.
         if self.is_rendering_in_progress:
             raise DocumentRenderingInProgress()
@@ -863,6 +950,9 @@ class Document(NotificationsMixin, models.Model):
                                                         base_url,
                                                         timeout=timeout)
             self.rendered_errors = errors and json.dumps(errors) or None
+
+        # Regenerate the cached content fields
+        self.regenerate_cache_with_fields()
 
         # Finally, note the end time of rendering and update the document.
         self.last_rendered_at = datetime.now()

--- a/apps/wiki/templates/wiki/includes/document_content.html
+++ b/apps/wiki/templates/wiki/includes/document_content.html
@@ -21,12 +21,6 @@
 {% set disabled_attr = ('title="%s"' % _('Please log in to use this feature.') if not is_logged_in else '') %}
 {% set search_doc_navigator_enabled = waffle.flag('search_doc_navigator') %}
 
-
-{% if not document.is_template %}
-  {% set quick_links_section_id = 'Quick_Links' %}
-  {% set quick_links_html = document.rendered_html|section_extract(quick_links_section_id) %}
-{% endif %}
-
 {% if document.is_template %}
   {% set macro_name = document.slug|replace('Template:','', 1) %}
   {% set template_search_link = url('search', locale=document.locale)|urlparams(locale='*', kumascript_macros=macro_name) %}
@@ -35,8 +29,6 @@
 {% set zone_stack = document.find_zone_stack() %}
 {% set is_zone = zone_stack|length %}
 {% set is_zone_root = is_zone and zone_stack[0].document == document %}
-{% set zone_subnav_section_id = 'Subnav' %}
-{% set zone_subnav_html = document|zone_section_extract(zone_subnav_section_id) %}
 
 {% set current_revision = document.current_revision %}
 {% if (user.is_authenticated() and current_revision and document.allows_revision_by(user)) and (current_revision.needs_technical_review() or current_revision.needs_editorial_review()) %}
@@ -177,7 +169,7 @@
 
         <!-- just the article content -->
         {% if not document.is_template %}
-          {% set document_html_safe = document_html|section_hide(zone_subnav_section_id, quick_links_section_id)|safe %}
+          {% set document_html_safe = body_html|safe %}
         {% else %}
           {% set document_html_safe = document_html|safe %}
         {% endif %}

--- a/apps/wiki/tests/test_helpers.py
+++ b/apps/wiki/tests/test_helpers.py
@@ -4,47 +4,8 @@ from django.contrib.auth.models import User
 
 from wiki.tests import TestCaseBase, revision, normalize_html
 from wiki.helpers import (revisions_unified_diff,
-                          section_extract, section_hide,
-                          zone_section_extract,
                           document_zone_management_links)
 from wiki.models import DocumentZone
-
-
-class ContentHelperTests(TestCaseBase):
-
-    def test_section_extract(self):
-        src = """
-            <h2>Foo</h2>
-            <p>Bar</p>
-            <h3 id="Quick_Links">Quick Links</h3>
-            <p>Foo, yay</p>
-            <h2>Baz</h2>
-            <p>Baz</p>
-        """
-        expected = """
-            <p>Foo, yay</p>
-        """
-        result = section_extract(src, 'Quick_Links')
-        eq_(normalize_html(expected), normalize_html(result))
-
-    def test_section_hide(self):
-        src = """
-            <h2>Foo</h2>
-            <p>Bar</p>
-            <h3 id="Quick_Links">Quick Links</h3>
-            <p>Foo, yay</p>
-            <h2>Baz</h2>
-            <p>Baz</p>
-        """
-        expected = """
-            <h2>Foo</h2>
-            <p>Bar</p>
-            <!-- -->
-            <h2>Baz</h2>
-            <p>Baz</p>
-        """
-        result = section_hide(src, 'Quick_Links')
-        eq_(normalize_html(expected), normalize_html(result))
 
 
 class RevisionsUnifiedDiffTests(TestCaseBase):
@@ -113,19 +74,6 @@ class DocumentZoneTests(TestCaseBase):
                             is_approved=True, save=True)
         self.other_doc = other_rev.document
         self.other_doc.save()
-
-    def test_zone_section_extract(self):
-        root_result = zone_section_extract(self.root_doc, 'links')
-        eq_(normalize_html(root_result),
-            normalize_html(self.root_links_content))
-
-        sub_result = zone_section_extract(self.sub_doc, 'links')
-        eq_(normalize_html(sub_result),
-            normalize_html(self.root_links_content))
-
-        sub_sub_result = zone_section_extract(self.sub_sub_doc, 'links')
-        eq_(normalize_html(sub_sub_result),
-            normalize_html(self.sub_sub_links_content))
 
     def test_document_zone_links(self):
         admin = User.objects.filter(is_superuser=True)[0]

--- a/apps/wiki/tests/test_views.py
+++ b/apps/wiki/tests/test_views.py
@@ -900,7 +900,7 @@ class DocumentSEOTests(TestCaseBase):
         make_page_and_compare_seo('nine',
           u'<p>I <em>am</em> awesome.'
               ' <a href="blah">A link</a> is also &lt;cool&gt;</p>',
-          'I am awesome. A link is also cool')
+          u'I am awesome. A link is also cool')
 
 
 class DocumentEditingTests(TestCaseBase):
@@ -2515,11 +2515,11 @@ class SectionEditingResourceTests(TestCaseBase):
             <p>test</p>
         """)
         replace_1 = """
-            <h1 id="s1">replace1</h1>
+            <h1 id="replace1">replace1</h1>
             <p>replace</p>
         """
         replace_2 = """
-            <h1 id="s2">replace2</h1>
+            <h1 id="replace2">replace2</h1>
             <p>replace</p>
         """
         expected = """


### PR DESCRIPTION
This is mostly the same as [the previous attempt](https://github.com/mozilla/kuma/pull/2047) that was reverted as part of yesterday's performance madness. Two main differences:
- `get_body_html` now does section ID injection and link annotation, two things that were missing before.
- The `get_*` model methods are now called in the view, rather than from the template. That should make it clearer what's going on with these fields, closer to code that mucks with content.
