### PR TITLE
Warn users against editing compiled stylesheets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ lib/product_details_json
 .DS_Store
 node_modules/
 media/redesign/css/*.css
+!media/redesign/css/README.md
 docs/_build/
 maintenance/media
 wheelhouse

--- a/media/redesign/css/README.md
+++ b/media/redesign/css/README.md
@@ -1,0 +1,2 @@
+These stylesheets are generated automatically. To change site style, edit the
+files in the *stylus* directory instead.


### PR DESCRIPTION
New contributors occasionally edit the compiled stylesheets in
media/redesign/css. When they run `compile-stylesheets`, their work is
overwritten.
