### PR TITLE
Adding a class for FAQs and other groups of links.

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -985,6 +985,37 @@ div.note {
     prevent-last-child-spacing(p, margin-bottom);
 }
 
+/* moreinfo styling */
+.moreinfo {
+    position: relative;
+    padding: $gutter-width $gutter-width $gutter-width 30px;
+    margin-bottom: $gutter-width;
+    background: #f4f7f8;
+
+    dl {
+        margin-bottom: 0;
+    }
+
+    dd {
+        margin-bottom: 10px;
+
+        &:last-child {
+            margin-bottom: 0;
+        }
+    }
+
+    &:after {
+        border-top: $gutter-width solid transparent;
+        border-bottom: $gutter-width solid transparent;
+        border-left: 15px solid #fff;
+        content: '';
+        display: block;
+        left: 0;
+        position: absolute;
+        top: 5px;
+    }
+}
+
 #page-comment {
     input {
         padding-top: 10px;


### PR DESCRIPTION
Adding a class to be used for FAQs and other lists of links for further reading. I call it ".moreinfo"

Satisfying a small part of Bug #994029. I will communicate the class name and usage to Chris. 

There is a testing page (https://developer.allizom.org/en-US/docs/User:stephaniehobson:moreinfo) that you can copy to your local dev if you like.
