### PR TITLE
Bug 1054558: Notification after successful connect

### DIFF
--- a/kuma/users/templates/socialaccount/signup.html
+++ b/kuma/users/templates/socialaccount/signup.html
@@ -20,7 +20,7 @@
 <section id="content">
   <div class="wrap">
     <section id="content-main" role="main">
-      <article id="browser_register">
+      <article id="browser_register" {% if matching_accounts.exists() %}data-account-match-for="{{ account.get_provider().name }}"{% endif %}>
           <h1>{{ _('Create your MDN profile to continue') }}</h1>
 
           {% set github_connect_url = provider_login_url('github', process='connect', next=request.session.sociallogin_next_url|default('/')) %}

--- a/media/redesign/js/auth.js
+++ b/media/redesign/js/auth.js
@@ -86,12 +86,70 @@
         });
     })();
 
+    // Track users successfully logging in
+    $(document).on('mdn:login', function(service) {
+        mdn.optimizely.push(['trackEvent', 'logout-' + service]);
+        mdn.analytics.trackEvent({
+            category: 'Authentication',
+            action: 'Signed out',
+            label: service
+        });
+    });
 
+    // Track users successfully logging out
+    $(document).on('mdn:logout', function(service) {
+        mdn.optimizely.push(['trackEvent', 'login-' + service]);
+        mdn.analytics.trackEvent({
+            category: 'Authentication',
+            action: 'Finished sign-in',
+            label: service
+        });
+    });
 
     /*
-        Track users successfully logging in and out
+        Show notifications about account association status as part of the
+        registration process.
     */
     ('localStorage' in win) && (function() {
+        try {
+            var $browserRegister = $('#browser_register');
+            var matchKey = 'account-match-for';
+            var matchCurrent = $browserRegister.data(matchKey);
+            var matchStored = localStorage.getItem(matchKey);
+
+            // The user is on the registration page and has been notified that
+            // there is an MDN profile with a matching email address.
+            if(matchCurrent && !matchStored) {
+                localStorage.setItem(matchKey, matchCurrent);
+            }
+
+            // After seeing the notice, the user tried to sign in with a second
+            // social account, but was again directed to the registration page.
+            // This will happen if the second social account was also not
+            // tied to an MDN profile.
+            else if(!matchCurrent && matchStored && $browserRegister.length) {
+                localStorage.removeItem(matchKey);
+            }
+
+            // After seeing the notice, the user tried to sign in with a second
+            // social account and was successful.
+            $(document).on('mdn:login', function(service) {
+                if(matchStored) {
+                    mdn.Notifier.growl('You can now use ' + matchStored + ' to sign in to this MDN profile.', { duration: 0, closable: true }).success();
+                    localStorage.removeItem(matchKey);
+                }
+            });
+        }
+        catch (e) {
+            // Browser probably doesn't support localStorage
+        }
+    })();
+
+    /*
+        Fire off events when the user logs in and logs out.
+    */
+    ('localStorage' in win) && (function() {
+        var login, logout;
         var serviceKey = 'login-service';
         var serviceStored = localStorage.getItem(serviceKey);
         var serviceCurrent = $(doc.body).data(serviceKey);
@@ -101,25 +159,13 @@
             // User just logged in
             if(serviceCurrent && !serviceStored) {
                 localStorage.setItem(serviceKey, serviceCurrent);
-
-                mdn.optimizely.push(['trackEvent', 'login-' + serviceCurrent]);
-                mdn.analytics.trackEvent({
-                    category: 'Authentication',
-                    action: 'Finished sign-in',
-                    label: serviceCurrent
-                });
+                $(document).trigger('mdn:login', [ serviceCurrent ]);
             }
 
             // User just logged out
             else if(!serviceCurrent && serviceStored) {
                 localStorage.removeItem(serviceKey);
-
-                mdn.optimizely.push(['trackEvent', 'logout-' + serviceStored]);
-                mdn.analytics.trackEvent({
-                    category: 'Authentication',
-                    action: 'Signed out',
-                    label: serviceStored
-                });
+                $(document).trigger('mdn:logout', [ serviceStored ]);
             }
 
         }
@@ -127,7 +173,5 @@
             // Browser probably doesn't support localStorage
         }
     })();
-
-
 
 })(window, document, jQuery);

--- a/settings.py
+++ b/settings.py
@@ -703,8 +703,8 @@ MINIFY_BUNDLES = {
             'js/libs/jquery-2.1.0.js',
             'redesign/js/components.js',
             'redesign/js/analytics.js',
-            'redesign/js/auth.js',
             'redesign/js/main.js',
+            'redesign/js/auth.js',
             'redesign/js/badges.js',
         ),
         'home': (


### PR DESCRIPTION
If a user tries to authenticate with a service that is not already
associated with their account (for example, GitHub) they might be
notified that there is already an MDN profile using the same email
address. When this happens, the user is given the option of
authenticating with a third-party service that /is/ associated with the
account (for example, Persona) to make both services (in this case,
GitHub and Persona) authentication options for that account.

These changes notify the user when this is done successfully.
