### PR TITLE
Ensure only the latest deletion log is passed to the template

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -549,9 +549,11 @@ def _document_deleted(request, deletion_logs):
     When a Document has been deleted, display a notice.
     
     """
+    deletion_log = deletion_logs.order_by('-pk')[0]
+
     return render(request,
                   'wiki/deletion_log.html',
-                  {'deletion_logs': deletion_logs})
+                  {'deletion_log': deletion_log})
 
 
 @newrelic.agent.function_trace()


### PR DESCRIPTION
I tried using `-1` index and `reverse()[0]` and neither passed back the latest log.

I _believe_ this will fix https://bugzilla.mozilla.org/show_bug.cgi?id=979204
