### PR TITLE
Fix 'Basics of HTML' broken link

### DIFF
--- a/apps/landing/templates/landing/learn_html.html
+++ b/apps/landing/templates/landing/learn_html.html
@@ -29,6 +29,11 @@
         <h2>{{ _('Introductory Level') }}</h2>
         <ul class="link-list">
           <li>
+            <h3 class="title"><a href="http://docs.webplatform.org/wiki/guides/the_basics_of_html" rel="external">{{ _('The Basics of HTML') }}</a></h3>
+            <h4 class="source">Webplatform</h4>
+            <p>{{ _('What HTML is, what it does, its history in brief, and what the structure of an HTML document looks like. The articles that follow this one look at each individual part of HTML in much greater depth.') }}</p>
+          </li>
+          <li>
             <h3 class="title"><a href="http://reference.sitepoint.com/html/page-structure" rel="external">{{ _('Basic Structure of a Web Page') }}</a></h3>
             <h4 class="source">SitePoint</h4>
             <p>{{ _('Learn how HTML elements fit together into the bigger picture.') }}</p>


### PR DESCRIPTION
The original link pointing to the Opera dev website was broken as the
document has been moved to the Webplatform site instead.

This commit fixes the link accordingly (reverts d8b7b8042c5 which removed
it entirely).
