### PR TITLE
Fix bug 971681: Re-render moved pages post-move.

### DIFF
--- a/apps/wiki/tasks.py
+++ b/apps/wiki/tasks.py
@@ -142,6 +142,11 @@ but could not be completed.
         return
 
     transaction.commit()
+
+    # Now that we know the move succeeded, re-render the whole tree.
+    for stale_doc in [doc] + doc.get_descendants():
+        stale_doc.schedule_rendering('max-age=0')
+    
     subject = 'Page move completed: ' + slug + ' (' + locale + ')'
     full_url = settings.SITE_URL + '/' + locale + '/docs/' + new_slug
     message = """


### PR DESCRIPTION
This just does a brute-force re-render of every page affected by the
move, as the last part of the page-move task. This will address both
the issue in the bug (which is stale JSON -- that gets rebuilt during
the render) as well as any other stale data (it may also, as a side
effect, fix bug 973605 by rebuilding the list of translations).
