### PR TITLE
Use placeholder selectors wherever possible

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -43,7 +43,7 @@ enable-toc-toggle() {
     padding-right: 0;
 }
 
-.review-base {
+$review-base {
     background: #fbf8e9;
     border-color: #f9f3d9;
     color: text-color;
@@ -143,7 +143,7 @@ enable-toc-toggle() {
 .reviews {
     set-message-base(false);
     set-smaller-font-size();
-    @extend .review-base;
+    @extend $review-base;
 
     p {
         margin: 0;
@@ -460,7 +460,7 @@ article {
     }
 
     &.warning-review {
-        @extend .review-base;
+        @extend $review-base;
     }
 }
 

--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -201,7 +201,7 @@
     margin-top: -(grid-spacing * 4);
 }
 
-.dev-program-pad {
+$dev-program-pad {
     background: light-background-color;
     padding: (grid-spacing);
     prevent-last-child-spacing(p, margin-bottom);
@@ -212,7 +212,7 @@
     margin-right: grid-margin;
 
     .dev-program-callout {
-        @extend .dev-program-pad;
+        @extend $dev-program-pad;
 
         h2 {
             set-larger-font-size();
@@ -238,7 +238,7 @@
 }
 
 .dev-program-explanation {
-    @extend .dev-program-pad;
+    @extend $dev-program-pad;
 }
 
 .dev-program-hacks {


### PR DESCRIPTION
The classes .review-base and .dev-program-pad have been updated to
placeholder selectors because, although they are extended, they do not
appear in markup. This saves 62 bytes of compiled CSS.
