### PR TITLE
bug 1052453 - add waffled GitHub beta notice

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -70,6 +70,15 @@
 
   {{ soapbox_messages(get_soapbox_messages(request.path)) }}
 
+  {% if waffle.flag('github_beta_notice') %}
+    <div class="global-notice">
+      <div class="wrap center">
+          <p><bdi>Help us <a href="https://wiki.mozilla.org/MDN/Development/GitHub_Beta">test GitHub Sign-in</a> on our stage server.</bdi></p>
+      </div>
+    </div>
+  {% endif %}
+
+
   {% if waffle.flag('badger') %}
     {% include "badger/includes/recent_badge_awards.html" %}
   {% endif %}


### PR DESCRIPTION
Spot-check:
- [ ] Make sure you have a "Beta Testers" group via [the local django groups admin interface](https://developer-local.allizom.org/admin/auth/group/)
- [ ] [Add a `github_beta_notice` waffle flag via local django admin interface](https://developer-local.allizom.org/admin/waffle/flag/add/), and pick the "Beta Testers" group
- [ ] [Edit your local profile](https://developer-local.allizom.org/en-US/profile/edit) and check "Beta tester"
- [ ] You should see the global notice about the GitHub beta across the site now.
