### PR TITLE
Fix bug 1053912: Update connection page labels

### DIFF
--- a/kuma/users/templates/socialaccount/snippets/provider_list.html
+++ b/kuma/users/templates/socialaccount/snippets/provider_list.html
@@ -12,13 +12,25 @@
         {% if provider.id == "persona" %}
           <li><a href="{{ provider_login_url(provider.id, process=process, next=next_url) }}" class="persona-button persona-loaded login-link" data-next="{{ next_url }}" data-service="{{ provider.name }}">
             <span class="persona-icon"><i aria-hidden="true"></i></span>
-            <span class="signin">{{ _('Sign in with Persona') }}</span>
+            <span class="signin">
+            {% if process == "connect" %}
+              {{ _('Connect with Persona') }}
+            {% else %}
+              {{ _('Sign in with Persona') }}
+            {% endif %}
+            </span>
           </a></li>
         {% elif provider.id == "github" %}
           {% if waffle.flag('github_login') %}
             <li><a href="{{ provider_login_url(provider.id, process=process, next=next_url) }}" class="github-button login-link" data-next="{{ next_url }}" data-service="{{ provider.name }}">
               <span class="github-icon"><i class="icon-github" aria-hidden="true"></i></span>
-              <span class="signin">{{ _('Sign in with GitHub') }}</span>
+              <span class="signin">
+              {% if process == "connect" %}
+                {{ _('Connect with GitHub') }}
+              {% else %}
+                {{ _('Sign in with GitHub') }}
+              {% endif %}
+              </span>
             </a></li>
           {% endif %}
         {# {% else %}

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -54,7 +54,8 @@ class SocialAccountConnectionsTests(test_utils.TestCase):
         self.client.login(username=u.username, password=TESTUSER_PASSWORD)
         url = reverse('socialaccount_connections')
         r = self.client.get(url)
-        test_strings = ['Disconnect', 'Connect a new account', 'Edit profile']
+        test_strings = ['Disconnect', 'Connect a new account', 'Edit profile',
+                        'Connect with']
 
         eq_(200, r.status_code)
         for test_string in test_strings:


### PR DESCRIPTION
Update labels on account connections page to connect instead of sign-in.

[John Karahalis edited this commit message to move the bug number to the
beginning of the first line.]
