### PR TITLE
Fix save buttons overlapping with title field on wiki edit page

### DIFF
--- a/media/redesign/stylus/wiki-edit.styl
+++ b/media/redesign/stylus/wiki-edit.styl
@@ -172,8 +172,17 @@ $summary-padding = 5px;
 }
 
 #edit-document {
-    .metadata {
+    #article-head {
+        position: relative;
         margin-top: $space-for-buttons;
+    }
+
+    #page-buttons {
+        top: -($space-for-buttons);
+    }
+
+    h1{
+        margin-top: 0;
     }
 
     .first-contrib-welcome {


### PR DESCRIPTION
![Buttons Overlapping](http://cl.ly/image/1e180P132j1g/Image%202014-06-13%20at%206.17.44%20pm.png)

The overlap is only in Chrome and Safari, not on Firefox.
