### PR TITLE
Remove Space Odyssey copy from error pages

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -25,7 +25,7 @@
     {% elif reason == 'bannedprofile' %}
       <p class="notice">{{ _("This user's account has been banned.") }}</p>
     {% endif %}
-  
+
     <img src="{{ MEDIA_URL }}img/beast-403.png" alt="" class="beast 403">
 
     {% if user.username %}
@@ -55,20 +55,16 @@
       </ul>
 
       {% trans %}
-      <p>No computer has ever made a mistake or distorted information. We are all, by any practical definition of the words, foolproof and incapable of error. So it can only be attributable to human error. If so, <a href="https://bugzilla.mozilla.org/form.mdn" rel="nofollow">file a bug</a> for my human operators.</p>
-      {% endtrans %}
-      
-      {% trans %}
       <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>
       {% endtrans %}
-  
+
   </section>
 
 </div>
 </section>
-      
+
 {% endblock %}
- 
+
 {% block site_js %}
     {{ super() }}
     {{ js('framebuster') }}

--- a/templates/handlers/400.html
+++ b/templates/handlers/400.html
@@ -43,17 +43,13 @@
         {% endtrans %}
       </ul>
 
-      {% trans %}
-      <p>No computer has ever made a mistake or distorted information. We are all, by any practical definition of the words, foolproof and incapable of error. So it can only be attributable to human error. If so, <a href="https://bugzilla.mozilla.org/form.mdn">file a bug</a> for my human operators.</p>
-      {% endtrans %}
-  
   </section>
 
 </div>
 </section>
-      
+
 {% endblock %}
- 
+
 {% block site_js %}
     {{ super() }}
     {{ js('framebuster') }}


### PR DESCRIPTION
While funny, some people who report bugs appear not to get the
reference, which might lead them to feel insulted. Quoting the
description of the Bugzilla keyword "ux-tone" used by the user
experience team:

```
User experience principle: interfaces should not blame the user, or
communicate in a way that is overly negative or dramatic.
```

---

I also intentionally remove the bug link. My thinking is that the error message is helpful enough already, suggesting specific courses of action, that linking to a bug form seems unprofessional (at least to me), and that truly important bugs will be reported whether we provide a link or not. But I am open to different opinions on this part of the PR.
