### PR TITLE
Select dir attribute of root element in RTL styles

### DIFF
--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -55,7 +55,7 @@
     <!--[if IE]><script src="media/js/libs/html5.js"></script><![endif]-->
   </head>
 
-  <body id="home" class="html-ltr">
+  <body id="home">
     <!-- Header -->
     <header id="main-header"><div class="center">
       <a href="//www.mozilla.org/" id="tabzilla">mozilla</a>

--- a/media/css/demos.css
+++ b/media/css/demos.css
@@ -586,7 +586,7 @@ body.popup .page-title { font: 200 1.714em/1 "Bebas Neue", "League Gothic", Haet
 #nav-toolbar .crumbs li.crumb-one { padding-left: 0; margin-left: 0; background: none; }
 #nav-toolbar .crumbs li a { text-decoration: underline; }
 
-.html-rtl #nav-toolbar .crumbs { float: right; }
-.html-rtl #nav-toolbar .crumbs li { padding-left: 13px; margin-left: 6px; background-position: 0 -798px; }
-.html-rtl #nav-toolbar .crumbs li.crumb-one { background: url("../img/wiki/nav-arrows.png") 0 -798px no-repeat; }
-.html-rtl #nav-toolbar .crumbs li:last-child { background: none; }
+html[dir="rtl"] #nav-toolbar .crumbs { float: right; }
+html[dir="rtl"] #nav-toolbar .crumbs li { padding-left: 13px; margin-left: 6px; background-position: 0 -798px; }
+html[dir="rtl"] #nav-toolbar .crumbs li.crumb-one { background: url("../img/wiki/nav-arrows.png") 0 -798px no-repeat; }
+html[dir="rtl"] #nav-toolbar .crumbs li:last-child { background: none; }

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -352,7 +352,7 @@ home-involved-background-y = 50px;
     /* In right-to-left languages, show some carousel items in reverse order
        and hide the pager. This is not a permanent solution,
        https://bugzilla.mozilla.org/show_bug.cgi?id=992745 */
-    .html-rtl & {
+    html[dir="rtl"] & {
         .owl-item {
             float: right;
         }
@@ -512,7 +512,7 @@ home-involved-background-y = 50px;
 }
 
 /* right to left */
-#home.html-rtl {
+html[dir="rtl"] #home {
 
     h2 {
         > selector-icon:before {

--- a/media/redesign/stylus/includes/grid.styl
+++ b/media/redesign/stylus/includes/grid.styl
@@ -91,7 +91,7 @@ draw-grid() {
     }
 
     /* adjustments to reverse the column containers in RTL */
-    .html-rtl .column-container {
+    html[dir="rtl"] .column-container {
         {grid-column-selector} {
             &:first-child {
                 margin-right: 0;

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -256,7 +256,7 @@ place-important(make-important) {
 bidi-style(ltr-prop, value, inverse-prop, inverse-value, make-important = false) {
     {ltr-prop}: value place-important(make-important);
 
-    .html-rtl & {
+    html[dir="rtl"] & {
         if (ltr-prop != inverse-prop) {
             {inverse-prop}: value place-important(make-important);
         }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -172,7 +172,7 @@ article {
     .external-icon:not([href^='https://mdn.mozillademos.org']) {
         white-space: pre-line;
 
-        .html-ltr &:before, .html-rtl &:after {
+        html[dir="ltr"] &:before, html[dir="rtl"] &:after {
             content: '\f08e';
             font-family: FontAwesome;
             set-font-size(9px);
@@ -181,7 +181,7 @@ article {
             margin-right: 3px;
         }
 
-        .html-rtl &:after {
+        html[dir="rtl"] &:after {
             transform: rotateY(180deg);
         }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,7 +57,7 @@
     {% include "includes/google_analytics.html" %}
   {% endif %}
 </head>
-<body {% block body_attributes %}{% endblock %} class="html-{{ DIR }} {% block bodyclass %}{% endblock %}">
+<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}">
 
   {% include "includes/config.html" %}
 

--- a/templates/base_popup.html
+++ b/templates/base_popup.html
@@ -25,7 +25,7 @@
   {% block extrahead %}{% endblock %}
 </head>
 
-<body id="{% block body_attributes %}{% endblock %}" class="html-{{ DIR }} popup {% block bodyclass %}{% endblock %}">
+<body id="{% block body_attributes %}{% endblock %}" class="popup {% block bodyclass %}{% endblock %}">
 {% block content %}{% endblock %}
 
 {# js #}


### PR DESCRIPTION
This commit removes the .html-rtl and .html-ltr classes and updates all
stylesheets to instead select the dir attribute of the root element.
This leaves us with one fewer value to worry about, which will make
certain types of debugging easier.
