### PR TITLE
Bug 1031714 - Add link colour for .warning-review

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -470,7 +470,15 @@ article {
 
     &.warning-review {
         @extend $review-base;
+
+        a,
+        a:hover,
+        a:visited {
+            color: $link-color;
+            border-color: $link-color;
+        }
     }
+
 }
 
 /* document warnings, bugs, etc. */


### PR DESCRIPTION
Added a link colour for .warning-review. This does not close the bug, only reference it.
