### PR TITLE
Initial notifier component addition

### DIFF
--- a/apps/dashboards/templates/dashboards/revisions.html
+++ b/apps/dashboards/templates/dashboards/revisions.html
@@ -8,7 +8,6 @@
 {% block content %}
 
     <div class="dashboard">
-        {% include 'wiki/includes/wiki_notifier.html' %}
         <h1>{{ title }}</h1>
         <form method="get" id="revision-filter">
             <div class="revision-field">
@@ -62,7 +61,6 @@
     var $filterForm = $('#revision-filter');
     var $pageInput = $('#revision-page');
     var currentLocale = '{{ request.locale }}';
-    var notifier = $('.notifier').mozNotifier();
     var controlsTemplate = '\
     <div class="action-bar">\
         <ul id="page-buttons">\
@@ -156,14 +154,14 @@
             history.pushState(null, '', location.pathname + '?' + $this.serialize());
         }
 
-        notifier.setMessage('Hang on! Updating filters…').show();
+        var notification = mdn.Notifier.growl(gettext('Hang on! Updating filters…'), { duration: 0 });
         $.ajax({
             url: $this.attr('action'),
             data: $this.serialize()
         }).then(function (content) {
             replaceContent(content);
             $this.trigger('ajaxComplete');
-            notifier.success('Updated filters.').hide();
+            notification.success(gettext('Updated filters.'), 2000);
             // Reset the page count to 0 in case of new filter
             $pageInput.val(1);
         });

--- a/apps/wiki/templates/wiki/document.html
+++ b/apps/wiki/templates/wiki/document.html
@@ -96,7 +96,6 @@
 {% endblock %}
 
 {% block content %}
-    {% include 'wiki/includes/wiki_notifier.html' %}
 
   {% if is_zone %}
       {% if is_zone_root %}

--- a/apps/wiki/templates/wiki/edit_document.html
+++ b/apps/wiki/templates/wiki/edit_document.html
@@ -188,7 +188,6 @@
 
         {% endif %}
       </fieldset>
-      {% include 'wiki/includes/wiki_notifier.html' %}
 
       <section class="wiki-block">
         {{ page_buttons(wiki, document, discard_href, 'bottom') }}

--- a/apps/wiki/templates/wiki/includes/wiki_notifier.html
+++ b/apps/wiki/templates/wiki/includes/wiki_notifier.html
@@ -1,1 +1,0 @@
-<div class="notifier"></div>

--- a/apps/wiki/templates/wiki/translate.html
+++ b/apps/wiki/templates/wiki/translate.html
@@ -150,8 +150,6 @@
     {% endif %}
 
   </div>
-  {% include 'wiki/includes/wiki_notifier.html' %}
-
 
 </form>
 

--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -498,10 +498,10 @@
         });
 
         // Save-and-edit submits to a hidden iframe, show loading message in notifier
