### PR TITLE
fix bug 945731 - Last homepage responsive updates

### DIFF
--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -465,6 +465,14 @@
                 display: block;
             }
         }
+
+        .home-contribute {
+            li {
+                &:last-child {
+                    border-bottom: 1px solid #ececec;
+                }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This marks the last responsive update to the homepage.  It turns out we did like all of them over the past few months, but adding the last item borders should be it.

https://bugzilla.mozilla.org/show_bug.cgi?id=945731
