### PR TITLE
fix bug 991739 - Dont' show external icon for attachments

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -160,7 +160,7 @@ enable-toc-toggle() {
 article {
   position: relative;
 
-  .external-icon {
+  .external-icon:not([href^='https://mdn.mozillademos.org']) {
     white-space: pre-line;
 
     &:before {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=991739

Did this with CSS and not JS, as CSS is better.
