### PR TITLE
[fix bug 998212] Privacy policy url fixed

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -150,7 +150,7 @@
         <p>
           {% trans copyright_url=devmo_url('Project:MDN/About#Copyrights_and_licenses'), about_url=devmo_url('Project:MDN/About'), thisyear=thisyear() %}
           <bdi>&copy; 2005-{{ thisyear }} Mozilla Developer Network and individual contributors<br />
-          Content is available under <a href="{{ copyright_url }}">these licenses</a> &middot; <a href="{{ about_url }}">About MDN</a> &middot; <a href="//github.com/mozilla/kuma">Contribute to the code</a> &middot; <a href="//www.mozilla.org/privacy/policies/websites/">Privacy policy</a></bdi>
+          Content is available under <a href="{{ copyright_url }}">these licenses</a> &middot; <a href="{{ about_url }}">About MDN</a> &middot; <a href="//github.com/mozilla/kuma">Contribute to the code</a> &middot; <a href="//www.mozilla.org/privacy/websites/">Privacy policy</a></bdi>
           {% endtrans %}
         </p>
         {% endblock %}


### PR DESCRIPTION
The url for the privacy policy has changed from https://www.mozilla.org/privacy/policies/websites/ to https://www.mozilla.org/privacy/websites/

we should update it.
