### PR TITLE
fix bug 1051019 - Make inputs more responsive

### DIFF
--- a/media/redesign/stylus/submission.styl
+++ b/media/redesign/stylus/submission.styl
@@ -82,7 +82,8 @@
     }
 
     input[type='url'], input[type='email'], input[type='text'] {
-        width: 450px;
+        width: 350px;
+        max-width: 100%;
     }
 
     label, .label {


### PR DESCRIPTION
This cuts down the box size; this is 10000% responsive but people don't create accounts on that small of a screen.
