### PR TITLE
add honeypot to signin page

### DIFF
--- a/apps/users/templates/users/browserid_signin.html
+++ b/apps/users/templates/users/browserid_signin.html
@@ -13,3 +13,21 @@
       </a>
     </p>
 </form>
+
+{# hidden form to measure bot submissions from this page #}
+<form class="hidden" method="post" action="{{ url('users.honeypot') }}">
+  {{ csrf() }}
+  <label for='wpName2'>Username</label>
+  <input id="wpName2" tabindex="1" size="20" placeholder="Enter your username" name="wpName" />
+
+  <label for='wpPassword2'>Password</label>
+  <input id="wpPassword2" tabindex="3" size="20" placeholder="Enter a password" type="password" name="wpPassword" />
+
+  <label for='wpRetype'>Confirm password</label>
+  <input id="wpRetype" tabindex="5" size="20" placeholder="Enter password again" type="password" name="wpRetype" />
+
+  <label for='wpEmail'>Email address (optional)</label>
+  <input id="wpEmail" tabindex="6" size="20" placeholder="Enter yourour email address" type="email" name="wpEmail" />
+
+  <input id="wpCreateaccount" tabindex="10" type="submit" value="Create your account" name="wpCreateaccount" />
+</form>

--- a/urls.py
+++ b/urls.py
@@ -6,13 +6,20 @@ from django.shortcuts import redirect, render
 from django.views.i18n import javascript_catalog
 from django.views.decorators.cache import cache_page
 
-import jingo
 import badger
 
 
 admin.autodiscover()
 badger.autodiscover()
 
+
+# Handle 404 and 500 errors
+def _error_page(request, status):
+    """Render error pages with jinja2."""
+    return render(request, '%d.html' % status, status=status)
+handler403 = lambda r: _error_page(r, 403)
+handler404 = lambda r: _error_page(r, 404)
+handler500 = lambda r: _error_page(r, 500)
 
 urlpatterns = patterns('',
    # Home / landing pages:
@@ -71,18 +78,12 @@ urlpatterns = patterns('',
     (r'^', include('tidings.urls')),
     (r'^humans.txt$', 'django.views.static.serve',
         {'document_root': settings.HUMANSTXT_ROOT, 'path': 'humans.txt'}),
+
+    url(r'^miel$', handler500, name='users.honeypot'),
 )
 
 if settings.DEBUG:
     urlpatterns += staticfiles_urlpatterns()
-
-# Handle 404 and 500 errors
-def _error_page(request, status):
-    """Render error pages with jinja2."""
-    return render(request, '%d.html' % status, status=status)
-handler403 = lambda r: _error_page(r, 403)
-handler404 = lambda r: _error_page(r, 404)
-handler500 = lambda r: _error_page(r, 500)
 
 if settings.SERVE_MEDIA:
     media_url = settings.MEDIA_URL.lstrip('/').rstrip('/')


### PR DESCRIPTION
The invisible honeypot form will trigger a 500 that New Relic will record at the 'miel' url so we can measure how many bots might be hitting the [Sign in to Edit](https://developer-local.allizom.org/en-US/users/login?next=/en-US/docs/User%253Agroovecoder%2524edit) page.
