### PR TITLE
Revision dash revamp

### DIFF
--- a/apps/dashboards/__init__.py
+++ b/apps/dashboards/__init__.py
@@ -30,5 +30,4 @@ DEFAULT_LOCALE = 'en-US'
 WAFFLE_FLAG = 'l10ndashboard'
 
 # Revisions
-
-PAGE_SIZE = 100
+PAGE_SIZE = 50

--- a/apps/dashboards/forms.py
+++ b/apps/dashboards/forms.py
@@ -1,0 +1,35 @@
+
+from django import forms
+from sumo.form_fields import StrippedCharField
+
+from django.conf import settings
+
+from tower import ugettext_lazy as _lazy
+from tower import ugettext as _
+
+LANG_CHOICES = [
+    ('', _lazy('All Locales'))
+] + settings.LANGUAGES
+
+class RevisionDashboardForm(forms.Form):
+
+    locale = forms.ChoiceField(choices=LANG_CHOICES,
+                    # Required for non-translations, which is
+                    # enforced in Document.clean().
+                    required=False,
+                    label=_lazy(u'Locale:'))
+
+    user = StrippedCharField(min_length=1, max_length=255,
+                    required=False,
+                    label=_lazy(u'User:'))
+
+    topic = StrippedCharField(min_length=1, max_length=255,
+                    required=False,
+                    label=_lazy(u'Topic:'))
+
+    start_date = forms.DateField(required=False, label=_lazy(u'Start Date:'),
+                    input_formats=settings.DATE_INPUT_FORMATS,
+                    widget = forms.TextInput(attrs={'pattern':'\d{1,2}/\d{1,2}/\d{4}'}))
+    end_date = forms.DateField(required=False, label=_lazy(u'End Date:'),
+                    input_formats=settings.DATE_INPUT_FORMATS,
+                    widget = forms.TextInput(attrs={'pattern':'\d{1,2}/\d{1,2}/\d{4}'}))

--- a/apps/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/apps/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -1,0 +1,46 @@
+{% if total %}
+    <table class="dashboard-table" width="100%">
+        <thead>
+            <tr>
+                <td class="dashboard-revision">Revision</td>
+                <td class="dashboard-title">Title</td>
+                <td class="dashboard-comment">Comment</td>
+                <td class="dashboard-author">Author</td>
+            </tr>
+        </thead>
+        <tbody>
+            {% for revision in revisions %}
+
+                {% set previous_id = revision.get_previous().id %}
+                {% set revision_url = url('wiki.document', revision.document.full_path, locale=revision.document.locale) %}
+                <tr
+                    tabindex="0"
+                    class="dashboard-row {% if not previous_id %}dashboard-row-new{% endif %}"
+                    data-revision-id="{{ revision.id }}"
+                    data-previous-id="{{ previous_id }}"
+                    data-view-url="{{ revision_url }}"
+                    data-edit-url="{{ url('wiki.edit_document', revision.document.full_path, locale=revision.document.locale) }}"
+                    data-compare-url="{{ url('wiki.compare_revisions', revision.document.full_path, locale=revision.document.locale) }}?from={{ previous_id if previous_id else revision.id }}&to={{ revision.id }}&raw=1"
+                    data-revert-url="{{ url('wiki.revert_document', revision.document.full_path, revision.id, locale=revision.document.locale) }}"
+                    data-history-url="{{ url('wiki.document_revisions', revision.document.full_path, locale=revision.document.locale) }}">
+                    <td class="dashboard-revision">
+                        <a href="{{ url('wiki.revision', revision.document.full_path, revision.id) }}">{{ datetimeformat(revision.created, format='datetime') }}</a>
+                        <br />
+                        <span class="locale">{{ revision.document.locale }}</span>
+                        {% if not previous_id %}<span class="new">{{ _('new') }}</span>{% endif %}
+                    </td>
+                    <td class="dashboard-title"><a href="{{ revision_url }}">{{ revision.title }}</a></td>
+                    <td class="dashboard-comment">{{ revision.comment }}</td>
+                    <td class="dashboard-author"><a href="{{ url('devmo.views.profile_view', username=revision.creator) }}">{{ revision.creator }}</a></td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+
+{% else: %}
+
+    <p>{{ _('There are no revisions matching this filter set.') }}</p>
+
+{% endif %}
+
+{{ revisions|paginator }}

