### PR TITLE
Bug 1043604: Add global Apache configuration

### DIFF
--- a/configs/htaccess
+++ b/configs/htaccess
@@ -59,10 +59,10 @@ RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
 
 # HACK: Django will eventually redirect the user to the right spot, but skip a
 # couple of redirects for these known legacy locales
-RewriteRule ^en/(.*)$     /mwsgi/en-US/$1 [L,QSA,NE,NC,E=CORS:True]
-RewriteRule ^cn/(.*)$     /mwsgi/zh-CN/$1 [L,QSA,NE,NC,E=CORS:True]
-RewriteRule ^zh_cn/(.*)$  /mwsgi/zh-CN/$1 [L,QSA,NE,NC,E=CORS:True]
-RewriteRule ^zh_tw/(.*)$  /mwsgi/zh-TW/$1 [L,QSA,NE,NC,E=CORS:True]
+RewriteRule ^en/(.*)$     /mwsgi/en-US/$1 [L,QSA,NE,NC]
+RewriteRule ^cn/(.*)$     /mwsgi/zh-CN/$1 [L,QSA,NE,NC]
+RewriteRule ^zh_cn/(.*)$  /mwsgi/zh-CN/$1 [L,QSA,NE,NC]
+RewriteRule ^zh_tw/(.*)$  /mwsgi/zh-TW/$1 [L,QSA,NE,NC]
 
 # These are some known static files
 RewriteCond %{REQUEST_URI} !/favicon.ico
@@ -72,9 +72,4 @@ RewriteCond %{REQUEST_URI} !/block_862be.html
 RewriteCond %{REQUEST_URI} !/block_f90c2.html
 
 # Everything else passes through the Django handler
-RewriteRule ^(.*)$ /mwsgi/$1 [L,QSA,NE,E=CORS:True]
-
-# Allow wide-open CORS on the site.
-Header set Access-Control-Allow-Origin "*" env=CORS
-Header set Access-Control-Allow-Methods "GET" env=CORS
-Header set Access-Control-Allow-Credentials "false" env=CORS
+RewriteRule ^(.*)$ /mwsgi/$1 [L,QSA,NE]

--- a/etc/apache/all-servers.conf
+++ b/etc/apache/all-servers.conf
@@ -1,0 +1,15 @@
+Header set Access-Control-Allow-Origin "*"
+Header set Access-Control-Allow-Methods "GET"
+Header set Access-Control-Allow-Credentials "false"
+
+<Location /media/fonts>
+    # Only enable CORS for fonts when the request is coming from a Mozilla domain
+    Header unset Access-Control-Allow-Origin
+    SetEnvIf Origin "https?://(.*\.mozilla\.(com|org|net))" CORS=$0
+    SetEnvIf Origin "https?://(mdn\.mozillademos\.org)" CORS=$0
+    Header set Access-Control-Allow-Origin %{CORS}e env=CORS
+
+    # block hotlinking by referer to .woff, .eof, .ttf files except mozilla domains
+    RewriteCond "%{HTTP_REFERER}" "!https?://.*\.mozilla\.(com|org|net)/.*$"
+    RewriteRule \.(woff|eot|ttf)$ - [F,NC,L,E=!CORS]
+</Location>

--- a/media/fonts/.htaccess
+++ b/media/fonts/.htaccess
@@ -1,12 +1,3 @@
-# CORS only for mozilla domains
-SetEnvIf Origin "https?://(.*\.mozilla\.(com|org|net))" CORS=$0
-SetEnvIf Origin "https?://(mdn\.mozillademos\.org)" CORS=$0
-Header set Access-Control-Allow-Origin %{CORS}e env=CORS
-
-# block hotlinking by referer to .woff, .eof, .ttf files except mozilla domains
-RewriteCond "%{HTTP_REFERER}" "!https?://.*\.mozilla\.(com|org|net)/.*$"
-RewriteRule \.(woff|eot|ttf)$ - [F,NC,L,E=!CORS]
-
 <FilesMatch "\.(ttf|woff|eot)$">
     Header append vary "Origin"
     ExpiresActive On

--- a/puppet/manifests/classes/site-config.pp
+++ b/puppet/manifests/classes/site-config.pp
@@ -54,11 +54,23 @@ class apache_config {
             Apache::Loadmodule['vhost_alias'],
         ];
     }
+    file { "/etc/apache2/conf.d/all-servers.conf":
+        source => "/home/vagrant/src/etc/apache/all-servers.conf",
+        require => [
+            Package['apache2'],
+            Apache::Loadmodule['env'],
+            Apache::Loadmodule['setenvif'],
+            Apache::Loadmodule['headers'],
+        ];
+    }
     service { "apache2":
         ensure    => running,
         enable    => true,
         require   => [ Package['apache2'], ],
-        subscribe => File['/etc/apache2/conf.d/mozilla-kuma-apache.conf']
+        subscribe => [
+            File['/etc/apache2/conf.d/mozilla-kuma-apache.conf'],
+            File['/etc/apache2/conf.d/all-servers.conf'],
+        ]
     }
 }
 


### PR DESCRIPTION
A new file is added, all-servers.conf, which contains Apache settings
that should be used on all servers. The file is hooked up to our local
environment via Puppet and the WebOps team <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1043604">will ensure that it's also
used on our public servers</a>.

To test, ensure that the ACAO header is set (with a value of <code>*</code>) on all valid URLs except for the URLs of font files.
