### PR TITLE
fix bug 753563 - Support username changes

### DIFF
--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -4,6 +4,7 @@ import time
 from django import forms
 from django.conf import settings
 from django.http import HttpResponseServerError
+from django.contrib.auth.models import User
 
 import basket
 from basket.base import BasketException
@@ -94,6 +95,9 @@ class UserProfileEditForm(forms.ModelForm):
                                 max_length=255, required=False)
     expertise = forms.CharField(label=_(u'Expertise'),
                                 max_length=255, required=False)
+    username = forms.RegexField(label=_(u'Username'), regex=r'^[\w_\+-]+$',
+                                max_length=30, required=False,
+                                error_message=_(u"Usernames can only contain letters, numbers and -, _, + characters."))
 
     class Meta:
         model = UserProfile
@@ -119,6 +123,13 @@ class UserProfileEditForm(forms.ModelForm):
                                           "subset of interests"))
 
         return self.cleaned_data['expertise']
+
+    def clean_username(self):
+        new_username = self.cleaned_data['username']
+
+        if User.objects.exclude(pk=self.instance.user.pk).filter(username=new_username).exists():
+            raise forms.ValidationError(_("Username already in use."))
+        return new_username
 
 
 def newsletter_subscribe(request, email, cleaned_data):

--- a/kuma/users/templates/users/profile_edit.html
+++ b/kuma/users/templates/users/profile_edit.html
@@ -63,6 +63,7 @@
                     <label>{{ _('Primary Email') }}</label>
                     {{ profile.user.email }} <a href="{{ url('account_email') }}">{{ _('Edit email') }}</a>
                   </li>
+                  {{ li_field(profile_form, 'username') }}
                   {{ li_field(profile_form, 'fullname') }}
                   {{ li_field(profile_form, 'title') }}
                   {{ li_field(profile_form, 'organization') }}

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -154,6 +154,7 @@ def profile_edit(request, username):
     if request.method != 'POST':
         initial = {
             'beta': profile.beta_tester,
+            'username': profile.user.username,
         }
         # Load up initial websites with either user data or required base URL
         for name, meta in UserProfile.website_choices:
@@ -186,7 +187,14 @@ def profile_edit(request, username):
                                          data=request.POST,
                                          prefix='newsletter')
 
+        # Don't validate if the username hasn't changed so people can keep already existing invalid usernames.
+        username_changed = request.user.username != request.POST['profile-username']
+
         if profile_form.is_valid() and newsletter_form.is_valid():
+            if username_changed:
+                profile.user.username = profile_form.cleaned_data['username']
+                profile.user.save()
+
             profile_new = profile_form.save(commit=False)
 
             # Gather up all websites defined by the model, save them.


### PR DESCRIPTION
Users now find an extra field on their profile edit page titled `Username`. Changing this
field allows them to change their username.
Existing usernames that do not comply with the new validation rules will not be affected.
