### PR TITLE
Removing dead ID, translate MDN text

### DIFF
--- a/apps/demos/templates/demos/launch.html
+++ b/apps/demos/templates/demos/launch.html
@@ -1,26 +1,26 @@
 <!DOCTYPE html>
-<html lang="en-US" dir="ltr" id="developer-mozilla-org" xmlns:fb="http://www.facebook.com/2008/fbml" xmlns:og="http://ogp.me/ns#">
+<html lang="en-US" dir="ltr" xmlns:fb="http://www.facebook.com/2008/fbml" xmlns:og="http://ogp.me/ns#">
 {% set full_url = request.build_absolute_uri(submission.get_absolute_url()) %}
 {% set short_url = full_url | bitly_shorten %}
 <head>
   <title>{{ page_title(_('{subtitle} | Demo Studio') | f(subtitle=submission.title)) }}</title>
-  
+
   <meta charset="utf-8">
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 
   <meta property="og:title" content="{{ submission.title }}"/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="{{ full_url }}"/>
-  <meta property="og:image" content="{{ request.build_absolute_uri(submission.screenshot_1.url) }}"/>    
+  <meta property="og:image" content="{{ request.build_absolute_uri(submission.screenshot_1.url) }}"/>
   <meta property="og:site_name" content="{{ page_title(_('Demo Studio')) }}"/>
   <meta property="og:description" content="{{ submission.summary }}"/>
 
   <meta name="description" content="{{ submission.summary }}" />
-  
+
   <link rel="stylesheet" type="text/css" media="all" href="{{ MEDIA_URL }}css/demowrap.css">
   {{ css('jquery-ui') }}
   <script src="{{ url('jsi18n') }}build:{{ BUILD_ID_JS }}"></script>
-  
+
   <!--[if IE]>
   <meta http-equiv="imagetoolbar" content="no">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
@@ -31,12 +31,12 @@
 <body>
   <header id="demobar">
   <h4 id="logo"><a href="{{ url('demos') }}"><img src="{{ MEDIA_URL }}img/mdn-logo-micro.png" alt="{{_('Mozilla Developer Network')}}" width="54" height="16"></a></h4>
-    
+
     <div class="title">
       <h1 class="demo-title"><a href="{{ submission.get_absolute_url() }}">{{ submission.title }}</a></h1>
       <p class="byline vcard">{% trans profile_link=profile_link(submission.creator) %}by {{ profile_link }}{% endtrans %}</p>
     </div>
-    
+
     <ul class="tools">
       <li>
         {% set likes = submission.likes.get_total_for_request(request) %}
@@ -46,7 +46,7 @@
                 {{ csrf() }}
                 <button type="submit" class="unlike" title="{{_('You like this demo. Undo?')}}"><span>{{_('You Like')}}</span></button>
         </form>
-        <form id="demo-like" target="like_receiver" method="POST" 
+        <form id="demo-like" target="like_receiver" method="POST"
             action="{{ url('demos_like', slug=submission.slug) }}?iframe=1"
             style="{{ likes > 0 and 'display: none' or ' ' }}">
                 {{ csrf() }}
@@ -85,7 +85,7 @@
         {% endif %}
       </ul>
     </nav>
-    
+
       <p id="close"><a href="{{ submission.demo_package.url.replace('.zip', '/index.html') }}" title="{{_('Remove this toolbar')}}">{{_('Remove toolbar')}}</a></p>
 
   {% if waffle.switch('jquery_upgrade') %}
@@ -125,12 +125,12 @@
         if (! $(e.target).parents().hasClass("share"))
           $shareOpts.hide();
       });
-      
+
       $("a, input, textarea, button").bind("focus", function(e) {
         if (! $(e.target).parents().hasClass("share"))
           $shareOpts.hide();
       });
-      
+
       $("#shorturl")
         .focus(function() {
           $(this).select().addClass("focus");
@@ -145,9 +145,9 @@
 
     });
     </script>
-    
+
   </header>
-  
+
   <iframe id="demoframe" border="no" frameborder="0" scrolling="auto"  seamless="seamless"
       src="{{ submission.demo_package.url.replace('.zip', '/index.html') }}"></iframe>
 
@@ -166,7 +166,7 @@
 
   <script type="text/javascript">
     $('#share-opts li a').click(function () {
-        window.open($(this).attr('href'), 'sharer', 
+        window.open($(this).attr('href'), 'sharer',
             'toolbar=0, status=0, resizable=1, width=626, height=436');
         return false;
     });

--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -78,7 +78,7 @@
 
         <ul id="page-buttons">
           <li><button class="btn-save" type="submit">{{ _('Move {d} Pages')|f(d=descendants_count) if descendants_count else _('Move Page') }}</button></li>
-          <li><a class="btn-discard" href="{{ url('wiki.document', document.full_path, locale=document.locale) }}">Cancel</a></li>
+          <li><a class="btn-discard" href="{{ url('wiki.document', document.full_path, locale=document.locale) }}">{{ _('Cancel') }}</a></li>
         </ul>
 
         {% if descendants_count: %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 {% from "includes/common_macros.html" import optimizely_script with context %}
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" id="developer-mozilla-org" class="redesign no-js">
+<html lang="{{ LANG }}" dir="{{ DIR }}" class="redesign no-js">
 <head prefix="og: http://ogp.me/ns#">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
@@ -27,7 +27,7 @@
   {% set social_logo = request.build_absolute_uri('/media/redesign/img/opengraph-logo.png') %}
   <meta property="og:type" content="website">
   <meta property="og:image" content="{{ social_logo }}">
-  <meta property="og:site_name" content="Mozilla Developer Network">
+  <meta property="og:site_name" content="{{ _('Mozilla Developer Network') }}">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:image" content="{{ social_logo }}">
   <meta name="twitter:site" content="@NewOnMDN">

--- a/templates/base_popup.html
+++ b/templates/base_popup.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" id="developer-mozilla-org">
+<html lang="{{ LANG }}" dir="{{ DIR }}">
 <head>
   <meta charset="utf-8">
   <title>{% block title %}{{ _('Mozilla Developer Network') }}{% endblock %}</title>
@@ -40,7 +40,7 @@
   {% endif %}
 
   {{ js('popup') }}
-  
+
 {% endblock %}
 {% block js %}{% endblock %}
 {# end js #}


### PR DESCRIPTION
We don't need the domain ID on documents, and we should translate "Mozilla Developer Network" for consistency.
