### PR TITLE
Remove unneeded negative match in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ lib/product_details_json
 .DS_Store
 node_modules/
 media/redesign/css/*.css
-!media/redesign/css/README.md
 docs/_build/
 maintenance/media
 wheelhouse


### PR DESCRIPTION
In aa86a0dc, a line was added to .gitignore to direct Git not to ignore
the file media/redesign/css/README.md. This negative match is not needed
because Git is otherwise only ignoring stylesheets in that directory.

(When aa86a0dc was written, I mistakenly read that the entire directory
was being ignored, hence the negative match.)
