### PR TITLE
fix bug 1056933 - Move close-button to first tab element in submenus, focus it when menu opens

### DIFF
--- a/media/redesign/js/auth.js
+++ b/media/redesign/js/auth.js
@@ -50,6 +50,7 @@
         $options.mozMenu({
             fadeInSpeed: fadeSpeed,
             fadeOutSpeed: fadeSpeed,
+            focusOnOpen: false,
             onOpen: function() {
                 $options.addClass(activeClass);
                 if(doMoveCloseButton()) {

--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -16,7 +16,7 @@
             fadeInSpeed: null,
             fadeOutSpeed: null,
             submenu: null,
-            focusOnOpen: false,
+            focusOnOpen: true,
             brickOnClick: false,
             onOpen: noop,
             onClose: noop
@@ -66,7 +66,7 @@
                     var $closeButton = $('<button type="button" class="submenu-close transparent">\
                         <span class="offscreen">' + gettext('Close submenu') + '</span>\
                         <i aria-hidden="true" class="icon-remove-sign"></i>\
-                    </button>').appendTo($submenu);
+                    </button>').prependTo($submenu);
 
                     // Hide the submenu when the main menu is blurred for hideDelay
                     $self.on('mouseleave focusout', function() {
@@ -126,7 +126,7 @@
 
                     // Find the first link for improved usability
                     if($submenu.settings.focusOnOpen) {
-                        var firstLink = $submenu.find('a').get(0);
+                        var firstLink = $submenu.find('a, button').get(0);
                         if(firstLink) {
                             try { // Putting in try/catch because of opacity/focus issues in IE
                                 $(firstLink).addClass(focusClass) && firstLink.focus();

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -324,7 +324,7 @@ component-submenu(menu-width, num-columns, background-color, arrow-border-color)
         width: col-width;
         display: inline-block;
 
-        &:nth-child(even) {
+        &:nth-of-type(2) {
             bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
             bidi-style(padding-left, $grid-spacing, padding-right, 0);
         }


### PR DESCRIPTION
Just putting this here for someone else to pick up or finish down the road.  Still need to test the wiki menus.

https://bugzilla.mozilla.org/show_bug.cgi?id=1056933
