### PR TITLE
Fix bug where profile submenu is shown by default

### DIFF
--- a/media/redesign/stylus/main/components.styl
+++ b/media/redesign/stylus/main/components.styl
@@ -182,3 +182,27 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     }
   }
 }
+
+/* All site submenus, including but not limited to wiki and profile submenus */
+.submenu {
+  component-submenu-method(160px, 1, button-background, button-shadow-color);
+  bidi-style(right, 0, left, auto);
+  top: 40px;
+  z-index: 3;
+  border-top: 1px solid button-shadow-color;
+  width: 160px !important; /* needs this due to overriding media query rule of component */
+
+  bdi {
+    bidi-value(text-align, left, right);
+  }
+
+  &:before {
+    bidi-style(right, 10px, left, auto);
+    top: -18px;
+  }
+
+  &:after {
+    bidi-style(right, 10px, left, auto);
+    top: -20px;
+  }
+}

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -338,29 +338,6 @@ article {
       font-size: 16px;
     }
   }
-
-  .submenu {
-    component-submenu-method(160px, 1, button-background, button-shadow-color);
-    bidi-style(right, 0, left, auto);
-    top: 40px;
-    z-index: 3;
-    border-top: 1px solid button-shadow-color;
-    width: 160px !important; /* needs this due to overriding media query rule of component */
-
-    bdi {
-      bidi-value(text-align, left, right);
-    }
-
-    &:before {
-      bidi-style(right, 10px, left, auto);
-      top: -18px;
-    }
-
-    &:after {
-      bidi-style(right, 10px, left, auto);
-      top: -20px;
-    }
-  }
 }
 
 /* kumascript errors block at the top of an article */


### PR DESCRIPTION
As part of implementing the advanced submenu used on the profile page
(#2028), the .submenu rule was moved from wiki.styl to components.styl
so that it would be available to both wiki and profile pages. When the
submenu system was refactored (#2044), the rule was moved back to
wiki.styl, making it unavailable to profile pages and therefore breaking
profile submenus.

This change moves the rule back to components.styl so that the rule is
available to both.
