### PR TITLE
fix bug 762097 - remove un-used translate_url vars

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -12,12 +12,6 @@
 
 {% block bodyclass %}document {% if is_zone %}zone{% endif %} {% if is_zone_root %}zone-landing{% endif %}{% endblock %}
 
-{% if document.parent %}
-  {# If there is a parent doc, use it for translating. #}
-  {% set translate_url = url('wiki.select_locale', document_path=document.parent.full_path) %}
-{% else %}
-  {% set translate_url = url('wiki.select_locale', document_path=document.full_path, locale=document.locale) %}
-{% endif %}
 {% if fallback_reason == 'no_translation' %}
   {% set help_link = url('wiki.translate', document_path=document.full_path, locale=document.locale)|urlparams(tolocale=request.locale) %}
 {% elif fallback_reason == 'translation_not_approved' %}

--- a/apps/wiki/templates/wiki/includes/document_content.html
+++ b/apps/wiki/templates/wiki/includes/document_content.html
@@ -1,11 +1,5 @@
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, get_document_buttons, get_document_subnav, get_approvals_html, document_watch with context %}
 
-{% if document.parent %}
-  {# If there is a parent doc, use it for translating. #}
-  {% set translate_url = url('wiki.select_locale', document_path=document.parent.full_path) %}
-{% else %}
-  {% set translate_url = url('wiki.select_locale', document_path=document.full_path, locale=document.locale) %}
-{% endif %}
 {% if fallback_reason == 'no_translation' %}
   {% set help_link = url('wiki.translate', document_path=document.full_path, locale=document.locale)|urlparams(tolocale=request.locale) %}
 {% elif fallback_reason == 'translation_not_approved' %}


### PR DESCRIPTION
This has all moved to the [`get_document_buttons` macro](https://github.com/mozilla/kuma/blob/master/apps/wiki/templates/wiki/includes/document_macros.html#L30-L54) now.
