### PR TITLE
Fix bug 872107 - Filter review list by locale

### DIFF
--- a/apps/wiki/templates/wiki/list_documents_for_review.html
+++ b/apps/wiki/templates/wiki/list_documents_for_review.html
@@ -20,6 +20,7 @@
 
       <div id="document-list" class="boxed">
         <h1>{{ title }}</h1>
+        <p>{{ _('Found {0} documents.')|f(count) }}</p>
         {% if documents.object_list %}
           <ul class="documents cols-3">
             {% for doc in documents.object_list %}
@@ -33,4 +34,3 @@
       </div>
       
 {% endblock %}
-{# vim: set ts=2 et sts=2 sw=2: #}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -903,10 +903,11 @@ def list_files(request):
 def list_documents_for_review(request, tag=None):
     """Lists wiki documents with revisions flagged for review"""
     tag_obj = tag and get_object_or_404(ReviewTag, name=tag) or None
-    docs = paginate(request, Document.objects.filter_for_review(tag=tag_obj),
-                    per_page=DOCUMENTS_PER_PAGE)
+    docs = Document.objects.filter_for_review(locale=request.locale, tag=tag_obj)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents_for_review.html',
-                        {'documents': docs,
+                        {'documents': paginated_docs,
+                         'count': docs.count(),
                          'tag': tag_obj,
                          'tag_name': tag})
 


### PR DESCRIPTION
Test URLs (currently all the same for all locales - this should fix that):

https://developer.mozilla.org/en-US/docs/needs-review/editorial
https://developer.mozilla.org/en-US/docs/needs-review/technical

https://developer.mozilla.org/de/docs/needs-review/editorial
https://developer.mozilla.org/de/docs/needs-review/technical
