### PR TITLE
Fix the puppet, chief and development server.

### DIFF
--- a/puppet/manifests/classes/site-config.pp
+++ b/puppet/manifests/classes/site-config.pp
@@ -150,30 +150,20 @@ class kuma_config {
         "kuma_south_migrate":
             user => "vagrant",
             cwd => "/home/vagrant/src",
-            command => "/home/vagrant/env/bin/python manage.py migrate events --delete-ghost-migrations --fake --noinput",
-            require => [ Exec["kuma_django_syncdb"] ];
-        "kuma_south_migrate2":
-            user => "vagrant",
-            cwd => "/home/vagrant/src",
-            command => "/home/vagrant/env/bin/python manage.py migrate users 0002 --fake --noinput",
-            require => [ Exec["kuma_south_migrate"] ];
-        "kuma_south_migrate3":
-            user => "vagrant",
-            cwd => "/home/vagrant/src",
             command => "/home/vagrant/env/bin/python manage.py migrate --noinput",
-            require => [ Exec["kuma_south_migrate2"] ];
+            require => [ Exec["kuma_django_syncdb"] ];
         "kuma_update_feeds":
             user => "vagrant",
             cwd => "/home/vagrant/src",
             command => "/home/vagrant/env/bin/python ./manage.py update_feeds",
             onlyif => "/usr/bin/mysql -B -uroot kuma -e'select count(*) from feeder_entry' | grep '0'",
-            require => [ Exec["kuma_south_migrate3"] ];
+            require => [ Exec["kuma_south_migrate"] ];
         "kuma_index_database":
             user => "vagrant",
             cwd => "/home/vagrant/src",
             command => "/home/vagrant/env/bin/python manage.py reindex -p 5",
             timeout => 600,
-            require => [ Service["elasticsearch"], Exec["kuma_south_migrate3"] ];
+            require => [ Service["elasticsearch"], Exec["kuma_south_migrate"] ];
     }
 }
 

--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -107,12 +107,6 @@ def update_info(ctx):
 def pre_update(ctx, ref=settings.UPDATE_REF):
     update_code(ref)
     update_info()
-    if ref == DEVMO_CLEANUP_TAG:
-        with ctx.lcd(settings.SRC_DIR):
-            ctx.local("python2.6 manage.py migrate events --delete-ghost-migrations --fake --noinput")
-            ctx.local("python2.6 manage.py migrate users 0002 --fake --noinput")
-            ctx.local("python2.6 manage.py migrate --noinput")
-
 
 
 @task

--- a/scripts/update_site.py
+++ b/scripts/update_site.py
@@ -68,8 +68,6 @@ def update_site(debug):
         (CHDIR, here),
         (EXEC, 'python2.6 vendor/src/schematic/schematic migrations/'),
         (EXEC, 'python2.6 manage.py syncdb --noinput'),
-        (EXEC, 'python2.6 manage.py migrate events --delete-ghost-migrations --fake --noinput'),
-        (EXEC, 'python2.6 manage.py migrate users 0002 --fake --noinput'),
         (EXEC, 'python2.6 manage.py migrate --noinput'),
         (EXEC, 'python2.6 manage.py update_badges'),
         (EXEC, 'python2.6 manage.py collectstatic --noinput'),


### PR DESCRIPTION
This should prevent the dev server to migrate backwards to 0002 of the users app as a fake and then fail when it tries to delete tables again in 0003.

The Puppet manifests are also required to be fixed to not create a bad state of the VM like the develop script above.

Chief doesn't automatically apply that because it checks for the git reference before running the fake migration.
