### PR TITLE
List top level docs and docs without parent

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -435,7 +435,8 @@ class BaseDocumentManager(models.Manager):
         return True
 
     def filter_for_list(self, locale=None, category=None, tag=None,
-                        tag_name=None, errors=None):
+                        tag_name=None, errors=None, noparent=None,
+                        toplevel=None):
         docs = (self.filter(is_template=False, is_redirect=False)
                     .exclude(slug__startswith='User:')
                     .exclude(slug__startswith='Talk:')
@@ -457,6 +458,12 @@ class BaseDocumentManager(models.Manager):
         if errors:
             docs = (docs.exclude(rendered_errors__isnull=True)
                         .exclude(rendered_errors__exact='[]'))
+        if noparent:
+            # List translated pages without English source associated
+            docs = docs.filter(parent__isnull=True)
+        if toplevel:
+            docs = docs.filter(parent_topic__isnull=True)
+
         # Leave out the html, since that leads to huge cache objects and we
         # never use the content in lists.
         docs = docs.defer('html')

--- a/apps/wiki/templates/wiki/list_documents.html
+++ b/apps/wiki/templates/wiki/list_documents.html
@@ -9,6 +9,10 @@
   {% set counter = _('Found {0} templates.')|f(count) %}
 {% elif errors %}
   {% set title = _('Documents with errors') %}
+{% elif toplevel %}
+  {% set title = _('Top level documents') %}
+{% elif noparent %}
+  {% set title = _('Documents with no parent') %}
 {% else %}
   {% set title = _('All documents') %}
 {% endif %}

--- a/apps/wiki/urls.py
+++ b/apps/wiki/urls.py
@@ -53,30 +53,36 @@ urlpatterns = patterns('wiki.views',
     url(r'^/ckeditor_config.js$', 'ckeditor_config',
         name='wiki.ckeditor_config'),
 
+    # internals
     url(r'^.json$', 'json_view', name='wiki.json'),
-
-    url(r'^/templates$', 'list_templates', name='wiki.list_templates'),
-    url(r'^/files$', 'list_files', name='wiki.list_files'),
-    url(r'^/tags$', 'list_tags', name='wiki.list_tags'),
-    url(r'^/new$', 'new_document', name='wiki.new_document'),
-    url(r'^/all$', 'list_documents', name='wiki.all_documents'),
     url(r'^/preview-wiki-content$', 'preview_revision', name='wiki.preview'),
-    url(r'^/with-errors$', 'list_documents_with_errors', name='wiki.errors'),
-
     url(r'^/move-requested$',
         TemplateView.as_view(template_name='wiki/move_requested.html'),
         name='wiki.move_requested'),
-
     url(r'^/get-documents$', 'autosuggest_documents', name='wiki.autosuggest_documents'),
-    url(r'^/external-signup$', 'external_signup', name='wiki.external_signup'),
+    url(r'^/load/$', 'load_documents', name='wiki.load_documents'),
 
-    url(r'^/category/(?P<category>\d+)$', 'list_documents',
-        name='wiki.category'),
+    # Special pages
+    url(r'^/templates$', 'list_templates', name='wiki.list_templates'),
+    url(r'^/files$', 'list_files', name='wiki.list_files'),
+    url(r'^/tags$', 'list_tags', name='wiki.list_tags'),
+    url(r'^/tag/(?P<tag>.+)$', 'list_documents', name='wiki.tag'),
+    url(r'^/new$', 'new_document', name='wiki.new_document'),
+    url(r'^/all$', 'list_documents', name='wiki.all_documents'),
+    url(r'^/with-errors$', 'list_documents_with_errors', name='wiki.errors'),
+    url(r'^/without-parent$', 'list_documents_without_parent', 
+        name='wiki.without_parent'),
+    url(r'^/top-level$', 'list_top_level_documents',
+        name='wiki.top_level'),
     url(r'^/needs-review/(?P<tag>[^/]+)$', 'list_documents_for_review',
         name='wiki.list_review_tag'),
     url(r'^/needs-review/?', 'list_documents_for_review',
         name='wiki.list_review'),
+    url(r'^/external-signup$', 'external_signup', name='wiki.external_signup'),
+    url(r'^/category/(?P<category>\d+)$', 'list_documents',
+    name='wiki.category'),
 
+    # Feeds
     url(r'^/feeds/(?P<format>[^/]+)/all/?',
         DocumentsRecentFeed(), name="wiki.feeds.recent_documents"),
     url(r'^/feeds/(?P<format>[^/]+)/l10n-updates/?',
@@ -93,10 +99,6 @@ urlpatterns = patterns('wiki.views',
         RevisionsFeed(), name="wiki.feeds.recent_revisions"),
     url(r'^/feeds/(?P<format>[^/]+)/files/?',
         AttachmentsFeed(), name="wiki.feeds.recent_files"),
-
-    url(r'^/tag/(?P<tag>.+)$', 'list_documents', name='wiki.tag'),
-
-    url(r'^/load/$', 'load_documents', name='wiki.load_documents'),
 
     (r'^/(?P<document_path>[^\$]+)', include(document_patterns)),
 )

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -860,11 +860,10 @@ def list_documents(request, category=None, tag=None):
                                              tag=tag_obj)
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents.html',
-                        {'documents': paginated_docs,
-                         'count': docs.count(),
-                         'category': category,
-                         'tag': tag})
-
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'category': category,
+                   'tag': tag})
 
 @require_GET
 def list_templates(request):
