### PR TITLE
Add switch for enabling or disabling Optimizely

### DIFF
--- a/templates/includes/common_macros.html
+++ b/templates/includes/common_macros.html
@@ -60,7 +60,7 @@
 {% endmacro %}
 
 {% macro optimizely_script() %}
-  {% if config.OPTIMIZELY_PROJECT_ID and config.OPTIMIZELY_PROJECT_ID != '0' %}
+  {% if waffle.switch('enable_optimizely') and config.OPTIMIZELY_PROJECT_ID and config.OPTIMIZELY_PROJECT_ID != '0' %}
   <script src="//cdn.optimizely.com/js/{{ config.OPTIMIZELY_PROJECT_ID }}.js"></script>
   {% endif %}
 {% endmacro %}


### PR DESCRIPTION
This will allow us to disable the Optimizely include when we are not
actively running experiments.
