### PR TITLE
Delete "The Basics of HTML" link.

### DIFF
--- a/apps/landing/templates/landing/learn_html.html
+++ b/apps/landing/templates/landing/learn_html.html
@@ -29,11 +29,6 @@
         <h2>{{ _('Introductory Level') }}</h2>
         <ul class="link-list">
           <li>
-            <h3 class="title"><a href="http://dev.opera.com/articles/view/12-the-basics-of-html/" rel="external">{{ _('The Basics of HTML') }}</a></h3>
-            <h4 class="source">Dev.Opera</h4>
-            <p>{{ _('What HTML is, what it does, its history in brief, and what the structure of an HTML document looks like. The articles that follow this one look at each individual part of HTML in much greater depth.') }}</p>
-          </li>
-          <li>
             <h3 class="title"><a href="http://reference.sitepoint.com/html/page-structure" rel="external">{{ _('Basic Structure of a Web Page') }}</a></h3>
             <h4 class="source">SitePoint</h4>
             <p>{{ _('Learn how HTML elements fit together into the bigger picture.') }}</p>


### PR DESCRIPTION
Please delete the "The Basics of HTML" link as the link is broken and is causing a 404 error.
