### PR TITLE
Install nodejs v0.10.26 from a package in our Amazon S3 space

### DIFF
--- a/puppet/manifests/classes/basics.pp
+++ b/puppet/manifests/classes/basics.pp
@@ -11,13 +11,14 @@ class basics {
           "libjpeg62", "libjpeg62-dev",
           "libfreetype6", "libfreetype6-dev",
           "libpng12-0", "libpng12-dev",
-          "libtidy-0.99-0", "libtidy-dev"]:
+          "libtidy-0.99-0", "libtidy-dev", "rlwrap"]:
             ensure => installed,
             require => Exec['apt-get-update'];
     }
     exec {
         "deadsnakes-ppa":
             command => "/usr/bin/add-apt-repository --yes ppa:fkrull/deadsnakes && apt-get update -qq",
+            creates => '/etc/apt/sources.list.d/fkrull-deadsnakes-precise.list',
             require => Package["python-software-properties"];
     }
     package {

--- a/puppet/manifests/classes/nodejs.pp
+++ b/puppet/manifests/classes/nodejs.pp
@@ -1,31 +1,50 @@
 # Get node.js and npm installed Ubuntu 12.04 LTS
 class nodejs {
-    # See also: https://launchpad.net/~chris-lea/+archive/node.js/
-    exec { 'install-chris-lea-node-repo':
-        command => '/usr/bin/apt-add-repository -y ppa:chris-lea/node.js && /usr/bin/apt-get update',
-        creates => '/etc/apt/sources.list.d/chris-lea-node_js-precise.list',
-        require => Package['python-software-properties']
+    exec { "nodejs_delete_old_ppa":
+        command => "/bin/rm /etc/apt/sources.list.d/chris-lea-node_js-precise.list*",
+        onlyif => "/bin/ls -1 /etc/apt/sources.list.d | /bin/grep -c 'chris-lea-node_js-precise.list'"
     }
-    package { 'nodejs':
-        ensure => '0.10.26-1chl1~precise1',
-        require => Exec['install-chris-lea-node-repo']
+    exec { "nodejs_uninstall_old_node":
+        command => "/usr/bin/apt-get remove -y nodejs",
+        onlyif => "/usr/bin/node --version | /bin/grep -c 'v0.6.12'"
+    }
+    exec { "nodejs_download":
+        cwd => "/home/vagrant/src/puppet/cache",
+        timeout => 300,
+        command => "/usr/bin/wget https://s3-us-west-2.amazonaws.com/pkgs.mozilla.net/vagrant/mdn/nodejs_0.10.26-1chl1~precise1_i386.deb",
+        creates => "/home/vagrant/src/puppet/cache/nodejs_0.10.26-1chl1~precise1_i386.deb",
+    }
+    package { "nodejs":
+        provider => "dpkg",
+        source => "/home/vagrant/src/puppet/cache/nodejs_0.10.26-1chl1~precise1_i386.deb",
+        require => [
+            Package["rlwrap"],
+            Exec['nodejs_download'],
+            Exec['nodejs_delete_old_ppa'],
+            Exec['nodejs_uninstall_old_node']
+        ]
     }
     file { "/usr/include/node":
         target => "/usr/include/nodejs",
         ensure => link,
         require => Package['nodejs']
     }
+    file { "/usr/local/lib/node_modules/fibers":
+        ensure => absent,
+        force => true
+    }
+    file { "/home/vagrant/src/kumascript/node_modules/fibers":
+        ensure => absent,
+        force => true
+    }
     exec { 'npm-fibers-install':
         command => "/usr/bin/npm install -g fibers@1.0.1",
         creates => "/usr/lib/node_modules/fibers",
         require => [
             Package["nodejs"],
-            File["/usr/include/node"]
+            File["/usr/include/node"],
+            File["/usr/local/lib/node_modules/fibers"],
+            File["/home/vagrant/src/kumascript/node_modules/fibers"]
         ]
-    }
-    # An old version of fibers lived here, ensure it's gone.
-    file { "/usr/local/lib/node_modules/fibers":
-        ensure => absent,
-        force => true
     }
 }


### PR DESCRIPTION
Looks like the exact package we were trying to install for nodejs went away on Saturday. This PR switches over to installing a copy of the package I recovered from cache and uploaded to our Amazon S3 space.

For bonus points, I also added a clause to stop the deadsnakes PPA from getting installed on every provision.
