### PR TITLE
fix bug 1071741 -- render the file list successfully and use correct feed URL.

### DIFF
--- a/kuma/attachments/templates/attachments/list_files.html
+++ b/kuma/attachments/templates/attachments/list_files.html
@@ -4,7 +4,7 @@
 
 {% block extrahead %}
 <link rel="alternate" type="application/atom+xml" title="{{title}}"
-      href="{{ url('wiki.feeds.recent_files', format='atom') }}" />
+      href="{{ url('attachments.feeds.recent_files', format='atom') }}" />
 {% endblock %}
 
 {% block content %}

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -351,3 +351,10 @@ class AttachmentTests(TestCaseBase):
         eq_('Files dict test file 2', file2['description'])
         eq_('text/plain', file2['mime_type'])
         ok_(test_file_2.name.split('/')[-1] in file2['url'])
+
+    def test_list_files(self):
+        list_files_url = reverse('attachments.list_files',
+                                 locale=settings.WIKI_DEFAULT_LANGUAGE)
+        resp = self.client.get(list_files_url)
+        eq_(200, resp.status_code)
+        ok_('All Files' in resp.content)


### PR DESCRIPTION
This is a regression from 8b54bed209ade8ea63a514c69d8904679d497316.
