### PR TITLE
Improve UX of Wiki Editor page

### DIFF
--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -126,6 +126,19 @@
 
         </header>
 
+        {% if request.user.get_profile().wiki_activity()|count == 0 %}
+          <section class="first-contrib-welcome">
+            <h2>{{_('Thank you for taking the time to improve MDN!')}}</h2>
+            <p>
+              {% trans url=devmo_url('Project:MDN/Contributing/Editor_guide/') %}
+                It looks like this is your first contribution to MDN. You can find answers to common editing questions within our <a target="_blank" href="{{ url }}">Editor Guide</a>.
+              {% endtrans %}
+            </p>
+            <p>{{_("Don't be afraid to break something, you can always revert your changes.")}}</p>
+            <p>{{_('Have fun and be proud of your contribution!')}}</p>
+          </section>
+        {% endif %}
+
         {% if revision_form %}
             {% include 'wiki/includes/guide_links.html' %}
             
@@ -139,15 +152,20 @@
             <input type="hidden" name="form" value="rev" />
             {{ revision_form.hidden_fields()|join|safe }}
 
-            {% include 'wiki/includes/revision_comment.html' %}
-
             <section class="page-meta">
               {% set tags = document.tags.all() %}
               <section id="page-tags" class="page-tags">
-                <h2><i aria-hidden="true" class="icon-tags"></i>{{ _('Tags') }}</h2>
+                <h2><i aria-hidden="true" class="icon-tags"></i>{{ _('Tags') }} <a href="{{ devmo_url('Project:MDN/Contributing/Editor_guide/Editing#The_tags_box') }}"><i aria-hidden="true" title="{{ _('Learn how to tag an article') }}" class="icon-question-sign editor-help-icon"></i></a></h2>
+                <p>
+                  {% trans url=devmo_url('Project:MDN/Contributing/Tagging_standards') %}
+                    Categorize the article. It will make the article findable under the right filters in the search engine. <a target="_blank" href="{{ url }}">Read the Tagging Guide</a>.
+                  {% endtrans %}
+                </p>
                 <input id="tagit_tags" type="text" name="tags" value="{% for tag in tags %}{{ tag.name }},{% endfor %}" maxlength="255" />
               </section>
             </section>
+
+            {% include 'wiki/includes/revision_comment.html' %}
 
             <section class="page-meta wiki-block">
               <section>

--- a/apps/wiki/templates/wiki/includes/attachment_list.html
+++ b/apps/wiki/templates/wiki/includes/attachment_list.html
@@ -2,16 +2,19 @@
 <section class="page-meta">
 <section id="page-attachments">
 
-  <h3><i aria-hidden="true" class="icon-paper-clip"></i>{{ _('Attachments') }}</h3>
+  <h3><i aria-hidden="true" class="icon-paper-clip"></i>{{ _('Attachments') }} <a href="{{ devmo_url('Project:MDN/Contributing/Editor_guide/Editing#The_attachments_box') }}"><i aria-hidden="true" title="{{ _('Learn how to use Attachments') }}" class="icon-question-sign editor-help-icon"></i></a></h3>
 
-  {% if show_attach_button and attachment_form %}
+  {% if show_attach_button and attachment_form and attachment_data|length %}
   <p class="add">
       <a href="javascript:;" id="page-attachments-button" class="button neutral">Attach Files<i aria-hidden="true" class="icon-paper-clip"></i></a>
   </p>
   {% endif %}
 
   <p id="page-attachments-no-message" class="{% if attachment_data|length %}hidden{% endif %}">
-    {{ _('This document has no attachments.') }}
+    {{ _('This document has no attachments. Images can be attached, and then embedded in the article.') }}
+    {% if show_attach_button and attachment_form and not attachment_data|length %}
+      <a href="javascript:;" id="page-attachments-button" class="button neutral">Attach Files<i aria-hidden="true" class="icon-paper-clip"></i></a>
+    {% endif %}
   </p>
 
   <script>

