### PR TITLE
fix bug 719651 -  Profile field validation for LinkedIn is not valid for international profiles

### DIFF
--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -20,9 +20,28 @@ class TestUserProfileEditForm(test_utils.TestCase):
             ('website', 'mozilla.org'),
             ('twitter', 'twitter.com/lmorchard'),
             ('github', 'github.com/lmorchard'),
-            ('stackoverflow', 'stackoverflow.com/users/lmorchard'),
-            ('linkedin', 'www.linkedin.com/in/lmorchard'),
+            ('stackoverflow', 'stackoverflow.com/users/testuser'),
+            ('linkedin', 'www.linkedin.com/in/testuser'),
         )
+        self._assert_protos_and_sites(protos, sites)
+
+    def test_linkedin_public_profile_urls(self):
+        """
+        Bug 719651 - Profile field validation for LinkedIn is not
+        valid for international profiles
+        https://bugzil.la/719651
+        """
+        protos = (
+            ('http://', True),
+            ('https://', True),
+        )
+        sites = (
+            ('linkedin', 'www.linkedin.com/in/testuser'),
+            ('linkedin', 'www.linkedin.com/pub/testuser/0/1/826')
+        )
+        self._assert_protos_and_sites(protos, sites)
+
+    def _assert_protos_and_sites(self, protos, sites):
         for proto, expected_valid in protos:
             for name, site in sites:
                 url = '%s%s' % (proto, site)

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -294,7 +294,6 @@ class ProfileViewsTest(TestCase):
             u'github': u'http://github.com/lmorchard',
             u'stackoverflow': u'http://stackoverflow.com/users/lmorchard',
             u'linkedin': u'https://www.linkedin.com/in/testuser',
-            u'linkedin': u'http://www.linkedin.com/pub/sean-parker/0/1/826',
             u'mozillians': u'https://mozillians.org/u/testuser',
             u'facebook': u'https://www.facebook.com/test.user'
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=719651

Supersedes https://github.com/mozilla/kuma/pull/2703
