### PR TITLE
Ensure document.querySelectorAll exists before loading prism

### DIFF
--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -119,7 +119,7 @@
     /*
         Syntax highlighting scripts
     */
-    $('article pre').length && (function() {
+    $('article pre').length && ('querySelectorAll' in document) && (function() {
         var mediaPath = win.mdn.mediaPath;
         $('<link />').attr({
             type: 'text/css',


### PR DESCRIPTION
Prevents the few IE8 errors we're seeing due to Prism
