### PR TITLE
Use IRC notices instead of channel messages to notify about test statuses.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,5 @@ notifications:
             - "irc.mozilla.org#mdndev"
         on_success: always
         on_failure: always
+        use_notice: true
+        skip_join: true


### PR DESCRIPTION
Also don't join/leave always.
