### PR TITLE
Fix bug 981147 - Prevent deleted wiki documents from being indexed

### DIFF
--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -488,6 +488,7 @@ def _get_seo_parent_title(slug_dict, document_locale):
 
 @newrelic.agent.function_trace()
 @allow_CORS_GET
+@prevent_indexing
 def _document_deleted(request, deletion_logs):
     """
     When a Document has been deleted, display a notice.


### PR DESCRIPTION
I think serving 200 is fine, but we can direct it to not be indexable.
