### PR TITLE
Quick Links glitch

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -103,7 +103,7 @@ enable-toc-toggle() {
     }
 }
 
-.quick-links li.toggleable a, .quick-links .title, #quick-links-toggle {
+.quick-links li.toggleable > a, .quick-links .title, #quick-links-toggle {
     bidi-style(padding-left, 20px, padding-right, 0);
     color: text-color;
     display: inline-block;


### PR DESCRIPTION
Update wiki style in order to make selection of links into Quick Links less greedy for toggleable lists.

This avoid to have sub links inside toggleable lists with unnecessary paddings. However, it preserve the style for the link that actually toggle the sublist.

This is necessary for fixing style issues with the HTMLRef kuma template that use sublists of links.
