### PR TITLE
Remove 'redesign-' prefix from css and JS

### DIFF
--- a/apps/dashboards/templates/dashboards/localization.html
+++ b/apps/dashboards/templates/dashboards/localization.html
@@ -2,7 +2,7 @@
 
 {% set title = _('Localization Dashboard') %}
 {% set scripts = ('dashboards',) %}
-{% set styles = ('redesign-dashboards', 'redesign-wiki', 'jquery-ui') %}
+{% set styles = ('dashboards', 'wiki', 'jquery-ui') %}
 {% set classes = 'compare' %}
 
 {% block title %}{{ _("Localization Dashboard") }}{% endblock %}

--- a/apps/dashboards/templates/dashboards/revisions.html
+++ b/apps/dashboards/templates/dashboards/revisions.html
@@ -2,7 +2,7 @@
 {% extends "base.html" %}
 {% set title = _('Revision Dashboard') %}
 {% set scripts = ('dashboards',) %}
-{% set styles = ('redesign-dashboards', 'redesign-wiki', 'jquery-ui') %}
+{% set styles = ('dashboards', 'wiki', 'jquery-ui') %}
 {% set classes = 'compare' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}

--- a/settings.py
+++ b/settings.py
@@ -582,11 +582,6 @@ MINIFY_BUNDLES = {
             'redesign/css/wiki.css',
             'redesign/css/sphinx.css',
         ),
-        'dashboards': (
-            'css/dashboards.css',
-            'js/libs/DataTables-1.9.4/media/css/jquery.dataTables.css',
-            'js/libs/DataTables-1.9.4/extras/Scroller/media/css/dataTables.scroller.css',
-        ),
         'users': (
             'redesign/css/users.css',
         ),
@@ -617,7 +612,7 @@ MINIFY_BUNDLES = {
         'profile': (
             'redesign/css/profile.css',
         ),
-        'redesign-dashboards': (
+        'dashboards': (
             'redesign/css/dashboards.css',
             'redesign/css/diff.css',
             'js/libs/DataTables-1.9.4/media/css/jquery.dataTables.css',
@@ -628,7 +623,7 @@ MINIFY_BUNDLES = {
         ),
     },
     'js': {
-        'redesign-main': (
+        'main': (
             'js/jquery-upgrade-compat.js',
             'redesign/js/components.js',
             'redesign/js/main.js',

--- a/templates/base.html
+++ b/templates/base.html
@@ -175,7 +175,7 @@
       {{ js('jquery1') }}
     {% endif %}
 
-    {{ js('redesign-main') }}
+    {{ js('main') }}
 
     {% if waffle.flag('ga_outbound_links') %}
       <script>


### PR DESCRIPTION
We've almost got a clean front-end setup back.  w00t.
