### PR TITLE
try making page buttons "sticky" like toc

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -232,7 +232,7 @@
               <div class="column-strip wiki-column" id="wiki-right">
               {% if toc_html %}
               <!-- table of contents -->
-              <div id="toc" class="toc toggleable">
+              <div id="toc" class="toc toggleable sticky">
                 <a href="#toc" class="title toggler" data-open-icon="icon-plus" data-closed-icon="icon-minus">{{ _('In This Article') }}<i></i></a>
                 <ol class="toggle-container">
                   {{ toc_html|safe }}

--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -15,7 +15,7 @@
   {% else %}
     {% set translate_url = url('wiki.select_locale', document_path=document.full_path, locale=document.locale) %}
   {% endif %}
-  <ul class="page-buttons">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
+  <ul class="page-buttons sticky">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
 
         <div class="submenu" id="languages-menu-submenu">
           <div class="submenu-column">

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -214,7 +214,9 @@
         Set up the scrolling TOC effect
     */
     (function() {
-        var $toc = $('#toc');
+        var $toc = $('#toc'),
+            $page_buttons = $('.page-buttons'),
+            $stickies = $('.sticky');
         if($toc.length) {
             var tocOffset = $toc.offset().top;
             var $toggler = $toc.find('> .toggler');
@@ -229,19 +231,32 @@
                 if(scroll > tocOffset && $toggler.css('pointer-events') == 'none') {
                     $toc.css({
                         width: $toc.css('width'),
-                        maxHeight: maxHeight
+                        maxHeight: maxHeight,
+                        top: $page_buttons.height()
                     });
 
-                    if(!$toc.hasClass(fixedClass)){
-                        $toc.addClass(fixedClass);
-                    }
+                    $page_buttons.css({
+                        left: $toc.position().left,
+                    });
+
+                    $stickies.each(function(i) {
+                        if(!$(this).hasClass(fixedClass)){
+                            $(this).addClass(fixedClass);
+                        }
+                    });
                 }
                 else {
                     $toc.css({
                         width: 'auto',
-                        maxHeight: 'none'
+                        maxHeight: 'none',
+                        top: 'auto'
                     });
-                    $toc.removeClass(fixedClass);
+                    $page_buttons.css({
+                        left: 'auto',
+                    });
+                    $stickies.each(function(i) {
+                        $(this).removeClass(fixedClass);
+                    });
                 }
 
                 // Should the TOC be one-column (auto-closed) or sidebar'd

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -572,17 +572,17 @@ div.bug, div.warning, div.overheadIndicator {
     border: 0 !important; /* overrides plugin selector */
 }
 
+.fixed {
+    position: fixed;
+    top: 0;
+    z-index: 10;
+    overflow-y: auto;
+}
+
 #toc {
     reverse-link-decoration();
     background: $light-background-color;
     padding: 20px 15px;
-
-    &.fixed {
-        position: fixed;
-        top: 0;
-        z-index: 10;
-        overflow-y: auto;
-    }
 
     > ol {
         set-smaller-font-size();


### PR DESCRIPTION
**DO NOT MERGE**

This is for @openjck, @darkwing, and @stephaniehobson to see something I want to try with an Optimizely A/B test: i.e., if we can "stick" the page buttons (especially the edit button) to the top of the window as the user scrolls. This should make it easier to edit, and so we should see an increased number of clicks on the "Edit" button.
