### PR TITLE
Add uncss and uglify to the dev environment

### DIFF
--- a/puppet/manifests/classes/cleancss.pp
+++ b/puppet/manifests/classes/cleancss.pp
@@ -1,0 +1,10 @@
+# Get clean-css
+class cleancss {
+    exec { 'cleancss-install':
+        command => '/usr/bin/npm install -g clean-css@2.1.8',
+        creates => '/usr/local/bin/cleancss',
+        require => [
+            Package['nodejs'],
+        ]
+    }
+}

--- a/puppet/manifests/classes/stylus.pp
+++ b/puppet/manifests/classes/stylus.pp
@@ -1,13 +1,13 @@
 # Get stylus
 class stylus {
     exec { 'stylus-install':
-        command => "/usr/bin/npm install -g stylus",
-        creates => "/usr/local/bin/stylus",
+        command => '/usr/bin/npm install -g stylus@0.42.1',
+        creates => '/usr/local/bin/stylus',
         require => [
-            Package["nodejs"],
+            Package['nodejs'],
         ]
     }
-    file { "/usr/local/bin/stylus":
+    file { '/usr/local/bin/stylus':
         require => Exec['stylus-install'],
     }
 }

--- a/puppet/manifests/classes/uglify.pp
+++ b/puppet/manifests/classes/uglify.pp
@@ -1,0 +1,10 @@
+# Get uglify
+class uglify {
+    exec { 'uglify-install':
+        command => '/usr/bin/npm install -g uglify-js@2.4.13',
+        creates => '/usr/local/bin/uglifyjs',
+        require => [
+            Package['nodejs'],
+        ]
+    }
+}

--- a/puppet/manifests/dev-vagrant.pp
+++ b/puppet/manifests/dev-vagrant.pp
@@ -68,6 +68,8 @@ class dev {
         python: stage => langs;
 
         stylus: stage => extras;
+        cleancss: stage => extras;
+        uglify: stage => extras;
 
         site_config: stage => main;
         dev_hacks_post: stage => hacks_post;

--- a/settings.py
+++ b/settings.py
@@ -583,6 +583,9 @@ TOWER_ADD_HEADERS = True
 
 # Bundles for JS/CSS Minification
 JINGO_MINIFY_USE_STATIC = False
+CLEANCSS_BIN = '/usr/bin/cleancss'
+UGLIFY_BIN = '/usr/bin/uglifyjs'
+
 MINIFY_BUNDLES = {
     'css': {
         'mdn': (
@@ -744,8 +747,6 @@ MINIFY_BUNDLES = {
         ),
     },
 }
-
-JAVA_BIN = '/usr/bin/java'
 
 #
 # Session cookies


### PR DESCRIPTION
Resolved #1794

Uglify is a modern JS minifier (YUI is long dead) and clean-css does massive optimizations to CSS beyond minification, like merging likewise selectors and more.

Notes
-  I'm not sure I have these puppet manifests correct
-  I had to upgrade NodeJS to get a reasonable clean-css and uglify version.

So...this is minimally waiting on (1) IT to upgrade Node and (2) someone to tell me if I've done the puppet stuff right.