--- a/apps/wiki/templates/wiki/includes/revision_comment.html
+++ b/apps/wiki/templates/wiki/includes/revision_comment.html
@@ -1,5 +1,5 @@
 <section class="page-meta"><section id="page-comment">
-  <h3><i aria-hidden="true" class="icon-comment-alt"></i>{{_('Revision Comment')}}</h3>
-  <p>{{_('Tell us why you made additions and changes.')}}</p>
+  <h3><i aria-hidden="true" class="icon-comment-alt"></i>{{_('Revision Comment')}} <a href="{{ devmo_url('Project:MDN/Contributing/Editor_guide/Editing#The_revision_comment_box') }}"><i aria-hidden="true" title="{{ _('Learn how to use Revision Comments') }}" class="icon-question-sign editor-help-icon"></i></a></h3>
+  <p>{{_('Tell us why you made additions and changes. It is optional, but will make page history easier to understand.')}}</p>
   {{ revision_form.comment | safe }}
 </section></section>

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -139,8 +139,13 @@
         <div class="localized">
           <section class="page-meta">
               <section id="page-tags" class="page-tags">
-                <h2><i aria-hidden="true" class="icon-tag"></i>{{ _('Tags') }}</h2>
-                <input id="tagit_tags" type="text" name="tags" value="{% if document.tags %}{% for tag in document.tags.all() %}{{ tag.name }},{% endfor %}{% endif %}" maxlength="255" />
+                <h2><i aria-hidden="true" class="icon-tag"></i>{{ _('Tags') }} <a href="{{ devmo_url('Project:MDN/Contributing/Editor_guide/Editing#The_tags_box') }}"><i aria-hidden="true" title="{{ _('Learn how to tag an article') }}" class="icon-question-sign editor-help-icon"></i></a></h2>
+                <p>
+                  {% trans url=devmo_url('Project:MDN/Contributing/Tagging_standards') %}
+                    Categorize the article. It will make the article findable under the right filters in the search engine. <a target="_blank" href="{{ url }}">Read the Tagging Guide</a>.
+                  {% endtrans %}
+                </p>
+                <input id="tagit_tags" type="text" name="tags" value="{% if document.tags %}{% for tag in document.tags.all() %}{{ tag.name }},{% endfor %}{% endif %}" maxlength="255">
               </section>
               <section class="page-tags">
                 <h2>{{_('Localization flags')}}</h2>

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -571,6 +571,13 @@ div.bug, div.warning, div.overheadIndicator {
   compat-only(background, none);
 }
 
+.page-meta section h2,
+.page-meta section h3 {
+  .editor-help-icon {
+    font-size: 20px;
+  }
+}
+
 #page-tags, #page-comment {
   @extend .wiki-block;
 }
@@ -614,8 +621,23 @@ div.bug, div.warning, div.overheadIndicator {
   h2 {selector-icon}, h3 {selector-icon} {
     @extend .right-icons;
   }
-}
 
+  .first-contrib-welcome {
+    background: light-background-color;
+    border: 5px solid header-background-color;
+    padding: 15px 15px 10px;
+    margin-bottom: 20px;
+
+    h2 {
+      margin: 0 0 .5em;
+      font: bold 18px/1.5 'Open Sans', sans-serif;
+    }
+
+    p {
+      margin-bottom: .6em;
+    }
+  }
+}
 
 /* ckeditor / content area styles */
 .ckeditor-container {


### PR DESCRIPTION
- Add a welcome message for first time contributor
- Add Help icons with links to relevant sections in Editor documentation
- Add explanations in page for Tags, Revision Comment and Attachments
- As Tags are now important for MDN search engine, moves them above Revision Comment

Checked with Ali, Holly, Janet, and more… :smiley: 

**Screenshot:**
![new-editor](https://f.cloud.github.com/assets/188748/2365947/9a49b728-a6e7-11e3-9953-38e4cfa60efa.png)
