### PR TITLE
Modify page move slug blocks

### DIFF
--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -114,9 +114,9 @@ def format_comment(rev):
     #  If a page move, say so
     if prev_rev and prev_rev.slug != rev.slug:
         comment += (jinja2.Markup('<span class="slug-change">'
-                                  'Moved From <strong>%s</strong> '
-                                  'to <strong>%s</strong></span>') %
-                    (prev_rev.slug, rev.slug))
+                                  '<span>%s</span>'
+                                  ' <i class="icon-long-arrow-right" aria-hidden="true"></i> '
+                                  '<span>%s</span></span>') % (prev_rev.slug, rev.slug))
 
     return comment
 

--- a/media/redesign/stylus/diff.styl
+++ b/media/redesign/stylus/diff.styl
@@ -64,6 +64,10 @@ td.diff_header {
     margin: 4px 0;
     clear: both;
 
+    span {
+        white-space: nowrap;
+    }
+
     a {
         color: #444;
     }


### PR DESCRIPTION
Don't let page move slugs wrap, use icon instead of English words.
