### PR TITLE
Readme: Use SVG badges.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,15 +2,15 @@
 Kuma
 ====
 
-.. image:: https://travis-ci.org/mozilla/kuma.png?branch=master
+.. image:: https://travis-ci.org/mozilla/kuma.svg?branch=master
    :target: https://travis-ci.org/mozilla/kuma
    :alt: Build Status
 
-.. image:: https://coveralls.io/repos/mozilla/kuma/badge.png?branch=master
+.. image:: https://img.shields.io/coveralls/mozilla/kuma/master.svg
    :target: https://coveralls.io/r/mozilla/kuma?branch=master
    :alt: Code Coverage Status
 
-.. image:: https://requires.io/github/mozilla/kuma/requirements.png?branch=master
+.. image:: https://requires.io/github/mozilla/kuma/requirements.svg?branch=master
    :target: https://requires.io/github/mozilla/kuma/requirements/?branch=master
    :alt: Requirements Status
 


### PR DESCRIPTION
Those badges look better on 2x (and more) displays. They're also a smaller download.

Note that the Travis CI badge was already sent as SVG.

I didn't put a bug number since all patches relating to this part of the code didn't (see eg. https://github.com/mozilla/kuma/commit/a07203543f6506ed5ef06c74bd1248e08ad1ee8d), and it seemed silly to file a bug form with questions such as "What would users do? What would happen as a result?" for this.

Full disclosure: I am http://shields.io's maintainer. I talked to all parties involved in each of the badges shown.
