### PR TITLE
Remove all compat-* functions in Stylus

### DIFF
--- a/media/css/demos.css
+++ b/media/css/demos.css
@@ -49,7 +49,7 @@
 #demostudio.landing #content-main { background: transparent; border-radius: 0; -moz-box-shadow: none; -webkit-box-shadow: none; box-shadow: none; }
 
 /* @Buttons *********/
-.section-demos button, .section-demos .button { display: inline-block; padding: .35em 14px .25em; color: #fff; border: 1px solid #8f4d4f; border-color: rgba(255,255,255,.2);
+.section-demos button, .section-demos .button { display: inline-block; padding: .35em 14px .25em; border: 1px solid #8f4d4f; border-color: rgba(255,255,255,.2);
   font: 1em/1 "Bebas Neue", "League Gothic", "Arial Narrow", sans-serif; letter-spacing: .05em; text-decoration: none;
   background: #861215 url("../img/button-shade.png") 0 .85em repeat-x;
   -moz-border-radius: 5px;

--- a/media/redesign/stylus/calendar.styl
+++ b/media/redesign/stylus/calendar.styl
@@ -6,7 +6,7 @@
        the width, and keep header content aligned. */
     #page-head, #map_canvas {
         width: 1000px;
-        override-compat-important(margin, 0 auto grid-spacing);
+        margin: 0 auto grid-spacing;
     }
 
     #page-head {

--- a/media/redesign/stylus/demo-studio.styl
+++ b/media/redesign/stylus/demo-studio.styl
@@ -60,7 +60,10 @@ html {
 
     /* remove ugly button styles */
     .button, button {
-        compat-important(box-shadow, none);
+        &, &:link, &:visited {
+            color: #fff;
+        }
+        box-shadow: none;
     }
 
     .gallery-head {
@@ -80,5 +83,5 @@ html {
 }
 
 #demostudio.landing, #demostudio.detail {
-    compat-important(background-position, center 0px);
+    background-position: center 0px;
 }

--- a/media/redesign/stylus/home.styl
+++ b/media/redesign/stylus/home.styl
@@ -91,7 +91,6 @@ home-involved-background-y = 50px;
             background-position: 0 -147px;
             background-size: 134px auto;
             color: #0095dd;
-            margin-left: 0 !important;
             float: left;
 
             &:before {
@@ -255,8 +254,6 @@ home-involved-background-y = 50px;
 
         a {
             text-decoration: underline;
-            compat-only(margin-left, 0);
-            compat-only(font-style, normal);
         }
     }
 
@@ -532,8 +529,8 @@ html[dir="rtl"] #home {
         }
 
         {selector-icon} {
-            compat-only(margin-right, 0);
-            compat-only(margin-left, icon-margin);
+            margin-right: 0;
+            margin-left: icon-margin;
         }
     }
 

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -115,28 +115,6 @@ generate-arrow(arrow-width = 10px) {
     }
 }
 