--- a/apps/dashboards/templates/dashboards/revisions.html
+++ b/apps/dashboards/templates/dashboards/revisions.html
@@ -1,75 +1,53 @@
 {% extends "base.html" %}
 {% set title = _('Revision Dashboard') %}
 {% set scripts = ('dashboards',) %}
-{% set styles = ('dashboards', 'wiki', 'jquery-ui') %}
+{% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
 
 {% block content %}
 
-  <div class="dashboard">
+    <div class="dashboard">
 
-    <h1>{{ title }}</h1>
+        <h1>{{ title }}</h1>
+        <form method="get" id="revision-filter">
+            <div class="revision-field">
+                <label for="id_locale">{{ _('Locale:') }}</label>
+                {{ form.locale }}
+            </div>
 
-    <h2>{{ _('Revision Filter') }}</h2>
-    <form method="get" id="revision-filter">
-      <label for="dash-locale">{{ _('Locale') }}:</label>
-      <select name="locale" id="dash-locale">
-        <option value="">{{ _('All Locales') }}</option>
-        {% for code, name in settings.LANGUAGES -%}
-          <option value="{{ code }}" {{ code|ifeq(request.GET.locale, "selected") }}>
-            {{ name }}
-          </option>
-        {%- endfor %}
-      </select>
+            <div class="revision-field">
+                <label for="id_user">{{ _('User:') }}</label>
+                {{ form.user }}
+            </div>
 
-      <label for="revision-dashboard-user">{{ _('User') }}:</label>
-      <input name="user" id="revision-dashboard-user" value="{{ request.GET.user }}" />
+            <div class="revision-field">
+                <label for="id_topic">{{ _('Topic:') }}</label>
+                {{ form.topic }}
+            </div>
+            <br />
 
-      {% if waffle.flag('revision-dashboard-newusers') %}
-        <label for="revision-dashboard-newusers">{{ _('New users only')}}</label>
-        <input type="checkbox" name="newusers" id="revision-dashboard-newusers" {% if request.GET.newusers %}checked{% endif %} />
-      {% endif %}
+            <div class="revision-field">
+                <label for="id_start_date">{{ _('Start Date:') }}</label>
+                {{ form.start_date }}
+            </div>
 
+            <div class="revision-field">
+                <label for="id_end_date">{{ _('End Date:') }}</label>
+                {{ form.end_date }}
+            </div>
 
-      <label for="revision-dashboard-topic">{{ _('Topic') }}:</label>
-      <input name="topic" id="revision-dashboard-topic" value="{{ request.GET.topic }}" />
-
-      <input type="submit" value="{{ _('Filter') }}" />
-    </form>
-
-    <table id="revisions-table">
-      <thead>
-        <tr>
-          <th class="revision-head-article">{{ _('Article') }}</th>
-          <th class="revision-head-date">{{ _('Date') }}</th>
-          <th class="revision-head-author">{{ _('Author') }}</th>
-        </tr>
-      </thead>
-      <tbody>
-      </tbody>
-    </table>
+            <button type="submit">{{ _('Filter') }}</button>
+            <input type="hidden" name="page" id="revision-page" value="{{ page }}" />
+        </form>
 
 
-    <div id="revisions-compare">
-      <div id="action-bar">
-        <ul id="page-buttons">
-          <li><a id="revert" href="#" class="button">{{ _('Revert') }}<i aria-hidden="true" class="icon-undo"></i></a></li>
-          <li><a id="view" href="#" class="button">{{ _('View Page') }}<i aria-hidden="true" class="icon-circle-arrow-right"></i></a></li>
-          <li class="page-edit"><a id="edit" href="#" class="button">{{ _('Edit Page') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
-          <li class="page-history"><a id="history" href="#" class="button">{{ _('History') }}<i aria-hidden="true" class="icon-book"></i></a></li>
-          <li id="ban-user"></li>
-        </ul>
-      </div>
-
-      <h2>{{ _('Revision Diff') }}</h2>
-      <div id="revision-address"></div>
-      <div id="diff-view">
-        <p>{{ _('Click an item in the revision list above to see details.') }}</p>
-      </div>
+        <div id="revision-replace-block">
+        {% include 'dashboards/includes/revision_dashboard_body.html' %}
+        </div>
     </div>
-  </div>
+
 {% endblock %}
 
 
@@ -77,148 +55,145 @@
 {{ js('jquery-ui') }}
 
 <script>
-$(document).ready(function(){
-  var $revTable       = $('#revisions-table'),
-      $revTableBody   = $('tbody', $revTable),
-      $revisionForm   = $('#revision-filter'),
-      $actionBar      = $('#action-bar'),
-      $localeInput    = $('#dash-locale'),
-      currentLocale   = '{{ request.locale }}',
-      localeKey       = '{LOCALE}',
-      baseURL         = '/' + localeKey + '/dashboards/revisions',
-      $revisionDashboardUser = $('#revision-dashboard-user'),
-      $revisionDashboardTopic = $('#revision-dashboard-topic'),
-      lastSelected;
-  $actionBar.hide();
-  $revTableBody.click(getRecordDetail);
+(function (jQuery) {
+    'use strict';
 
-  // Create the autocomplete for user
-  $revisionDashboardUser.mozillaAutocomplete({
-    minLength: 3,
-    labelField: 'label',
-    autocompleteUrl: '{{ url('dashboards.user_lookup') }}',
-    onSelect: function(item, isSilent) {
-      // Do something upon selection
-      if(!isSilent) loadRecords();
-    },
-    buildRequestData: function(req) {
-      // Should add locale value here
-      req.locale = getLocale();
-      req.user = req.term;
-      return req;
-    }
-  });
+    var $revisionReplaceBlock = $('#revision-replace-block');
+    var $localeInput = $('#id_locale');
+    var $filterForm = $('#revision-filter');
+    var $pageInput = $('#revision-page');
+    var currentLocale = '{{ request.locale }}';
 
-  // Create the autocomplete for topic
-  $revisionDashboardTopic.mozillaAutocomplete({
-    minLength: 3,
-    labelField: 'label',
-    autocompleteUrl: '{{ url('dashboards.topic_lookup') }}',
-    onSelect: function(item, isSilent) {
-      // Do something upon selection
-      if(!isSilent) loadRecords();
-    },
-    buildRequestData: function(req) {
-      // Should add locale value here
-      req.locale = getLocale();
-      req.topic = req.term;
-      return req;
-    }
-  });
+    var controlsTemplate = '\
+    <div class="action-bar">\
+        <ul id="page-buttons">\
+            <li><a id="revert" href="$reverturl" class="button">{{ _('Revert') }}<i aria-hidden="true" class="icon-undo"></i></a></li><li><a id="view" href="$viewurl" class="button">{{ _('View Page') }}<i aria-hidden="true" class="icon-circle-arrow-right"></i></a></li><li class="page-edit"><a id="edit" href="$editurl" class="button">{{ _('Edit Page') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li class="page-history"><a id="history" href="$historyurl" class="button">{{ _('History') }}<i aria-hidden="true" class="icon-book"></i></a></li>\
+        </ul>\
+    </div>';
 
-  function getLocale() {
-    return $localeInput.get(0).value || currentLocale;
-  }
-
-  function getSourceURL() {
-    return baseURL.replace(localeKey, getLocale()) + '?' + $revisionForm.serialize();
-  }
-
-  // Upon form submission, get records
-  $revisionForm.submit(function(e) {
-    e.preventDefault();
-    loadRecords();
-
-    if('pushState' in history) {
-      history.pushState(null, '', location.pathname + '?' + $revisionForm.serialize());
-    }
-  });
-
-  // When the username is clicked, filter
-  $revTable.delegate('a.creator', 'click', function(ev) {
-    ev.preventDefault();
-    $revisionDashboardUser.val($(ev.target).text())
-    loadRecords();
-  });
-
-  // Triggers a change in record source
-  function loadRecords() {
-    var settings = $revTable.dataTable.settings[0];
-    settings.sAjaxSource = getSourceURL();
-    $revTable.dataTable.ext.oApi._fnAjaxUpdate(settings);
-  }
-
-  // Fires off an AJAX request to get the necessary data
-  function getRecordDetail(e){
-    var parent        =   $(e.target).parents('tr').get(0),
-        data          =   $revTable.fnGetData(parent),
-        $diffView     =   $('#diff-view'),
-        $revertLink   =   $('a#revert'),
-        $viewLink     =   $('a#view'),
-        $editLink     =   $('a#edit'),
-        $historyLink  =   $('a#history'),
-        $banUserItem  =   $('#ban-user');
-
-    if(e.target.tagName == 'A') return;
-
-    // Manage selection colors
-    if(lastSelected) {
-      lastSelected.removeClass('selected')
-    }
-    lastSelected = $(parent).addClass('selected');
-
-    // Update the revision address block
-    $('#revision-address').text(data.title + " - " + data.doc_url);
-
-    // Load diff content
-    $('a', $actionBar).attr('href', '');
-    $actionBar.show();
-    $diffView.html(gettext('Loading ...'));
-    $diffView.load(data.compare_url, function(resp, status, xhr){
-      if (status == 'error') {
-        $diffView.html('Error: ' + xhr.status + ' ' + xhr.statusText);
-      } else {
-        $revertLink.attr('href', data.revert_url);
-        $viewLink.attr('href', data.doc_url);
-        $editLink.attr('href', data.edit_url);
-        $historyLink.attr('href', data.history_url);
-        $banUserItem.html(data.ban_link);
-      }
+    // Create the autocomplete for user
+    $('#id_user').mozillaAutocomplete({
+        minLength: 3,
+        labelField: 'label',
+        autocompleteUrl: '{{ url("dashboards.user_lookup") }}',
+        buildRequestData: function (req) {
+            // Should add locale value here
+            req.locale = getLocale();
+            req.user = req.term;
+            return req;
+        }
     });
-  }
 
-  // Create the feature-rich table
-  $revTable.dataTable({
-    'bPaginate': false,
-    'bLengthChange': false,
-    'bFilter': false,
-    'bSort': false,
-    'bAutoWidth': false,
-    'aoColumns': [
-      {'mData': 'richTitle'},
-      {'mData': 'date'},
-      {'mData': 'creator'}
-    ],
-    'sScrollY': '300px',
-    'sDom': 'frtiS',
-    'oScroller':{
-      'loadingIndicator': true,
-      'serverWait': 500
-    },
-    'bServerSide': true,
-    'bDeferRender': true,
-    'sAjaxSource': getSourceURL()
-  });
-});
+    // Create the autocomplete for topic
+    $('#id_topic').mozillaAutocomplete({
+        minLength: 3,
+        labelField: 'label',
+        autocompleteUrl: '{{ url("dashboards.topic_lookup") }}',
+        buildRequestData: function (req) {
+            // Should add locale value here
+            req.locale = getLocale();
+            req.topic = req.term;
+            return req;
+        }
+    });
+
+    // Enable keynav
+    $revisionReplaceBlock.mozKeyboardNav({
+        itemSelector: '.dashboard-row',
+        onEnterKey: function (item) {
+            $(item).trigger('mdn:click');
+        },
+        alwaysCollectItems: true
+    });
+
+    // Focus on the first item, if there
+    focusFirst();
+
+    // Create date pickers
+    $('#id_start_date, #id_end_date').datepicker();
+
+    // When an item is clicked, load its detail
+    $revisionReplaceBlock.on('click mdn:click', '.dashboard-row', function (e) {
+        var $this = $(this);
+        var $detail;
+
+        // Don't interrupt links and stop if a request is already running
+        if (e.target.tagName == 'A' || $this.attr('data-running')) return;
+
+        if ($this.attr('data-loaded')) {
+            $this.find('.dashboard-detail').slideToggle();
+        } else {
+            $this.attr('data-running', 1);
+            $.ajax({
+                url: $this.attr('data-compare-url')
+            }).then(function (content) {
+                // Prepend the controls
+                var controls = controlsTemplate
+                                        .replace('$reverturl', $this.attr('data-revert-url'))
+                                        .replace('$viewurl', $this.attr('data-view-url'))
+                                        .replace('$editurl', $this.attr('data-edit-url'))
+                                        .replace('$historyurl', $this.attr('data-history-url'));
+
+                $detail = $('<div class="dashboard-detail">' + controls + content + '</div>').appendTo($this).slideDown();
+                $this.attr('data-loaded', 1);
+                $this.removeAttr('data-running');
+            });
+        }
+    });
+
+    // AJAX loads for pagination
+    $revisionReplaceBlock.on('click', '.pagination a', function (e) {
+        e.preventDefault();
+        $pageInput.val(this.href.split('page=')[1]);
+        $filterForm.submit();
+    });
+
+    // Filter form submission handler; loads content via AJAX, updates URL state
+    $filterForm.on('submit', function (e) {
+        e.preventDefault();
+        var $this = $(this);
+
+        if ('pushState' in history) {
+            history.pushState(null, '', location.pathname + '?' + $this.serialize());
+        }
+
+        $.ajax({
+            url: $this.attr('action'),
+            data: $this.serialize()
+        }).then(function (content) {
+            replaceContent(content);
+            $this.trigger('ajaxComplete');
+
+            // Reset the page count to 0 in case of new filter
+            $pageInput.val(1);
+        });
+    });
+
+    // Returns the current locale
+    function getLocale() {
+        return $localeInput.get(0).value || currentLocale;
+    }
+
+    // Focuses on the first row in the table
+    function focusFirst() {
+        var first = $revisionReplaceBlock.find('.dashboard-row').first();
+        first.length && first.get(0).focus();
+    }
+
+    // Replaces table body content and scrolls to top of the page
+    function replaceContent(content) {
+        $revisionReplaceBlock.fadeOut(function () {
+            $(this).html(content).fadeIn(function () {
+                focusFirst();
+            });
+
+            // Animate to top!
+            $('html, body').animate({
+                scrollTop: $revisionReplaceBlock.offset().top
+            }, 2000);
+        });
+    }
+
+})(jQuery);
 </script>
 {% endblock %}

--- a/apps/dashboards/views.py
+++ b/apps/dashboards/views.py
@@ -1,4 +1,5 @@
 import json
+import datetime
 
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.models import User
@@ -11,11 +12,14 @@ from jinja2 import escape
 from waffle.decorators import waffle_flag
 
 from sumo.urlresolvers import reverse
+from sumo.utils import paginate, smart_int
 
 from users.helpers import ban_link
 
 from wiki.models import Document, Revision
 from wiki.helpers import format_comment
+
+from dashboards.forms import RevisionDashboardForm
 
 from . import (DEFAULT_LOCALE, LOCALES, ORDERS, LANGUAGES,
                LOCALIZATION_FLAGS, WAFFLE_FLAG, PAGE_SIZE)
@@ -28,7 +32,7 @@ def fetch_localization_data(request):
     topic = request.GET.get('topic', '')
     orderby = request.GET.get('orderby', '-modified')
     localization_flags = request.GET.get('localization_flags', 'update-needed')
-    
+
     display_start = int(request.GET.get('iDisplayStart', 0))
 
     docs = (Document.objects.exclude(locale=DEFAULT_LOCALE)
@@ -43,11 +47,12 @@ def fetch_localization_data(request):
     # Build up a dict of the filter conditions, if any, then apply
     # them all in one go.
     query_kwargs = {}
-    
+
     if locale and locale in LANGUAGES:
         query_kwargs['locale'] = locale
-        
-    # Filter out documents where we can't compare to a parent (English) document
+
+    # Filter out documents where we can't compare to a
+    # parent (English) document
     query_kwargs['parent__isnull'] = False
 
     # We want to see outdated locale documents
@@ -61,7 +66,7 @@ def fetch_localization_data(request):
 
     if topic:
         query_kwargs['slug__icontains'] = topic
-        
+
     if query_kwargs:
             docs = docs.filter(**query_kwargs)
             total = docs.count()
@@ -69,7 +74,7 @@ def fetch_localization_data(request):
         # If no filters, just do a straight count(). It's the same
         # result, but much faster to compute.
         total = docs.count()
-        
+
     if total >= display_start:
         # Only bother with this if we're actually going to get
         # some documents from it. Otherwise it's a pointless but
@@ -135,106 +140,60 @@ def localization(request):
 @require_GET
 def revisions(request):
     """Dashboard for reviewing revisions"""
-    if request.is_ajax():
-        username = request.GET.get('user', None)
-        locale = request.GET.get('locale', None)
-        topic = request.GET.get('topic', None)
-        newusers = request.GET.get('newusers', None)
 
-        display_start = int(request.GET.get('iDisplayStart', 0))
+    filter_form = RevisionDashboardForm(request.GET)
+    page = request.GET.get('page', 1)
 
-        revisions = (Revision.objects.select_related('creator')
-                     .order_by('-created')
-                     .defer('content'))
+    revisions = (Revision.objects.select_related('creator')
+                        .order_by('-created')
+                        .defer('content'))
+
+    query_kwargs = False
+
+    # We can validate right away because no field is required
+    if filter_form.is_valid():
+        query_kwargs = {}
+        query_kwargs_map = {
+            'user': 'creator__username__istartswith',
+            'locale': 'document__locale',
+            'topic': 'slug__icontains',
+        }
 
         # Build up a dict of the filter conditions, if any, then apply
         # them all in one go.
-        query_kwargs = {}
-        if username:
-            query_kwargs['creator__username__istartswith'] = username
-        if locale:
-            query_kwargs['document__locale'] = locale
-        if topic:
-            query_kwargs['slug__icontains'] = topic
-        if newusers:
-            # Users with the first edit not older than 7 days or
-            # with fewer than 20 revisions at all
-            sql = """SELECT id, creator_id, MIN(created)
-                     FROM wiki_revision
-                     GROUP BY creator_id
-                     HAVING COUNT(*) <= 20
-                     OR MIN(created) >= DATE_SUB(NOW(), INTERVAL 7 DAY)"""
-            result = list(Revision.objects.raw(sql))
-            if result:
-                users = [u.creator_id for u in result]
-                query_kwargs['creator__id__in'] = users
-            else:
-                revisions = Revision.objects.none()
+        for fieldname, kwarg in query_kwargs_map.items():
+            filter_arg = filter_form.cleaned_data[fieldname]
+            if filter_arg:
+                query_kwargs[kwarg] = filter_arg
 
-        if query_kwargs:
-            revisions = revisions.filter(**query_kwargs)
-            total = revisions.count()
-        else:
-            # If no filters, just do a straight count(). It's the same
-            # result, but much faster to compute.
-            total = Revision.objects.count()
+        start_date = filter_form.cleaned_data['start_date']
+        if start_date:
+            end_date = (filter_form.cleaned_data['end_date'] or
+                                datetime.datetime.now())
+            query_kwargs['created__range'] = [start_date, end_date]
 
-        if total >= display_start:
-            # Only bother with this if we're actually going to get
-            # some revisions from it. Otherwise it's a pointless but
-            # potentially complex query.
-            revisions = revisions[display_start:display_start + PAGE_SIZE]
+    if query_kwargs:
+        revisions = revisions.filter(**query_kwargs)
+        total = revisions.count()
+    else:
+        # If no filters, just do a straight count(). It's the same
+        # result, but much faster to compute.
+        total = Revision.objects.count()
 
-        # build the master JSON
-        revision_json = {
-            'iTotalRecords': total,
-            'iTotalDisplayRecords': total,
-            'aaData': []
-        }
-        for rev in revisions:
-            prev = rev.get_previous()
-            from_rev = str(prev.id if prev else rev.id)
-            doc_url = reverse('wiki.document', args=[rev.document.full_path],
-                              locale=rev.document.locale)
-            articleUrl = '<a href="%s" target="_blank">%s</a>' % (doc_url,
-                    escape(rev.document.slug))
-            articleLocale = ('<span class="dash-locale">%s</span>'
-                             % rev.document.locale)
-            articleComment = ('<span class="dashboard-comment">%s</span>'
-                              % format_comment(rev))
-            articleIsNew = ''
-            if rev.based_on_id is None and not rev.document.is_redirect:
-                articleIsNew = '<span class="dashboard-new">New: </span>'
-            richTitle = (articleIsNew + articleUrl + articleLocale +
-                         articleComment)
+    # Only bother with this if we're actually going to get
+    # some revisions from it. Otherwise it's a pointless but
+    # potentially complex query.
+    revisions = paginate(request, revisions, per_page=PAGE_SIZE)
 
-            revision_json['aaData'].append({
-                'id': rev.id,
-                'prev_id': from_rev,
-                'doc_url': doc_url,
-                'edit_url': reverse('wiki.edit_document',
-                    args=[rev.document.full_path], locale=rev.document.locale),
-                'compare_url': reverse('wiki.compare_revisions',
-                    args=[rev.document.full_path], locale=rev.document.locale)
-                    + '?from=%s&to=%s&raw=1' % (from_rev, str(rev.id)),
-                'revert_url': reverse('wiki.revert_document',
-                    args=[rev.document.full_path, rev.id],
-                    locale=rev.document.locale),
-                'history_url': reverse('wiki.document_revisions',
-                    args=[rev.document.full_path], locale=rev.document.locale),
-                'creator': ('<a href="" class="creator">%s</a>'
-                            % escape(rev.creator.username)),
-                'title': rev.title,
-                'richTitle': richTitle,
-                'date': rev.created.strftime('%b %d, %y - %H:%M'),
-                'slug': rev.document.slug,
-                'ban_link': ban_link(rev.creator, request.user)
-            })
+    context = {'revisions': revisions, 'page': page, 'total': total}
 
-        result = json.dumps(revision_json)
-        return HttpResponse(result, mimetype='application/json')
+    # Serve the response HTML conditionally upon reques type
+    if request.is_ajax():
+      return render(request, 'dashboards/includes/revision_dashboard_body.html', context)
+    else:
+      context['form'] = filter_form
 
-    return render(request, 'dashboards/revisions.html')
+    return render(request, 'dashboards/revisions.html', context)
 
 
 @require_GET

--- a/apps/wiki/templates/wiki/includes/revision_diff_table.html
+++ b/apps/wiki/templates/wiki/includes/revision_diff_table.html
@@ -1,1 +1,6 @@
-{{ diff_table(revision_from.content, revision_to.content, revision_from.id, revision_to.id) }}
+{% if revision_from.id != revision_to.id %}
+	{% set from_content = revision_from.content %}
+{% else %}
+	{% set from_content = '' %}
+{% endif %}
+{{ diff_table(from_content, revision_to.content, revision_from.id, revision_to.id) }}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1604,6 +1604,7 @@ def compare_revisions(request, document_slug, document_locale):
 
     context = {'document': doc, 'revision_from': revision_from,
                          'revision_to': revision_to}
+
     if request.GET.get('raw', 0):
         response = render(request,
                                 'wiki/includes/revision_diff_table.html',

--- a/media/redesign/stylus/dashboards.styl
+++ b/media/redesign/stylus/dashboards.styl
@@ -1,140 +1,88 @@
 /*
-  Used to style the dashboard widgets in the dashboard apps
+    Used to style the dashboard widgets in the dashboard apps
 */
 
 @import 'includes/vars'
 @import 'includes/mixins'
+@import 'includes/grid'
 
-
-.dashboard {
-
-  tbody { 
-    white-space: no-wrap;
-    overflow: hidden;
-  }
-
-  #action-bar { 
-    position: relative; 
-  }
-
-  #revisions-compare { 
-    width: 100%; 
-  }
-
-  #revisions-table {
-    tr {
-      vendorize(transition-property, all);
-      vendorize(transition-duration, .5s);
-      cursor: pointer;
-
-      &:hover {
-        create-gradient(#cae1f4, #eee, top); /* "to bottom" as the standard */
-      }
-
-      &.selected {
-        create-gradient(#d7d3c8, #f6f4ec, top); /* "to bottom" as the standard */
-        font-weight: bold;
-      }
-    }
-  }
-
-  div.DTS div.dataTables_scrollHead {
-    create-gradient(#424f5a, #6a7b86, top); /* "to bottom" as the standard */
-    color: #fff;
-  }
-
-  table.dataTable {
-    tr.odd {
-      create-gradient(#d4dde4, #eaeff2, top); /* "to bottom" as the standard */
-    }
-
-    td {
-      border-right: 1px solid #ccc;
-      white-space: normal;
-      vertical-align: top;
-    }
-  }
-
-  #revisions-table {
-    .revision-head-date, .revision-head-author {
-      width: 20% !important;
-    }
-    .dashboard-comment {
-      color: #666;
-      display: block;
-      font-style: italic;
-      margin-right: 50px;
-      padding-top: 3px;
-
-      .selected & {
-        font-weight: normal;
-      }
-    }
-    .dash-locale {
-      float: right;
-      padding-top: 3px;
-    }
-    .dashboard-new {
-        font-weight: bold;
-    }
-  }
-
-  .dataTables_info {
-      float: none;
-      text-align: right;
-      padding: 10px 20px;
-  }
-
-  table.dataTable {
-    thead {
-      th {
-        pointer-events: none;
-      }
-    }
-  }
-
-  #page-buttons {
-    position: static;
-    margin: 20px 0;
+/* New revision dashboard styles */
+.dashboard-table {
     width: 100%;
-  }
 
-  #revision-address {
-    color: #666;
-    margin: -10px 0 20px;
-  }
-
-  #revision-filter {
-    display: block;
-    margin: 0 0 20px 0;
-
-    select, input {
-      margin-right: 30px;
-      display: inline-block;
+    thead tr {
+        background: #3a3a3a;
+        color: #fff;
+        font-weight: bold;
     }
 
-    label {
-      font-weight: bold;
+    .dashboard-revision, .dashboard-title, .dashboard-comment, .dashboard-author {
+        padding: 6px;
+        display: inline-block;
+        vertical-align: text-top;
     }
-  }
 
-  #dashboard-filter {
-    height: 50px;
+    tbody tr {
+        border-bottom: 1px solid #ccc;
+        cursor: pointer;
 
-    li {
-      float: left;
-      height: 50px;
-      margin-right: 25px;
-    }
-  }
-
-  .doc-list {
-      width: 100%;
-
-      tr {
-        th {
-          font-weight: bold;
+        &:hover {
+            background: #f4f7f8;
         }
-      }
-  }
+
+        &:nth-child(even) {
+            background: #f7f7f7;
+
+            &:hover {
+            background: #f4f7f8;
+            }
+        }
+
+        .new, .locale {
+            font-size: 11px;
+            border-radius: 8px;
+            color: #fff;
+            display: inline-block;
+            margin-right: 6px;
+            padding: 2px 4px;
+        }
+        .new {
+            background: rgba(green, 0.6);
+        }
+        .locale {
+            background: rgba(#777, 0.6);
+        }
+    }
+
+    .dashboard-detail {
+        display: none;
+        padding: 0 grid-spacing;
+    }
+
+    .dashboard-revision, .dashboard-title, .dashboard-comment, .dashboard-author {
+        @extend $column-strip;
+    }
+
+    #page-buttons {
+        li {
+            display: inline-block;
+            margin-right: list-item-spacing;
+        }
+    }
+}
+
+
+#revision-filter {
+    #id_start_date, #id_end_date {
+        width: 100px;
+    }
+    label {
+        display: inline-block;
+        margin-right: list-item-spacing;
+    }
+    .revision-field {
+        display: inline-block;
+        margin: 0 grid-spacing (grid-spacing / 2) 0;
+        white-space: nowrap;
+    }
 }

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -1,5 +1,6 @@
 @import 'includes/vars'
 @import 'includes/mixins'
+@import 'main/components'
 
 /*** Display ***/
 

--- a/settings.py
+++ b/settings.py
@@ -813,6 +813,9 @@ RECAPTCHA_USE_SSL = False
 RECAPTCHA_PRIVATE_KEY = 'SET ME IN SETTINGS_LOCAL'
 RECAPTCHA_PUBLIC_KEY = 'SET ME IN SETTINGS_LOCAL'
 
+# date format, needed for custom revision dashboard
+DATE_INPUT_FORMATS = ('%d/%m/%Y', '%Y/%m/%d', '%m/%d/%Y', '%d-%m-%Y', '%Y-%m-%d', '%m-%d-%Y')
+
 # content flagging
 FLAG_REASONS = (
     ('notworking', _('This demo is not working for me')),


### PR DESCRIPTION
There are two issues that I'm aware of at the moment, and I'd like a pythonista's thoughts on best handling them:
1.  Via HTML5, I am validating the date with an attributes, but someone could put an invalid date in the querystring, and that presently throws a 500.  I'd love some advice on restructuring the view to avoid this issue.  Remember that the results will be served up via AJAX.
2.  In `revision_diff_table.html`, I added a "show_controls" conditional so that I wouldn't have to build those button URLs on the client side.  Brilliant, right?  The problem is that if from "/en-us/dashboards/revisions" the user calls "/es/blah/blah" to get that content fragment, the button text is in Spanish and not English.  :(

Any advice would be appreciated!
