### PR TITLE
fix bug 981581: Bugfix for "new" link annotation on absolute URLs

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -2,6 +2,7 @@
 import re
 import urllib
 from urllib import urlencode
+from urlparse import urlparse
 from collections import defaultdict
 
 from xml.sax.saxutils import quoteattr
@@ -365,6 +366,7 @@ class LinkAnnotationFilter(html5lib_Filter):
     def __init__(self, source, base_url):
         html5lib_Filter.__init__(self, source)
         self.base_url = base_url
+        self.base_url_parsed = urlparse(base_url)
 
     def __iter__(self):
         from wiki.models import Document
@@ -382,9 +384,10 @@ class LinkAnnotationFilter(html5lib_Filter):
                     continue
 
                 href = attrs['href']
-                if href.startswith(self.base_url):
+                href_parsed = urlparse(href)
+                if href_parsed.netloc == self.base_url_parsed.netloc:
                     # Squash site-absolute URLs to site-relative paths.
-                    href = '/%s' % href[len(self.base_url):]
+                    href = href_parsed.path
 
                 # Prepare annotations record for this path.
                 links[href] = dict(
@@ -472,9 +475,10 @@ class LinkAnnotationFilter(html5lib_Filter):
                 if 'href' in attrs:
 
                     href = attrs['href']
-                    if href.startswith(self.base_url):
+                    href_parsed = urlparse(href)
+                    if href_parsed.netloc == self.base_url_parsed.netloc:
                         # Squash site-absolute URLs to site-relative paths.
-                        href = '/%s' % href[len(self.base_url):]
+                        href = href_parsed.path
 
                     if href in links:
                         # Update class names on this link element.

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -822,7 +822,7 @@ class ContentSectionToolTests(TestCase):
         document(title=u'DOM/StyleSheet', locale=u'en-US',
                  slug=u'DOM/StyleSheet', save=True)
 
-        base_url = u'http://testserver/'
+        base_url = u'https://testserver'
         vars = dict(
             base_url=base_url,
             exist_url=d.get_absolute_url(),


### PR DESCRIPTION
Turns out the link annotation algorithm was sensitive to a site base url with or without trailing slash. That made [pages like this](https://developer.mozilla.org/en-US/docs/MDN/Doc_status/Editorial_reviews) show links as pages in need of creation, when in fact the pages did exist. 

This PR tweaks the test to reflect prod more accurately & trigger the bug, and makes the algo more robust.
