### PR TITLE
Fix Bug #1063588 - Add Persona to Profile link broken

### DIFF
--- a/kuma/users/templates/socialaccount/signup.html
+++ b/kuma/users/templates/socialaccount/signup.html
@@ -31,17 +31,17 @@
           {% if matching_accounts.exists() %}
             <div class="notification warning">
               {% trans count=matching_accounts.count(), persona_login_url=persona_login_url, persona_next_url=persona_next_url %}
-                  An account already exists with an email address below. Do you already have an MDN account?
-                  <a href="{{ persona_login_url }}" class="launch-persona-login" data-next="{{ persona_next_url }}">Yes, connect with my MDN account</a>
+                  A profile already exists with an email address below. Do you already have an MDN profile?
+                  <a href="{{ persona_login_url }}" class="launch-persona-login" data-next="{{ persona_next_url }}">Yes, connect with my MDN profile</a>
                   {% pluralize %}
-                  An account already exists with one of these email addresses below. Do you already have an MDN account?
-                  <a href="{{ persona_login_url }}" class="launch-persona-login" data-next="{{ persona_next_url }}">Yes, connect with my MDN account</a>
+                  A profile already exists with one of these email addresses below. Do you already have an MDN profile?
+                  <a href="{{ persona_login_url }}" class="launch-persona-login" data-next="{{ persona_next_url }}">Yes, connect with my MDN profile</a>
               {% endtrans %}</div>
           {% elif account.provider == 'github' %}
-              {# Only show this notification if we're sure it's not the Persona based MDN account #}
+              {# Only show this notification if we're sure it's not the Persona based MDN profile #}
               <div class="notification">
                 {% trans persona_login_url=persona_login_url, persona_next_url=persona_next_url %}
-                  Have an MDN account already? <a href="{{ persona_login_url }}">Yes, connect with my MDN account</a>
+                  Have an MDN profile already? <a href="{{ persona_login_url }}">Yes, connect with my MDN profile</a>
                 {% endtrans %}
               </div>
           {% endif %}

--- a/kuma/users/templates/users/profile_edit.html
+++ b/kuma/users/templates/users/profile_edit.html
@@ -104,7 +104,7 @@
                       {% for persona_account in accounts.persona %}{{ persona_account.uid }}{% if not loop.last %}, {% endif %}{% endfor %}
                     </div>
                     {% else %}
-                    <a class="field-management" href="{{ provider_login_url('persona', process='connect', next=next_url) }}">
+                    <a href="{{ url('account_login') }}" class="field-management launch-persona-login" data-next="{{ next_url }}" data-service="Persona" data-process="connect">
                       {{ _('Use your Persona account to sign in.') }}
                     </a>
                     <div class="account"></div>


### PR DESCRIPTION
Added the necessary data attributes and class to pop the persona login window.

Also fixed some wording while I was in there.

To test this you need to disconnect all Persona accounts and then on the edit profile page click "Use your Persona account to sign in"
