### PR TITLE
Bug 1072921: Add more isolation of allauth-related tests.

### DIFF
--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -98,8 +98,6 @@ class SocialAccountConnectionsTests(TestCaseBase):
 
 class AllauthPersonaTestCase(TestCase):
     fixtures = ['test_users.json']
-    persona_signup_email = 'personatestuser@example.com'
-    persona_signup_username = 'personatestuser'
     existing_persona_email = 'testuser@test.com'
     existing_persona_username = 'testuser'
 
@@ -141,10 +139,12 @@ class AllauthPersonaTestCase(TestCase):
         message and the Persona-specific signup form, correctly
         populated, and does not display the failure copy.
         """
+        persona_signup_email = 'templates_persona_auth_copy@example.com'
+
         with mock.patch('requests.post') as requests_mock:
             requests_mock.return_value.json.return_value = {
                 'status': 'okay',
-                'email': self.persona_signup_email,
+                'email': persona_signup_email,
             }
             r = self.client.post(reverse('persona_login'),
                                  follow=True)
@@ -167,7 +167,7 @@ class AllauthPersonaTestCase(TestCase):
                 ' required="required" '
                 'placeholder="Username" id="id_username" />',
                 '<input type="hidden" name="email" '
-                'value="%s" id="id_email" />' % self.persona_signup_email,
+                'value="%s" id="id_email" />' % persona_signup_email,
             )
             verify_strings_in_response(expected_strings, r)
             unexpected_strings = (
@@ -264,6 +264,9 @@ class AllauthPersonaTestCase(TestCase):
         indication that Persona was used to log in, and a logout link
         appear in the auth tools section of the page.
         """
+        persona_signup_email = 'templates_persona_signup_copy@example.com'
+        persona_signup_username = 'templates_persona_signup_copy'
+
         engine = import_module(settings.SESSION_ENGINE)
         store = engine.SessionStore()
         store.save()
@@ -272,12 +275,12 @@ class AllauthPersonaTestCase(TestCase):
         with mock.patch('requests.post') as requests_mock:
             requests_mock.return_value.json.return_value = {
                 'status': 'okay',
-                'email': self.persona_signup_email,
+                'email': persona_signup_email,
             }
             r = self.client.post(reverse('persona_login'),
                                  follow=True)
-            data = {'username': self.persona_signup_username,
-                    'email': self.persona_signup_email}
+            data = {'username': persona_signup_username,
+                    'email': persona_signup_email}
             r = self.client.post(
                 reverse('socialaccount_signup',
                         locale=settings.WIKI_DEFAULT_LANGUAGE),
@@ -285,7 +288,7 @@ class AllauthPersonaTestCase(TestCase):
 
             profile_url = reverse(
                 'users.profile',
-                kwargs={'username': self.persona_signup_username},
+                kwargs={'username': persona_signup_username},
                 locale=settings.WIKI_DEFAULT_LANGUAGE)
             signout_url = urlparams(
                 reverse('account_logout',

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -523,7 +523,7 @@ class AllauthPersonaTestCase(TestCase):
         with mock.patch('requests.post') as requests_mock:
             requests_mock.return_value.json.return_value = {
                 'status': 'okay',
-                'email': 'personatestuser1@example.com',
+                'email': 'views_persona_auth@example.com',
             }
             r = self.client.post(reverse('persona_login'),
                                  follow=True)
@@ -590,8 +590,8 @@ class AllauthPersonaTestCase(TestCase):
         store = engine.SessionStore()
         store.save()
         self.client.cookies[settings.SESSION_COOKIE_NAME] = store.session_key
-        persona_signup_email = 'personatestuser2@example.com'
-        persona_signup_username = 'personatestuser2'
+        persona_signup_email = 'views_persona_django_user@example.com'
+        persona_signup_username = 'views_persona_django_user'
 
         with mock.patch('requests.post') as requests_mock:
             old_count = User.objects.count()
@@ -630,8 +630,8 @@ class AllauthPersonaTestCase(TestCase):
         store = engine.SessionStore()
         store.save()
         self.client.cookies[settings.SESSION_COOKIE_NAME] = store.session_key
-        persona_signup_email = 'personatestuser3@example.com'
-        persona_signup_username = 'personatestuser3'
+        persona_signup_email = 'views_persona_socialaccount@example.com'
+        persona_signup_username = 'views_persona_socialaccount'
 
         with mock.patch('requests.post') as requests_mock:
             requests_mock.return_value.json.return_value = {


### PR DESCRIPTION
Two things going on here:
1. Expand the work done in 183fa261c7e7a8cce216b3f4977154a787ba124e to
   the test cases in test_templates.py. Although there's less going on
   in that file and so probably a lower risk of order dependence, we
   probably want more tests there later and so it's a good bit of
   future-proofing.
2. When a unique email address and/or username is needed for test
   isolation, instead of using sequential numbers use a name/address
   based on the name of the test method in which it's used. This will
   hopefully avoid issues down the road where we might lose track of
   which numbers had already been used in existing tests.
