### PR TITLE
Make i18n for 'callout-firefoxos' link in homepage.html

### DIFF
--- a/apps/landing/templates/landing/homepage.html
+++ b/apps/landing/templates/landing/homepage.html
@@ -86,7 +86,7 @@
       <a href="{{ devmo_url('Mozilla/Firefox_for_Android') }}"><span>{{ _('Develop<br />Firefox for Android') }}</span><i></i></a>
     </div>
     <div class="column-callout callout-firefoxos">
-      <a href="/en-US/docs/Mozilla/Firefox_OS"><span>{{ _('Build<br />Firefox OS') }}</span><i></i></a>
+      <a href="{{ devmo_url('Mozilla/Firefox_OS') }}"><span>{{ _('Build<br />Firefox OS') }}</span><i></i></a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Even if we visit [the homepage with setting ja locale](https://developer.mozilla.org/ja/), the link of "Firefox OS をビルドする (en-us: "Build Firefox OS")" is not localized. Therefore the link always jumps to `https://developer.mozilla.org/en-US/docs/Mozilla/Firefox_OS`. This is the serious globalization issue.

This bug is caused with that Kuma has not made it i18n with using `devmo_url()`. So this pull request fix it.
