### PR TITLE
Stop loading unused DekiScript modules

### DIFF
--- a/kumascript_settings_local.json-dist
+++ b/kumascript_settings_local.json-dist
@@ -20,19 +20,12 @@
         "template_class": "EJSTemplate",
         "autorequire": {
             "mdn": "MDN:Common",
-            "Culture": "DekiScript:Culture",
             "Date": "DekiScript:Date",
-            "Json": "DekiScript:Json",
-            "List": "DekiScript:List",
-            "Map": "DekiScript:Map",
-            "Meta": "DekiScript:Meta",
-            "Num": "DekiScript:Num",
             "Page": "DekiScript:Page",
             "String": "DekiScript:String",
             "Uri": "DekiScript:Uri",
             "Web": "DekiScript:Web",
-            "Wiki": "DekiScript:Wiki",
-            "Xml": "DekiScript:Xml"
+            "Wiki": "DekiScript:Wiki"
         }
     }
 }

--- a/puppet/files/vagrant/kumascript_settings_local.json
+++ b/puppet/files/vagrant/kumascript_settings_local.json
@@ -20,19 +20,12 @@
         "template_class": "EJSTemplate",
         "autorequire": {
             "mdn": "MDN:Common",
-            "Culture": "DekiScript:Culture",
             "Date": "DekiScript:Date",
-            "Json": "DekiScript:Json",
-            "List": "DekiScript:List",
-            "Map": "DekiScript:Map",
-            "Meta": "DekiScript:Meta",
-            "Num": "DekiScript:Num",
             "Page": "DekiScript:Page",
             "String": "DekiScript:String",
             "Uri": "DekiScript:Uri",
             "Web": "DekiScript:Web",
-            "Wiki": "DekiScript:Wiki",
-            "Xml": "DekiScript:Xml"
+            "Wiki": "DekiScript:Wiki"
         }
     }
 }


### PR DESCRIPTION
This removes the loading from Kuma, the templates themselves should also be removed from MDN.
