### PR TITLE
Work around a character-encoding issue in search.

### DIFF
--- a/apps/search/store.py
+++ b/apps/search/store.py
@@ -15,8 +15,17 @@ PAGE_PARAM = 'page'
 
 def referrer_url(request):
     referrer = request.META.get('HTTP_REFERER', None)
-    if (referrer is None or
-            reverse('search', locale=request.locale) != URL(referrer).path):
+
+    # Non-ASCII referers can be problematic.
+    # TODO: The 'ftfy' library can probably fix these, but may not be
+    # worth the effort.
+    try:
+        urlpath = URL(referrer).path
+    except UnicodeDecodeError:
+        urlpath = None
+        
+    if (referrer is None or urlpath is None or
+            reverse('search', locale=request.locale) != urlpath):
         return None
     return referrer
 

--- a/apps/search/tests/test_utils.py
+++ b/apps/search/tests/test_utils.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 from test_utils import TestCase
 
+from search.store import referrer_url
 from search.utils import QueryURLObject
 
 
@@ -28,3 +29,17 @@ class URLTests(TestCase):
 
         eq_(url.merge_query_param('spam', 'eggs'), original)
         eq_(url.merge_query_param('spam', 'spam'), original + '&spam=spam')
+
+
+    def test_referer_bad_encoding(self):
+        class _TestRequest(object):
+            # In order to test this we just need an object that has
+            # 'locale' and 'META', but not the full attribute set of
+            # an HttpRequest. This is that object.
+            def __init__(self, locale, referer):
+                self.locale = locale
+                self.META = {'HTTP_REFERER': referer}
+
+        request = _TestRequest('es', 'http://developer.mozilla.org/es/docs/Tutorial_de_XUL/A\xc3\x83\xc2\xb1adiendo_botones')
+        ok_(referrer_url(request) is None)
+        


### PR DESCRIPTION
The problem here is that non-ASCII referers will sometimes behave
properly but sometimes not. Properly fixing this would likely be more
effort than it's worth, as it would involve cleaning up things like
borked "Ã±" sequences in referers.

So this simply slaps a small band-aid on the problem: when URLObject
throws a UnicodeDecodeError, we bail out rather than trying to undo
whatever sequence of multiply-encoded byte mangling turned the referer
into the monster that it is.
