### PR TITLE
hides the submenu on focusout

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -71,7 +71,7 @@
                     });
 
                     // Hide the submenu when the submenu is blurred for hideDelay
-                    $submenu.on('mouseleave', function() {
+                    $submenu.on('mouseleave focusout', function() {
                         clear(showTimeout);
                         closeSubmenu($submenu);
                     });


### PR DESCRIPTION
When using the keyboard it's somewhat annoying that the language and advanced submenus stays visible even when focus is somewhere else. this prevents that.
