### PR TITLE
Ensure noninteractive mode for tracking analytics events

### DIFF
--- a/media/redesign/js/analytics.js
+++ b/media/redesign/js/analytics.js
@@ -107,14 +107,16 @@
                 analytics.trackEvent([
                     'JavaScript error',
                     e.originalEvent.message,
-                    e.originalEvent.filename + ':' + e.originalEvent.lineno
+                    e.originalEvent.filename + ':' + e.originalEvent.lineno,
+                    true
                 ]);
             });
             $(doc).ajaxError(function(e, request, settings) {
                 analytics.trackEvent([
                     'Ajax error',
                     settings.url,
-                    e.result
+                    e.result,
+                    true
                 ]);
             });
         }


### PR DESCRIPTION
Based on a comment here:  http://davidwalsh.name/track-errors-google-analytics
