### PR TITLE
Fix small font size for code samples

### DIFF
--- a/media/redesign/stylus/main/tags.styl
+++ b/media/redesign/stylus/main/tags.styl
@@ -94,7 +94,7 @@ p, dl, table, pre {
 
 pre {
   compat-only(line-height, 19px);
-  font-size: smaller-font-size !important;
+  font-size: base-font-size !important;
   border: 0;
   background: #f6f6f2;
   padding: 15px;


### PR DESCRIPTION
Superseding https://github.com/mozilla/kuma/pull/1996
