### PR TITLE
Simplify variables in compile-stylesheets

### DIFF
--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-BASEDIR=$(dirname $0)
-CSSDIR=$BASEDIR/../media/redesign/css
-STYLUSDIR=$BASEDIR/../media/redesign/stylus
+KUMABASE=$(dirname $(dirname $0))
+CSSDIR=$KUMABASE/media/redesign/css
+STYLUSDIR=$KUMABASE/media/redesign/stylus
 
 for opt in "$@"; do
   case $opt in


### PR DESCRIPTION
Super minor. This is just slightly more readable. It also might make the output of `compile-stylesheets` less verbose depending on how you use it.