@@ -872,19 +871,16 @@ def list_templates(request):
     docs = Document.objects.filter(is_template=True).order_by('title')
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents.html',
-                        {'documents': paginated_docs,
-                         'count': docs.count(),
-                         'is_templates': True})
-
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'is_templates': True})
 
 @require_GET
 def list_tags(request):
     """Returns listing of all tags"""
     tags = DocumentTag.objects.order_by('name')
     tags = paginate(request, tags, per_page=DOCUMENTS_PER_PAGE)
-    return render(request, 'wiki/list_tags.html',
-                        {'tags': tags})
-
+    return render(request, 'wiki/list_tags.html', {'tags': tags})
 
 @require_GET
 def list_files(request):
@@ -892,9 +888,7 @@ def list_files(request):
     files = paginate(request,
                      Attachment.objects.order_by('title'),
                      per_page=DOCUMENTS_PER_PAGE)
-    return render(request, 'wiki/list_files.html',
-                        {'files': files})
-
+    return render(request, 'wiki/list_files.html', {'files': files})
 
 @require_GET
 def list_documents_for_review(request, tag=None):
@@ -903,10 +897,10 @@ def list_documents_for_review(request, tag=None):
     docs = Document.objects.filter_for_review(locale=request.locale, tag=tag_obj)
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents_for_review.html',
-                        {'documents': paginated_docs,
-                         'count': docs.count(),
-                         'tag': tag_obj,
-                         'tag_name': tag})
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'tag': tag_obj,
+                   'tag_name': tag})
 
 @require_GET
 def list_documents_with_errors(request):
@@ -914,9 +908,31 @@ def list_documents_with_errors(request):
     docs = Document.objects.filter_for_list(locale=request.locale, errors=True)
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     return render(request, 'wiki/list_documents.html',
-                         {'documents': paginated_docs,
-                          'count': docs.count(),
-                          'errors': True})
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'errors': True})
+
+@require_GET
+def list_documents_without_parent(request):
+    """Lists wiki documents without parent (no English source document)"""
+    docs = Document.objects.filter_for_list(locale=request.locale,
+                                            noparent=True)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
+    return render(request, 'wiki/list_documents.html',
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'noparent': True})
+
+@require_GET
+def list_top_level_documents(request):
+    """Lists documents directly under /docs/"""
+    docs = Document.objects.filter_for_list(locale=request.locale,
+                                            toplevel=True)
+    paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
+    return render(request, 'wiki/list_documents.html',
+                  {'documents': paginated_docs,
+                   'count': docs.count(),
+                   'toplevel': True})
 
 
 @login_required


### PR DESCRIPTION
New maintenance pages :)
- Introduces https://developer-local.allizom.org/fr/docs/without-parent to list where localized documents have no parent set to an English document (translation association lost)
- Introduces https://developer-local.allizom.org/en-US/docs/top-level to list top-level pages (those living directly under docs/)
- I sorted routes in urls.py a bit, because I wanted to have a better overview of our special/maintenance pages.
- I fixed some indentation issues Jannis mentioned in the previous diff. 

Things to consider (as follow-ups?):
0) https://developer-local.allizom.org/en-US/docs/without-parent does not make sense now. As there is no translation source to set for English.
1) There is a "category" route, which I think we are not using at all. We do have categories for docs? I think this might be an inheritance from Kitsune which we could get rid of.
2) "The filter_for_list method "is slowly becoming a kitchen sink and harder to test". Jannis proposes  "multiple model manager methods". I looked at the other managers in that file, but I had no clue how to refactor it that way. Would love to help with that and learn about it in a follow-up. 
