### PR TITLE
Fix bug 1002282: Add Serbian locale.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -136,6 +136,7 @@ MDN_LANGUAGES = (
                  'ro',
                  'ru',
                  'sq',
+                 'sr-CYRL',
                  'ta',
                  'th',
                  'tr',


### PR DESCRIPTION
Based on previous commits, this seems like what's needed. Though if someone familiar with it could check whether it's actually supposed to be `sr-CYRL` instead, I'd appreciate that.
