### PR TITLE
add temporary task logger to file for debugging

### DIFF
--- a/apps/wiki/management/commands/render_document.py
+++ b/apps/wiki/management/commands/render_document.py
@@ -9,6 +9,7 @@ import urlparse
 import hashlib
 import logging
 from optparse import make_option
+import traceback
 
 # HACK: This is the fattest hack I've written in awhile. I blame ianbicking
 # http://blog.ianbicking.org/illusive-setdefaultencoding.html
@@ -27,6 +28,9 @@ from django.core.management.base import (BaseCommand, NoArgsCommand,
 from wiki.models import (Document, Revision,
                          DocumentRenderingInProgress)
 from wiki.tasks import render_document
+
+
+log = logging.getLogger('k.task')
 
 
 class Command(BaseCommand):
@@ -109,6 +113,8 @@ class Command(BaseCommand):
         if self.options['defer']:
             logging.info(u"Queuing deferred render for %s (%s)" %
                           (doc, doc.get_absolute_url()))
+            log.debug('render_document(%s, %s, %s)' % (doc.pk, cc, self.base_url))
+            log.debug(''.join(traceback.format_stack()))
             render_document.delay(doc.pk, cc, self.base_url)
             logging.debug(u"Queued.")
 
@@ -119,4 +125,4 @@ class Command(BaseCommand):
                 render_document(doc, cc, self.base_url)
                 logging.debug(u"DONE.")
             except DocumentRenderingInProgress:
-                logging.error(u"Rendering is already in progress for this document") 
+                logging.error(u"Rendering is already in progress for this document")

--- a/settings.py
+++ b/settings.py
@@ -1120,6 +1120,11 @@ LOGGING = {
             'filters': ['require_debug_false'],
             'level': logging.ERROR,
         },
+        'kuma_task_logger': {
+            'class': 'logging.FileHandler',
+            'filename': '/tmp/kuma_task.log',
+            'level': logging.DEBUG
+        }
     },
     'loggers': {
         'mdn': {
@@ -1137,6 +1142,11 @@ LOGGING = {
         'elasticsearch': {
             'level': logging.ERROR,
             'handlers': ['console'],
+        },
+        'k.task': {
+            'handlers': ['kuma_task_logger'],
+            'level': logging.DEBUG,
+            'propagate': True,
         },
     },
 }


### PR DESCRIPTION
This isn't great, but it's the only thing I can think to do to learn where we are triggering all the `render_document` tasks.
