### PR TITLE
mockuped new layout for wikipages when tinking about top contributors

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_content.html
+++ b/apps/wiki/templates/wiki/includes/document_content.html
@@ -117,7 +117,9 @@
         <a class="button from-search-next only-icon"><i aria-hidden="true" class="icon-chevron-right"></i></a>
       </span>
       {% endif %}
-    <h1>{{ document.title }}</h1>
+  </div>
+  <main role="main" class="wiki-wrapper">
+      <h1>{{ document.title }}</h1>
 
       {% if messages %}
         {% for message in messages %}
@@ -128,33 +130,9 @@
           {% endif %}
         {% endfor %}
       {% endif %}
-
-  </div>
   {% endif %}
 
-  <!-- start the main content container -->
-    <div id="wiki-column-container" class="{% if show_right %}wiki-right-present{% else %}wiki-right-closed wiki-right-none{% endif %} {% if show_left %}wiki-left-present{% else %}wiki-left-closed wiki-left-none{% endif %}">
-
-      {% if show_left and not is_zone_root %}
-      <!-- additional controls row; hidden unless needed -->
-      <div id="wiki-controls" class="column-container column-container-reverse">
-        <div class="column-strip">
-          <!-- Show TOC "show" link -->
-        </div>
-        <div class="column-half">
-        </div>
-        <div class="column-strip quick-links hidden">
-          <a href="#show-quick-links" class="title smaller" id="show-quick-links"><i aria-hidden="true" class="icon-caret-down"></i>{{ _('Show Sidebar') }}</a>
-        </div>
-      </div>
-      {% endif %}
-
-      <!-- content row with three strips -->
-      <div class="column-container column-container-reverse">
-
         {% if show_right %}
-          <!-- TOC, approvals, etc -->
-          <div class="column-strip wiki-column" id="wiki-right">
           {% if toc_html %}
           <!-- table of contents -->
           <div id="toc" class="toc toggleable">
@@ -164,7 +142,6 @@
             </ol>
           </div>
           {% endif %}
-          </div>
         {% endif %}
 
         <!-- just the article content -->
@@ -173,9 +150,6 @@
         {% else %}
           {% set document_html_safe = document_html|safe %}
         {% endif %}
-
-        <!-- center: main article content -->
-        <div id="wiki-content" class="{{ content_class }} wiki-column text-content">
 
           {% if request.user.is_authenticated() and document_html %}
             {% if render_raw_fallback %}
@@ -233,7 +207,7 @@
           {% endif %}
 
           <!-- just the article content -->
-          <article id="wikiArticle">
+          <div class="wiki-article">
             {% if not fallback_reason %}
               {% if not document_html %}
                 {{ _("This article doesn't have any content yet.") }}
@@ -254,7 +228,8 @@
             {% else %}
               {{ _("This article doesn't have approved content yet.") }}
             {% endif %}
-          </article>
+            </div>
+          <!--/article-->
 
           {% if not is_zone_root %}
             <!-- attachments list -->
@@ -262,39 +237,35 @@
               {% include 'wiki/includes/attachment_list.html' %}
             {% endif %}
 
-            <!-- contributors -->
-            <div class="wiki-block contributors">
-              <h2 class="offscreen">{{ _('Document Tags and Contributors') }}</h2>
-              {% if tags|length %}
+          {% endif %}
+          </main>
+           <!-- contributors -->
+            <aside class="contributors">
+                          {% if tags|length %}
               <!-- tags if present -->
               <div class="tag-attach-list tags contributor-sub">
-                <i aria-hidden="true" class="icon-tags"></i><strong>{{ _('Tags:') }}</strong>
+                <strong><i aria-hidden="true" class="icon-tags"></i>{{ _('Tags:') }}</strong>
                 <ul class="tag-list">{% for tag in tags %}<li><a href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a></li>{% endfor %}</ul>
               </div>
               {% endif %}
               {% trans contributors=user_list(contributors) %}
               <div class="contributor-sub">
