### PR TITLE
Change email link UX change.

### DIFF
--- a/kuma/users/templates/account/email.html
+++ b/kuma/users/templates/account/email.html
@@ -5,14 +5,17 @@
 {% block content %}
     <h1>{{ _("E-mail Addresses") }}</h1>
 {% if user.emailaddress_set.all %}
+
+<div class="text-content">
 <p>{{ _("The following e-mail addresses are associated with your account:") }}</p>
 
 <form action="{{ url('account_email') }}" class="email_list" method="post">
 {{ csrf() }}
 <fieldset class="blockLabels">
 
+<ul class="no-bullets">
   {% for emailaddress in user.emailaddress_set.all() %}
-<div class="ctrlHolder">
+<li class="ctrlHolder">
       <label for="email_radio_{{loop.index}}" class="{% if emailaddress.primary %}primary_email{%endif%}">
 
       <input id="email_radio_{{loop.index}}" type="radio" name="email" {% if emailaddress.primary %}checked="checked"{%endif %} value="{{emailaddress.email}}"/>
@@ -25,14 +28,15 @@
     {% endif %}
       {% if emailaddress.primary %}<span class="primary">{{ _("Primary") }}</span>{% endif %}
 </label>
-</div>
+</li>
   {% endfor %}
+</ul>
 
-<div class="buttonHolder">
+<p class="buttonHolder">
       <button class="secondaryAction" type="submit" name="action_primary" >{{ _("Make Primary") }}</button>
       <button class="secondaryAction" type="submit" name="action_send" >{{ _("Re-send Verification") }}</button>
       <button class="primaryAction" type="submit" name="action_remove" >{{ _("Remove") }}</button>
-</div>
+</p>
 
 </fieldset>
 </form>
@@ -52,7 +56,7 @@
     </form>
 
 {% endblock %}
-
+</div>
 
 {% block extra_body %}
 <script type="text/javascript">

--- a/kuma/users/templates/users/profile_edit.html
+++ b/kuma/users/templates/users/profile_edit.html
@@ -55,7 +55,7 @@
                   {{ li_field(profile_form, 'beta') }}
                   <li id="field_email" class="field type_email required">
                     <label>{{ _('Primary Email') }}</label>
-                    {{ profile.user.email }} <a href="{{ url('account_email') }}">{{ _('Change') }}</a>
+                    {{ profile.user.email }} <a href="{{ url('account_email') }}">{{ _('Edit email') }}</a>
                   </li>
                   {{ li_field(profile_form, 'fullname') }}
                   {{ li_field(profile_form, 'title') }}


### PR DESCRIPTION
Changed wording next to primary email to make change of link functionality clear to regular users. Added a bit of styling to change email address page.
