### PR TITLE
Bug 1002040: Expand the page-move error mail a bit more.

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -5,6 +5,7 @@ import re
 import json
 import newrelic.agent
 import operator
+import traceback
 import sys
 
 from pyquery import PyQuery
@@ -1504,21 +1505,26 @@ class Document(NotificationsMixin, models.Model):
                 # move.
                 exc_class, exc_message, exc_tb = sys.exc_info()
                 message = """
-                Failure occurred while attempting to move document
-                with id %(doc_id)s.
+Failure occurred while attempting to move document
+with id %(doc_id)s.
 
-                That document can be viewed at:
+That document can be viewed at:
 
-                https://developer.mozilla.org/%(locale)s/docs/%(slug)s
+https://developer.mozilla.org/%(locale)s/docs/%(slug)s
 
-                The exception raised was:
+The exception raised was:
 
-                Exception type: %(exc_class)s
+Exception type: %(exc_class)s
 
-                Exception message: %(exc_message)s
+Exception message: %(exc_message)s
+
+Full traceback:
+
+%(traceback)s
                 """ % {'doc_id': child.id, 'locale': child.locale,
                        'slug': child.slug, 'exc_class': exc_class,
-                       'exc_message': exc_message}
+                       'exc_message': exc_message,
+                       'traceback': traceback.format_exc(e)}
                 raise PageMoveError(message)
 
     def repair_breadcrumbs(self):

--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -120,10 +120,10 @@ def move_page(locale, slug, new_slug, email):
     except Document.DoesNotExist:
         transaction.rollback()
         message = """
-        Page move failed.
+Page move failed.
 
-        Move was requested for document with slug %(slug)s in locale
-        %(locale)s, but no such document exists.
+Move was requested for document with slug %(slug)s in locale
+%(locale)s, but no such document exists.
         """ % {'slug': slug, 'locale': locale}
         logging.error(message)
         send_mail('Page move failed', message, settings.DEFAULT_FROM_EMAIL,
@@ -134,14 +134,14 @@ def move_page(locale, slug, new_slug, email):
     except PageMoveError as e:
         transaction.rollback()
         message = """
-        Page move failed.
+Page move failed.
 
-        Move was requested for document with slug %(slug)s in locale
-        %(locale)s, but could not be completed.
+Move was requested for document with slug %(slug)s in locale
+%(locale)s, but could not be completed.
 
-        Diagnostic info:
+Diagnostic info:
 
-        %(message)s
+%(message)s
         """ % {'slug': slug, 'locale': locale, 'message': e.message}
         logging.error(message)
         send_mail('Page move failed', message, settings.DEFAULT_FROM_EMAIL,
@@ -150,12 +150,12 @@ def move_page(locale, slug, new_slug, email):
     except Exception as e:
         transaction.rollback()
         message = """
-        Page move failed.
+Page move failed.
 
-        Move was requested for document with slug %(slug)s in locale %(locale)s,
-        but could not be completed.
+Move was requested for document with slug %(slug)s in locale %(locale)s,
+but could not be completed.
 
-        %(info)s
+%(info)s
         """ % {'slug': slug, 'locale': locale, 'info': e}
         logging.error(message)
         send_mail('Page move failed', message, settings.DEFAULT_FROM_EMAIL,
@@ -166,12 +166,12 @@ def move_page(locale, slug, new_slug, email):
     subject = 'Page move completed: ' + slug + ' (' + locale + ')'
     full_url = settings.SITE_URL + '/' + locale + '/docs/' + new_slug
     message = """
-    Page move completed.
+Page move completed.
 
-    The move requested for the document with slug %(slug)s in locale
-    %(locale)s, and all its children, has been completed.
+The move requested for the document with slug %(slug)s in locale
+%(locale)s, and all its children, has been completed.
 
-    You can now view this document at its new location: %(full_url)s.
+You can now view this document at its new location: %(full_url)s.
     """ % {'slug': slug, 'locale': locale, 'full_url': full_url}
     send_mail(subject, message, settings.DEFAULT_FROM_EMAIL,
               [user.email])

--- a/apps/wiki/tests/test_models.py
+++ b/apps/wiki/tests/test_models.py
@@ -1797,7 +1797,11 @@ class PageMoveTests(TestCase):
                 'https://developer.mozilla.org/%s/docs/%s' % (grandchild_doc.locale,
                                                               grandchild_doc.slug),
                 "Exception type: <type 'exceptions.Exception'>",
-                'Exception message: Requested move would overwrite a non-redirect page.']
+                'Exception message: Requested move would overwrite a non-redirect page.',
+                'in _move_tree',
+                'in _move_conflicts',
+                'raise Exception("Requested move would overwrite a non-redirect page.")',
+            ]
             for s in err_strings:
                 ok_(s in e.message)
 


### PR DESCRIPTION
This adds the full traceback of the exception to the error, so that
less-easy things like character-encoding problems can be traced more
effectively.
