### PR TITLE
Update placeholder for Firefox

### DIFF
--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -174,6 +174,10 @@ override-main-nav-color(hex) {
       input, i, .search-trigger {
         color: hex !important;
       }
+
+      input {
+      	 set-placeholder-style(color, hex);
+      }
     }
   }
 
@@ -192,7 +196,7 @@ set-placeholder-style(prop, value) {
     {prop}: value;
   }
   &::-moz-placeholder {
-    {prop}: value;
+  	{prop}: value;
   }
 }
 


### PR DESCRIPTION
Some site called "MDN" says it's only one colon: https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-placeholder

Also setting the white zone placeholder color.
