### PR TITLE
add coveralls reporting to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,12 +31,16 @@ install:
     - pip install -U pip wheel Django==1.4.13
     - pip install --no-index --find-links=travis_wheels -r requirements/compiled.txt
     - pip install --find-links=base_wheels -r requirements/prod.txt -r requirements/dev.txt
+    - pip install coveralls
 
 before_script:
     - mysql -e 'create database kuma;'
 
 script:
-    - python manage.py test --noinput -v2 actioncounters contentflagging dashboards kuma.demos devmo kpi landing search kuma.users wiki kuma.events
+    - coverage run --include=`pwd`/kuma/*,`pwd`/apps/* manage.py test --noinput -v2 actioncounters contentflagging dashboards kuma.demos devmo kpi landing search kuma.users wiki kuma.events
+
+after_success:
+    - coveralls
 
 notifications:
     irc:

--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,10 @@ Kuma
    :target: https://travis-ci.org/mozilla/kuma
    :alt: Build Status
 
+.. image:: https://coveralls.io/repos/mozilla/kuma/badge.png?branch=master
+  :target: https://coveralls.io/r/mozilla/kuma?branch=master
+   :alt: Coder Coverage Status
+
 .. image:: https://requires.io/github/mozilla/kuma/requirements.png?branch=master
    :target: https://requires.io/github/mozilla/kuma/requirements/?branch=master
    :alt: Requirements Status


### PR DESCRIPTION
Merge if we like. I've enabled coveralls.io reporting for mozilla/kuma repo and this worked for my groovecoder/kuma repo already:

https://coveralls.io/r/groovecoder/kuma

We're currently sitting at 86% coverage, and coveralls should help us improve that.
