### PR TITLE
Issue #2062: Bugfix for case-flexibility in real world links

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -444,7 +444,7 @@ class LinkAnnotationFilter(html5lib_Filter):
                                                    path_locale=href_locale))
 
                 # Gather up this link for existence check
-                needs_existence_check[locale][slug].add(href)
+                needs_existence_check[locale.lower()][slug.lower()].add(href)
 
         # Perform existence checks for all the links, using one DB query per
         # locale for all the candidate slugs.
@@ -457,7 +457,9 @@ class LinkAnnotationFilter(html5lib_Filter):
             
             # Remove the slugs that pass existence check.
             for slug in existing_slugs:
-                del slug_hrefs[slug]
+                lslug = slug.lower()
+                if lslug in slug_hrefs:
+                    del slug_hrefs[lslug]
 
             # Mark all the links whose slugs did not come back from the DB
             # query as "new"

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -787,6 +787,8 @@ class ContentSectionToolTests(TestCase):
 
         document(title=u'Héritée', locale=u'fr', slug=u'CSS/Héritage',
                  save=True)
+        document(title=u'DOM/StyleSheet', locale=u'en-US',
+                 slug=u'DOM/StyleSheet', save=True)
 
         base_url = u'http://testserver/'
         vars = dict(
@@ -823,6 +825,11 @@ class ContentSectionToolTests(TestCase):
                 <a href="%(tag_url)s">Tag link</a>
                 <a href="%(feed_url)s">Feed link</a>
                 <a href="%(templates_url)s">Templates link</a>
+                <a href="/en-US/docs/DOM/stylesheet">Case sensitive 1</a>
+                <a href="/en-US/docs/DOM/Stylesheet">Case sensitive 1</a>
+                <a href="/en-US/docs/DOM/StyleSheet">Case sensitive 1</a>
+                <a href="/en-us/docs/dom/StyleSheet">Case sensitive 1</a>
+                <a href="/en-US/docs/dom/Styles">For good measure</a>
         """ % vars
         expected = u"""
                 <li><a href="%(nonen_slug)s">Héritée</a></li>
@@ -844,6 +851,11 @@ class ContentSectionToolTests(TestCase):
                 <a href="%(tag_url)s">Tag link</a>
                 <a href="%(feed_url)s">Feed link</a>
                 <a href="%(templates_url)s">Templates link</a>
+                <a href="/en-US/docs/DOM/stylesheet">Case sensitive 1</a>
+                <a href="/en-US/docs/DOM/Stylesheet">Case sensitive 1</a>
+                <a href="/en-US/docs/DOM/StyleSheet">Case sensitive 1</a>
+                <a href="/en-us/docs/dom/StyleSheet">Case sensitive 1</a>
+                <a class="new" href="/en-US/docs/dom/Styles">For good measure</a>
         """ % vars
 
         # Split the markup into lines, to better see failures


### PR DESCRIPTION
Turns out that links are case-insensitive and real content does not have links with consistent case. So, a quick bugfix is in order.
