### PR TITLE
Fix bug 1008828: Show correct locale/slug in page move error.

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1492,6 +1492,10 @@ class Document(NotificationsMixin, models.Model):
 
         # Finally, step 10: recurse through all of our children.
         for child in self.children.all().filter(locale=self.locale):
+            # Save the original slug and locale so we can use them in
+            # the error message if something goes wrong.
+            old_child_slug, old_child_locale = child.slug, child.locale
+            
             child_title = child.slug.split('/')[-1]
             try:
                 child._move_tree('/'.join([new_slug, child_title]), user)
@@ -1521,8 +1525,8 @@ Exception message: %(exc_message)s
 Full traceback:
 
 %(traceback)s
-                """ % {'doc_id': child.id, 'locale': child.locale,
-                       'slug': child.slug, 'exc_class': exc_class,
+                """ % {'doc_id': child.id, 'locale': old_child_locale,
+                       'slug': old_child_slug, 'exc_class': exc_class,
                        'exc_message': exc_message,
                        'traceback': traceback.format_exc(e)}
                 raise PageMoveError(message)


### PR DESCRIPTION
The root of the problem was a child page move failing after the
child's locale/slug had already been changed in-memory; in that case
the new locale/slug would end up in the error message instead of the
original.

Now the original locale/slug get stashed away prior to attempting the
child move, and if the child move fails they get inserted in the error
message to ensure the error points to the correct URL.
