### PR TITLE
Restore Stack Overflow icon to profile edit page

### DIFF
--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -75,7 +75,7 @@ class UserProfile(ModelBase):
             label=_(u'Stack Overflow'),
             prefix='https://stackoverflow.com/users/',
             regex='^https?://stackoverflow.com/users/',
-            fa_icon='icon-stackexchange',
+            fa_icon='icon-stack-overflow',
         )),
         ('linkedin', dict(
             label=_(u'LinkedIn'),


### PR DESCRIPTION
This icon has a different name in the latest version of FontAwesome.
