### PR TITLE
fix bug 1057496 - Hide print link on tablet and under

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -1317,7 +1317,7 @@ details {
         width: auto !important;
     }
 
-    #quick-links-toggle,  #wiki-controls {
+    #quick-links-toggle,  #wiki-controls, .page-print {
         display: none;
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1057496
