### PR TITLE
Do not duplicate declarations with bidi-value()

### DIFF
--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -248,7 +248,9 @@ bidi-style(ltr-prop, value, inverse-prop, inverse-value, make-important = false)
     {ltr-prop}: value make-important;
 
     .html-rtl & {
-        {inverse-prop}: value make-important;
+        if (ltr-prop != inverse-prop) {
+            {inverse-prop}: value make-important;
+        }
         {ltr-prop}: inverse-value make-important;
     }
 }


### PR DESCRIPTION
Before these changes the following input:

```
p {
    bidi-value(float, left, right);
}
```

... would compile to the following output:

```
p {
    float: left;
}

.html-rtl p {
    float: left;
    float: right;
}
```

After these changes, the unnecessary "float: left" in the RTL version is
not included. This saves about 250 bytes of compiled CSS -- it's
something!
