### PR TITLE
Move tabzilla lower in priority, less blocking styles

### DIFF
--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -240,5 +240,22 @@
         $menus.parent().find('.submenu').mozKeyboardNav();
     })();
 
+    /*
+        Tabzilla :/
+    */
+    (function() {
+        var $tabzilla = $('#tabzilla');
+
+        $tabzilla.length && $.ajax({
+            url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
+            dataType: 'script',
+            cache: true,
+            success: function() {
+                $('<link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" type="text/css" rel="stylesheet" />').appendTo(doc.head);
+                $tabzilla.removeClass('hidden');
+            }
+        });
+    })();
+
 
 })(document, jQuery);

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,6 @@
   <link rel="home" href="{{ url('home') }}">
   <link rel="copyright" href="#copyright">
 
-  <link rel="stylesheet" href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css">
   {% block site_css %}
     {{ css('mdn', 'all') }}
 
@@ -86,7 +85,7 @@
   <header id="main-header"><div class="center">
 
     <div class="clear header-login">
-      <a href="//www.mozilla.org/" id="tabzilla" class="no-track">mozilla</a>
+      <a href="//www.mozilla.org/" id="tabzilla" class="no-track hidden">mozilla</a>
       {% if not is_sphinx %}
         {% include "includes/login.html" %}
       {% endif %}
@@ -192,8 +191,6 @@
       {{ js(script) }}
     {% endfor %}
   {% endblock %}
-
-  <script src="//mozorg.cdn.mozilla.net/{{ request.locale }}/tabzilla/tabzilla.js" async></script>
 
   {% block js %}{% endblock %}
 </body>


### PR DESCRIPTION
This PR moves everything to do with Tabzilla to the bottom of the page, thus removing one render-blocking resource (the stylesheet) from the header.  #PageSpeed
