### PR TITLE
fix bug 1066469 - Allow looser highlighting syntax

### DIFF
--- a/media/js/syntax-prism.js
+++ b/media/js/syntax-prism.js
@@ -37,7 +37,7 @@
 
         // Do we need to highlight any lines?
         // Legacy format: highlight:[8,9,10,11,17,18,19,20]
-        lineSearch = klass.match(/highlight: ?\[(.*)\]/);
+        lineSearch = klass.match(/highlight:? ?\[(.*)\]/);
         if(lineSearch && lineSearch[1]) {
             $pre.attr('data-line', lineSearch[1]);;
         }


### PR DESCRIPTION
Apparently there are code samples that need highlighting that _don't_ use a `:` as supposed to.  This makes highlighting matching a bit looser.
