### PR TITLE
removed live sample iframe border

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -778,12 +778,7 @@ span.cke_skin_kuma {
   }
 }
 
-/* Styles for live sample iframe */
 
-.live-sample-frame {
-  border: 1px solid #ccc;
-  box-shadow: 0px 0px 1px 1px #ddd;
-}
 
 /*
   Small desktop.  We go to a two-column layout


### PR DESCRIPTION
I liked the idea of having a visual separation to show live samples, but right now this would require more styling imo, this sample image illustrates what it gives on a live sample made this weekend for the mdn weekend Paris
![screen shot 2014-03-10 at 10 30 24](https://f.cloud.github.com/assets/288803/2372209/f3e1bae2-a836-11e3-8f98-c237930aadaa.png)
padding would be nice, but would interfere with layout if the size is 100% (unless we use box-sizing: border-box), but this is only working since ie8.

I think we have a better look without it until we give it a proper appearance 
