### PR TITLE
ensure button colors stay correct as well as link text-decorations

### DIFF
--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -148,6 +148,7 @@ draw-grid();
             > a {
                 &:link, &:visited, &:hover, &:active {
                     color: menu-link-color;
+                    text-decoration: none;
                 }
             }
 

--- a/media/redesign/stylus/main/tags.styl
+++ b/media/redesign/stylus/main/tags.styl
@@ -137,20 +137,10 @@ label {
 
 /* links and buttons */
 a {
-    &:link, &:visited, &:focus, &:active {
-        color: link-color;
-    }
+    color: link-color;
+    text-decoration: none;
 
-    &:link, &:visited {
-        text-decoration: none;
-    }
-
-    &:link:hover, &:link:focus, &:link:active {
-        text-decoration: underline;
-    }
-
-    &:visited:hover, &:visited:focus, &:visited:active {
-        color: link-color;
+    &:hover, &:focus, &:active {
         text-decoration: underline;
     }
 
@@ -164,26 +154,18 @@ a {
     }
 }
 
-a.button, a.button:link, a.button:visited {
-    color: button-color;
-    text-decoration: none;
-
-    &.negative {
-        color: #fff;
-    }
-}
-
 .button, button, input[type='submit'], input[type='button'] {
     border: 0;
     cursor: pointer;
     display: inline-block;
     line-height: 1;
     background-color: button-background;
-    color: button-color;
     text-transform: uppercase;
     padding: 5px 11px;
     border-radius: 4px;
     vendorize(box-shadow, inset 0 -1px button-shadow-color);
+    color: button-color;
+    text-decoration: none;
 
     &.only-icon {
         {selector-icon} {
@@ -195,6 +177,10 @@ a.button, a.button:link, a.button:visited {
         span {
             offscreen();
         }
+    }
+
+    &:hover {
+        text-decoration: none;
     }
 
     &.neutral, &.negative, &.positive {

--- a/media/redesign/stylus/wiki-syntax.styl
+++ b/media/redesign/stylus/wiki-syntax.styl
@@ -41,5 +41,4 @@ pre em code[class*='language-'] {
 
 pre[class*='language-'].twopartsyntaxbox, pre[class*='language-'].syntaxbox {
     background: rgba(212, 221, 228, 0.5);
-    margin-bottom: 0;
 }


### PR DESCRIPTION
I found that the "Edit" button a profile was of the wrong color, likely due to last compat-only removals.  I've updated the link structures a bit to ensure that the base color of a link is overriden by more specific usages.
