### PR TITLE
fix bug 992653 - Prevent adv menu from going offscreen on mobile

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -51,7 +51,7 @@
               {% endif %}
             </ul>
           </div>
-        </div></li>{% endif %}<li><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><button id="advanced-menu" class="only-icon" aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false"><span>{{ _('Advanced') }}</span><i aria-hidden="true" class="icon-cog"></i></button>
+        </div></li>{% endif %}<li class="page-buttons-edit"><a href="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" class="button">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li><li><button id="advanced-menu" class="only-icon" aria-haspopup="true" aria-owns="advanced-menu-submenu" aria-expanded="false"><span>{{ _('Advanced') }}</span><i aria-hidden="true" class="icon-cog"></i></button>
 
         <div class="submenu" id="advanced-menu-submenu">
           <!-- this page -->

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -1134,6 +1134,10 @@ div.revision-info li {
     }
   }
 
+  .page-buttons > li.page-buttons-edit {
+    display: none;
+  }
+
   /* display the attachments table as inline */
   #page-attachments {
 


### PR DESCRIPTION
Fixing this by preventing the "Edit" button from showing up on iOS and smaller.  No need for it as CKE probably wouldn't work there anyway.