-                <i aria-hidden="true" class="icon-group"></i><strong>Contributors to this page:</strong> {{ contributors }}
+                <strong><i aria-hidden="true" class="icon-group"></i>Contributors to this page:</strong> {{ contributors }}
               </div>
               {% endtrans %}
               {% if current_revision.creator %}
                 <div class="contributor-sub">
-                  <i aria-hidden="true" class="icon-time"></i><strong>{{ _('Last updated by:') }}</strong>
+                  <strong><i aria-hidden="true" class="icon-time"></i>{{ _('Last updated by:') }}</strong>
                   <a href="{{ url('devmo.views.profile_view', username=current_revision.creator) }}">{{ current_revision.creator }}</a>,
                   {{ datetimeformat(current_revision.created, format='datetime') }}
                 </div>
               {% endif %}
-            </div>
-          {% endif %}
-        </div>
 
-        {% if show_left %}
+                      {% if show_left %}
           <!-- quick links and zone subnav strip -->
           <div id="wiki-left" class="column-strip wiki-column">
 
           {% if not is_zone_root %}
-
-            <a href="#quick-links" class="title smaller" id="quick-links-toggle"><i aria-hidden="true" class="icon-caret-up"></i>{{ _('Hide Sidebar') }}</a>
 
             {% if zone_subnav_html %}
               <!-- zone subnav -->
@@ -312,10 +283,8 @@
             {% endif %}
 
           {% endif %}
-
-          </div>
+            </div>
+            </aside>
         {% endif %}
-      </div>
     </div>
-  </div>
 </div> <!-- ends "main-content" -->

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -142,6 +142,7 @@
 
         if(scroll > tocOffset && $toggler.css('pointer-events') == 'none') {
           $toc.css({
+            left: $toc.offset().left,
             width: $toc.css('width'),
             maxHeight: maxHeight
           });
@@ -152,9 +153,9 @@
         }
         else {
           $toc.css({
-            width: 'auto',
-            maxHeight: 'none'
-          });
+            left: "",
+            width: ""
+            });
           $toc.removeClass(fixedClass);
         }
 

--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -342,7 +342,7 @@ a.persona-button {
   compat-only(padding, 0);
 }
 
