### PR TITLE
Bug 755382: Switch to contextless error handlers.

### DIFF
--- a/apps/devmo/tests/error_urls.py
+++ b/apps/devmo/tests/error_urls.py
@@ -1,0 +1,22 @@
+"""
+URL patterns for testing our custom error handlers.
+
+"""
+
+from django.conf.urls import patterns
+from django.conf.urls import url
+
+from devmo.views import error_page
+
+
+urlpatterns = patterns('',
+    url(r'^error_403/',
+        lambda r: error_page(r, 403),
+        name='test_error_403'),
+    url(r'^error_404/',
+        lambda r: error_page(r, 404),
+        name='test_error_404'),
+    url(r'^error_500/',
+        lambda r: error_page(r, 500),
+        name='test_error_500'),
+)

--- a/apps/devmo/tests/test_views.py
+++ b/apps/devmo/tests/test_views.py
@@ -557,3 +557,12 @@ class LoggingTests(test_utils.TestCase):
             eq_(1, len(mail.outbox))
         except:
             pass
+
+class ErrorViewTests(test_utils.TestCase):
+    urls = 'devmo.tests.error_urls'
+
+    def test_error_handlers(self):
+        for status_code in (403, 404, 500):
+            resp = self.client.get('/en-US/error_%s/' % status_code)
+            eq_(status_code, resp.status_code)
+            eq_(0, len(resp.context.keys()))

--- a/urls.py
+++ b/urls.py
@@ -9,7 +9,6 @@ from django.views.decorators.cache import cache_page
 import jingo
 import badger
 
-
 admin.autodiscover()
 badger.autodiscover()
 
@@ -76,13 +75,11 @@ urlpatterns = patterns('',
 if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
 
-# Handle 404 and 500 errors
-def _error_page(request, status):
-    """Render error pages with jinja2."""
-    return render(request, '%d.html' % status, status=status)
-handler403 = lambda r: _error_page(r, 403)
-handler404 = lambda r: _error_page(r, 404)
-handler500 = lambda r: _error_page(r, 500)
+# Handle errors through jinja
+from devmo.views import error_page
+handler403 = lambda r: error_page(r, 403)
+handler404 = lambda r: error_page(r, 404)
+handler500 = lambda r: error_page(r, 500)
 
 if settings.SERVE_MEDIA:
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')


### PR DESCRIPTION
DO NOT MERGE

This is simply a proof of concept of switching our error-handling views to supply no template context. Spoiler: it breaks a lot of things, because we have error templates which rely on having a bunch of context available to them.

Questions to answer from this:
1. Is it worth the effort of cleaning up our error templates, to get the additional safety of contextless errors?
2. Should all of our error views be contextless, or just a subset? (500 should absolutely be contextless, 404 probably should be, 403 is debatable).
