### PR TITLE
Implement font-size width rems

### DIFF
--- a/media/redesign/stylus/badges.styl
+++ b/media/redesign/stylus/badges.styl
@@ -31,7 +31,7 @@
             white-space: normal;
             text-decoration: none;
             width: 128px;
-            font-size: smaller-font-size;
+            set-smaller-font-size();
 
             &:before {
                 content: '✸ ';
@@ -221,7 +221,7 @@ input[type="submit"].delete-badge {
 
     .badge-text {
         font-weight: bold;
-        font-size: 18px;
+        set-font-size(18px);
         line-height: 20px;
     }
 }
@@ -262,7 +262,7 @@ input[type="submit"].delete-badge {
 
     .badge-notify {
         font-weight: bold;
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         text-transform: uppercase;
     }
 
@@ -273,7 +273,7 @@ input[type="submit"].delete-badge {
     .badge-headline {
         font-weight: bold;
         color: text-color;
-        font-size: 18px;
+        set-font-size(18px);
         font-weight: bold;
         line-height: 22px;
     }

--- a/media/redesign/stylus/calendar.styl
+++ b/media/redesign/stylus/calendar.styl
@@ -30,7 +30,7 @@
 }
 
 table.events {
-    font-size: 12px;
+    set-smaller-font-size();
 
     thead {
         background: #d6d6c6;

--- a/media/redesign/stylus/dashboards.styl
+++ b/media/redesign/stylus/dashboards.styl
@@ -39,7 +39,7 @@
         }
 
         .new, .locale {
-            font-size: 11px;
+            set-font-size(11px);
             border-radius: 8px;
             color: #fff;
             display: inline-block;
@@ -64,7 +64,7 @@
     }
 
     .dashboard-slug {
-        @extend .smaller;
+        set-smaller-font-size();
         opacity: 0.8;
         font-style: italic;
         display: block;

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -60,7 +60,7 @@ home-involved-background-y = 50px;
             color: #0095dd;
             background-position: 0 -222px;
             background-size: 205px auto;
-            font-size: 30px;
+            set-font-size(30px);
             margin-right: 5px;
 
             &.blue {
@@ -108,7 +108,7 @@ home-involved-background-y = 50px;
     }
 
     .entry-meta {
-        @extend .smaller;
+        set-smaller-font-size();
         font-style: italic;
     }
 }
@@ -151,7 +151,7 @@ home-involved-background-y = 50px;
     }
 
     h3 {
-        @extend .larger;
+        set-larger-font-size();
         font-weight: bold;
         font-family: 'Open Sans Extra Bold', sans-serif;
 
@@ -192,7 +192,7 @@ home-involved-background-y = 50px;
         padding: 100px grid-spacing grid-spacing grid-spacing;
         position: relative;
         overflow-x: hidden;
-        font-size: larger-font-size;
+        set-larger-font-size();
 
         &:before {
             bidi-style(content, '\f061', content, '\f060');
@@ -200,7 +200,7 @@ home-involved-background-y = 50px;
             font-family: 'FontAwesome';
             bottom: grid-spacing;
             position: absolute;
-            font-size: 24px;
+            set-font-size(24px);
             z-index: 4;
         }
     }
@@ -246,7 +246,7 @@ home-involved-background-y = 50px;
         letter-spacing: 0;
         line-height: normal;
         margin-bottom: 0;
-        font-size: base-font-size;
+        set-font-size(base-font-size);
 
         a {
             text-decoration: underline;
@@ -279,12 +279,12 @@ home-involved-background-y = 50px;
         }
 
         .number {
-            font-size: 30px;
+            set-font-size(30px);
             font-weight: bold;
         }
 
         h2 {
-            @extend .larger;
+            set-larger-font-size();
             padding-bottom: (grid-spacing / 2);
             border-bottom: 1px solid #e0e2e4;
             margin-bottom: 110px;
@@ -319,7 +319,7 @@ home-involved-background-y = 50px;
     }
 
     .home-demos-list-item {
-        @extend .smaller;
+        set-smaller-font-size();
         display: block;
         text-align: center;
         margin: 0 auto;
@@ -382,7 +382,7 @@ home-involved-background-y = 50px;
     }
 
     h3 {
-        @extend .larger;
+        set-larger-font-size();
         font-weight: bold;
         text-transform: uppercase;
     }
@@ -413,7 +413,7 @@ home-involved-background-y = 50px;
 
     .column-callout {
         a {
-            font-size: base-bump-font-size;
+            set-font-size(base-bump-font-size);
         }
     }
 }
@@ -441,7 +441,7 @@ home-involved-background-y = 50px;
 
         .column-callout {
             a {
-                font-size: larger-font-size;
+                set-larger-font-size();
             }
         }
 
@@ -476,7 +476,7 @@ home-involved-background-y = 50px;
         }
 
         .home-demos h2, .home-contribute h2, .column-hacks > h2 {
-            font-size: 20px;
+            set-font-size(20px);
 
             > i {
                 display: none;

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -6,6 +6,32 @@
 
 VENDOR-PREFIXES = '-webkit-' '-moz-' '-ms-';
 
+set-font-size(value) {
+    font-size: value;
+
+    if (value is not inherit) {
+        font-size: remify(value);
+    }
+}
+
+remify(value) {
+    u = unit(value);
+
+    if (u is 'px') {
+        return unit(value/base-font-size, 'rem')
+    } else {
+        return unit(value, u)
+    }
+}
+
+set-smaller-font-size() {
+    set-font-size(smaller-font-size);
+}
+set-larger-font-size() {
+    set-font-size(base-bump-font-size);
+}
+
+
 /* vendorizes a propery */
 vendorize(property, value) {
     for prefix in VENDOR-PREFIXES {
@@ -135,7 +161,7 @@ set-message-base() {
     compat-only(border-style, solid);
     padding: (grid-spacing / 2);
     margin-bottom: grid-spacing;
-    font-size: smaller-font-size;
+    set-smaller-font-size();
 
     & *:last-child {
         margin-bottom: 0;
@@ -245,17 +271,17 @@ bidi-value-vendorize(prop, ltr, rtl, make-important = false) {
     These are not dynamic but serve as mixins so that styles wont be repeated throughout files
 */
 heading-1() {
-    font-size: (content-block-margin * 2);
+    set-font-size((content-block-margin * 2));
     letter-spacing: -2px;
 }
 
 heading-2() {
-    font-size: 30px;
+    set-font-size(30px);
     letter-spacing: -1px;
 }
 
 big-search() {
-    @extend .larger;
+    set-larger-font-size();
     display: block;
     margin: 0 auto;
     background: rgba(255, 255, 255, 0.2);
@@ -339,7 +365,7 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
     }
 
     a {
-        @extend .smaller;
+        set-smaller-font-size();
         padding: 5px 0;
         display: block;
     }
@@ -381,20 +407,6 @@ component-submenu-method(menu-width, num-columns, background-color, arrow-border
             }
         }
     }
-}
-
-/*
-    CLASSES TO BE EXTENDED BY OTHER CLASSES
-
-    These are very "general" and non-specific on purpose
-    There's a good chance these classes wont be used directly in HTML
-*/
-.smaller {
-    font-size: smaller-font-size;
-}
-
-.larger {
-    font-size: larger-font-size;
 }
 
 

--- a/media/redesign/stylus/learn.styl
+++ b/media/redesign/stylus/learn.styl
@@ -22,12 +22,12 @@
             text-align: justify;
 
             &.intro {
-                font-size: base-bump-font-size;
+                set-font-size(base-bump-font-size);
             }
         }
 
         &.landing p {
-            font-size: larger-font-size;
+            set-larger-font-size();
             text-align: center;
         }
 
@@ -58,7 +58,7 @@
         li {
             background: none;
             float: left;
-            font-size: smaller-font-size;
+            set-smaller-font-size();
             margin: 0 0 0 10%;
             text-shadow: 0 0 1px #000;
             width: 22%;
@@ -122,7 +122,7 @@ h2 {
     position: relative;
 
     h2 {
-        font-size: base-font-size;
+        set-font-size(base-font-size);
         line-height: 1.22;
     }
 
@@ -151,7 +151,7 @@ h2 {
 
 #learn-fineprint {
     clear: both;
-    font-size: 11px;
+    set-font-size(11px);
     margin: grid-spacing grid-spacing (grid-spacing * 2);
 }
 
@@ -165,14 +165,14 @@ h2 {
 }
 
 .link-list {
-    font-size: smaller-font-size;
+    set-smaller-font-size();
 
     .title {
         margin: 5px 0;
     }
 
     .source {
-        font-size: 11px;
+        set-font-size(11px);
         font-weight: normal;
         color: #666;
     }
@@ -257,7 +257,7 @@ h2 {
         background: rgba(0,0,0,.85);
         border-radius: 5px;
         color: #ccc;
-        font-size: 11px;
+        set-font-size(11px);
         padding: (grid-spacing / 2);
         text-shadow: 0 0 1px #000;
         vendorize(box-shadow, 0 2px 2px rgba(0,0,0,.15));

--- a/media/redesign/stylus/main/components.styl
+++ b/media/redesign/stylus/main/components.styl
@@ -54,7 +54,7 @@
 
   .toggle-container {
     a {
-      @extend .smaller;
+      set-smaller-font-size();
       display: block;
       padding: list-item-spacing grid-spacing;
     }

--- a/media/redesign/stylus/main/globals.styl
+++ b/media/redesign/stylus/main/globals.styl
@@ -1,4 +1,4 @@
-/* 
+/*
   Styles for overall document.  Minimally styles the canvas.
 */
 
@@ -6,10 +6,12 @@
 
 html {
   background: #fff;
+  font-size: base-font-size;
 }
 
 body {
-  font: 14px/1.5 site-font-family;
+  font-family: site-font-family;
+  line-height: 1.5;
   color: text-color;
   create-gradient-background(header-background-color);
 }

--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -20,13 +20,21 @@
   title-header();
 }
 
+.smaller {
+  set-smaller-font-size();
+}
+
+.larger {
+  set-larger-font-size();
+}
+
 .grid-padding {
   padding: grid-spacing;
 }
 
 .heading-link {
   font-style: italic;
-  font-size: base-font-size;
+  set-font-size(base-font-size);
   font-weight: normal;
   display: inline-block;
   margin-left: (grid-spacing * 2);
@@ -49,7 +57,7 @@ draw-grid();
 
   .wrap {
     @extend .center;
-    @extend .smaller;
+    set-smaller-font-size();
     compat-important(padding-left, 24px);
     compat-important(padding-right, 24px);
     compat-important(padding-top, 10px);
@@ -204,7 +212,7 @@ draw-grid();
   position: absolute;
   right: 200px;
   top: 12px;
-  font-size: small-bump-font-size;
+  set-font-size(small-bump-font-size);
 
   li + li {
     bidi-style(border-left, 1px solid #bbb, border-right, 0);
@@ -240,7 +248,7 @@ a.persona-button {
     outline: none;
     display: block;
     float: left;
-    font-size: 14px;
+    set-font-size(base-font-size);
     line-height: 24px;
     color: white;
     padding: 0 10px 0 20px;
@@ -349,7 +357,7 @@ main {
 
 /* footer */
 footer {
-  @extend .smaller;
+  set-smaller-font-size();
   background: #fff;
   padding:  first-content-top-padding 0 0 0;
 
@@ -436,7 +444,7 @@ footer {
 
         > a {
           i {
-            @extend .larger;
+            set-larger-font-size();
           }
         }
       }

--- a/media/redesign/stylus/main/tags.styl
+++ b/media/redesign/stylus/main/tags.styl
@@ -59,12 +59,12 @@ h2 {
 }
 
 h3 {
-  font-size: 24px;
+  set-font-size(24px);
   letter-spacing: -0.5px;
 }
 
 h4 {
-  font-size: 18px;
+  set-font-size(18px);
   letter-spacing: -0.25px;
 }
 
@@ -94,7 +94,7 @@ p, dl, table, pre {
 
 pre {
   compat-only(line-height, 19px);
-  font-size: base-font-size !important;
+  set-font-size(base-font-size !important);
   border: 0;
   background: #f6f6f2;
   padding: 15px;
@@ -126,7 +126,7 @@ input[type=text], input[type=password], input[type=search], input[type=email], i
 
 input, button, textarea, select, optgroup, option {
   font-family: inherit;
-  font-size: inherit;
+  set-font-size(inherit);
   font-style: inherit;
   font-weight: inherit;
 }

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -15,7 +15,7 @@
     b {
         color: #a19f93;
         font-weight: normal;
-        font-size: larger-font-size;
+        set-larger-font-size();
     }
 
     .photo {
@@ -29,7 +29,7 @@
     .links {
         border-spacing: (grid-spacing / 2);
         display: table;
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         margin: -(@border-spacing); // Offset outer border
 
         li {
@@ -42,7 +42,7 @@
         }
 
         i {
-            font-size: base-font-size;
+            set-font-size(base-font-size);
             text-align: center;
         }
 
@@ -71,7 +71,7 @@
     }
 
     .bio {
-        font-size: smaller-font-size;
+        set-smaller-font-size();
     }
 
     .info {
@@ -96,20 +96,20 @@
         margin-bottom: 5px;
 
         h2 {
-            font-size: base-font-size;
+            set-font-size(base-font-size);
             margin-bottom: 0;
         }
 
         li {
             display: inline;
-            font-size: smaller-font-size;
+            set-smaller-font-size();
             margin: 0 10px 0 0;
         }
     }
 
     .memberSince {
         color: #6a9412;
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         font-style: italic;
     }
 
@@ -145,7 +145,7 @@
 
 table.activity {
     border-collapse: collapse;
-    font-size: smaller-font-size;
+    set-smaller-font-size();
     width: 100%;
 
     td, th {
@@ -154,7 +154,7 @@ table.activity {
 
     th {
         h3 {
-            font-size: base-bump-font-size;
+            set-font-size(base-bump-font-size);
             margin: 0 0 (grid-spacing / 4);
         }
         &.date {
@@ -189,7 +189,7 @@ table.activity {
     }
 
     .actions {
-        font-size: 10px;
+        set-font-size(10px);
 
         li {
             display: inline;
@@ -209,7 +209,7 @@ table.activity {
     }
 
     .extra {
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         figcaption {
             margin: (grid-spacing / 2) 0;
         }
@@ -282,7 +282,7 @@ table.activity {
 
 .profile-display, .profile-edit {
     .page-title {
-        font-size: 26px;
+        set-font-size(26px);
         letter-spacing: 0;
         margin-bottom: (grid-spacing / 2);
     }

--- a/media/redesign/stylus/promote.styl
+++ b/media/redesign/stylus/promote.styl
@@ -69,7 +69,7 @@ preview-box-total-width = (preview-box-width + (box-padding * 2) + (box-border-w
     }
 
     h3, h4, label {
-        font-size: 16px;
+        set-font-size(base-bump-font-size);
     }
 
     h4 {

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -65,7 +65,7 @@ p {
     }
 
     h4 {
-        @extend .larger
+        set-larger-font-size();
     }
 
     h4, {selector-icon} { /* bug #938074 */
@@ -98,7 +98,7 @@ p {
 }
 
 .result-list-link {
-    @extend .smaller;
+    set-smaller-font-size();
     font-style: italic;
 
     {selector-icon} {
@@ -128,7 +128,7 @@ p {
             margin-bottom: 30px;
         }
         legend {
-            font-size: 24px;
+            set-font-size(24px);
             letter-spacing: -0.5px;
             margin: -7px 0 (grid-spacing / 2);
 

--- a/media/redesign/stylus/submission.styl
+++ b/media/redesign/stylus/submission.styl
@@ -3,7 +3,7 @@
 
 .submission {
     .section {
-        font-size: small-bump-font-size;
+        set-font-size(small-bump-font-size);
         margin: 0 0 grid-spacing;
         padding: 35px 0 0;
         position: relative;
@@ -11,7 +11,7 @@
         & > legend {
             b {
                 display: block;
-                font-size: base-bump-font-size;
+                set-font-size(base-bump-font-size);
                 position: absolute;
             }
         }
@@ -40,7 +40,7 @@
     .note {
         color: #666;
         font-family: inherit;
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         font-style: normal;
         font-weight: normal;
     }

--- a/media/redesign/stylus/wiki-editor.styl
+++ b/media/redesign/stylus/wiki-editor.styl
@@ -1,15 +1,15 @@
 @import 'includes/vars'
 
 /* styles for the WYSIWYG editor which we cannot take directly from screen.css */
-html, body { 
-  background: #fff; 
+html, body {
+  background: #fff;
 }
-html.maximized { 
-  overflow-y: auto !important; 
+html.maximized {
+  overflow-y: auto !important;
 }
-body { 
-  font: 14px/1.5 'Open Sans', sans-serif; 
-  padding: 0 grid-spacing; 
+body {
+  font: 14px/1.5 'Open Sans', sans-serif;
+  padding: 0 grid-spacing;
 }
 
 
@@ -20,7 +20,7 @@ body {
   position: relative;
 
   &:before {
-    font-size: 10px;
+    set-font-size(10px);
     content: 'SEO Summary';
     position: absolute;
     top: -16px;
@@ -50,7 +50,7 @@ pre {
   position: relative;
 }
 pre:before {
-  font-size: 12px;
+  set-smaller-font-size();
   font-family: arial, sans-serif;
   font-style: italic;
   position: absolute;
@@ -80,7 +80,7 @@ createLanguageQuery('xml', 'XML');
 li[data-default-state='open'] > a:after {
   content: '(defaults to "open")';
   color: #666;
-  font-size: 12px;
+  set-smaller-font-size();
   font-family: arial, sans-serif;
   font-style: italic;
   display: inline-block;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -73,7 +73,7 @@ enable-toc-toggle() {
 
 /* quick links */
 .quick-links {
-  @extend .smaller;
+  set-smaller-font-size();
   position: relative;
   margin-bottom: grid-spacing;
 
@@ -135,7 +135,7 @@ enable-toc-toggle() {
 
 .quick-links {selector-icon}, #quick-links-toggle {selector-icon} {
   bidi-style(left, -6px, right, auto);
-  font-size: 14px;
+  set-font-size(base-font-size);
   position: absolute;
   top: 1px;
 
@@ -150,8 +150,8 @@ enable-toc-toggle() {
 /* document review form stuff */
 .reviews {
   set-message-base();
-  @extend .smaller;
-  @extend .review-base
+  set-smaller-font-size();
+  @extend .review-base;
 
   p {
     margin: 0;
@@ -176,7 +176,7 @@ article {
     .html-ltr &:before, .html-rtl &:after {
       content: '\f08e';
       font-family: FontAwesome;
-      font-size: 9px;
+      set-font-size(9px);
       display: inline-block;
       opacity: 0.5;
       margin-right: 3px;
@@ -212,7 +212,7 @@ article {
   }
 
   .contributor-avatars {
-    @extend .smaller;
+    set-smaller-font-size();
     color: #777;
     padding: 10px 10px 6px;
     border-bottom: 1px solid rgb(241, 241, 241);
@@ -315,7 +315,7 @@ article {
 }
 
 .from-search-navigate {
-  @extend .larger;
+  set-larger-font-size();
   position: relative;
   color: #ced1d2;
   display: inline-block;
@@ -325,7 +325,7 @@ article {
 }
 
 .from-search-navigate-up, .from-search-navigate-down {
-  @extend .smaller;
+  set-smaller-font-size();
   position: absolute;
   left: 0;
 }
@@ -340,7 +340,7 @@ article {
 
 .from-search-toc {
   component-submenu-method(200px, 1, button-background, button-shadow-color)
-  @extend .smaller;
+  set-smaller-font-size();
   border: 1px solid button-shadow-color;
   left: 66px;
   top: 0;
@@ -364,7 +364,7 @@ article {
 }
 
 .redirected-from {
-  @extend .smaller;
+  set-smaller-font-size();
   margin-top: -(grid-spacing);
   font-style: italic;
   opacity: 0.7;
@@ -372,7 +372,7 @@ article {
 
 /* wiki article cookie crumbs */
 .crumbs {
-  @extend .smaller;
+  set-smaller-font-size();
   margin-bottom: (grid-spacing / 2);
 
   li {
@@ -390,7 +390,7 @@ article {
       font-family: FontAwesome;
       text-decoration: none;
       color: #c1c2c4;
-      font-size: 70%;
+      set-font-size(70%);
     }
   }
 
@@ -422,7 +422,7 @@ article {
     }
 
     {selector-icon} {
-      font-size: 16px;
+      set-font-size(base-bump-font-size);
     }
   }
 
@@ -452,7 +452,7 @@ article {
 /* notice at the top of the article */
 .notice {
   set-message-base();
-  font-size: base-font-size;
+  set-font-size(base-font-size);
   compat-important(border-width, 2px);
 }
 
@@ -462,7 +462,7 @@ article {
   background: rgba( 193, 56, 50, 0.85);
   compat-important(border-color, rgba(0, 0, 0, 0.1));
   compat-only(color, #fff);
-  font-size: base-font-size;
+  set-font-size(base-font-size);
 
   pre {
     padding: (grid-spacing / 2) !important;
@@ -501,7 +501,7 @@ div.bug, div.warning, div.overheadIndicator {
 
 /* contributors block at the bottom of the article */
 .contributors {
-  @extend .smaller;
+  set-smaller-font-size();
   color: #777;
 
   {selector-icon} {
@@ -524,7 +524,7 @@ div.bug, div.warning, div.overheadIndicator {
   position: relative;
 
   ul, > a {
-    @extend .smaller;
+    set-smaller-font-size();
     display: inline-block;
   }
 
@@ -553,7 +553,7 @@ div.bug, div.warning, div.overheadIndicator {
 }
 
 .tags a, .tagit li {
-  @extend .smaller;
+  set-smaller-font-size();
   padding: 1px 4px;
   border: 1px solid #cee9f9 !important; /* overrides plugin selector */
   text-decoration: none;
@@ -571,7 +571,7 @@ div.bug, div.warning, div.overheadIndicator {
 }
 
 .tagit li {
-  font-size: base-font-size;
+  set-font-size(base-font-size);
 }
 
 .tagit, .tagit-new {
@@ -660,7 +660,7 @@ div.bug, div.warning, div.overheadIndicator {
 .page-meta section h2,
 .page-meta section h3 {
   .editor-help-icon {
-    font-size: 20px;
+    set-font-size(20px);
   }
 }
 
@@ -682,7 +682,7 @@ div.bug, div.warning, div.overheadIndicator {
     margin-bottom: (grid-spacing);
 
     .action {
-      @extend .larger;
+      set-larger-font-size();
       display: block;
       line-height: 20px;
     }
@@ -699,7 +699,7 @@ div.bug, div.warning, div.overheadIndicator {
 
   h2 {
     font-family: site-font-family;
-    font-size: 28px; /* Change to h3 after redesign launched */
+    set-font-size(28px); /* Change to h3 after redesign launched */
     compat-only(text-transform, none);
     margin-bottom: grid-spacing;
   }
@@ -815,7 +815,7 @@ span.cke_skin_kuma {
 /* compare page */
 .compare, #revision-list {
   ul {
-    @extend .smaller;
+    set-smaller-font-size();
     compat-only(min-width, 0);
   }
 
@@ -839,7 +839,7 @@ span.cke_skin_kuma {
 .offline-notice {
   margin-top: -20px;
   margin-bottom: 20px;
-  font-size: 11px;
+  set-font-size(11px);
   margin-left: 6px;
 }
 

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -79,7 +79,7 @@
     }
 
     h3.title {
-        font-size: base-font-size;
+        set-font-size(base-font-size);
         margin: 6px 0 0 0;
     }
 }
@@ -94,7 +94,7 @@
 
     .masthead-text {
         p {
-            @extend .larger;
+            set-larger-font-size();
             font-weight: light-font-weight;
         }
     }
@@ -210,7 +210,7 @@
         @extend .dev-program-pad;
 
         h2 {
-            font-size: larger-font-size;
+            set-larger-font-size();
         }
     }
 }
@@ -238,13 +238,13 @@
 
 .dev-program-hacks {
     h3 {
-        font-size: larger-font-size;
+        set-larger-font-size();
         margin-bottom: 4px;
     }
 
     p {
         color: #bbb;
-        font-size: smaller-font-size;
+        set-smaller-font-size();
         margin-bottom: 10px;
 
         a {


### PR DESCRIPTION
So right now we're using set pixel sizes which aren't necessarily great for different devices.  This PR adds a bit more flexibility.

This will change the overall font-size of MDN, and they'll look a bit bigger than before.  If you believe the font-size is too big, instead of just saying that in this PR, adjust the `font-size` on the `html` element in Dev Tools element. It's currently `100%` so adjust it to `95%`, etc.

Also, I'd like multiple eyes on this before we merge or reject.  @groovecoder @lmorchard @openjck @jezdez
