### PR TITLE
Restore .errorlist styles

### DIFF
--- a/media/redesign/stylus/main/content.styl
+++ b/media/redesign/stylus/main/content.styl
@@ -336,3 +336,11 @@ div.tip {
     vendorize(column-count, 3);
 }
 
+ul.errorlist {
+    color: #900;
+    font-weight: bold;
+
+    li {
+        margin: 5px 0;
+    }
+}


### PR DESCRIPTION
Not sure where these got lost. The CSS migration seems like a likely
candidate, and that might be it, but I could swear they were moved over.
