### PR TITLE
Ensure zone image doesn't overlap title on mobile

### DIFF
--- a/media/redesign/stylus/zones.styl
+++ b/media/redesign/stylus/zones.styl
@@ -285,15 +285,23 @@ $dev-program-pad {
                 position: static;
             }
         }
+    }
 
-        .zone-image {
-            opacity: 0.2;
-        }
+    .zone-landing-header .zone-image, .zone-article-header .zone-image {
+        opacity: 0.2;
     }
 }
 
 @media $media-query-mobile {
-    .zone-landing-header .zone-image {
+    .zone-landing-header .zone-image, .zone-article-header .zone-image {
         display: none;
+    }
+
+    .zone-landing h1 {
+        width: auto;
+    }
+
+    .zone-landing-header {
+        display: block;
     }
 }


### PR DESCRIPTION
Zone images can overlay the title on zone pages other than the landing page.  Fixes.
