### PR TITLE
Fix bug 1069108 - If GA is loaded but blocked, ensure users get to external links

### DIFF
--- a/media/redesign/js/analytics.js
+++ b/media/redesign/js/analytics.js
@@ -38,7 +38,8 @@
             };
 
             // If Analytics has loaded, go ahead with tracking
-            if (ga) {
+            // Checking for ".create" due to Ghostery mocking of ga
+            if (ga && ga.create) {
                 // Send event to GA
                 ga('send', data);
             }
@@ -103,7 +104,7 @@
             Sends universal analytics client side error
         */
         trackError: function(description) {
-            win.ga && ga('send', 'exception', {
+            win.ga && ga.create && ga('send', 'exception', {
                 'exDescription': description
             });
         }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1069108

So when you install Ghostery and disallow Google Analytics, Ghostery shims a basic `ga` function which tricks us into thinking GA is there and will work.  Huh.

Anywhoo, this addition does a basic Timeout -> window.location to ensure the user gets there in the case of Ghostery or likewise plugins.  It's important to note that this bails out on GA, so if for some reason GA is slow, we don't wait the full time anymore.

The `1200` wait is arbitrary so when spot-checking, get a feel for how long you wait and we can decide if it's too slow or not.

To spot-check:
- [x] Install Ghostery (https://www.ghostery.com/en/)
- [x] Bring up the homepage.
- [x] In the Ghostery panel, disalllow Analytics and refresh the page
- [x] Click the "read more at hacks.mozilla.org"
- [x] Be taken away to Hacks finally
