### PR TITLE
run south migrate before ES index

### DIFF
--- a/puppet/manifests/classes/site-config.pp
+++ b/puppet/manifests/classes/site-config.pp
@@ -158,7 +158,7 @@ class kuma_config {
             cwd => "/home/vagrant/src",
             command => "/home/vagrant/env/bin/python manage.py reindex -p 5",
             timeout => 600,
-            require => [ Service["elasticsearch"] ];
+            require => [ Service["elasticsearch"], Exec["kuma_south_migrate"] ];
     }
 }
 


### PR DESCRIPTION
This fixes the issue where we have to run `vagrant provision` twice.
