### PR TITLE
Correct Firefox placeholder pseudo-class

### DIFF
--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -191,7 +191,7 @@ set-placeholder-style(prop, value) {
   &::-webkit-input-placeholder {
     {prop}: value;
   }
-  &::-moz-input-placeholder {
+  &::-moz-placeholder {
     {prop}: value;
   }
 }


### PR DESCRIPTION
The pseudo-element is named ::-moz-placeholder in Firefox, not
::-moz-input-placeholder.

https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-placeholder
