### PR TITLE
fix bug 1059971 - Don't attempt to close non-existant menu

### DIFF
--- a/media/redesign/js/components.js
+++ b/media/redesign/js/components.js
@@ -54,7 +54,7 @@
                 // If no submenu, go
                 if(!$submenu.length) {
                     clear(showTimeout);
-                    closeSubmenu($.fn.mozMenu.$openMenu.submenu);
+                    if($.fn.mozMenu.$openMenu) closeSubmenu($.fn.mozMenu.$openMenu.submenu);
                     return;
                 }
 


### PR DESCRIPTION
To test, hover your mouse first over "Connect" in the main menu.  Warning shows in console.  This fixes said issue. 

https://bugzilla.mozilla.org/show_bug.cgi?id=1059971
