### PR TITLE
Bug 675842: Remove waffle flag for page move.

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -77,7 +77,7 @@
                   <li><a href="{{ url('wiki.new_document') }}?parent={{ document.id }}">{{ _('New sub-page') }}</a></li>
                   <li><a href="{{ url('wiki.new_document') }}?clone={{ document.id }}">{{ _('Clone this page') }}</a></li>
                 {% endif %}
-                {% if user.is_authenticated() and waffle.flag('page_move') %}
+                {% if user.is_authenticated() and user.has_perm('wiki.move_tree') %}
                   <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}">{{ _('Move this page') }}</a></li>
                 {% endif %}
                 {% if user.is_superuser %}

--- a/apps/wiki/views.py
+++ b/apps/wiki/views.py
@@ -1363,7 +1363,6 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_iframe_target,
 @process_document_path
 @check_readonly
 @prevent_indexing
-@waffle_flag('page_move')
 def move(request, document_slug, document_locale):
     """Move a tree of pages"""
     doc = get_object_or_404(


### PR DESCRIPTION
This removes the waffle flag check that controls access to the page
move view; going forward, access will be controlled by the permissions
infrastructure.
