### PR TITLE
fix bug 1056472, 1056639 - Don't encode angle brackets in code samples

### DIFF
--- a/media/js/syntax-prism.js
+++ b/media/js/syntax-prism.js
@@ -33,7 +33,7 @@
         $pre.addClass('language-' + defaultBrush);
 
         // Format PRE content for Prism highlighting
-        $pre.html('<code class="language-' + brush + '">' + $.trim($pre.html().replace(/</g, '&lt;').replace(/>/g, '&gt;')) + '</code>');
+        $pre.html('<code class="language-' + brush + '">' + $.trim($pre.html()) + '</code>');
 
         // Do we need to highlight any lines?
         // Legacy format: highlight:[8,9,10,11,17,18,19,20]


### PR DESCRIPTION
It appears we're using HTML tags for presentation inside `<pre>` tags  _sigh_

https://bugzilla.mozilla.org/show_bug.cgi?id=1056472
https://bugzilla.mozilla.org/show_bug.cgi?id=1056639
