### PR TITLE
Prevent massive amounts of site AJAX errors via search

### DIFF
--- a/media/redesign/js/search.js
+++ b/media/redesign/js/search.js
@@ -137,7 +137,7 @@
         }
 
         if (url === '') {
-            if (key === null) {
+            if (key === null || key === undefined) {
                 return this;
             } else {
                 url = key;


### PR DESCRIPTION
I'm seeing loads of AJAX errors that only occur when _not_ coming from search, and I think the fix is as simple as this.  We don't need this AJAX request if no referrer, right Janis?
