### PR TITLE
Fix bug 1056487 - broken Opera Dev links on MDN 'Learn Javascript' page

### DIFF
--- a/apps/landing/templates/landing/learn_javascript.html
+++ b/apps/landing/templates/landing/learn_javascript.html
@@ -38,8 +38,8 @@
             <p>{{ _('What is JavaScript and how can it help you?') }}</p>
           </li>
           <li>
-            <h3 class="title"><a href="http://dev.opera.com/articles/view/programming-the-real-basics/" rel="external">{{ _('Programming &ndash; The Real Basics')|safe }}</a></h3>
-            <h4 class="source">Dev.Opera Web</h4>
+            <h3 class="title"><a href="http://docs.webplatform.org/wiki/tutorials/Programming_-_the_real_basics" rel="external">{{ _('Programming &ndash; The Real Basics')|safe }}</a></h3>
+            <h4 class="source">Webplatform</h4>
             <p>{{ _('Basic fundamentals of programming. Following articles introduce what you can do with JavaScript, best practices for using it, and more.') }}</p>
           </li>
           <li>
@@ -48,8 +48,8 @@
             <p>{{ _('Video tutorial on making pages interactive with JavaScript') }}</p>
           </li>
           <li>
-            <h3 class="title"><a href="http://dev.opera.com/articles/view/javascript-best-practices/" rel="external">{{ _('JavaScript Best Practices') }}</a></h3>
-            <h4 class="source">Dev.Opera</h4>
+            <h3 class="title"><a href="http://docs.webplatform.org/wiki/tutorials/javascript_best_practices" rel="external">{{ _('JavaScript Best Practices') }}</a></h3>
+            <h4 class="source">Webplatform</h4>
             <p>{{ _('Learn about some of the obvious and (not so) obvious best practices when writing JavaScript.') }}</p>
           </li>
         </ul>


### PR DESCRIPTION
As for bug 1038541, the pages have been moved to webplatform.
