### PR TITLE
Make contributor bar more efficient

### DIFF
--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -175,10 +175,13 @@
           {% endif %}
         <h1>{{ document.title }}</h1>
         {% if waffle.flag('top_contributors') %}
-        <div class="contributor-avatars">
-            <span class="quickstat">
             {% set contributors = document.get_contributors() %}
-            {% trans count=contributors.count() %}
+            {% set contrib_limit = 13 %}
+            {% set contrib_count = contributors.count() %}
+
+        <div class="contributor-avatars" data-all-text="{{ _('Show all') }}&hellip;<span class='hidden'>{{ _('contributors') }}</span>" {% if contrib_count > contrib_limit %}data-has-hidden="1"{% endif %}>
+            <span class="quickstat">
+            {% trans count=contrib_count %}
             by {{ count }} contributor:
             {% pluralize %}
             by {{ count }} contributors:
@@ -186,7 +189,7 @@
             </span>
             <ul>
             {% for contributor in contributors %}
-                <li>
+                <li class="{% if loop.index > contrib_limit %}hidden{% else %}shown{% endif %}">
                 <a href="{{ contributor.get_absolute_url() }}" title="{% trans username=contributor.username %}View profile: {{ username }}{% endtrans %}">
                 <noscript data-class="avatar" data-alt="{{ contributor.username }}" data-src="{{ gravatar_url(contributor, size=34) }}">{{ contributor.username }}</noscript></a>
                 </li>

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -205,76 +205,79 @@ article {
     h1 {
         margin-bottom: 20px;
     }
+}
 
-    .contributor-avatars {
-        set-smaller-font-size();
-        color: #777;
-        padding: 10px 10px 6px;
-        border-bottom: 1px solid rgb(241, 241, 241);
-        border-top: 1px solid rgb(241, 241, 241);
-        background: none repeat scroll 0% 0% rgba(234, 239, 243, 0.4);
-        margin-top: -20px;
-        margin-bottom: 20px;
+.contributor-avatars {
+    set-smaller-font-size();
+    color: #777;
+    padding: 10px 10px 6px;
+    border-bottom: 1px solid rgb(241, 241, 241);
+    border-top: 1px solid rgb(241, 241, 241);
+    background: none repeat scroll 0% 0% rgba(234, 239, 243, 0.4);
+    margin-top: -20px;
+    margin-bottom: 20px;
 
-        ul {
-            display: inline;
-            opacity: 0.7;
-            margin-left: 2px;
-            vendorize(transition, opacity .3s ease-in-out);
+    ul {
+        display: inline;
+        opacity: 0.7;
+        margin-left: 2px;
+        vendorize(transition, opacity .3s ease-in-out);
 
-            &:hover,
-            &.focused {
-                opacity: 1;
-            }
+        &:hover,
+        &.focused {
+            opacity: 1;
+        }
 
-            li {
+        li {
+            margin: 0 5px 4px 0;
+
+            &, .no-js  &.hidden {
                 display: inline-block;
-                margin: 0 5px 4px 0;
-
-                &.hidden {
-                    display: none;
-                }
             }
 
-            a {
-                &:focus {
-                    outline: none;
-
-                    img {
-                        vendorize(transform, scale(1.7));
-                    }
-                }
+            &.hidden {
+                display: none;
             }
         }
 
-        .avatar {
-            vertical-align: text-bottom;
-            border-radius: 2px;
-            max-width: 20px;
-            opacity: 0;
-            vendorize(transition, all .2s);
-
-            &.loaded {
-                opacity: 1;
-            }
-
-            &:hover,
-            &:focus{
-                vendorize(transform, scale(1.7));
-            }
-        }
-
-        button {
-            set-smaller-font-size();
-            margin-left: -2px;
-            color: #777;
-            text-transform: none;
-            padding: 5px 0;
-
-            &:hover,
+        a {
             &:focus {
-                color: #4D4E53;
+                outline: none;
+
+                img {
+                    vendorize(transform, scale(1.7));
+                }
             }
+        }
+    }
+
+    .avatar {
+        vertical-align: text-bottom;
+        border-radius: 2px;
+        max-width: 20px;
+        opacity: 0;
+        vendorize(transition, all .2s);
+
+        &.loaded {
+            opacity: 1;
+        }
+
+        &:hover,
+        &:focus{
+            vendorize(transform, scale(1.7));
+        }
+    }
+
+    button {
+        set-smaller-font-size();
+        margin-left: -2px;
+        color: #777;
+        text-transform: none;
+        padding: 5px 0;
+
+        &:hover,
+        &:focus {
+            color: #4D4E53;
         }
     }
 }


### PR DESCRIPTION
I've rewritten most of the contributor bar stuff.  Here's how I've made it more efficient:
1.  Using event delegation instead of assignment to each individual link.
2.  I'm never querying for elements before I need them, thanks to adding a classname for both shown and hidden elements, as well as using a data-attribute to track that.
3.  Un-nesting CSS for this block.

Let me know if you have questions.
