### PR TITLE
fix bug 990607: Ignore badly encoded referer headers when detecting search referer

### DIFF
--- a/apps/search/store.py
+++ b/apps/search/store.py
@@ -15,8 +15,11 @@ PAGE_PARAM = 'page'
 
 def referrer_url(request):
     referrer = request.META.get('HTTP_REFERER', None)
-    if (referrer is None or
-            reverse('search', locale=request.locale) != URL(referrer).path):
+    try:
+        if (referrer is None or
+                reverse('search', locale=request.locale) != URL(referrer).path):
+            return None
+    except UnicodeDecodeError:
         return None
     return referrer
 

--- a/apps/search/tests/test_store.py
+++ b/apps/search/tests/test_store.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+from base64 import b64decode
+from nose.tools import raises, eq_
+from test_utils import TestCase
+from search.store import referrer_url
+
+
+class MockRequest(object):
+    pass
+
+
+class StoreTests(TestCase):
+
+    def test_bug_990607(self):
+        """bug 990607: referer_url fails on strangely encoded referers"""
+
+        # HACK: Having trouble getting the exact awkward encoding from the
+        # header. This is the result of copying from the browser, then 
+        # `pbpaste | base64`. But, it reproduces the error, at least. I suspect
+        # the problem is a mashed up encoding between ISO-8859 and UTF-8
+        problematic_referer = b64decode("""
+            aHR0cDovL2RldmVsb3Blci5tb3ppbGxhLm9yZy9mci9kb2NzL0phdmFTY3Jpc
+            HQvUsODwqlmw4PCqXJlbmNlX0phdmFTY3JpcHQvUsODwqlmw4PCqXJlbmNlX0
+            phdmFTY3JpcHQvT2JqZXRzX2dsb2JhdXgvRGF0ZS9wYXJzZQ==
+        """)
+        
+        req = MockRequest()
+        req.locale = 'en-US'
+        req.META = dict(HTTP_REFERER=problematic_referer)
+
+        result = referrer_url(req)
+        eq_(result, None)


### PR DESCRIPTION
Not sure if this is the best way to resolve this bug, but it at least stops [the error](https://rpm.newrelic.com/accounts/263620/applications/3172075/traced_errors/1535457945). The problem is that Python's `urlobject.URLObject` just does not gracefully handle a `Referer:` header that looks like this:

```
http://developer.mozilla.org/fr/docs/JavaScript/RÃ©fÃ©rence_JavaScript/RÃ©fÃ©rence_JavaScript/Objets_globaux/Date/parse
```
