### PR TITLE
Bug 1018707 - Empty CustomCSS

### DIFF
--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -193,7 +193,15 @@ article, .quick-links {
 article {
     position: relative;
 
-    .external-icon:not([href^='https://mdn.mozillademos.org']) {
+    a {
+        text-decoration: none;
+
+        &:hover, &:focus, &:active {
+            text-decoration: underline;
+        }
+    }
+
+    .external-icon:not([href^='https://mdn.mozillademos.org']):not(.ignore-external) {
         white-space: pre-line;
 
         html[dir='ltr'] &:before, html[dir='rtl'] &:after {
@@ -216,13 +224,6 @@ article {
         }
     }
 
-    a {
-        text-decoration: none;
-
-        &:hover, &:focus, &:active {
-            text-decoration: underline;
-        }
-    }
 }
 
 /* header and draft notices */


### PR DESCRIPTION
Moved the default link styles to be first in the declaration.

Moved the .ignore-external class out of customCSS and into wiki.styl. I will remove it from customCSS when this change is live.

There is a test page here: https://developer.allizom.org/en-US/docs/User:stephaniehobson:links (which is macro errors on staging but not on local or prod for some reason). The previous .ignore-external code was not actually working so we will see some changes around the site.
