### PR TITLE
 fix bug 1055107 - Add syntax highlighting to the document preview interface

### DIFF
--- a/kuma/wiki/templates/wiki/preview.html
+++ b/kuma/wiki/templates/wiki/preview.html
@@ -5,22 +5,21 @@
 
 {% block content %}
 
-  {% if kumascript_errors %}
-    {% include 'wiki/includes/kumascript_errors.html' %}
-  {% endif %}
+    {% if kumascript_errors %}
+        {% include 'wiki/includes/kumascript_errors.html' %}
+    {% endif %}
 
-  <div class="warning warning-review">
-    <p>{{ _('This is a preview of an unsaved document.') }}</p>
-  </div>
+    <div class="warning warning-review">
+        <p>{{ _('This is a preview of an unsaved document.') }}</p>
+    </div>
 
-  <div>
     <div class="page-title">
         <h1 class="page-title">{{ title }}</h1>
     </div>
-    <div id="wikiArticle" class="text-content">
+
+    <article id="wikiArticle" class="text-content">
         {{ content|safe }}
-    </div>
-  </div>
+    </article>
 
 {% endblock %}
 

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -1058,7 +1058,7 @@ class ArticlePreviewTests(TestCaseBase):
                         {'content': '<h1>Test Content</h1>'})
         eq_(200, response.status_code)
         doc = pq(response.content)
-        eq_('Test Content', doc('div#wikiArticle h1').text())
+        eq_('Test Content', doc('article#wikiArticle h1').text())
 
     def test_preview_locale(self):
         raise SkipTest


### PR DESCRIPTION
Prism will now highlight in preview mode due to article. \o/
