### PR TITLE
Bug 1070001: Re-org Stylus - Activity

### DIFF
--- a/apps/authkeys/templates/authkeys/base.html
+++ b/apps/authkeys/templates/authkeys/base.html
@@ -8,21 +8,23 @@
 {% endblock %}
 
 {% block content %}
-<header id="section-head">
-<div class="wrap">
-    <h1 class="intro">{% block intro %}{{ _("API Keys: <b>...</b>" | safe) }}{% endblock %}</h1>
-</div>
-</header>
+<div class="text-content readable-line-length">
+  <header id="section-head">
+  <div class="wrap">
+      <h1 class="intro">{% block intro %}{{ _("API Keys: <b>...</b>" | safe) }}{% endblock %}</h1>
+  </div>
+  </header>
 
-<section id="content">
-<div class="wrap">
-  <section id="content-main" role="main">
-    <div class="boxed">
-      <section>
-        {% block subcontent %}{% endblock %}
-      </section>
-    </div>
+  <section id="content">
+  <div class="wrap">
+    <section id="content-main" role="main">
+      <div class="boxed">
+        <section>
+          {% block subcontent %}{% endblock %}
+        </section>
+      </div>
+    </section>
+  </div>
   </section>
 </div>
-</section>
 {% endblock %}

--- a/apps/authkeys/templates/authkeys/list.html
+++ b/apps/authkeys/templates/authkeys/list.html
@@ -7,27 +7,28 @@
     These are your API keys. They're useful for building applications that
     perform tasks on MDN on your behalf. If you have stopped using any of
     them, or suspect one has been exposed to parties you don't trust with your
-    account, click the <span class="button">X</span> to delete the key.  It's
-    easy to create a replacement key at any time.
+    account delete the key. It's easy to create a replacement key at any time.
 {% endtrans %}</p>
 <p><a class="button positive" href="{{ url('authkeys.new') }}">{{ _('Create a new key') }}</a></p>
 {% if not keys %}
     <p>{{ _("You have no API keys, yet.") }}</p>
 {% else %}
-    <table class="keys" cellpadding="4">
+    <ul class="option-list">
         {% for key in keys %}
-        <tr class="key" id="key-{{ key.pk }}">
-            <td class="actions">
-                <a class="button negative"
-                   title="{{ _('Delete key') }}"
-                   href="{{ url('authkeys.delete', pk=key.pk) }}">{{ _('X') }}</a>
-                <a class="button positive"
+        <li id="key-{{ key.pk }}">
+            <span class="created">{{ key.created }}</span> &nbsp;
+            <span class="description">{{ key.description }}</span>
+            <span class="option-list-options">
+                <a class="button"
                    title="{{ _('View key usage history') }}"
                    href="{{ url('authkeys.history', pk=key.pk) }}">{{ _('History ({count})') | f(count=key.history.count()) }}</a>
-            </td>
-            <td class="created">{{ key.created }}</td>
-            <td class="description">{{ key.description }}</td>
-        </tr>
+                <a class="button transparent only-icon"
+                   href="{{ url('authkeys.delete', pk=key.pk) }}">
+                   <span>{{ _('Delete key') }}</span><i aria-hidden="true" class="icon-trash"></i>
+                </a>
+            </span>
+
+        </li>
         {% endfor %}
     </table>
 {% endif %}

--- a/apps/authkeys/tests/test_views.py
+++ b/apps/authkeys/tests/test_views.py
@@ -76,7 +76,7 @@ class KeyViewsTest(TestCase):
         page = pq(resp.content)
 
         for ct, key in ((1, self.key1), (1, self.key2), (0, self.key3)):
-            key_row = page.find('.keys #key-%s' % key.pk)
+            key_row = page.find('.option-list #key-%s' % key.pk)
             eq_(ct, key_row.length)
             if ct > 0:
                 eq_(key.description, key_row.find('.description').text())
