### PR TITLE
 Use the correct csrfmiddlewaretoken input to populate the ad-hoc preview form.

### DIFF
--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -370,8 +370,7 @@
                 $("<input type='hidden' name='title' />").val(title).appendTo($form);
 
                 // Add the CSRF ?
-                $('input[name=csrfmiddlewaretoken]').clone().appendTo($form);
-
+                $('#wiki-page-edit, #translate-document').find('input[name=csrfmiddlewaretoken]').clone().appendTo($form);
                 // Submit the form, and then get rid of it
                 $form.get(0).submit();
                 $form.remove();


### PR DESCRIPTION
This is a regression from 7258e049f80743796ca7907b05e8022a36d832b8. Fixes bug #1054294.
