### PR TITLE
fix bug 797845 - Disable save button if no edits have been made

### DIFF
--- a/media/js/wiki-tags-edit.js
+++ b/media/js/wiki-tags-edit.js
@@ -1,6 +1,7 @@
 (function($) {
     $(document).ready(function() {
 
+        var $form = $('#wiki-page-edit');
         var $idTagsField = $('#tagit_tags');
 
         // Create a hidden input type for the purposes of saving
@@ -23,6 +24,13 @@
                     }
                 });
                 hiddenTags.val(itemTexts.join(','));
+
+                // Check whether there are net changes in tags
+                if (undefined !== originalTags && hiddenTags.val() !== originalTags) {
+                    $('#page-tags').addClass('dirty').trigger('mdn:dirty');
+                } else {
+                    $('#page-tags').removeClass('dirty').trigger('mdn:clean');
+                }
             };
         };
 
@@ -41,5 +49,11 @@
 
         // Remove the hidden field since it wont be submitted anyways
         $idTagsField.remove();
+
+        // Keep track of tag dirtiness
+        var originalTags = hiddenTags.val();
+        $form.on('mdn:save-success', function() {
+            originalTags = hiddenTags.val();
+        });
     })
 })(jQuery);

--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -546,7 +546,7 @@ footer {
 }
 
 /* disabling of elements */
-.disabled {
+.disabled, [disabled] {
     pointer-events: none;
     cursor: default;
 }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -444,7 +444,7 @@ article {
         a, button, input[type='submit'], input[type='button'] {
             set-smaller-font-size();
 
-            &.disabled {
+            &.disabled, &[disabled] {
                 opacity: 0.8;
             }
         }


### PR DESCRIPTION
I introduced 'dirtiness' tracking on the wiki edit page. The save buttons are disabled as long as the page is found to be clean. There are three sections that can affect dirtiness: The metadata header fields, the wiki editor content and the tags. The dirtiness tracking is thorough: Changing a bunch of fields and then changing them back counts as a clean slate and will disable saving the revision, effectively preventing null revisions in all possible scenarios.

Disabled buttons are visually different, though still green. I used the already included `disabled` CSS rule to match other pages where this might be used.

Bugzilla says @a2sheppy is appointed mentor, would this be about what you had in mind?
Also I had help from @groovecoder to figure out which files to mess with.

EDIT: I redid part of the commit. Managed to simplify some code. It's quite elegant now.
