### PR TITLE
fix bug 906883 with browserid_form and csrf_exempt

### DIFF
--- a/apps/users/templates/users/browserid_signin.html
+++ b/apps/users/templates/users/browserid_signin.html
@@ -2,6 +2,7 @@
 <h1>{{ _('Sign In with Persona') }}</h1>
 <form class="browserid boxed" action="{{url('users.browserid_verify')}}" method="POST">
   <input type="hidden" name="next" id="next" value="{{ next_url }}" />
+  {{ browserid_form }}
 
   {{ errorlist(form) }}
   {% include "users/browserid_explanation.html" %}

--- a/apps/users/views.py
+++ b/apps/users/views.py
@@ -72,6 +72,7 @@ def set_browserid_explained(response):
     return response
 
 
+@csrf_exempt
 @ssl_required
 @login_required
 @require_POST


### PR DESCRIPTION
This makes browserid_change_email work the same as browserid_verify,
since _verify_browserid on the assertion is an effective CSRF protection
