### PR TITLE
Fix bug 971073: Clear cache on just-deleted document.

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -1326,7 +1326,11 @@ class Document(NotificationsMixin, models.Model):
             signals.pre_delete.send(sender=self.__class__,
                                     instance=self)
             if not self.deleted:
+                cache_key = (DOCUMENT_LAST_MODIFIED_CACHE_KEY_TMPL %
+                             self.natural_cache_key)
                 Document.objects.filter(pk=self.pk).update(deleted=True)
+                cache.delete(cache_key)
+
             signals.post_delete.send(sender=self.__class__,
                                      instance=self)
 


### PR DESCRIPTION
The root issue here is not actually whether the document gets
re-rendered; it's that viewing the document causes last-modified info
to go into the cache, so that only a force-refresh afterward clears
it. This adds a cache bust of the document's last-modified info to the
delete() method to ensure we show an uncached "this document has been
deleted" immediately.
