### PR TITLE
Removing padding from transparent page buttons

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -408,6 +408,11 @@ article {
             }
         }
 
+        .transparent {
+        	padding-left: 0;
+        	padding-right: 0;
+        }
+
         {selector-icon} {
             set-font-size(base-bump-font-size);
         }


### PR DESCRIPTION
Because the Languages button has no background color, the spacing between it and the button next to it looks double.  Just my opinion but needs updating.
