### PR TITLE
added a contextmenu for quicker access to edit page and view history.

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -77,9 +77,15 @@
 
 {% block content %}
   {% include 'wiki/includes/document_content.html' %}
+
+  <menu type="context" id="edit-history-menu">
+    <menuitem data-action="$edit" label="{{_("Edit page")}}"></menuitem>
+    <menuitem data-action="$history" label="{{_("View page history")}}"></menuitem>
+  </menu>
+
 {% endblock %}
 
-{% block body_attributes %}data-slug="{{ document.slug }}" data-docid="{{ document.id }}"{% endblock body_attributes %}
+{% block body_attributes %}data-slug="{{ document.slug }}" data-docid="{{ document.id }}" contextmenu="edit-history-menu"{% endblock body_attributes %}
 
 {% block js %}
   {% if waffle.flag('search_doc_navigator') %}

--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -87,7 +87,7 @@
               $self[0].focus();
             }
           });
-          
+
           $closeButton.on('click', function(){
             closeSubmenu($(this).parent());
           });
@@ -233,7 +233,7 @@
         if(e.keyCode == 27) {
           $(this).siblings('a').trigger('mdn:click').focus();
         };
-      }); 
+      });
 
       // Click event to show/hide
       $self.on('click mdn:click', '.toggler', function(e) {
@@ -291,6 +291,18 @@
       function getState($li) {
         return $li.attr(closedAttribute);
       }
+    });
+  };
+  /*
+  adds a native html5 contextmenu
+  callback passes two arguments, event.target and the menu-element
+  */
+  $.fn.mozContextMenu = function (callback) {
+    $(this).each(function() {
+      var $menu = $('#' + $(this).attr('contextmenu'));
+      $(this).on('contextmenu', function(event) {
+        callback(event.target, $menu);
+      });
     });
   };
 

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -200,6 +200,26 @@
   });
 
   /*
+  Adds a context menu to edit page or view history
+  if right-click on a link it will edit/view history on the links href.
+  */
+  $('body[contextmenu=edit-history-menu]').mozContextMenu(function(target, $contextMenu) {
+      var $menuitems = $contextMenu.find('menuitem');
+      var href = target.href ? target.href : location.href;
+
+      $menuitems.removeAttr('disabled');
+
+      // if target is an anchor other than MDN
+      if (target.hostname && target.hostname !== location.hostname) {
+        $menuitems.attr('disabled', true);
+      }
+
+      $contextMenu.on('click', function(event) {
+        location.href = href + $(event.target).data('action');
+      });
+  });
+
+  /*
     Stack overflow search form, used for dev program
 
     ex: http://stackoverflow.com/search?q=[firefox]+or+[firefox-os]+or+[html5-apps]+foobar
@@ -214,7 +234,7 @@
     }
   });
 
-  /* 
+  /*
     jQuery extensions used within the wiki.
   */
   $.extend({


### PR DESCRIPTION
When using firefox, You can now right-click anywhere on the page to see a edit and view history option. If you right-click on a link that leads to a MDN page you can go to the edit or view history page of that link.