-        var notifier = $('.notifier').mozNotifier();
+        var notifications = [];
         $('.btn-save-and-edit').on('click', function () {
 
-            notifier.setMessage('Saving changes…').show();
+            notifications.push(mdn.Notifier.growl('Saving changes…', { duration: 0 }));
 
             mdn.analytics.trackEvent({
                 category: 'Wiki',
@@ -524,7 +524,8 @@
         $('.btn-save-and-edit').show();
 
         $('#save-and-edit-target').on('load', function () {
-            notifier.success().hide();
+            notifications[0].success(null, 2000);
+            notifications.shift();
 
             if (supportsLocalStorage) {
                 var if_doc = $(this).get(0).contentDocument;

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -128,9 +128,8 @@
         if($link.hasClass('disabled')) return;
 
         var $form = $link.closest('form');
-        var notifier = $('.notifier').mozNotifier();
 
-        notifier.setMessage('Updating subscription status.').show();
+        var notification = mdn.Notifier.growl(gettext('Updating subscription status'), { duration: 0 });
 
         $link.addClass('disabled');
         $.ajax($form.attr('action'), {
@@ -139,8 +138,7 @@
         	data: $form.serialize()
         }).done(function(data) {
 
-            var message = '';
-
+            var message;
             data = JSON.parse(data);
             if(data.status == 1) {
                 $link.text($link.data('unsubscribe-text'));
@@ -151,7 +149,7 @@
                 message = 'You have been unsubscribed from this document.';
             }
 
-            notifier.success().setMessage(message).hide(2000);
+            notification.success(gettext(message), 2000);
 
             $link.removeClass('disabled');
         });

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -436,3 +436,28 @@ $right-icons {
     margin-left: 0 !important;
     margin-right: 10px !important;
 }
+
+
+/*  media block
+    for use when you want an item of defined width on the left and some stuff on the right of it
+    http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/ */
+.media,
+.media-body {
+    overflow: hidden;
+    _overflow: visible;
+    zoom: 1;
+}
+
+.media-img {
+    float: left;
+    margin-right: ($grid-spacing / 2);
+
+    img {
+        display: block;
+    }
+}
+
+.media-imgExt {
+    float: right;
+    margin-left: ($grid-spacing / 2);
+}

--- a/media/redesign/stylus/main/components.styl
+++ b/media/redesign/stylus/main/components.styl
@@ -100,35 +100,184 @@
     reverse-link-decoration();
 }
 
-.notifier {
-        background: rgba(252, 246, 212, 1);
-        border: 1px solid rgba(0, 0, 0, 0.1);
-        height: 25px;
-        left: 35%;
-        line-height: 1.6;
-        opacity: 0.6;
-        padding: 2px 4px;
-        position: fixed;
-        text-align: center;
-        top: -34px;
-        width: 30%;
-        z-index: 100;
-        transition: background 0.3s ease-out, top 0.3s ease-out 1.5s, opacity 0.3s ease-out 1.5s;
+/* hoping to one day use these colours to generate most colours we use on MDN but just here for now */
 
-        &.show-notifier {
-            opacity: 1;
-            top: 0;
-            transition: top 0.3s ease-in, opacity 0.3s ease-in;
+$red = #ea3b28;
+$yellow = #ffcb00;
+$green = #70a300;
+$blue = #0095dd;
+$grey = #c7ccce;
+
+$negative = $red;
+$warning = $yellow;
+$positive = $green;
+$neutral = $blue;
+$default = $grey;
+
+$text-dark = $text-color;
+$text-light = #fff;
+
+/* functions to transform the base colours into variations of themselves */
+
+theme-pale-light($color) {
+    return tint($color, 80%);
+}
+
+theme-pale-medium($color) {
+    $color = theme-pale-light($color);
+    $color = darken($color, 20%);
+    return $color;
+}
+
+theme-pale-dark($color) {
+    return darken($color, 20%);
+}
+
+/* functions to get correct text colours for variations of theme colours */
+
+theme-pale-text($color) {
+    $color = theme-pale-light($color);
+    $color = darken($color, 60%);
+    return $color;
+}
+
+theme-pale-contrast-text($color){
+    $hu = hue($color);
+    $lite = lightness($color);
+    $sat = saturation($color);
+    if (($hu < 20deg || $hu > 199deg) && $sat > 30% && $lite < 70%) {
+        $color = $text-light;
+    } else if ($lite < 50%) {
+        $color = $text-light;
+    } else {
+        $color = $text-dark;
+    }
+    return $color;
+}
+
+/* function to apply all the generated colours to a notification to theme it */
+
+notification-theme($color) {
+    background-color: theme-pale-light($color);
+    border-color: theme-pale-medium($color);
+    color: theme-pale-contrast-text(theme-pale-light($color));
+
+    .notification-button {
+        background-color: theme-pale-medium($color);
+        color: theme-pale-text($color);
+
+        &:hover, &:focus {
+          background: transparent;
+          text-decoration: none;
         }
+    }
 
-        &.success {
-            color: #fff;
-            background: rgba(141, 180, 86, 1);
+    .notification-img i {
+        color: theme-pale-dark($color);
+    }
+
+    button.close {
+        color: theme-pale-medium($color);
+
+        &:hover, &:focus {
+            color: theme-pale-dark($color);
         }
+    }
 
-        &.fail {
-            color:#fff;
-            background: rgba(193, 56, 50, 0.85);
-        }
+}
 
+/* style notifications */
+
+.notification {
+    @extends .media;
+    border-radius: 2px;
+    border-style: solid;
+    border-width: 2px;
+    margin-bottom: $grid-spacing;
+    padding: ($grid-spacing / 2);
+    position: relative;
+
+    &.closed {
+        display: none;
+    }
+
+    &.clickable {
+        cursor: pointer;
+    }
+
+    /* little x button in top right corner */
+    button.close {
+        background: transparent;
+        border: 0;
+        box-shadow: none;
+        display: block;
+        padding: 2px;
+        position: absolute;
+        top: 0;
+        right: 0px;
+    }
+
+    /* theme the various notification states */
+    notification-theme($default);
+
+    &.info {
+        notification-theme($neutral);
+    }
+
+    &.success {
+        notification-theme($positive);
+    }
+
+    &.warning {
+        notification-theme($warning);
+    }
+
+    &.error {
+        notification-theme($negative);
+    }
+}
+
+.notification-message {
+    @extends .media-body; /* here incase there's an icon, has the added benfiit of acting like a clearfix */
+
+    /* remove margin from first element in message */
+     & *:first-child {
+        margin-top: 0;
+    }
+}
+
+/* optional icon, message displays fine without it */
+.notification-img {
+    @extends .media-img;
+
+    {$selector-icon} {
+        font-size: $larger-font-size;
+        margin: 0;
+    }
+}
+
+/* class to add to <button> and <a> to make them look buttony */
+.notification-button {
+    border: 1px solid;
+    border-radius: 2px;
+    box-shadow: none;
+    display: inline-block;
+    line-height: 1;
+    margin: 5px 5px 0 0;
+    padding: 2px 5px 3px;
+    text-transform: none;
+}
+
+
+.notification-tray {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 999999;
+    width: 300px;
+    font-size: $smaller-font-size;
+
+    .notification {
+        margin-bottom: 8px;
+    }
 }


### PR DESCRIPTION
Sending an early PR os that Stephanie and John can take a look, let me know what they think.

`mdn.notify` has two uses right now:

```
*  `discover(parentElement)`: Finds notifications under a given parent (which would have been rendered with the initial server request), and adds close icon and other items accordingly.  Options are passed via separate `data-` attributes

*  `growl(message, options)`:  Adds a growl message to the growl notification tray, options passed via said object.  
```

A `handle` is returned from creating the notification, with a few methods for updating the notification style/status, its message, and the ability to close the item.  You also (dangerously) get access to the element itself.

To Do:

```
*  Decide if `mdn.Notifier` is where we want this to go.
*  Apparently "icon-times" isn't available in our version of Font Awesome, so I'm using the trash can icon for deletion now.  Gross.  Need to either upgrade FA (may be difficult) or find a an image to use.
*  Convert $.fn.mozNotifier uses to this new component.
```

Let me know what you think!
