### PR TITLE
Change email link UX change.

### DIFF
--- a/kuma/users/templates/users/profile_edit.html
+++ b/kuma/users/templates/users/profile_edit.html
@@ -56,7 +56,7 @@
                   {{ li_field(profile_form, 'beta') }}
                   <li id="field_email" class="field type_email required">
                     <label>{{ _('Primary Email') }}</label>
-                    {{ profile.user.email }} <a href="{{ url('account_email') }}">{{ _('Change') }}</a>
+                    {{ profile.user.email }} <a href="{{ url('account_email') }}">{{ _('Edit email') }}</a>
                   </li>
                   {{ li_field(profile_form, 'fullname') }}
                   {{ li_field(profile_form, 'title') }}


### PR DESCRIPTION
Changed wording next to primary email to make change of link functionality clear to regular users.
