### PR TITLE
fix bug 1049660 - Remove preview buttons for templates

### DIFF
--- a/kuma/wiki/templates/wiki/includes/page_buttons.html
+++ b/kuma/wiki/templates/wiki/includes/page_buttons.html
@@ -26,9 +26,11 @@
   <li>
     <button type="submit" class="button positive btn-save">{{ _('Save Changes') }}<i aria-hidden="true" class="icon-save"></i></button>
   </li>
+  {% if (not document and not is_template) or (document and not document.is_template) %}
   <li>
     <button type="button" class="btn-preview" data-preview-url="{{ url('wiki.preview') }}">{{ _('Preview Changes') }}<i aria-hidden="true" class="icon-play-circle"></i></button>
   </li>
+  {% endif %}
   <li>
     <a href="{{ discard_href }}" class="button negative btn-discard">{{ _('Discard Changes') }}<i aria-hidden="true" class="icon-undo"></i></a>
   </li>

--- a/kuma/wiki/templates/wiki/new_document.html
+++ b/kuma/wiki/templates/wiki/new_document.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% from "includes/error_list.html" import errorlist %}
-{% from 'wiki/includes/page_buttons.html' import page_buttons %}
+{% from 'wiki/includes/page_buttons.html' import page_buttons with context %}
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Create a New {title}')|fe(title=('Template' if is_template else 'Article')) %}
 {% block title %}{{ page_title(title) }}{% endblock %}

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -23,7 +23,7 @@ from waffle.models import Flag
 
 from devmo.tests import SkippedTestCase
 from kuma.wiki.events import EditDocumentEvent
-from kuma.wiki.constants import REDIRECT_CONTENT
+from kuma.wiki.constants import REDIRECT_CONTENT, TEMPLATE_TITLE_PREFIX
 from kuma.wiki.models import (Document, Revision, HelpfulVote,
                               DocumentTag, Attachment)
 from kuma.wiki.tests import (TestCaseBase, document, revision, new_document_data,
@@ -306,6 +306,20 @@ class NewDocumentTests(TestCaseBase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(1, len(doc('form#wiki-page-edit input[name="title"]')))
+
+    def test_new_document_preview_button(self):
+        """HTTP GET to new document URL shows preview button for basic doc
+        and not for template doc"""
+        self.client.login(username='admin', password='testpass')
+        response = self.client.get(reverse('wiki.new_document'))
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        ok_(len(doc('.btn-preview')) > 0)
+
+        response = self.client.get(reverse('wiki.new_document') +
+                                                    '?slug=' + TEMPLATE_TITLE_PREFIX)
+        doc = pq(response.content)
+        eq_(0, len(doc('.btn-preview')))
 
     def test_new_document_form_defaults(self):
         """The new document form should have all all 'Relevant to' options


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1049660
