### PR TITLE
Fix Bug 925043 - TOC contains empty <code> tags

### DIFF
--- a/apps/wiki/content.py
+++ b/apps/wiki/content.py
@@ -738,13 +738,15 @@ class SectionTOCFilter(html5lib_Filter):
                         yield t
             elif ('StartTag' == token['type'] and
                   token['name'] in TAGS_IN_TOC and
+                  self.in_header and
                   not self.skip_header):
                 yield token
             elif (token['type'] in ("Characters", "SpaceCharacters")
                   and self.in_header):
                 yield token
             elif ('EndTag' == token['type'] and
-                    token['name'] in TAGS_IN_TOC):
+                  token['name'] in TAGS_IN_TOC and
+                  self.in_header):
                 yield token
             elif ('EndTag' == token['type'] and
                     token['name'] in HEAD_TAGS_TOC):

--- a/apps/wiki/tests/test_content.py
+++ b/apps/wiki/tests/test_content.py
@@ -536,6 +536,22 @@ class ContentSectionToolTests(TestCase):
                   .filter(H3TOCFilter).serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
+    def test_bug_925043(self):
+        '''Bug 925043 - Redesign TOC has a bunch of empty <code> tags in markup'''
+        doc_src = """
+            <h2 id="Print">Mastering <code>print</code></h2>
+            <code>print 'Hello World!'</code>
+        """
+        expected = """
+            <li>
+                <a href="#Print" rel="internal">Mastering<code>print</code></a>
+            </li>
+        """
+        result = (wiki.content
+                  .parse(doc_src)
+                  .filter(SectionTOCFilter).serialize())
+        eq_(normalize_html(expected), normalize_html(result))
+
     def test_dekiscript_macro_conversion(self):
         doc_src = u"""
             <span>Just a span</span>


### PR DESCRIPTION
Prior to this fix all the document's code tags were put into the table of contents.
https://bugzilla.mozilla.org/show_bug.cgi?id=925043
