### PR TITLE
Fix bug 1056487 - broken links on MDN 'Learn Javascript' page

### DIFF
--- a/apps/landing/templates/landing/learn_html.html
+++ b/apps/landing/templates/landing/learn_html.html
@@ -30,7 +30,7 @@
         <ul class="link-list">
           <li>
             <h3 class="title"><a href="http://docs.webplatform.org/wiki/guides/the_basics_of_html" rel="external">{{ _('The Basics of HTML') }}</a></h3>
-            <h4 class="source">Webplatform</h4>
+            <h4 class="source">Web Platform</h4>
             <p>{{ _('What HTML is, what it does, its history in brief, and what the structure of an HTML document looks like. The articles that follow this one look at each individual part of HTML in much greater depth.') }}</p>
           </li>
           <li>

--- a/apps/landing/templates/landing/learn_javascript.html
+++ b/apps/landing/templates/landing/learn_javascript.html
@@ -38,8 +38,8 @@
             <p>{{ _('What is JavaScript and how can it help you?') }}</p>
           </li>
           <li>
-            <h3 class="title"><a href="http://dev.opera.com/articles/view/programming-the-real-basics/" rel="external">{{ _('Programming &ndash; The Real Basics')|safe }}</a></h3>
-            <h4 class="source">Dev.Opera Web</h4>
+            <h3 class="title"><a href="http://docs.webplatform.org/wiki/tutorials/Programming_-_the_real_basics" rel="external">{{ _('Programming &ndash; The Real Basics')|safe }}</a></h3>
+            <h4 class="source">Web Platform</h4>
             <p>{{ _('Basic fundamentals of programming. Following articles introduce what you can do with JavaScript, best practices for using it, and more.') }}</p>
           </li>
           <li>
@@ -48,8 +48,8 @@
             <p>{{ _('Video tutorial on making pages interactive with JavaScript') }}</p>
           </li>
           <li>
-            <h3 class="title"><a href="http://dev.opera.com/articles/view/javascript-best-practices/" rel="external">{{ _('JavaScript Best Practices') }}</a></h3>
-            <h4 class="source">Dev.Opera</h4>
+            <h3 class="title"><a href="http://docs.webplatform.org/wiki/tutorials/javascript_best_practices" rel="external">{{ _('JavaScript Best Practices') }}</a></h3>
+            <h4 class="source">Web Platform</h4>
             <p>{{ _('Learn about some of the obvious and (not so) obvious best practices when writing JavaScript.') }}</p>
           </li>
         </ul>


### PR DESCRIPTION
As for bug 1038541, the pages have been moved to webplatform.

Now also using proper naming for the Web Platform site on the
'Learn HTML' page.
