### PR TITLE
Make mobile nav items inline-block

### DIFF
--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -475,10 +475,7 @@ footer {
       text-align: left;
 
       > li {
-        display: block;
-        width: auto;
-        margin-left: 0;
-        margin: 10px 0;
+        margin: 10px 10px 10px 0;
       }
     }
   }


### PR DESCRIPTION
So I don't like the tall menu for mobile anymore; wasted space.  Fixing.
