### PR TITLE
Fix UnicodeEncodeError when sending mails after document edits with unicode characters in the title.

### DIFF
--- a/apps/devmo/email_utils.py
+++ b/apps/devmo/email_utils.py
@@ -145,10 +145,10 @@ def emails_with_users_and_watches(subject,
 
         return msg
 
-    for u, w in users_and_watches:
-        if hasattr(u, 'profile'):
-            locale = u.profile.locale
+    for user, watch in users_and_watches:
+        if hasattr(user, 'profile'):
+            locale = user.profile.locale
         else:
             locale = default_locale
 
-        yield _make_mail(locale, u, w)
+        yield _make_mail(locale, user, watch)

--- a/apps/wiki/events.py
+++ b/apps/wiki/events.py
@@ -98,8 +98,8 @@ class EditDocumentEvent(InstanceEvent):
         revision = self.revision
         document = revision.document
         log.debug('Sending edited notification email for document (id=%s)' %
-                   document.id)
-        subject = _('[MDN] Page "{document_title}" changed by {creator}')
+                  document.id)
+        subject = _(u'[MDN] Page "{document_title}" changed by {creator}')
         context = context_dict(revision)
 
         return email_utils.emails_with_users_and_watches(


### PR DESCRIPTION
This should fix the following traceback:

```
Task tidings.events._fire_task with id f7ef5e0b-6e24-4596-a249-69aa6340b829 raised exception:
"UnicodeEncodeError('ascii', u'Web\\u6280\\u672f\\u6587\\u6863', 3, 7, 'ordinal not in range(128)')"


Task was called with args: (<wiki.events.EditDocumentEvent object at 0x41c8ad0>,) kwargs: {'exclude': <User: liminjun>}.

The contents of the full traceback was:

Traceback (most recent call last):
  File "/path/to/kuma/vendor/packages/celery/celery/execute/trace.py", line 181, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/path/to/kuma/vendor/src/django-tidings/tidings/events.py", line 132, in _fire_task
    for m in self._mails(self._users_watching(exclude=exclude)):
  File "/path/to/kuma/apps/devmo/email_utils.py", line 154, in emails_with_users_and_watches
    yield _make_mail(locale, u, w)
  File "/path/to/kuma/apps/devmo/email_utils.py", line 70, in wrapper
    return f(settings.WIKI_DEFAULT_LANGUAGE, *args, **kwargs)
  File "/path/to/kuma/apps/devmo/email_utils.py", line 136, in _make_mail
    subject.format(**context_vars),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 3-6: ordinal not in range(128)
```

Also renamed some variable to have more than one character in the name.
