### PR TITLE
Fix top signin github button width

### DIFF
--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -348,10 +348,11 @@ a.github-button {
 .oauth-icon {
     border-radius: 4px;
     text-align: center;
-    padding: 0px 5px 1px;
+    padding: 0px 7px;
     font-size: $base-bump-font-size;
     bidi-style(margin-left, 4px, margin-right, 0);
     color: #fff;
+    display: inline-block;
     create-gradient(#43a6e2, #287cc2);
 
     {$selector-icon} {


### PR DESCRIPTION
The top open auth github button was looking "cut off" -- this fixes said problem.
