### PR TITLE
Fix Bug 1071591 - Download description alignments

### DIFF
--- a/media/redesign/stylus/wiki-customcss.styl
+++ b/media/redesign/stylus/wiki-customcss.styl
@@ -2096,7 +2096,9 @@ a.new.glossaryLink:active {
 a.new.glossaryLink:hover {
     text-decoration: underline;
 }
+
 /* download buttons */
+
 a.download-button {
     margin-bottom: 20px;
     padding: 10px;
@@ -2121,14 +2123,38 @@ a.download-button:link {
 a.download-button .right-align {
     float: right;
 }
+
 /* download box stuff */
+
 li.download-box {
+    position: relative;
     text-align: center;
-    vertical-align: middle;
+    img {
+        float: none;
+    }
 }
-li.download-box img {
-    float: none;
+
+.download-desc {
+    padding-bottom: 3em;
 }
+
+.download-button {
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    -webkit-transform: translate(-50%, 0);
+            transform: translate(-50%, 0);
+}
+
+@media $media-query-mobile {
+    .download-desc > span:first-child {
+        font-weight: 700;
+        display: block;
+    }
+}
+
+/* -- */
+
 span.comment {
     display: none;
 }


### PR DESCRIPTION
To keep headings aligned at the top I removed vertical-align:centre and to keep buttons aligned at the bottom I absolutely position them at the bottom in a space created by adding padding to the bottom of the description.

Also added a fix to keep the "headings" on a separate line on mobile since they look weird on the same line as the image.
