### PR TITLE
fix bug 797845 - Disable save button if no edits have been made

### DIFF
--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -217,6 +217,9 @@
         if ($body.is('.edit, .new, .translate')) {
             initMetadataEditButton();
             initSaveAndEditButtons();
+            if(window.waffle && window.waffle.flag_is_active('dirtiness_tracking')) {
+                initDirtinessTracking();
+            }
             initArticlePreview();
             initAttachmentsActions();
             if(!isTemplate) {
@@ -589,6 +592,10 @@
             $('#id_comment').val('');
             // Re-enable the form; it gets disabled to prevent double-POSTs
             $form.data('disabled', false).removeClass('disabled');
+            // Trigger a `mdn:save-success` event so dirtiness can be reset throughout the page
+            if(window.waffle && window.waffle.flag_is_active('dirtiness_tracking')) {
+                $form.trigger('mdn:save-success');
+            }
             return true;
         });
 
@@ -829,6 +836,76 @@
             // Show the spinner
             $pageAttachmentsSpinner.css('opacity', 1);
         });
+    }
+
+    //
+    // Initializes logic that keeps track of whether changes have been made to the article
+    // So far three sections contribute to dirtiness: Metadata, editor content and tags
+    //
+    function initDirtinessTracking() {
+      // These are all fields that count towards an edit, excluding the editor and tags
+      var $metaDataFields = $('.metadata input:not([type="hidden"]), .metadata select');
+      var editor = CKEDITOR.instances['id_content'];
+
+      function onDirty() {
+        $('.btn-save-and-edit').attr('disabled', false);
+        $('.btn-save').attr('disabled', false);
+      }
+      // Called when everything is clean
+      function onClean() {
+        $('.btn-save-and-edit').attr('disabled', true);
+        $('.btn-save').attr('disabled', true);
+      }
+
+      function resetDirty() {
+        editor.resetDirty();
+        $metaDataFields.each(function() {
+          var $this = $(this);
+          $this.data('original', $this.val());
+        })
+        $form.find('.dirty').removeClass('dirty');
+        $form.trigger('mdn:clean');
+      }
+
+      // Three custom events are used to track changes throughout the page
+      // Dirtiness is marked by the class `dirty`, cleanliness by `clean`
+      $form.on('mdn:save-success', resetDirty)
+      .on('mdn:dirty', onDirty)
+      .on('mdn:clean', function() { // Gets triggered when a section is clean, others may still be dirty
+        if (!$('.dirty').length)
+          onClean();
+      });
+
+      // Keep track of editor dirtiness
+      var editorDirty = false;
+      function checkEditorDirtiness() {
+        var wasDirty = editorDirty;
+        editorDirty = editor.checkDirty();
+        if (editorDirty && !wasDirty) {
+          $form.find('.editor-container').addClass('dirty').trigger('mdn:dirty');
+        } else if (!editorDirty && wasDirty) {
+          $form.find('.editor-container').removeClass('dirty').trigger('mdn:clean');
+        }
+      }
+      editor.on('contentDom', function() {
+        // CKEditor 4.2 allows the 'change' event to be used though that's not in yet
+        editor.document.on('keyup', checkEditorDirtiness);
+        editor.on('paste setData', checkEditorDirtiness);
+      });
+
+      // Keep track of metadata dirtiness
+      $metaDataFields.on('change input', function() {
+        var $this = $(this);
+        if ($this.val() !== $this.data('original')) {
+          if (!$this.hasClass('dirty')) {
+            $this.addClass('dirty').trigger('mdn:dirty');
+          }
+        } else {
+          $this.removeClass('dirty').trigger('mdn:clean');
+        }
+      });
+
+      resetDirty();
     }
 
     $(doc).ready(init);

--- a/media/js/wiki-tags-edit.js
+++ b/media/js/wiki-tags-edit.js
@@ -1,6 +1,7 @@
 (function($) {
     $(document).ready(function() {
 
+        var $form = $('#wiki-page-edit');
         var $idTagsField = $('#tagit_tags');
 
         // Create a hidden input type for the purposes of saving
@@ -23,6 +24,15 @@
                     }
                 });
                 hiddenTags.val(itemTexts.join(','));
+
+                // Check whether there are net changes in tags
+                if(window.waffle && window.waffle.flag_is_active('dirtiness_tracking')) {
+                    if (undefined !== originalTags && hiddenTags.val() !== originalTags) {
+                        $('#page-tags').addClass('dirty').trigger('mdn:dirty');
+                    } else {
+                        $('#page-tags').removeClass('dirty').trigger('mdn:clean');
+                    }
+                }
             };
         };
 
@@ -41,5 +51,13 @@
 
         // Remove the hidden field since it wont be submitted anyways
         $idTagsField.remove();
+
+        // Keep track of tag dirtiness
+        if(window.waffle && window.waffle.flag_is_active('dirtiness_tracking')) {
+            var originalTags = hiddenTags.val();
+            $form.on('mdn:save-success', function() {
+                originalTags = hiddenTags.val();
+            });
+        }
     })
 })(jQuery);

--- a/media/redesign/stylus/main/structure.styl
+++ b/media/redesign/stylus/main/structure.styl
@@ -550,7 +550,7 @@ footer {
 }
 
 /* disabling of elements */
-.disabled {
+.disabled, [disabled] {
     pointer-events: none;
     cursor: default;
 }

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -444,7 +444,7 @@ article {
         a, button, input[type='submit'], input[type='button'] {
             set-smaller-font-size();
 
-            &.disabled {
+            &.disabled, &[disabled] {
                 opacity: 0.8;
             }
         }


### PR DESCRIPTION
Supercedes https://github.com/mozilla/kuma/pull/2722/files

I've added a waffle flag wrapper around this functionality in case of problems.  We should probably start with admins.

Stephanie:  can you add a style for the disabled button.  Maybe grey background?
