### PR TITLE
Fix problem with save/preview/discard buttons on edit page

### DIFF
--- a/media/redesign/stylus/wiki-edit.styl
+++ b/media/redesign/stylus/wiki-edit.styl
@@ -13,6 +13,9 @@ $summary-padding = 5px;
 
 #new-document, #edit-document, #translate-document, .move-page {
     .page-buttons {
+        bidi-value(text-align, right, left);
+        float: none;
+        padding: 0;
         margin-bottom: -10px;
 
         li {


### PR DESCRIPTION
They should not be on the same line as the links to the style and editor guide.

This needs to be merged before the sticky wiki edit buttons are pushed.