-/* use this in the case of having to override styles from old template :( */
-compat-important(prop, value) {
-    {prop}: value !important;
-}
-
-/* Override an !important set by compat-important() with another !important.
-   This should be removed after all CSS has been migrated to Stylus. */
-override-compat-important(prop, value) {
-    compat-important(prop, value);
-}
-
-/* used for style which are only present to override other styles -- these will be deleted once legacy design is gone */
-compat-only(prop, value, more-selector = '') {
-    compat-important(prop, value);
-
-    if more-selector {
-        & {more-selector} {
-            compat-important(prop, value);
-        }
-    }
-}
-
 /* used to denote an old IE style */
 old-ie(prop, value, important = false) {
     {prop}: value (important ? unquote('!important') : '');
@@ -156,16 +134,18 @@ slider(duration=default-animation-duration, maximum-height = 10000px) {
 }
 
 /* sets the base styles for messages (review, warning, error, notice, etc.) */
-set-message-base() {
-    compat-only(border-width, 5px);
-    compat-only(border-style, solid);
+set-message-base(remove-last-spacing = true) {
+    border-width: 5px;
+    border-style: solid;
     padding: (grid-spacing / 2);
     margin-bottom: grid-spacing;
     set-smaller-font-size();
 
-    & *:last-child {
-        margin-bottom: 0;
-        padding-bottom: 0;
+    if(remove-last-spacing) {
+        & *:last-child {
+            margin-bottom: 0;
+            padding-bottom: 0;
+        }
     }
 }
 
@@ -192,7 +172,7 @@ remove-center-spacing() {
 /* overrides the navigation menu color - zones and homepage */
 override-main-nav-color(hex) {
     #main-nav > ul > li > a, .user-state a {
-        compat-important(color, hex);
+        color: hex;
     }
 
     #main-nav > ul > li {
@@ -358,12 +338,6 @@ component-submenu(menu-width, num-columns, background-color, arrow-border-color)
             bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
             bidi-style(padding-left, grid-spacing, padding-right, 0);
         }
-    }
-
-    .title {
-        compat-only(font-size, base-font-size);
-        compat-only(padding-left, 0);
-        compat-only(background, none);
     }
 
     a {

--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -58,11 +58,8 @@ draw-grid();
     .wrap {
         @extend .center;
         set-smaller-font-size();
-        compat-important(padding-left, 24px);
-        compat-important(padding-right, 24px);
-        compat-important(padding-top, 10px);
-        compat-important(padding-bottom, 10px);
-        compat-important(max-width, max-width-default);
+        padding: 10px 24px;
+        max-width: max-width-default;
 
         prevent-last-child-spacing(p, margin-bottom);
     }
@@ -144,13 +141,14 @@ draw-grid();
             }
 
             > a, .search-trigger {
-                compat-important(text-decoration, none);
-                compat-important(text-transform, uppercase);
-                compat-important(font-weight, bold);
+                text-transform: uppercase;
+                font-weight: bold;
             }
 
             > a {
-                compat-important(color, menu-link-color);
+                &:link, &:visited, &:hover, &:active {
+                    color: menu-link-color;
+                }
             }
 
             > a, .search-wrap {
@@ -672,8 +670,8 @@ label {selector-icon} {
             margin-left: 8px;
             padding-left: @margin-left + 2;
             bidi-style(border-left, 1px solid #bbb, border-right, 0);
-            bidi-style(padding-right, 10px, padding-left, 10px, true); /* compat-important */
-            bidi-style(margin-right, 8px, margin-left, 6px, true); /* compat-important */
+            bidi-style(padding-right, 10px, padding-left, 10px);
+            bidi-style(margin-right, 8px, margin-left, 6px);
         }
     }
 

--- a/media/redesign/stylus/main/tags.styl
+++ b/media/redesign/stylus/main/tags.styl
@@ -70,8 +70,8 @@ h4 {
 
 /* basic text */
 {selector-icon} {
-    bidi-style(margin-left, icon-margin, margin-right, 0); /* compat-only */
-    bidi-style(margin-right, 0, margin-left, icon-margin); /* compat-only */
+    bidi-style(margin-left, icon-margin, margin-right, 0);
+    bidi-style(margin-right, 0, margin-left, icon-margin);
     display: inline-block;
 
     &:before {
@@ -92,17 +92,17 @@ p, dl, table, pre {
     margin-bottom: content-block-margin;
 }
 
+pre, code {
+    font-family: 'Courier New', 'Andale Mono', monospace;
+}
+
 pre {
-    compat-only(line-height, 19px);
-    set-font-size(base-font-size !important);
+    set-font-size(base-font-size);
+    line-height: 19px;
     border: 0;
     background: #f6f6f2;
     padding: 15px;
     overflow: auto;
-}
-
-pre, code {
-    font: 100% 'Courier New', 'Andale Mono', monospace;
 }
 
 code {
@@ -165,7 +165,12 @@ a {
 }
 
 a.button, a.button:link, a.button:visited {
+    color: button-color;
     text-decoration: none;
+
+    &.negative {
+        color: #fff;
+    }
 }
 
 .button, button, input[type='submit'], input[type='button'] {
@@ -173,16 +178,12 @@ a.button, a.button:link, a.button:visited {
     cursor: pointer;
     display: inline-block;
     line-height: 1;
-    compat-important(background-color, button-background);
-    compat-important(color, button-color);
-    compat-important(text-transform, uppercase);
-    compat-important(padding, 5px 11px);
-    compat-important(border-radius, 4px);
+    background-color: button-background;
+    color: button-color;
+    text-transform: uppercase;
+    padding: 5px 11px;
+    border-radius: 4px;
     vendorize(box-shadow, inset 0 -1px button-shadow-color);
-    compat-only(background-image, none);
-    compat-only(font-family, site-font-family);
-    compat-only(font-size, base-font-size);
-    compat-only(letter-spacing, normal);
 
     &.only-icon {
         {selector-icon} {
@@ -197,27 +198,27 @@ a.button, a.button:link, a.button:visited {
     }
 
     &.neutral, &.negative, &.positive {
-        compat-important(color, #fff);
+        color: #fff;
     }
 
     &.neutral {
-        compat-important(background-color, #0095dd);
+        background-color: #0095dd;
         vendorize(box-shadow, inset 0 -1px #00539f);
     }
 
     &.negative {
-        compat-important(background-color, #ea3b28);
+        background-color: #ea3b28;
         vendorize(box-shadow, inset 0 -1px #c13832);
     }
 
     &.positive {
-        compat-important(background-color, #70a300);
+        background-color: #70a300;
         vendorize(box-shadow, inset 0 -1px #486900);
     }
 
     &.transparent {
         vendorize(box-shadow, none);
-        compat-important(background-color, transparent);
+        background-color: transparent;
     }
 
     &::-moz-focus-inner {

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -52,16 +52,11 @@
     }
 
     .edit > a {
-        compat-only(margin, 0 5px 0 0);
+        margin: 0 5px 0 0;
     }
 
     .submenu {
         @extend $advanced-menu;
-
-        a {
-            compat-only(float, none);
-            compat-only(margin, 0);
-        }
     }
 
     .main {
@@ -118,7 +113,7 @@
         top: @padding;
         right: @padding;
 
-        a {
+        & > a {
             float: left;
             margin-left: (grid-spacing / 2);
         }
@@ -324,7 +319,7 @@ table.activity {
         & > a {
             display: block;
             text-align: center;
-            override-compat-important(margin, (grid-spacing / 2) 0);
+            margin: (grid-spacing / 2) 0;
         }
 
         #edit-profile i {

--- a/media/redesign/stylus/promote.styl
+++ b/media/redesign/stylus/promote.styl
@@ -220,8 +220,8 @@ preview-box-total-width = (preview-box-width + (box-padding * 2) + (box-border-w
 
 #button-preview {
     width: preview-box-width;
-    override-compat-important(padding, box-padding);
-    override-compat-important(border, box-border);
+    padding: box-padding;
+    border: box-border;
 
     /* Thanks to the #button-builder width we set above, there should be
        preview-box-margin-left amount of space on the left of this box after
@@ -229,7 +229,7 @@ preview-box-total-width = (preview-box-width + (box-padding * 2) + (box-border-w
     float: right;
 
     &.fixed {
-        override-compat-important(margin-left, (step-box-total-width + preview-box-left-margin));
+        margin-left: (step-box-total-width + preview-box-left-margin);
         position: fixed;
         z-index: 99;
         top: 20px;

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -6,10 +6,6 @@ body.search-results {
     create-gradient-background(header-background-color);
 }
 
-main {
-    compat-important(background, transparent); /* temporarily important until we migrate all CSS */
-}
-
 /* update the header search size */
 minimize-header-search();
 
@@ -23,10 +19,6 @@ minimize-header-search();
 /* block mentioning the number of results returned */
 h3 {selector-icon}, fieldset {selector-icon} {
     bidi-style(margin-right, (grid-spacing * .75), margin-left, 0);
-}
-
-p {
-    compat-only(padding-left, 0);
 }
 
 .search-results-explanation {

--- a/media/redesign/stylus/users.styl
+++ b/media/redesign/stylus/users.styl
@@ -7,7 +7,7 @@
 
 article.main {
     form {
-        override-compat-important(margin, (gutter-width * 1.5) 0);
+        margin: (gutter-width * 1.5) 0;
 
         ul, li {
             padding: 0;

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -44,16 +44,9 @@ enable-toc-toggle() {
 }
 
 .review-base {
-    compat-important(background, #fbf8e9);
-    compat-important(border-color, #f9f3d9);
-    compat-only(color, text-color);
-}
-
-
-/* general wiki section */
-#content-main {
-    compat-only(padding, 0);
-    compat-only(width, auto);
+    background: #fbf8e9;
+    border-color: #f9f3d9;
+    color: text-color;
 }
 
 .wiki-main-content {
@@ -148,7 +141,7 @@ enable-toc-toggle() {
 
 /* document review form stuff */
 .reviews {
-    set-message-base();
+    set-message-base(false);
     set-smaller-font-size();
     @extend .review-base;
 
@@ -158,10 +151,6 @@ enable-toc-toggle() {
 
     li {
         padding-top: list-item-spacing;
-    }
-
-    button {
-        compat-important(font-size, smaller-font-size);
     }
 }
 
@@ -269,15 +258,15 @@ article {
         }
 
         button {
+            set-smaller-font-size();
             margin-left: -2px;
-            compat-important(color, #777);
-            compat-important(text-transform, none);
-            compat-important(font-size, 12px);
-            compat-important(padding, 5px 0);
+            color: #777;
+            text-transform: none;
+            padding: 5px 0;
 
             &:hover,
             &:focus {
-                compat-important(color, #4D4E53);
+                color: #4D4E53;
             }
         }
     }
@@ -299,7 +288,7 @@ article {
     position: absolute;
     top: (grid-spacing * .75) + 2px;
     display: none;
-    compat-only(font-size, 24px);
+    font-size: 24px;
 
     &.disabled {
         opacity: 0.3;
@@ -412,9 +401,7 @@ article {
         position: relative;
 
         a, button, input[type='submit'], input[type='button'] {
-            compat-important(font-size, smaller-font-size);
-            compat-only(font-family, site-font-family);
-            compat-only(letter-spacing, normal);
+            set-smaller-font-size();
 
             &.disabled {
                 opacity: 0.8;
@@ -453,7 +440,7 @@ article {
 .notice {
     set-message-base();
     set-font-size(base-font-size);
-    compat-important(border-width, 2px);
+    border-width: 2px;
 }
 
 /* warning elements */
@@ -461,8 +448,8 @@ article {
     set-message-base();
     background: rgba(193, 56, 50, 0.85);
     color: #c13832;
-    compat-important(border-color, rgba(0, 0, 0, 0.1));
-    compat-only(color, #fff);
+    border-color: rgba(0, 0, 0, 0.1);
+    color: #fff;
     font-style: italic;
     margin: 0 0 grid-spacing 0;
     set-font-size(base-font-size);
@@ -474,10 +461,6 @@ article {
 
     &.warning-review {
         @extend .review-base;
-
-        p {
-            compat-important(color, text-color);
-        }
     }
 }
 
@@ -493,13 +476,10 @@ div.bug, div.warning, div.overheadIndicator {
 /* page attachments block at the bottom of the article */
 #page-attachments {
     @extend .wiki-block;
-    compat-only(background, #fff);
 }
 
 #page-attachments-button {
-    compat-only(font-size, smaller-font-size);
-    compat-only(font-family, site-font-family);
-    compat-only(letter-spacing, normal);
+    set-smaller-font-size();
 }
 
 /* contributors block at the bottom of the article */
@@ -570,7 +550,6 @@ div.bug, div.warning, div.overheadIndicator {
 
 .tag-list li {
     margin-right: 6px;
-    compat-only(margin-right, 6px);
 }
 
 .tagit li {
@@ -583,11 +562,8 @@ div.bug, div.warning, div.overheadIndicator {
 
 #toc {
     reverse-link-decoration();
-    compat-only(margin-left, 0);
-    compat-only(font-size, base-font-size);
-    compat-only(margin-left, 0, 'ol ol, ul ul');
     background: light-background-color;
-    compat-important(padding, grid-spacing (grid-spacing * .75));
+    padding: 20px 15px;
 
     &.fixed {
         position: fixed;
@@ -597,7 +573,7 @@ div.bug, div.warning, div.overheadIndicator {
     }
 
     > ol {
-        compat-important(font-size, smaller-font-size);
+        set-smaller-font-size();
     }
 
     ol ol {
@@ -605,7 +581,7 @@ div.bug, div.warning, div.overheadIndicator {
     }
 
     li {
-        compat-important(padding-top, (grid-spacing / 2));
+        padding-top: (grid-spacing / 2);
         position: relative;
 
         &:before {
@@ -628,7 +604,7 @@ div.bug, div.warning, div.overheadIndicator {
     }
 
     .title {
-        compat-only(margin-bottom, 0);
+        margin-bottom: 0;
     }
 
     a.title {
@@ -744,13 +720,8 @@ span.cke_skin_kuma {
 
 /* compare page */
 .compare, #revision-list {
-    ul {
+    ul, input[type='submit'] {
         set-smaller-font-size();
-        compat-only(min-width, 0);
-    }
-
-    input[type='submit'], a.button {
-        compat-only(font-size, smaller-font-size);
     }
 }
 
@@ -812,8 +783,8 @@ span.cke_skin_kuma {
 .move-lookup-link {
     display: inline-block;
     margin-left: (grid-spacing * 2);
-    compat-important(color, link-color);
-    compat-important(text-transform, none);
+    color: link-color;
+    text-transform: none;
 
     &:hover {
         text-decoration: underline;

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -116,10 +116,10 @@
     }
 
     a.button, button {
-        compat-important(color, #fff);
+        color: #fff;
         &:not(.transparent) {
-            old-ie(background-color, #0095dd, true); /* old ie */
-            compat-important(background-color, rgba(0, 0, 0, 0.1));
+            old-ie(background-color, #0095dd); /* old ie */
+            background-color: rgba(0, 0, 0, 0.1);
             vendorize(box-shadow, inset 0 -1px rgba(0, 0, 0, .1));
         }
     }


### PR DESCRIPTION
The compat-\* functions were used to override styles from the old design.
The functions used !important to do this. By removing the functions and
the associated use of !important, our stylesheets will be more
maintainable and reliable. This also reduces the size of compiled CSS by
2.04KB.

Some bugs were fixed just by removing these functions. At the same time,
some bugs were revealed by removing these functions. (For example,
errors related to selector specificity suddenly manifested as
user-facing bugs when !important was removed.)

Newly-manifesting bugs like these were searched for and corrected, but
it is possible that some remain. If we find any more, we can correct
them with later commits.
