### PR TITLE
Fix bug 972533: Enhancements to admin handling of deleted pages.

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -584,6 +584,15 @@ class DeletedDocumentManager(BaseDocumentManager):
         return super(DeletedDocumentManager, self).get_query_set().filter(deleted=True)
 
 
+class DocumentAdminManager(BaseDocumentManager):
+    """
+    A manager used only in the admin site, which does not perform any
+    filtering based on deleted status.
+    
+    """
+    pass
+
+
 class DocumentTag(TagBase):
     """A tag indexing a document"""
     class Meta:
@@ -634,6 +643,7 @@ class Document(NotificationsMixin, models.Model):
 
     objects = DocumentManager()
     deleted_objects = DeletedDocumentManager()
+    admin_objects = DocumentAdminManager()
 
     title = models.CharField(max_length=255, db_index=True)
     slug = models.CharField(max_length=255, db_index=True)

--- a/apps/wiki/templates/admin/wiki/purge_documents.html
+++ b/apps/wiki/templates/admin/wiki/purge_documents.html
@@ -1,0 +1,60 @@
+{% extends "admin/base_site.html" %}
+{% load i18n admin_modify adminmedia %}
+
+{% block title %}{% trans "Purge documents" %} {{ block.super }}{% endblock %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {{ media }}
+{% endblock %}
+
+{% block extrastyle %}
+  {{ block.super }}
+  <link rel="stylesheet" type="text/css"
+        href="{% admin_media_prefix %}css/forms.css" />
+{% endblock %}
+
+{% block coltype %}{% if ordered_objects %}colMS{% else %}colM{% endif %}{% endblock %}
+
+{% block bodyclass %}change-form{% endblock %}
+
+{% block breadcrumbs %}{% if not is_popup %}
+<div class="breadcrumbs">
+     <a href="{% url admin:index %}">{% trans "Home" %}</a> &rsaquo;
+     <a href="{% url admin:app_list "wiki" %}">{% trans "Wiki" %}</a> &rsaquo;
+     <a href="{% url admin:wiki_document_changelist %}">{% trans "Documents" %}</a> &rsaquo;
+     {% trans "Purge documents" %}
+</div>
+{% endif %}{% endblock %}
+
+{% block content %}
+<h1>{% trans "Purge documents" %}</h1>
+
+<div>
+  <form enctype="multipart/form-data" method="post" action="">
+    {% csrf_token %}
+    <div>
+      <p>
+        {% blocktrans %}
+          The following documents will be permanently removed from the database. This action cannot be undone. To cancel, press the "Back" button in your browser.
+        {% endblocktrans %}
+      <p>
+      <fieldset class="module aligned">
+          <div class="form-row">
+	    <div>
+	      <ul>
+                {% for doc in to_purge %}
+                  <li><a href="{{ doc.get_absolute_url }}">{{ doc }}</a></li>
+                {% endfor %}
+	      </ul>
+	    </div>
+          </div>
+      </fieldset>
+      <div class="submit-row">
+	<input class="default" type="submit" name="confirm_purge"
+               value="{% trans "Purge documents" %}" />
+      </div>
+    </div>
+  </form>
+</div>
+{% endblock %}

--- a/urls.py
+++ b/urls.py
@@ -30,6 +30,9 @@ urlpatterns = patterns('',
 
     # Django admin:
     (r'^grappelli/', include('grappelli.urls')),
+    url(r'^admin/wiki/document/purge/',
+        'wiki.admin.purge_view',
+        name='wiki.admin_bulk_purge'),
     (r'^admin/', include('smuggler.urls')),
     (r'^admin/', include(admin.site.urls)),
 


### PR DESCRIPTION
This adds a new manager to Document, which does not perform any
filtering based on deleted status, and uses that manager for the
admin; this ensures the admin always shows all Documents currently in
the database.

Building on that, the admin filters now include one to show only
deleted Documents.

The admin actions for Document are also updated:
- A new "purge" action is added, to bulk-purge deleted Documents.
- A new "undelete" action is added, to bulk-undelete deleted
  Documents.
- The built-in Django "delete" action is removed, since we want people
  using the standard deletion UI (and because the admin delete action
  bypasses the model delete() method, which is not what we want for
  deleting Documents).
