### PR TITLE
Add review_tags, summary, tags to translation json

### DIFF
--- a/apps/wiki/models.py
+++ b/apps/wiki/models.py
@@ -569,6 +569,10 @@ class Document(NotificationsMixin, models.Model):
                     'locale': translation.locale,
                     'localization_tags': [tag.name for tag in
                           translation.current_revision.localization_tags.all()],
+                    'review_tags': [tag.name for tag in
+                          translation.current_revision.review_tags.all()],
+                    'summary': translation.current_revision.summary,
+                    'tags': [tag.name for tag in translation.tags.all()],
                     'title': translation.title,
                     'url': reverse('wiki.document',
                                    args=[translation.full_path],


### PR DESCRIPTION
I added last_edit and localization_tags here some time ago and I should have added all these fields, too :) So here are the missing ones. Will allow me to build even nicer doc status pages for our localizers as they are now also interested in status of the newly added review flags and so on.

With these fields added and KumaScript erros at zero, I would be interested in another full rebuild, but I don't know what @lmorchard thinks or if he has time for that.
