### PR TITLE
Fix bug 931135

### DIFF
--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -147,13 +147,15 @@ def move_page(locale, slug, new_slug, email):
         return
 
     transaction.commit()
+    subject = 'Page move completed: ' + slug + ' (' + locale + ')'
+    full_url = settings.SITE_URL + '/' + locale + '/docs/' + new_slug
     message = """
     Page move completed.
 
     The move requested for the document with slug %(slug)s in locale
     %(locale)s, and all its children, has been completed.
 
-    You can now view this document at its new slug, %(new_slug)s.
-    """ % {'slug': slug, 'locale': locale, 'new_slug': new_slug}
-    send_mail('Page move completed', message, settings.DEFAULT_FROM_EMAIL,
+    You can now view this document at its new location: %(full_url)s.
+    """ % {'slug': slug, 'locale': locale, 'full_url': full_url}
+    send_mail(subject, message, settings.DEFAULT_FROM_EMAIL,
               [user.email])


### PR DESCRIPTION
Improves emails sent after a successful page move by adding the slug
and locale on the subject line, and by replacing the slug with the
full new URL in the body.

Note that two pair of eyes say this should work, but I'm unable to be 100% sure because I am not receiving emails sent from my VM.
