### PR TITLE
Revert "Simplify variables in compile-stylesheets"

### DIFF
--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-KUMABASE=$(dirname $(dirname $0))
-CSSDIR=$KUMABASE/media/redesign/css
-STYLUSDIR=$KUMABASE/media/redesign/stylus
+BASEDIR=$(dirname $0)
+CSSDIR=$BASEDIR/../media/redesign/css
+STYLUSDIR=$BASEDIR/../media/redesign/stylus
 
 for opt in "$@"; do
   case $opt in


### PR DESCRIPTION
This reverts commit f069acc1dad00797465ecc55d0e21109dfc218e0.

Commit f069acc1 changed the way that the Kuma root was detected in
compile-stylesheets so that output from Stylus would be less verbose.
The particular implementation, however, introduced a bug where the
script could not be run from within its own directory. As it turns out,
there is no easy, portable way to do what commit f069acc1 intended.
