### PR TITLE
update nodejs ensure provision to current version

### DIFF
--- a/puppet/manifests/classes/nodejs.pp
+++ b/puppet/manifests/classes/nodejs.pp
@@ -7,7 +7,7 @@ class nodejs {
         require => Package['python-software-properties']
     }
     package { 'nodejs':
-        ensure => '0.10.26-1chl1~precise1',
+        ensure => '0.10.28-1chl1~precise1',
         require => Exec['install-chris-lea-node-repo']
     }
     file { "/usr/include/node":


### PR DESCRIPTION
Fixes nodejs version in puppet

``` bash
$ sudo apt-cache show nodejs | grep Version
Version: 0.10.28-1chl1~precise1
Version: 0.6.12~dfsg1-1ubuntu1
```
