### PR TITLE
removed window._gaq closure

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -386,9 +386,9 @@
 {% block js %}
   {% if waffle.flag('search_doc_navigator') %}
   <script type="text/javascript">
-    (function($, ga) {
-      $('.from-search-toc').mozSearchResults('{{ search_url|safe }}', ga);
-    })(jQuery, window._gaq || []);
+    (function($) {
+      $('.from-search-toc').mozSearchResults('{{ search_url|safe }}');
+    })(jQuery);
   </script>
   {% endif %}
 {% endblock %}

--- a/media/redesign/js/search.js
+++ b/media/redesign/js/search.js
@@ -6,17 +6,16 @@
     var fromSearchNav = $('.from-search-navigate');
     if(fromSearchNav.length) {
         var fromSearchList = $('.from-search-toc');
-        var ga = window._gaq || [];
         fromSearchNav.mozMenu({
             submenu: fromSearchList,
             brickOnClick: true,
             onOpen: function(){
-                ga.push(['_trackEvent',
+                mdn.analytics.trackEvent(['_trackEvent',
                                  'Search doc navigator',
                                  'Open on hover']);
             },
             onClose: function(){
-                ga.push(['_trackEvent',
+                mdn.analytics.trackEvent(['_trackEvent',
                                  'Search doc navigator',
                                  'Close on blur']);
             }
@@ -69,7 +68,7 @@
         storage.flush();
     }
 
-    $.fn.mozSearchResults = function(url, ga) {
+    $.fn.mozSearchResults = function(url) {
         var next_doc;
         var prev_doc;
         var data;
@@ -89,7 +88,7 @@
                     href: doc.url,
                     on: {
                         click: function() {
-                            ga.push(['_trackEvent',
+                            mdn.analytics.trackEvent(['_trackEvent',
                                              'Search doc navigator',
                                              'Click',
                                              $(this).attr('href'),
@@ -107,7 +106,7 @@
                         $('.from-search-next').each(function() {
                             $(this).attr('href', next_doc.url)
                                          .on('click', function() {
-                                                ga.push(['_trackEvent',
+                                                mdn.analytics.trackEvent(['_trackEvent',
                                                                  'Search doc navigator',
                                                                  'Click next',
                                                                  next_doc.url,
@@ -123,7 +122,7 @@
                         $('.from-search-previous').each(function() {
                             $(this).attr('href', prev_doc.url)
                                          .on('click', function() {
-                                                ga.push(['_trackEvent',
+                                                mdn.analytics.trackEvent(['_trackEvent',
                                                                  'Search doc navigator',
                                                                  'Click previous',
                                                                  prev_doc.url,


### PR DESCRIPTION
When Google's `ga.js` file loads it overwrites the global variable; depending on the timing of `ga.js`'s load (async script)  you might be pushing to an effective noop array ref. Tried to maintain the local var ref pattern in case a third party lib (ghostery, etc...) messed with the global.

(Duplicate/reopen of #2169 per a fat fingers misclick/close)
