### PR TITLE
Removing stray brace in submenu

### DIFF
--- a/apps/wiki/templates/wiki/includes/document_macros.html
+++ b/apps/wiki/templates/wiki/includes/document_macros.html
@@ -69,7 +69,6 @@
                 {% if user.is_superuser %}
                   <li><a href="{{ url('admin:wiki_document_change', document.id) }}">{{ _('View in admin') }}</a></li>
                 {% endif %}
-}
 
 {#
     # HACK: https://bugzil.la/972545 - Don't delete pages that have children


### PR DESCRIPTION
A stray brace made it into the wiki submenu.  This removes it.
