### PR TITLE
fix bug 775485 - welcome email tweaks

### DIFF
--- a/apps/devmo/helpers.py
+++ b/apps/devmo/helpers.py
@@ -171,7 +171,7 @@ def soapbox_messages(soapbox_messages):
 
 
 @register.function
-def add_utm(url_, campaign, source='notification', medium='email'):
+def add_utm(url_, campaign, source='developer.mozilla.org', medium='email'):
     """Add the utm_* tracking parameters to a URL."""
     url_obj = URLObject(url_).add_query_params({
         'utm_campaign': campaign,

--- a/kuma/users/tasks.py
+++ b/kuma/users/tasks.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import User
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
 
+import constance.config
 
 WELCOME_EMAIL_STRINGS = [
     "Like words?",
@@ -26,7 +27,7 @@ def send_welcome_email(user_pk, locale):
         email = EmailMultiAlternatives(
             _('Take the next step to get involved on MDN!'),
             content_plain,
-            settings.DEFAULT_FROM_EMAIL,
+            constance.config.WELCOME_EMAIL_FROM,
             [user.email],
         )
         email.attach_alternative(content_html, 'text/html')

--- a/kuma/users/templates/users/email/welcome/html.ltxt
+++ b/kuma/users/templates/users/email/welcome/html.ltxt
@@ -35,22 +35,22 @@
         <p>{{ _('Want to talk to someone about MDN? There are a few ways you can do that:') }}</p>
         <ul>
             <li>
-              {% trans list_link='https://lists.mozilla.org/listinfo/dev-mdc' %}
+              {% trans list_link=add_utm('https://lists.mozilla.org/listinfo/dev-mdc', 'welcome') %}
                 Mailing list: <a href="{{ list_link }}">subscribe</a> to tell us about what you're interested in on MDN and ask questions about the site.
               {% endtrans %}
             </li>
             <li>
               {% trans
                 channel_link='irc://irc.mozilla.org/mdn',
-                irc_link='https://wiki.mozilla.org/IRC'
+                irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome')
               %}
                 Real-time chat: <a href="{{ irc_link }}">#mdn channel on irc.mozilla.org</a>. (Get more info about <a href="{{ irc_link }}">IRC</a>.) You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and community manager Janet Swisher (jms).
               {% endtrans %}
             </li>
             <li>
               {% trans
-                blog_link='https://blog.mozilla.org/community',
-                tagged_link='https://blog.mozilla.org/community/category/developer-engagement/'
+                blog_link=add_utm('https://blog.mozilla.org/community', 'welcome'),
+                tagged_link=add_utm('https://blog.mozilla.org/community/category/developer-engagement/', 'welcome')
               %}Blog: On the <a href="{{ blog_link }}">about:community</a> blog, look for the posts tagged with <a href="{{ tagged_link }}">Developer Engagement</a>.
               {% endtrans %}
             </li>

--- a/kuma/users/templates/users/email/welcome/plain.ltxt
+++ b/kuma/users/templates/users/email/welcome/plain.ltxt
@@ -33,24 +33,28 @@ of intro tasks you can choose based on your interests.
 
 
 {# L10n: This is an email. Whitespace matters! #}
-{% trans %}
+{% trans
+    list_link=add_utm('https://lists.mozilla.org/listinfo/dev-mdc', 'welcome'),
+    irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome'),
+    blog_link=add_utm('https://blog.mozilla.org/community/category/developer-engagement', 'welcome')
+%}
 Want to talk to someone about MDN? There are a few ways you can do that:
 
-* Mailing list: https://lists.mozilla.org/listinfo/dev-mdc
+* Mailing list: {{ list_link }}
 
                 Subscribe to tell us about what you're interested in on MDN and
                 ask questions about the site.
 
 * Real-time chat: #mdn channel on irc.mozilla.org
 
-                  (See https://wiki.mozilla.org/IRC for more info about IRC.)
+                  (See {{ irc_link }} for more info about IRC.)
 
                   You can find the MDN writing staff admins there: Eric Shepherd
                   (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg),
                   Florian Scholz (fscholz), Chris Mills (chrismills), and
                   community manager Janet Swisher (jms).
 
-* Blog: https://blog.mozilla.org/community/category/developer-engagement
+* Blog: {{ blog_link }}
 {% endtrans %}
 
 {# L10n: This is an email. Whitespace matters! #}

--- a/settings.py
+++ b/settings.py
@@ -1094,6 +1094,10 @@ CONSTANCE_CONFIG = dict(
         'Number of expired sessions to cleanup up in one go.',
     ),
 
+    WELCOME_EMAIL_FROM = (
+        "Janet Swisher, MDN Community Manager <no-reply@mozilla.org>",
+        'Email address from which welcome emails will be sent',
+    ),
 
 )
 


### PR DESCRIPTION
Couple of updates to welcome emails:
- Add more GA tracking and update 'utm_source' to 'developer.mozilla.org' so we show up correctly as a source in GA for other Mozilla properties like wiki.mozilla.org
- Update the `From:` email address to "Janet Swisher, MDN Community Manager" instead of "notifications"

Spot-check instructions:
- [x] [Add a `welcome_email` switch](https://developer-local.allizom.org/admin/waffle/switch/add/) set to active
- [x] Register a new account in [en-US](https://developer-local.allizom.org/en-US/)
  - You should see the welcome email output in the `foreman start` console output