-main {
+#content {
   background: #fff;
   min-height: 200px;
 

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -14,7 +14,6 @@ make-wiki-blocks-flat() {
 
 enable-toc-toggle() {
   #toc {
-    padding: (grid-spacing / 2) grid-spacing;
 
     .toggler {
       pointer-events: auto;
@@ -426,6 +425,10 @@ div.bug, div.warning, div.overheadIndicator {
 
 .contributor-sub {
   padding: 4px 0;
+  margin-bottom: 20px;
+  strong {
+    display: block;
+  }
 }
 
 /* table of contents column */
@@ -437,18 +440,14 @@ div.bug, div.warning, div.overheadIndicator {
 .tag-attach-list {
   position: relative;
 
-  ul, > a {
+  a {
     @extend .smaller;
     display: inline-block;
   }
 
   ul {
-    bidi-style(padding-left, 6px, padding-right, 0);
     margin-bottom: 0;
-
-    li {
-      margin-bottom: 0;
-    }
+    margin-top: 4px;
   }
 
   > a {
@@ -498,17 +497,18 @@ div.bug, div.warning, div.overheadIndicator {
   compat-only(font-size, base-font-size);
   compat-only(margin-left, 0, 'ol ol, ul ul');
   background: light-background-color;
-  compat-important(padding, grid-spacing (grid-spacing * .75));
 
   &.fixed {
-    position: fixed;
+    position: fixed !important;
     top: 0;
+    right: auto !important;
     z-index: 10;
     overflow-y: auto;
   }
 
   > ol {
     compat-important(font-size, smaller-font-size);
+    margin: -20px grid-spacing 0;
   }
 
   ol ol {
@@ -545,6 +545,8 @@ div.bug, div.warning, div.overheadIndicator {
   a.title {
     position: relative;
     text-decoration: none;
+    display: inline-block;
+    margin: (grid-spacing /2) grid-spacing;
   }
 }
 
@@ -746,13 +748,13 @@ span.cke_skin_kuma {
 
 /* Page deletion styles */
 .delete-document {
-  textarea { 
-    width: 500px; 
-    max-width: 100%; 
+  textarea {
+    width: 500px;
+    max-width: 100%;
     margin-bottom: grid-spacing;
   }
-  label { 
-    display: block; 
+  label {
+    display: block;
   }
 }
 
@@ -761,6 +763,34 @@ span.cke_skin_kuma {
 .live-sample-frame {
   border: 1px solid #ccc;
   box-shadow: 0px 0px 1px 1px #ddd;
+}
+.wiki-wrapper {
+  max-width: 79.1428571%;
+  margin-right: 3%;
+  position: relative;
+  float: left;
+  #toc {
+    position: absolute;
+    right: 0;
+    width: 250px;
+  }
+}
+.wiki-article {
+  margin-right: 292px;
+}
+.themeUpdated {
+  display: none;
+}
+.contributors {
+  width: 17.8571429%;
+  float: left;
+  border: 0;
+  padding:0;
+  margin:99px 0 0;
+  background: transparent;
+}
+#wiki-left {
+  width: auto;
 }
 
 /*
@@ -781,6 +811,38 @@ span.cke_skin_kuma {
     #wiki-left {
       float: none;
     }
+  }
+  .wiki-wrapper {
+    max-width: 74.5%;
+    .wiki-article {
+      margin-right: 0;
+    }
+    #toc {
+      position: relative;
+      right: auto;
+      width: auto;
+      margin-bottom:20px;
+      padding: 0;
+      overflow: hidden;
+      .toggler {
+        pointer-events: auto;
+        color: #0095DD;
+        display: block;
+        padding: 20px;
+        margin: 0;
+        i {
+          display: inline-block;
+          top: 23px;
+          right:20px;
+        }
+      }
+      > ol {
+        margin-bottom: 20px;;
+      }
+    }
+  }
+  .contributors {
+    width: 22.5%;
   }
 
   /* hide redirected from info on small screens */
@@ -824,7 +886,15 @@ span.cke_skin_kuma {
     display: none;
   }
 }
-
+@media all and (max-width: 1023px) {
+  .wiki-wrapper {
+    max-width: 100%;
+  }
+  .contributors {
+    width: auto;
+    float: none;
+  }
+}
 /* Mobile updates */
 @media media-query-mobile {
   #languages-menu-submenu {

--- a/templates/base.html
+++ b/templates/base.html
@@ -137,9 +137,9 @@
   </div></header>
 
   <!-- Content will go here -->
-  <main id="content" role="main"><div class="center clear">
+  <div id="content"><div class="center clear">
   {% block content %}{% endblock %}
-  </div></main>
+  </div></div>
 
   <!-- Footer -->
   <footer><div class="center">


### PR DESCRIPTION
*\* DO NOT MERGE **
this is just a test on how the wikipages could be arranged.
I was looking at #2127 and how the top contributors could be visually presented. It resulted in this mockup/POC. It can be viewed here https://developer-local.allizom.org/en-US/docs/Web/CSS/background-size and here are some thoughts:
1. IMHO The reading order is more relevant, "See also" is moved to a more natural place. eg. if you read from left to right you read, headline, content, TOC, and last complementary info and links.
2. I've tighten up the TOC and the complimentary column to be 250px instead of 315px, no need for them to take up so much space (And as a side note it fits like a glove in the [golden ratio](http://en.wikipedia.org/wiki/Golden_ratio)).
![wiki-golden-ratio](https://f.cloud.github.com/assets/74497/2482112/d0f93304-b0e5-11e3-8cd5-f9ac3737703a.jpg)
3. the line-lengths in the main column feels more comfortable like this. 
4. The last column enlightens the fact that this is a wiki

I know that other pages has been screwed up, I have only been focusing on a "normal" wikipage right now.

Thoughts?
