### PR TITLE
Remove unwanted wrapping elements to prevent mobile phone width overlap

### DIFF
--- a/apps/users/templates/users/activate.html
+++ b/apps/users/templates/users/activate.html
@@ -8,10 +8,8 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article class="main">
+
+  <article>
     <h1>{{ title }}</h1>
     {% if account %}
       <p>{% trans %}
@@ -35,7 +33,5 @@
         email or typed in the correct address.{% endtrans %}</p>
     {% endif %}
   </article>
-    </div>
-   </div>
-</section>
+    
 {% endblock content %}

--- a/apps/users/templates/users/change_email.html
+++ b/apps/users/templates/users/change_email.html
@@ -5,38 +5,34 @@
 {% set classes = 'change_email' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="change-email" class="main">
-          <h1>{{ _('Change email with Persona') }}</h1>
-            <form class="browserid boxed" action="{{url('users.browserid_change_email')}}" method="POST">
-              <input type="hidden" name="next" value="{{ next_url }}" />
 
-              {% trans browserid_href='https://persona.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
-              <h3>What's this?</h3>
-              <p>MDN has switched to <a href="{{ browserid_href }}" target="_blank" rel="external">Persona</a>, a safe and simple way to sign in with just your e-mail address.
-              <a href="{{ why_browserid }}" rel="external">Learn more about why Mozilla is using Persona</a>.</p>
-              {% endtrans %}
-              <p>{% trans %}
-              To change your MDN email, simply sign in below with the new email 
-              address.
-              {% endtrans %}</p>
+  <article id="change-email">
+      <h1>{{ _('Change email with Persona') }}</h1>
+        <form class="browserid boxed" action="{{url('users.browserid_change_email')}}" method="POST">
+          <input type="hidden" name="next" value="{{ next_url }}" />
 
-              {% include "users/browserid_signin.html" %}
-              
-              {% if messages %}
-                <ul class="messages errorlist">
-                  {% for message in messages %}
-                    <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>
-                      {{ message }}
-                    </li>
-                  {% endfor %}
-                </ul>
-              {% endif %}
-            </form>
-      </article>
-    </div>
-   </div>
-</section>
+          {% trans browserid_href='https://persona.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
+          <h3>What's this?</h3>
+          <p>MDN has switched to <a href="{{ browserid_href }}" target="_blank" rel="external">Persona</a>, a safe and simple way to sign in with just your e-mail address.
+          <a href="{{ why_browserid }}" rel="external">Learn more about why Mozilla is using Persona</a>.</p>
+          {% endtrans %}
+          <p>{% trans %}
+          To change your MDN email, simply sign in below with the new email 
+          address.
+          {% endtrans %}</p>
+
+          {% include "users/browserid_signin.html" %}
+          
+          {% if messages %}
+            <ul class="messages errorlist">
+              {% for message in messages %}
+                <li {% if message.tags %} class="{{ message.tags }}"{% endif %}>
+                  {{ message }}
+                </li>
+              {% endfor %}
+            </ul>
+          {% endif %}
+        </form>
+  </article>
+      
 {% endblock content %}

--- a/apps/users/templates/users/change_email_complete.html
+++ b/apps/users/templates/users/change_email_complete.html
@@ -8,10 +8,7 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="register" class="main">
+  <article id="register">
     <h1>{{ title }}</h1>
     <p>
       {% if duplicate %}
@@ -23,7 +20,4 @@
       {% endif %}
     </p>
   </article>
-    </div>
-   </div>
-</section>
 {% endblock %}

--- a/apps/users/templates/users/change_email_done.html
+++ b/apps/users/templates/users/change_email_done.html
@@ -5,10 +5,7 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="register" class="main">
+  <article id="register">
     <h1>{{ title }}</h1>
     <p>
       {% trans new_email=email %}
@@ -17,7 +14,4 @@
       {% endtrans %}
     </p>
   </article>
-    </div>
-   </div>
-</section>
 {% endblock %}

--- a/apps/users/templates/users/login.html
+++ b/apps/users/templates/users/login.html
@@ -5,19 +5,15 @@
 {% set classes = 'login' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
+
       {% if request.user.is_authenticated() %}
-        <article class="main">
+        <article>
           <h3>{{ _('You are already logged in.') }}</h3>
         </article>
       {% else %}
-        <article id="login" class="main">
+        <article id="login">
             {% include "users/browserid_signin.html" %}
         </article>
       {% endif %}
-    </div>
-  </div>
-</section>
+    
 {% endblock %}

--- a/apps/users/templates/users/pw_change.html
+++ b/apps/users/templates/users/pw_change.html
@@ -5,10 +5,7 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="pw-change" class="main">
+      <article id="pw-change">
         <h1>{{ title }}</h1>
         <form class="boxed" method="post" action="">
           {{ csrf() }}
@@ -22,7 +19,4 @@
           </fieldset>
         </form>
       </article>
-    </div>
-   </div>
-</section>
 {% endblock content %}

--- a/apps/users/templates/users/pw_change_complete.html
+++ b/apps/users/templates/users/pw_change_complete.html
@@ -4,16 +4,12 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="pw-reset" class="main">
-    <h1>{{ title }}</h1>
-    <p>{% trans profile_url=url('devmo.views.profile_edit', username=user.username) %}You have successfully changed your password.
-      <a href="{{ profile_url }}">Go back to edit profile page.</a>{% endtrans %}
-    </p>
-  </article>
-    </div>
-   </div>
-</section>
+
+<article id="pw-reset">
+  <h1>{{ title }}</h1>
+  <p>{% trans profile_url=url('devmo.views.profile_edit', username=user.username) %}You have successfully changed your password.
+    <a href="{{ profile_url }}">Go back to edit profile page.</a>{% endtrans %}
+  </p>
+</article>
+    
 {% endblock content %}

--- a/apps/users/templates/users/pw_reset_complete.html
+++ b/apps/users/templates/users/pw_reset_complete.html
@@ -4,15 +4,9 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="pw-reset" class="main">
+  <article id="pw-reset">
     <h1>{{ title }}</h1>
     <p>{{ _('You can now log in.') }}</p>
     {% include "users/login_form.html" %}
   </article>
-    </div>
-   </div>
-</section>
 {% endblock content %}

--- a/apps/users/templates/users/pw_reset_confirm.html
+++ b/apps/users/templates/users/pw_reset_confirm.html
@@ -5,10 +5,7 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="pw-reset" class="main">
+  <article id="pw-reset">
     {% if validlink %}
       <h1>{{ title }}</h1>
       <form class="boxed" method="post" action="">
@@ -35,7 +32,4 @@
       <p>{{ _('The password reset link was invalid, possibly because it has already been used. Please request a new password reset.') }}</p>
     {% endif %}
   </article>
-    </div>
-   </div>
-</section>
 {% endblock content %}

--- a/apps/users/templates/users/pw_reset_form.html
+++ b/apps/users/templates/users/pw_reset_form.html
@@ -5,10 +5,7 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="pw-reset" class="main">
+      <article id="pw-reset">
         <h1>{{ title }}</h1>
         <p>
           {% trans %} Forgotten your password? Enter your email address below,
@@ -29,7 +26,4 @@
           </fieldset>
         </form>
       </article>
-    </div>
-   </div>
-</section>
 {% endblock content %}

--- a/apps/users/templates/users/pw_reset_sent.html
+++ b/apps/users/templates/users/pw_reset_sent.html
@@ -5,10 +5,7 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-  <article id="pw-reset" class="main">
+  <article id="pw-reset">
     <h1>{{ title }}</h1>
     <p>
       {% trans %}
@@ -17,7 +14,4 @@
       {% endtrans %}
     </p>
   </article>
-    </div>
-   </div>
-</section>
 {% endblock content %}

--- a/apps/users/templates/users/register_done.html
+++ b/apps/users/templates/users/register_done.html
@@ -5,18 +5,12 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="register" class="main">
-        <h1>{{ _('Thank you for registering!') }}</h1>
-        {# L10n: This string appears on the 'thank you for registering' page. #}
-        <p>{% trans %}Thank you for being awesome!{% endtrans %}</p>
-        <p>{% trans %}Before you can log in, you need to confirm your email
-          address. We've sent you an email with a confirmation link in it. Just
-          click the link and you'll be ready to go!{% endtrans %}</p>
-      </article>
-    </div>
-   </div>
-</section>
+<article id="register">
+  <h1>{{ _('Thank you for registering!') }}</h1>
+  {# L10n: This string appears on the 'thank you for registering' page. #}
+  <p>{% trans %}Thank you for being awesome!{% endtrans %}</p>
+  <p>{% trans %}Before you can log in, you need to confirm your email
+    address. We've sent you an email with a confirmation link in it. Just
+    click the link and you'll be ready to go!{% endtrans %}</p>
+</article>
 {% endblock %}

--- a/apps/users/templates/users/resend_confirmation.html
+++ b/apps/users/templates/users/resend_confirmation.html
@@ -5,28 +5,22 @@
 {% set classes = 'password' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="pw-reset" class="main">
-        <h1>{{ title }}</h1>
-        <p>{% trans %}
-          To activate your account you must first confirm your email
-          address. Enter your email and submit the form below, and we will
-          resend the confirmation email.
-          {% endtrans %}</p>
+<article id="pw-reset">
+  <h1>{{ title }}</h1>
+  <p>{% trans %}
+    To activate your account you must first confirm your email
+    address. Enter your email and submit the form below, and we will
+    resend the confirmation email.
+    {% endtrans %}</p>
 
-        <form class="boxed" method="post" action="">
-          <fieldset>
-            {{ csrf() }}
-            <ul>
-              {{ form.as_ul()|safe }}
-              <li class="submit"><button type="submit">{{ _('Resend confirmation email') }}</button></li>
-            </ul>
-          </fieldset>
-        </form>
-      </article>
-    </div>
-   </div>
-</section>
+  <form class="boxed" method="post" action="">
+    <fieldset>
+      {{ csrf() }}
+      <ul>
+        {{ form.as_ul()|safe }}
+        <li class="submit"><button type="submit">{{ _('Resend confirmation email') }}</button></li>
+      </ul>
+    </fieldset>
+  </form>
+</article>
 {% endblock content %}

--- a/apps/users/templates/users/resend_confirmation_done.html
+++ b/apps/users/templates/users/resend_confirmation_done.html
@@ -5,10 +5,7 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="register" class="main">
+      <article id="register">
         <h1>{{ title }}</h1>
         <p>{% trans %}Before you can log in, you need to confirm your email
           address. We've sent a new confirmation email to any account using
@@ -16,7 +13,4 @@
           follow the link in the email.{% endtrans %}
         </p>
       </article>
-    </div>
-   </div>
-</section>
 {% endblock %}

--- a/apps/users/templates/users/send_email_reminder_done.html
+++ b/apps/users/templates/users/send_email_reminder_done.html
@@ -4,23 +4,17 @@
 {% set classes = 'register' %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-      <article id="register" class="main">
-        {% if error == 'no_email' %}
-          <h1>{{ _('No email found for this account') }}</h1>
-          <p>
-          {% trans bug_url='http://mzl.la/mdn-bug' %}Could not find email for <strong>{{ username }}</strong>. Please <a href="{{ bug_url }}">file a bug</a> to restore your account.{% endtrans %}
-          </p>
-        {% else %}
-          <h1>{{ _('Reminder email sent.') }}</h1>
-          <p>
-          {% trans %}We've sent a reminder email to the address registered for <strong>{{ username }}</strong>.{% endtrans %}
-          </p>
-        {% endif %}
-      </article>
-    </div>
-   </div>
-</section>
+<article id="register">
+  {% if error == 'no_email' %}
+    <h1>{{ _('No email found for this account') }}</h1>
+    <p>
+    {% trans bug_url='http://mzl.la/mdn-bug' %}Could not find email for <strong>{{ username }}</strong>. Please <a href="{{ bug_url }}">file a bug</a> to restore your account.{% endtrans %}
+    </p>
+  {% else %}
+    <h1>{{ _('Reminder email sent.') }}</h1>
+    <p>
+    {% trans %}We've sent a reminder email to the address registered for <strong>{{ username }}</strong>.{% endtrans %}
+    </p>
+  {% endif %}
+</article>
 {% endblock %}

--- a/apps/users/templates/users/user_banned.html
+++ b/apps/users/templates/users/user_banned.html
@@ -5,28 +5,22 @@
 {% block title %}{{ page_title(title) }}{% endblock %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
-	  <article id="profile-banned" class="main">
-	    <h1>{{ title }}</h1>
-	    <p>
-	    	{{ _('You have been banned for the following reason:') }}
-	    </p>
-	    <ul>
-	    	{% if bans | length %}
-		    	{% for ban in bans %}
-		    	<li>{{ ban.reason }}</li>
-		    	{% endfor %}
-		    {% endif %}
-	    </ul>
+<article id="profile-banned">
+  <h1>{{ title }}</h1>
+  <p>
+  	{{ _('You have been banned for the following reason:') }}
+  </p>
+  <ul>
+  {% if bans | length %}
+    {% for ban in bans %}
+      <li>{{ ban.reason }}</li>
+    {% endfor %}
+  {% endif %}
+  </ul>
 
-	    {% trans %}
-	    <p><a href="mailto:mdn-admins@mozilla.org?subject=Ban Appeal">Click here</a> to appeal this ban.</p>
-	    {% endtrans %}
+  {% trans %}
+  <p><a href="mailto:mdn-admins@mozilla.org?subject=Ban Appeal">Click here</a> to appeal this ban.</p>
+  {% endtrans %}
 
-	  </article>
-	</div>
-  </div>
-</section>
+</article>
 {% endblock %}

--- a/apps/users/tests/test_views.py
+++ b/apps/users/tests/test_views.py
@@ -83,7 +83,7 @@ class LoginTestCase(TestCase):
         response = self.client.get(login_uri, follow=True)
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_("You are already logged in.", doc.find('div#content-main').text())
+        eq_("You are already logged in.", doc.find('article').text())
 
     @mock.patch_object(Site.objects, 'get_current')
     def test_django_login_redirects_to_next(self, get_current):
@@ -287,7 +287,7 @@ class ChangeEmailTestCase(TestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_('Unable to change email for user testuser',
-            doc('.main h1').text())
+            doc('article h1').text())
         u = User.objects.get(username='testuser')
         eq_(old_email, u.email)
 

--- a/apps/wiki/templates/wiki/list_documents_for_review.html
+++ b/apps/wiki/templates/wiki/list_documents_for_review.html
@@ -17,9 +17,6 @@
 {% set crumbs = [(None, title)] %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-    <div id="content-main" class="full">
 
       <div id="document-list" class="boxed">
         <h1>{{ title }}</h1>
@@ -34,9 +31,6 @@
           <p>{{ _('There are no articles.') }}</p>
         {% endif %}
       </div>
-
-    </div>
-   </div>
-</section>
+      
 {% endblock %}
 {# vim: set ts=2 et sts=2 sw=2: #}

--- a/apps/wiki/templates/wiki/preview.html
+++ b/apps/wiki/templates/wiki/preview.html
@@ -7,34 +7,28 @@
 {% block bodyclass %}document{% endblock %}
 
 {% block content %}
-<section id="content">
-  <div class="wrap">
-  	
-    <div id="content-main" class="full">
-    	
-      {% if kumascript_errors %}
-	    {% include 'wiki/includes/kumascript_errors.html' %}
-	  {% endif %}
-    	
-      <div class="warning warning-review">
-  		<p>{{ _('This is a preview of an unsaved document.') }}</p>
-  	  </div>
-    	
-      <article class="article" role="main">
-      <header id="article-head">
-        <div class="title">
-            <h1 class="page-title">{{ title }}</h1>
-        </div>
-      </header>
-      
-       <div id="wikiArticle" class="page-content boxed">
-       		{{ content|safe }}
-       </div>
-      
-  	  </article>
-    </div>
+
+  {% if kumascript_errors %}
+    {% include 'wiki/includes/kumascript_errors.html' %}
+  {% endif %}
+	
+  <div class="warning warning-review">
+	<p>{{ _('This is a preview of an unsaved document.') }}</p>
   </div>
-</section>
+	
+  <article class="article" role="main">
+    <header id="article-head">
+      <div class="title">
+          <h1 class="page-title">{{ title }}</h1>
+      </div>
+    </header>
+    
+     <div id="wikiArticle" class="page-content boxed">
+     		{{ content|safe }}
+     </div>
+    
+  </article>
+
 {% endblock %}
 
 {% block breadcrumbs %}


### PR DESCRIPTION
We have a bunch of templates with old styling widths on them, and that causes issues on FFOS phones, whereby the content is too wide and you have to scroll horizontally.  This prevents that issue and the pages are now responsive.
