### PR TITLE
If the content stretches to TOC, ensure TOC is on top

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -503,7 +503,7 @@ div.bug, div.warning, div.overheadIndicator {
   &.fixed {
     position: fixed;
     top: 0;
-    z-index: 2;
+    z-index: 10;
     overflow-y: auto;
   }
 


### PR DESCRIPTION
Stretched tables can make the TOC go under the content -- this prevents. that.
