### PR TITLE
fix bug 1052922 - Prevent link background from bleeding outside of the login widget

### DIFF
--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -373,6 +373,7 @@ a.github-button {
     position: relative;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
+    overflow: hidden;
 
     a {
         display: block;


### PR DESCRIPTION
A very basic fix for this issue.  https://bugzilla.mozilla.org/show_bug.cgi?id=1052922
