### PR TITLE
Waffle cleanup -- remove references to now-unused 'elasticsearch' flag.

### DIFF
--- a/apps/search/tests/test_filters.py
+++ b/apps/search/tests/test_filters.py
@@ -1,7 +1,5 @@
 from nose.tools import ok_
 
-from waffle.models import Flag
-
 from search.filters import (SearchQueryBackend, HighlightFilterBackend,
                             LanguageFilterBackend, DatabaseFilterBackend)
 from search.tests import ElasticTestCase
@@ -10,10 +8,6 @@ from search.views import SearchView
 
 class FilterTests(ElasticTestCase):
     fixtures = ['test_users.json', 'wiki/documents.json']
-
-    def setUp(self):
-        super(FilterTests, self).setUp()
-        Flag.objects.create(name='elasticsearch', everyone=True)
 
     def test_search_query(self):
         class SearchQueryView(SearchView):

--- a/apps/search/tests/test_views.py
+++ b/apps/search/tests/test_views.py
@@ -1,7 +1,5 @@
 from nose.tools import eq_
 
-from waffle.models import Flag
-
 from search.models import Filter, FilterGroup
 from search.tests import ElasticTestCase
 from search.views import SearchView
@@ -9,10 +7,6 @@ from search.views import SearchView
 
 class ViewTests(ElasticTestCase):
     fixtures = ['test_users.json', 'wiki/documents.json']
-
-    def setUp(self):
-        super(ViewTests, self).setUp()
-        Flag.objects.create(name='elasticsearch', everyone=True)
 
     def test_search_rendering(self):
         """The search view """

--- a/apps/search/views.py
+++ b/apps/search/views.py
@@ -41,15 +41,6 @@ class SearchView(ListAPIView):
     pagination_serializer_class = SearchSerializer
     topic_param = 'topic'
 
-    @csrf_exempt
-    def dispatch(self, request, *args, **kwargs):
-        # Google Custom Search results page
-        if not flag_is_active(request, 'elasticsearch'):
-            query = request.GET.get('q', '')
-            return render(request, 'landing/searchresults.html',
-                          {'query': query})
-        return super(SearchView, self).dispatch(request, *args, **kwargs)
-
     def initial(self, request, *args, **kwargs):
         super(SearchView, self).initial(request, *args, **kwargs)
         self.drilldown_faceting = flag_is_active(request,


### PR DESCRIPTION
See [#1898](https://github.com/mozilla/kuma/issues/1898). The "elasticsearch" flag was the only one I could still find being used anywhere, and then only in the setup for a test case.
