### PR TITLE
fix bug 1000200 - Prevent move enter key block

### DIFF
--- a/apps/wiki/templates/wiki/move_document.html
+++ b/apps/wiki/templates/wiki/move_document.html
@@ -66,7 +66,7 @@
                 <input type="hidden" value="{{ document.locale }}" id="locale" name="locale"/>
               </dd>
               <dd class="parent-suggest-container">
-                <button class="transparent move-lookup-link">{{ _('Lookup by Document Title') }}</button>
+                <button class="transparent move-lookup-link" type="button">{{ _('Lookup by Document Title') }}</button>
 
                 <div id="parent-suggest-input-container">
                     <input type="text" placeholder="{{ _('Parent Title') }}" id="parent-suggestion" disabled />


### PR DESCRIPTION
Hilarious, submission via enter key bricking the form because the button is  a submit type by default.
