### PR TITLE
Fix bug 1010022 - Change the unsubscribe message to sentence case

### DIFF
--- a/templates/tidings/unsubscribe.html
+++ b/templates/tidings/unsubscribe.html
@@ -1,0 +1,18 @@
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "base.html" %}
+{% set title = _('Unsubscribe') %}
+{% set crumbs = [(None, title)] %}
+
+{% block content %}
+  <article>
+    <h1>{{ _('Are you sure you want to unsubscribe?') }}</h1>
+    {# TODO: Once Watches know how to describe themselves, print that description. #}
+    <form action="" method="post">
+      {{ csrf() }}
+      <div class="submit-or-cancel">
+        <input type="submit" value="{{ _('Unsubscribe') }}" />
+        <a href="/"{# Discards l10n. Better ideas? #}>{{ _('Cancel') }}</a>
+      </div>
+    </form>
+  </article>
+{% endblock %}

--- a/templates/tidings/unsubscribe_error.html
+++ b/templates/tidings/unsubscribe_error.html
@@ -1,0 +1,20 @@
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "base.html" %}
+{% set title = _('Unsubscribe') %}
+{% set crumbs = [(None, title)] %}
+
+{% block content %}
+<article>
+  <h1>{{ _('Unsubscribe Error') }}</h1>
+
+  <p>
+    {% trans %}
+      We could not find your subscription. Either it has already been
+      cancelled, or there was a mistake in the unsubscribe link. Please make
+      sure the entire link from the email made it into the browser. If the last
+      part of the link wraps onto a second line in the email, try copying and
+      pasting the link into the browser.
+    {% endtrans %}
+  </p>
+</article>
+{% endblock %}

--- a/templates/tidings/unsubscribe_success.html
+++ b/templates/tidings/unsubscribe_success.html
@@ -1,0 +1,12 @@
+{# vim: set ts=2 et sts=2 sw=2: #}
+{% extends "base.html" %}
+{% set title = _('Unsubscribe') %}{# Having this change to "Unsubscribed" draws my eye and bothers me. #}
+{% set crumbs = [(None, title)] %}
+
+{% block content %}
+<article>
+  <h1>{{ _('Unsubscribed') }}</h1>
+
+  <p>{{ _('You have been unsubscribed.') }}</p>
+</article>
+{% endblock %}


### PR DESCRIPTION
Overriding `unsubscribe.html` template in `django-tidings`, so that we don't have the unsubscribe message in uppercase.
