### PR TITLE
Prevent long list of tags from breaking translate page.

### DIFF
--- a/apps/wiki/templates/wiki/includes/revision_diff.html
+++ b/apps/wiki/templates/wiki/includes/revision_diff.html
@@ -39,8 +39,8 @@
 
       {% if revision_from.tags or revision_to.tags %}
       <dt>{{ _('Tags:') }}</dt>
-      <dd class="rev-from">{{ revision_from.tags }}</dd>
-      <dd class="rev-to">{{ revision_to.tags }}</dd>
+      <dd class="rev-from"> {{ ', '.join(revision_from.tags.split(',')) }}</dd>
+      <dd class="rev-to"> {{ ', '.join(revision_to.tags.split(',')) }}</dd>
       {% endif %}
 
       <dt>{{ _('Content:') }}</dt>


### PR DESCRIPTION
Long lists of tags were being output without spaces and if the single line was long enough it would break the page layout.

Fixed at the output source assuming .tags is an object, however if it is a string it might be better for us to add the space in earlier in the processing of the output.

If your export of the DB is the same as mine then you can test by editing [this page](https://developer-local.allizom.org/ja/docs/Web/API/MediaQueryList$edit).
