### PR TITLE
fix bug 1063580 - Synchronize template URL format between kuma and kumascript

### DIFF
--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -33,3 +33,10 @@ class KumascriptClientTests(TestCaseBase):
         for n in ('title', 'slug', 'locale', 'path'):
             eq_(env_vars[n], result_vars[n])
         eq_(sorted([u'foo', u'bar', u'baz']), sorted(result_vars['tags']))
+
+    def test_url_normalization(self):
+        """Ensure that template URLs are normalized to lowercase for kumascript"""
+        eq_(kumascript._format_slug_for_request('Template:SomEthing'), 'Template:something')
+        eq_(kumascript._format_slug_for_request('Template:SomEthing:Template:More'),
+            'Template:something:template:more')
+


### PR DESCRIPTION
Just leaving this here for now.
### Core Issue

kumascript requests template content from kuma with the template name in all lowercase (ex: `Template:discussionlist` instead of `Template:DiscussionList`).  When templates are updated in kuma, however, kuma sends the `DiscussionList` original format.  Since kumascript creates the cache key from the URL, we have different cache keys for the same template, and thus template contents aren't updated upon shift-refresh.

What I've chosen to do is send kumascript the lowercased template URLs to cure the issue.  I had created the likewise functionality in kumascript instead, but it looks like kuma uses headers to communicate with kumascript, so I believe we'll have less compat issues if we make kuma always send lowercase template names.
### To Spot-Check

Create one document and two templates; these are mine:  https://gist.github.com/darkwing/9c7d8b4ad4d4e4374946

As of right now, when you update the "DiscussionList" template and shift-refresh the document, the document does not pick up the DiscussionList updated content.  With this fix, when you shift-refresh the document, the updated DiscussionList content will be there when re-rendered.  No need to shift-refresh individual templates to try to push through changes!
### To Do
- [ ] Add a test to kuma to ensure the URL is sent lower-cased.
