### PR TITLE
Fix bug 1055078 - Update JS files to pass JSHint

### DIFF
--- a/media/js/demos.js
+++ b/media/js/demos.js
@@ -6,7 +6,7 @@ $(document).ready(function () {
 
         var $el = $(this),
             $form = $el.find('form');
-        
+
         // Wire up reply form reveal link in threaded comments.
         $el.find('.show_reply').click(function () {
             $form.slideDown();
@@ -27,7 +27,7 @@ $(document).ready(function () {
       interval: 250,
       over: function() {
         var $demo = $(this),
-            content = $demo.html(), 
+            content = $demo.html(),
             offs = $demo.offset(),
             $contentContainer = $('body'),
             fadeDuration = 200,
@@ -40,9 +40,9 @@ $(document).ready(function () {
 
         $demoHover = $contentContainer.find('div.demohover');
 
-        if ($demo.parents('#featured-demos').length) {
+        if($demo.parents('#featured-demos').length) {
           $demoHover.addClass('featured');
-        };
+        }
 
         $demoHover
             .addClass( $(this).attr('class') )
@@ -53,7 +53,7 @@ $(document).ready(function () {
                     $(this).remove();
                 });
             });
-      }, 
+      },
       out: function() { /* do nothing */ }
     });
 
@@ -66,8 +66,8 @@ $(document).ready(function () {
     $('#demos-head .learnmore .button').click(function(){
       $learnPop.slideToggle(slideSpeed).removeAttr('aria-hidden');
       $(this).blur();
-      if ($tagsList.is(':visible')) { 
-        $tagsList.hide().attr('aria-hidden', 'true'); 
+      if ($tagsList.is(':visible')) {
+        $tagsList.hide().attr('aria-hidden', 'true');
       }
       return false;
     });
@@ -76,8 +76,8 @@ $(document).ready(function () {
     $('#demos-head .tags .button, #demo-tags .button').click(function() {
       $tagsList.slideToggle(slideSpeed).removeAttr('aria-hidden');
       $(this).blur();
-      if ($learnPop.is(':visible')) { 
-        $learnPop.hide().attr('aria-hidden', 'true'); 
+      if ($learnPop.is(':visible')) {
+        $learnPop.hide().attr('aria-hidden', 'true');
       }
       return false;
     });

--- a/media/js/moz-jquery-plugins.js
+++ b/media/js/moz-jquery-plugins.js
@@ -29,9 +29,9 @@
             // Shows an 'invalid' style if something good isn't picked
             requireValidOption: false,
             // Callback for selection;  true selection or 'silent' selection
-            onSelect: function(selectionObj, isSilent){},
+            onSelect: function(selectionObj, isSilent) {},
             // Callback for when a selection is deselected via this plugin
-            onDeselect: function(oldSelection){},
+            onDeselect: function(oldSelection) {},
             // URL to hit to retrieve results
             autocompleteURL: '',
             // Element to style and add 'valid' and 'invalid' classes to
@@ -198,7 +198,7 @@
             this.options.select = function(event, ui, isSilent) {
                 // Set the selection
                 var selection = self.selection = ui.item;
-                if(selection.value != undefined) {
+                if(selection.value !== undefined) {
                         // Call the select method if present
                     if(select) select.call(self, event, ui);
                     // Set the INPUT element's value to the item value
@@ -270,14 +270,14 @@
                             .attr('title', item.url)
                             .append($('<a></a>').text(item.label))
                             .appendTo(list);
-                }
+                };
             }
         },
 
         reposition: function() {
-            this.menu.element.position( $.extend({
+            this.menu.element.position($.extend({
                 of: this.element
-            }, this.options.position ))
+            }, this.options.position));
         }
     });
 
@@ -290,7 +290,7 @@
             var placeholder = $input.attr('placeholder');
 
             var valCheck = function() {
-                var box = $input[0]
+                var box = $input[0];
                 if(box.value == placeholder) {
                      box.value = '';
                 }
@@ -301,7 +301,7 @@
             $input.bind({
                 blur: valCheck,
                 focus: function() {
-                    if($input.val() == '') {
+                    if($input.val() === '') {
                         $input.val(placeholder);
                     }
                 }

--- a/media/js/profile.js
+++ b/media/js/profile.js
@@ -112,7 +112,7 @@
                 var color = placeholder.parent().css("color");
                 var length;
 
-                if(words[0] == ""){ words.length = 0; }
+                if(words[0] === ""){ words.length = 0; }
                 currcount = limit - words.length;
                 placeholder.text(currcount);
 

--- a/media/js/wiki-admin.js
+++ b/media/js/wiki-admin.js
@@ -1,29 +1,29 @@
 // See also: http://stackoverflow.com/questions/6086651/minimize-the-list-filter-in-django-admin
 (function($){
-ListFilterCollapsePrototype = {
-    bindToggle: function(){
-        var that = this;
-        this.$filterTitle.click(function(){
-            that.$filterContent.slideToggle();
-            that.$list.toggleClass('filtered');
-        });
-    },
-    init: function(filterEl) {
-        this.$filterTitle = $(filterEl).children('h2');
-        this.$filterContent = $(filterEl).children('h3, ul');
-        $(this.$filterTitle).css('cursor', 'pointer');
-        this.$list = $('#changelist');
-        this.bindToggle();
+    ListFilterCollapsePrototype = {
+        bindToggle: function(){
+            var that = this;
+            this.$filterTitle.click(function(){
+                that.$filterContent.slideToggle();
+                that.$list.toggleClass('filtered');
+            });
+        },
+        init: function(filterEl) {
+            this.$filterTitle = $(filterEl).children('h2');
+            this.$filterContent = $(filterEl).children('h3, ul');
+            $(this.$filterTitle).css('cursor', 'pointer');
+            this.$list = $('#changelist');
+            this.bindToggle();
+        }
+    };
+    function ListFilterCollapse(filterEl) {
+        this.init(filterEl);
     }
-}
-function ListFilterCollapse(filterEl) {
-    this.init(filterEl);
-}
-ListFilterCollapse.prototype = ListFilterCollapsePrototype;
+    ListFilterCollapse.prototype = ListFilterCollapsePrototype;
 
-$(document).ready(function(){
-    $('#changelist-filter').each(function(){
-        var collapser = new ListFilterCollapse(this);
+    $(document).ready(function(){
+        $('#changelist-filter').each(function(){
+            var collapser = new ListFilterCollapse(this);
+        });
     });
-});
 })(django.jQuery);

--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -156,7 +156,7 @@
 
           var populate = function () {
               // Bail if the fields value has changed
-              if ($field.data(_changed) == true) return;
+              if ($field.data(_changed) === true) return;
 
               var values = [], field_val, field_val_raw, split;
               dependencies.each(function() {
@@ -349,8 +349,8 @@
             var $titleNode = $('#id_title');
             var data;
 
-            if(CKEDITOR.instances['id_content']) {
-                data = $.trim(CKEDITOR.instances['id_content'].getSnapshot());
+            if(CKEDITOR.instances.id_content) {
+                data = $.trim(CKEDITOR.instances.id_content.getSnapshot());
             }
             else if(ace_editor && ace_editor) {
                 data = $.trim(ace_editor.getSession().getValue());
@@ -386,7 +386,7 @@
     function initMetadataEditButton () {
 
         if ($('#article-head .metadata').length) {
-            var show_meta = function (ev) {
+            var showMeta = function (ev) {
                 // Disable and hide the save-and-edit button when editing
                 // metadata, since that can change the URL of the page and
                 // tangle up where the iframe posts.
@@ -394,13 +394,13 @@
                 $('#article-head .title').hide();
                 $('#article-head .metadata').show();
                 $('#article-head .metadata #id_title').focus();
-            }
+            };
 
             // Properties button reveals the metadata fields
-            $('#btn-properties').on('click', show_meta);
+            $('#btn-properties').on('click', showMeta);
             // Form errors reveal the metadata fields, since they're the most
             // likely culprits
-            $('#edit-document .errorlist').each(show_meta);
+            $('#edit-document .errorlist').each(showMeta);
 
         } else {
             $('#btn-properties').hide();
@@ -503,7 +503,7 @@
         });
     }
     function hideDraftBox() {
-        $draftDiv && $draftDiv.css('display', 'none');
+        if($draftDiv) $draftDiv.css('display', 'none');
     }
 
 
@@ -651,12 +651,12 @@
             DRAFT_TIMEOUT_ID = setTimeout(saveDraft, 3000);
         };
         if(isTemplate) {
-            ace_editor.on && ace_editor.on('change', callback);
+            if(ace_editor.on) ace_editor.on('change', callback);
         }
         else {
             try {
                 var $content = $('#id_content');
-                $content.ckeditorGet && $content.ckeditorGet().on('key', callback);
+                if($content.ckeditorGet) $content.ckeditorGet().on('key', callback);
             }
             catch(e) {
                 console.log(e);
@@ -779,23 +779,23 @@
                     }
                     else { // We have to cherry pick which were good and which were bad
                         $.each(invalidIndexes, function() {
-                            if(this == 0) {
+                            if(this === 0) {
                                 // Add message to the clone row
                                 $('<div class="attachment-error"></div>')
                                     .appendTo($attachmentsFormCloneRow.find('.page-attachment-actions-file-cell'))
-                                    .text(result[this]['error'])
+                                    .text(result[this]['error']);
                             }
                         });
                     }
                 }
                 else {
                     // Show error message?
-                    console.warn('No textarea')
+                    console.warn('No textarea');
                 }
             }
-            catch(e) {
+            catch(ex) {
                 // Show error message?
-                console.warn('Exception! ', e);
+                console.warn('Exception! ', ex);
             }
             $pageAttachmentsSpinner.css('opacity', 0);
         });
@@ -810,7 +810,7 @@
             var valid = true;
             $attachmentsNewTable.find('input[required], textarea[required]').each(function() {
                 var $this = $(this);
-                if($this.val() == '') {
+                if($this.val() === '') {
                     e.preventDefault();
                     e.stopPropagation();
                     $this.addClass('attachment-required');
@@ -822,7 +822,9 @@
             });
             if(!valid) {
                 running = false;
-                setTimeout(function() { $attachmentsForm.data('disabled', false); }, 200);
+                setTimeout(function() {
+                    $attachmentsForm.data('disabled', false);
+                }, 200);
                 return;
             }
 

--- a/media/redesign/js/analytics.js
+++ b/media/redesign/js/analytics.js
@@ -103,7 +103,7 @@
             Sends universal analytics client side error
         */
         trackError: function(description) {
-            win.ga && ga('send', 'exception', {
+            if(win.ga) ga('send', 'exception', {
                 'exDescription': description
             });
         }

--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -50,7 +50,7 @@
                 // If no submenu, go
                 if(!$submenu.length) {
                     clear(showTimeout);
-                    $.fn.mozMenu.$openMenu && closeSubmenu(getOpenParent());
+                    if($.fn.mozMenu.$openMenu) closeSubmenu(getOpenParent());
                     return;
                 }
 
@@ -119,7 +119,7 @@
                         var firstLink = $submenu.find('a').get(0);
                         if(firstLink) {
                             try { // Putting in try/catch because of opacity/focus issues in IE
-                                $(firstLink).addClass(focusClass) && firstLink.focus();
+                                if($(firstLink).addClass(focusClass)) firstLink.focus();
                             }
                             catch(e){
                                 console.log('Exception! ', e);
@@ -138,14 +138,14 @@
 
         // Clears the current timeout, interrupting fade-ins and outs as necessary
         function clear(timeout) {
-            timeout && clearTimeout(timeout);
+            if(timeout) clearTimeout(timeout);
         }
 
         // Closes a given submenu
         function closeSubmenu($sub) {
             closeTimeout = setTimeout(function() {
                 // Set the z-index to one less so another menu would get top spot if overlapping and opening
-                $sub && $sub.css('z-index', 99998).removeClass('open').attr('aria-hidden', 'true').fadeOut(settings.fadeOutSpeed);
+                if($sub) $sub.css('z-index', 99998).removeClass('open').attr('aria-hidden', 'true').fadeOut(settings.fadeOutSpeed);
                 settings.onClose();
             }, settings.hideDelay);
         }
@@ -165,8 +165,8 @@
 
         return this.each(function() {
 
-            var $items = $(this).find(settings.itemSelector);
-            if(!$items.length) return;
+            var $children = $(this).find(settings.itemSelector);
+            if(!$children.length) return;
 
             var $self = $(this);
 
@@ -174,10 +174,11 @@
                 var code = e.keyCode;
                 var charCode = e.charCode;
                 var numberKeyStart = 49;
+                var $items;
 
                 // If we should always get fresh items, do so
                 if(settings.alwaysCollectItems) {
-                    var $items = $(this).find(settings.itemSelector);
+                    $items = $(this).find(settings.itemSelector);
                 }
 
                 // Up and down buttons
@@ -204,7 +205,7 @@
                     var $prev = $($items.get(index - 1));
 
                     if(code == 38) {    // up
-                        $prev.length && selectItem($prev);
+                        if($prev.length) selectItem($prev);
                     }
                     else if(code == 40) {    // down
                         selectItem($next.length ? $next : $items.first());
@@ -213,7 +214,7 @@
                 // Number keys: 1, 2, 3, etc.
                 else if(charCode >= numberKeyStart && charCode <= 57) {
                     var item = $items.get(charCode - numberKeyStart);
-                    item && selectItem(item);
+                    if(item) selectItem(item);
                 }
                 // Enter key
                 else if(code == 13) {
@@ -261,7 +262,7 @@
                 e.stopPropagation();
                 if(e.keyCode == 27) {
                     $(this).siblings('a').trigger('mdn:click').focus();
-                };
+                }
             });
 
             // Click event to show/hide
@@ -412,7 +413,7 @@
         function closeItem($item, callback) {
             $item.fadeOut(300, function() {
                 $item.addClass('closed');
-                callback && callback.apply($item, null);
+                if(callback) callback.apply($item, null);
             });
         }
 
@@ -437,7 +438,7 @@
             // Add URL click event
             if(options.url) {
                 $item.addClass('clickable').on('click', function() {
-                    win.location = defaults.url
+                    win.location = defaults.url;
                 });
             }
 
@@ -543,7 +544,7 @@
 
                 return handle;
             }
-        }
+        };
     })();
 
 })(window, document, jQuery);

--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -12,7 +12,9 @@
     (function() {
         var $mainItems = $('#main-nav > ul > li');
         $mainItems.find('> a').mozMenu({
-            brickOnClick: function(e) { return e.target.tagName == 'I'; }
+            brickOnClick: function(e) {
+                return e.target.tagName == 'I';
+            }
         });
         $mainItems.find('.submenu').mozKeyboardNav();
     })();
@@ -76,8 +78,8 @@
                     return;
                 }
 
-                e && e.preventDefault();
-                timeout && clearTimeout(timeout);
+                if(e) e.preventDefault();
+                if(timeout) clearTimeout(timeout);
                 timeout = setTimeout(function() {
                     if(isAdd) {
                         $navItems.fadeOut(100, function() {
@@ -98,7 +100,7 @@
                         timeout = setTimeout(function() {
                             $searchWrap.removeClass('expanded');
                             $navItems.fadeIn(400);
-                        } , 500);
+                        }, 500);
                     }
                 }, delay);
             };
@@ -148,7 +150,7 @@
     $(doc).ajaxSend(function(event, xhr, settings) {
         function getCookie(name) {
             var cookieValue = null;
-            if (doc.cookie && doc.cookie != '') {
+            if (doc.cookie && doc.cookie !== '') {
                 var cookies = doc.cookie.split(';');
                 for (var i = 0; i < cookies.length; i++) {
                     var cookie = jQuery.trim(cookies[i]);
@@ -193,7 +195,7 @@
     });
     $('#skip-main').each(function() { // Only one, so using each as closure
         var id = this.href.split('#')[1];
-        id && $('#' + id).attr('role', 'main');
+        if(id) $('#' + id).attr('role', 'main');
     });
 
     /*
@@ -244,7 +246,7 @@
     /*
         Tabzilla
     */
-    $('#tabzilla').length && $.ajax({
+    if($('#tabzilla').length) $.ajax({
         url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
         dataType: 'script',
         cache: true
@@ -253,13 +255,12 @@
     /*
         Track users successfully logging in and out
     */
-    ('localStorage' in win) && (function() {
+    if('localStorage' in win) (function() {
         var serviceKey = 'login-service';
         var serviceStored = localStorage.getItem(serviceKey);
         var serviceCurrent = $('body').data(serviceKey);
 
         try {
-
             // User just logged in
             if(serviceCurrent && !serviceStored) {
                 localStorage.setItem(serviceKey, serviceCurrent);
@@ -283,9 +284,8 @@
                     label: serviceStored
                 });
             }
-
         }
-        catch (e) {
+        catch(e) {
             // Browser probably doesn't support localStorage
         }
     })();

--- a/media/redesign/js/promote.js
+++ b/media/redesign/js/promote.js
@@ -1,7 +1,7 @@
 function PromoteMDN(userSettings) {
 
     // For the time being, we are not gonna do anything if querySelectorAll is not available in the browser
-    if (!'querySelectorAll' in document) {
+    if (!('querySelectorAll' in document)) {
         return;
     }
 
@@ -131,8 +131,7 @@ function PromoteMDN(userSettings) {
                 if (text.match(keywordRegex)) {
                     var exactWord = keywordRegex.exec(text);
                     exactWord = exactWord[0].trim();
-                    var link = '<a href="'+ dataset[keyword] + options.trackingString +'" class="'+ options.linkClass
-                        +'">' + exactWord + '</a>';
+                    var link = '<a href="'+ dataset[keyword] + options.trackingString +'" class="'+ options.linkClass +'">' + exactWord + '</a>';
                     placeholder = getPlaceholder(placeholderIndex);
                     placeholderIndex++;
                     text = text.replace(exactWord, placeholder);
@@ -150,8 +149,8 @@ function PromoteMDN(userSettings) {
             text = text.replace(l, anchorsExisting[l]);
         }
 
-        for(var l in anchorsNew) {
-            text = text.replace(l, ' ' + anchorsNew[l] + ' ');
+        for(var c in anchorsNew) {
+            text = text.replace(c, ' ' + anchorsNew[l] + ' ');
         }
 
         o.innerHTML = text;
@@ -190,9 +189,9 @@ function PromoteMDN(userSettings) {
         }
 
         return out;
-    };
+    }
 
     function getPlaceholder(placeholderIndex) {
         return '{_m$d$n_repl$ace_' + placeholderIndex + '_}';
     }
-};
+}

--- a/media/redesign/js/search-navigator.js
+++ b/media/redesign/js/search-navigator.js
@@ -182,7 +182,7 @@
         // Set in motion the process to show and populate or hide the navigator!
         if(!url) {
             if(key) {
-                url = key
+                url = key;
             }
         }
         else {

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -180,7 +180,7 @@
     /*
         Syntax highlighting scripts
     */
-    $('article pre').length && ('querySelectorAll' in doc) && (function() {
+    if($('article pre').length && ('querySelectorAll' in doc)) (function() {
         var syntaxScript = doc.createElement('script');
         syntaxScript.setAttribute('data-manual', '');
         syntaxScript.async = 'true';
@@ -331,7 +331,7 @@
 
         var value = $(this).find('#stack-search').val();
 
-        if(value != '') {
+        if(value !== '') {
             win.location = 'http://stackoverflow.com/search?q=[firefox]+or+[firefox-os]+or+[html5-apps]+' + value;
         }
     });
@@ -415,7 +415,7 @@
        https://developer.mozilla.org/en-US/docs/Web/MathML/Authoring#Fallback_for_Browsers_without)MathML_support
        and https://github.com/fred-wang/mathml.css.
     */
-    $('math').length && (function() {
+    if($('math').length) (function() {
         // Test for MathML support
         var $div = $('<div class="offscreen"><math xmlns="http://www.w3.org/1998/Math/MathML"><mspace height="23px" width="77px"/></math></div>').appendTo(document.body);
         var box = $div.get(0).firstChild.firstChild.getBoundingClientRect();
@@ -451,7 +451,7 @@
         },
         // Used within the wiki new/move pages
         slugifyString: function(str, allowSlash, allowMultipleUnderscores) {
-            var regex = new RegExp('[\?\&\"\'\#\*\$' + (allowSlash ? '' : '\/') + ' +?]', 'g');
+            var regex = new RegExp('[?&\"\'#*$' + (allowSlash ? '' : '\/') + ' +?]', 'g');
 
             // Remove anything from the slug that could cause big problems
             // "$" is used for verb delimiter in URLs
@@ -519,17 +519,17 @@
             });
 
             if(timeoutFlag) {
-                timer && clearTimeout(timer);
-            }else{
+                if(timer) clearTimeout(timer);
+            }
+            else {
                 timer = setTimeout(timeout, 6000);
             }
-        };
+        }
 
         // If the page does not have any YouTube videos
         if(!$youtubeIframes.length) return;
 
-        var origin = win.location.protocol + '//' + win.location.hostname +
-                    (win.location.port ? ':' + win.location.port: '');
+        var origin = win.location.protocol + '//' + win.location.hostname + (win.location.port ? ':' + win.location.port: '');
 
         //Enable JS API on all YouTube iframes, might cause flicker!
         $youtubeIframes.each(function() {


### PR DESCRIPTION
Checking our JS changes with JSHint will be important so that all front-end work is uniform.

There's one exception in JSHint tests which is in wiki-edit.js, and that is using ".error".  I don't feel comfortable using that key in that way, I think "array" syntax is better there.