@@ -129,7 +129,7 @@ class KeyViewsTest(TestCase):
         eq_(200, resp.status_code)
 
         page = pq(resp.content)
-        eq_(self.key1.description, page.find('.key .description').text())
+        eq_(self.key1.description, page.find('.description').text())
 
         resp = self.client.post(url, follow=False)
         ok_(302, resp.status_code)

--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -137,7 +137,9 @@
 
     {% if waffle.flag('badger') and award_list %}
       <section id="profile-badges" class="profile-section">
-        <h2>{{ _("Recent Badge Awards") }}</h2>
+        <header>
+            <h2>{{ _("Recent Badge Awards") }}</h2>
+        </header>
         {% include "badger/includes/awards_as_badges_list.html" %}
       </section>
     {% endif %}
@@ -169,9 +171,9 @@
             {% if wiki_activity and wiki_activity|length %}
             <table class="activity">
               <thead>
-                <th scope="col" class="page">{{ _("Page") }}</th>
-                <th scope="col" class="date">{{ _("Date") }}</th>
-                <th scope="col" class="summary">{{ _("Comment") }}</th>
+                <th scope="col" class="activity-page">{{ _("Page") }}</th>
+                <th scope="col" class="activity-date">{{ _("Date") }}</th>
+                <th scope="col" class="activity-summary">{{ _("Comment") }}</th>
               </thead>
               <tbody>
                 {% for rev in wiki_activity %}
@@ -179,7 +181,7 @@
                 <tr>
                   <th scope="row">
                       <h3><a href="{{ rev.document.get_absolute_url() }}">{{ rev.document.title }}</a></h3>
-                      <ul class="actions">
+                      <ul class="activity-actions">
                           <li><a href="{{ rev.document.get_absolute_url() }}$edit" class="edit">{{ _("Edit page") }}</a></li>
                           <li>{% if previous_rev %}<a href="{{ rev.document.get_absolute_url() }}$compare?from={{ previous_rev.id }}&amp;to={{ rev.id }}" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
                           <li><a href="{{ rev.document.get_absolute_url() }}$history" class="history">{{ _("View page history") }}</a></li>

--- a/media/redesign/stylus/components/activity.styl
+++ b/media/redesign/stylus/components/activity.styl
@@ -1,0 +1,58 @@
+@require '../includes/vars';
+@require '../includes/mixins';
+
+.activity {
+    border-collapse: collapse;
+    set-smaller-font-size();
+    width: 100%;
+
+    td,
+    th {
+        padding: 6px 3px;
+    }
+
+    h3 {
+        set-font-size($base-bump-font-size);
+        margin: 0 0 ($grid-spacing / 4);
+    }
+
+    thead {
+        background: $header-background-color;
+        th {
+            font-weight: bold;
+        }
+    }
+
+    tbody {
+        h3 {
+            margin-bottom: 4px;
+        }
+
+        tr {
+            &:nth-child(even) {
+                background: $light-background-color;
+            }
+        }
+
+        th {
+            font-weight: 200;
+        }
+    }
+}
+
+.activity-date {
+    width: 120px;
+}
+
+.activity-page {
+    width: 40%;
+}
+
+.activity-actions {
+    set-font-size(10px);
+
+    li {
+        display: inline;
+        margin: 0 10px 5px 0;
+    }
+}

--- a/media/redesign/stylus/profile.styl
+++ b/media/redesign/stylus/profile.styl
@@ -2,6 +2,7 @@
 @require 'includes/mixins';
 @require 'components/components';
 @require 'components/tagit';
+@require 'components/activity';
 
 /*** Display ***/
 


### PR DESCRIPTION
Moved .activity into its own file and changing class names to reflect component structure.

Also removed .actions reference from API key page (there were two different uses for the .actions class, but turns out it wasn't doing anything on API page, so re-styled that page to use a different component).

Pages to test (you will have to create some API keys):
https://developer-local.allizom.org/en-US/profiles/stephaniehobson
https://developer-local.allizom.org/en-US/users/account/keys
