### PR TITLE
Reset main content class within wiki

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -154,7 +154,7 @@
 
 
 
-    <div class="document-main" id="document-main"><div class="center">
+    <div class="wiki-main-content" {% if not is_zone %}id="document-main"{% endif %}><div class="center">
 
       {% if not is_zone_root %}
       <div class="article-meta">


### PR DESCRIPTION
Fixes issue where background color not applied to content area in wiki.

Once this is merged and pushed, we have to remove the last line of:

https://developer.mozilla.org/en-US/docs/Template:CustomCSS
