### PR TITLE
Simplify registration page copy

### DIFF
--- a/kuma/users/templates/users/browserid_register.html
+++ b/kuma/users/templates/users/browserid_register.html
@@ -21,21 +21,13 @@
     <section id="content-main" role="main">
       <article id="browser_register" class="main">
 
-        <div id="persona-explanation">
-          <h1>{{ _('Persona is here!') }}</h1>
-          <p>{% trans browserid_href='https://persona.org/', why_browserid='http://identity.mozilla.com/post/12950196039/deploying-browserid-at-mozilla' %}
-          MDN has switched to <a href="{{ browserid_href }}" rel="external">Persona</a>,
-          a safe and simple way to sign in with just your e-mail address. <a href="{{ why_browserid }}" rel="external">Learn more about it.</a>
-          {% endtrans %}</p>
-          <p>
-          {% trans bug_href='https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Mozilla%20Developer%20Network&component=Login' %}
-          <strong>Having trouble logging in? <a href="{{ bug_href }}" rel="external">Let us know.</a></strong>
-          {% endtrans %}
-          </p>
-        </div>
+        <h1>{{ _('Register') }}</h1>
+        <p id="persona-explanation">{% trans persona_href='https://login.persona.org/about' %}
+        MDN uses <a href="{{ persona_href }}" rel="external">Persona</a>,
+        a safe and simple way to sign in with just your e-mail address.
+        {% endtrans %}</p>
 
         <form id="create_user" class="boxed submission" method="post" action="">
-          <h2>{{ _('New MDN Members') }}</h2>
           <p>{% trans %}
             We couldn't find an MDN profile for your Persona. If you're new here,
             you can pick an MDN username now and complete your registration.
@@ -45,6 +37,10 @@
             but when you join you'll be able to edit docs, submit demos, and have
             your own profile page.
           {% endtrans %}</p>
+          <p>{% trans bug_href='https://bugzilla.mozilla.org/enter_bug.cgi?alias=&assigned_to=nobody%40mozilla.org&attach_text=&blocked=&bug_file_loc=http%3A%2F%2F&bug_ignored=0&bug_mentors=---&bug_severity=normal&bug_status=NEW&cc=jkarahalis%40mozilla.com&cc=lcrouch%40mozilla.com&cf_fx_iteration=---&cf_fx_points=---&comment=&component=Login&contenttypeentry=&contenttypemethod=autodetect&contenttypeselection=text%2Fplain&data=&defined_groups=1&dependson=&description=&flag_type-4=X&flag_type-607=X&flag_type-791=X&flag_type-800=X&flag_type-803=X&form_name=enter_bug&keywords=&maketemplate=Remember%20values%20as%20bookmarkable%20template&op_sys=All&priority=--&product=Mozilla%20Developer%20Network&qa_contact=&rep_platform=All&requestee_type-4=&requestee_type-607=&requestee_type-791=&requestee_type-800=&see_also=&short_desc=&status_whiteboard=%5Bpersona-no-email%5D&target_milestone=---&version=unspecified&format=__standard__' %}
+            <strong>Having trouble logging in? <a href="{{ bug_href }}" rel="external">Let us know</a>.</strong>
+          {% endtrans %}</p>
+
           {{ errorlist(register_form) }}
 
           {{ csrf() }}

--- a/media/redesign/stylus/users.styl
+++ b/media/redesign/stylus/users.styl
@@ -7,8 +7,6 @@
 
 article.main {
     form {
-        margin: ($gutter-width * 1.5) 0;
-
         ul, li {
             padding: 0;
             margin: 0;


### PR DESCRIPTION
Because we no longer offer the "Forgot Password" form, the only function
of the page is registration. The page title is updated to reflect this
and the "New MDN Members" heading is removed.

Other changes are made, mostly minor. The Bugzilla link is removed -- we
only receive about one report per month, so it seems unnecessary to
burden all users with this notice. People who deeply care about getting
their old accounts back will likely submit a bug with or without this
notice.
