### PR TITLE
Fix Bug 1069432 - Padding between syntax box and following h3 too small

### DIFF
--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -464,8 +464,8 @@ $right-icons {
 
 /* Styles for code blocks - used for wiki document and WYSIWYG editor */
 $code-block {
-    background: rgba(234, 239, 242, 0.25);
-    border-left: 6px solid rgba(0, 83, 159, 0.65);
+    background: $code-block-background-color;
+    border-left: 6px solid $code-block-border-color;
     background-image:  url($media-url-dir + 'blueprint-dark.png');
     background-position: top center;
     background-repeat: repeat;

--- a/media/redesign/stylus/includes/vars.styl
+++ b/media/redesign/stylus/includes/vars.styl
@@ -4,6 +4,9 @@ $link-color = #0095dd;
 $menu-link-color = $text-color;
 $header-background-color = #eaeff2;
 $light-background-color = #f4f7f8;
+$code-block-background-color = #fafbfc;
+$code-block-background-alt-color = #dde4e9;
+$code-block-border-color = #558abb;
 
 /* typography */
 $light-font-weight = 200;

--- a/media/redesign/stylus/wiki-customcss.styl
+++ b/media/redesign/stylus/wiki-customcss.styl
@@ -369,24 +369,7 @@ table.html5ArticleToc {
     display: inline;
     margin: 0 0.25em;
 }
-/* The syntax box: the first one is now used anywhere (DOM, JS, CSS, ...) The twoparts is used for CSS properties */
-pre.syntaxbox {
-    margin-bottom: 1em;
-    background-color: #ffe;
-}
-pre.twopartsyntaxbox {
-    margin-bottom: 0;
-    background-color: #ffe;
-}
-pre.twopartsyntaxbox + pre {
-    border-top: none;
-    margin-top: 0;
-}
-/* Allow the content of the syntax box to wrap, to prevent horizontal scrolling */
-pre.syntaxbox code[class*="language-"],
-pre.twopartsyntaxbox code[class*="language-"] {
-    white-space: pre-line;
-}
+
 table.withoutBorder,
 table.withoutBorder td,
 table.withoutBorder tr,

--- a/media/redesign/stylus/wiki-syntax-error.styl
+++ b/media/redesign/stylus/wiki-syntax-error.styl
@@ -1,0 +1,6 @@
+/* styles code that appears in error messages */
+
+.error pre[class*='language-'] {
+    background: none;
+    margin: 10px 0 0 0;
+}

--- a/media/redesign/stylus/wiki-syntax-syntaxbox.styl
+++ b/media/redesign/stylus/wiki-syntax-syntaxbox.styl
@@ -1,0 +1,22 @@
+/*
+    Syntax boxes are used for short, non-functional code snippets.
+    .syntaxbox is used anywhere (DOM, JS, CSS, ...)
+    .twopartsyntaxbox is used for CSS properties
+*/
+
+pre.syntaxbox,
+pre.twopartsyntaxbox {
+    background: $code-block-background-alt-color;
+}
+
+pre.twopartsyntaxbox {
+    margin-bottom: 0;
+}
+
+/* Allow the content of the syntax box to wrap, to prevent horizontal scrolling */
+
+pre.syntaxbox code[class*="language-"],
+pre.twopartsyntaxbox code[class*="language-"] {
+    white-space: pre-line;
+}
+

--- a/media/redesign/stylus/wiki-syntax.styl
+++ b/media/redesign/stylus/wiki-syntax.styl
@@ -5,38 +5,33 @@
 @import 'includes/vars';
 @import 'includes/mixins';
 
-code[class*='language-'], pre[class*='language-'] {
+code[class*='language-'],
+pre[class*='language-'] {
     color: inherit;
     text-shadow: none;
 }
 
 pre[class*='language-'] {
-    margin: 0 0 24px 0;
+    margin: 0 0 $grid-spacing 0;
 
     span.comment {
         display: inherit;
     }
 }
 
-.error pre[class*='language-'] {
-    margin: 10px 0 0 0;
-    background: none;
-}
-
-:not(pre)>code[class*='language-'], pre[class*='language-'] {
+:not(pre)>code[class*='language-'],
+pre[class*='language-'] {
     @extend $code-block;
 }
 
-/*
-    Some places in the wiki feature <pre><em><code>
-*/
+/* Some places in the wiki feature <pre><em><code> */
+
 pre em code[class*='language-'] {
-    background-image: none;
+    background: none transparent;
     border-left: 0;
-    background: transparent;
 }
 
-pre.twopartsyntaxbox, pre.syntaxbox {
-    background: rgba(212, 221, 228, 0.5) !important;
-    margin-bottom: 0;
-}
+/* components based on the above */
+
+@import 'wiki-syntax-syntaxbox';
+@import 'wiki-syntax-error';


### PR DESCRIPTION
Integrated styles for syntax from customCSS into the main files.
- Moved styles into individual 'component' files after talking to @darkwing and @openjck.
- Extracted colours into variables (made rgba values into hex to avoid contrast problems on dark background colours)
- Switched to grid spacing variables where it looked applicable.
- Removed competing and redundant rules (do we really need to declare margin-top:0 specifically if there is no margin-top on the element?) 

You will need to run compress assets to properly test this!

Some test pages:
https://developer.mozilla.org/en-US/docs/Web/API/Blob.Blob
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#Syntax
https://developer.mozilla.org/en-US/docs/Web/API/AudioBuffer
