### PR TITLE
First refactor of the search navigator JS

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -165,14 +165,14 @@
       <!-- heading -->
       <div id="wiki-document-head" class="document-head">
         {% if search_doc_navigator_enabled %}
-          <span class="from-search-previous-box">
+          <span class="from-search-previous-box hidden">
             <a href="" class="button from-search-previous only-icon"><i aria-hidden="true" class="icon-chevron-left"></i></a>
           </span>
-          <span class="hidden">
+          <span class="from-search-navigate-wrap hidden">
             <a href="" class="from-search-navigate"><span class="from-search-navigate-up"><i aria-hidden="true" class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i aria-hidden="true" class="icon-double-angle-down"></i></span></a>
           </span>
           <div class="from-search-toc hidden"><ol></ol></div>
-          <span class="from-search-next-box">
+          <span class="from-search-next-box hidden">
             <a class="button from-search-next only-icon"><i aria-hidden="true" class="icon-chevron-right"></i></a>
           </span>
           {% endif %}

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -209,10 +209,6 @@ article {
     padding-left: (grid-spacing * 2);
 }
 
-.from-search-previous-box, .from-search-next-box {
-  display: none;
-}
-
 .from-search-previous, .from-search-next {
   position: absolute;
   top: (grid-spacing * .75) + 2px;


### PR DESCRIPTION
This will be first step of the search nav refactor.  In this I validate that the search navigator should display, _at all_, on the given wiki page.  I also modify the show/hide of the "<", ">", and "^v" placement.
