### PR TITLE
Fix nit with tag display

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -563,6 +563,7 @@ div.bug, div.warning, div.overheadIndicator {
 
     ul {
         bidi-style(padding-left, 6px, padding-right, 0);
+        display: inline;
         margin-bottom: 0;
 
         li {


### PR DESCRIPTION
Fix problem where articles with long lists of tags had the entire list wrap to the next line instead of just the tags, separating the heading from the tags.

Can see what I mean on [this page](https://developer.allizom.org/en-US/docs/Web/Guide/CSS/Media_queries) by shrinking your browser window a bit so the tags wrap to a second line.
