### PR TITLE
Reverting quick links change to they work with icons

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -96,7 +96,7 @@ enable-toc-toggle() {
     }
 }
 
-.quick-links li.toggleable > a, .quick-links .title, #quick-links-toggle {
+.quick-links li.toggleable a, .quick-links .title, #quick-links-toggle {
     bidi-style(padding-left, 20px, padding-right, 0);
     color: text-color;
     display: inline-block;


### PR DESCRIPTION
Basically reverting this:  https://github.com/mozilla/kuma/pull/2393/files
