### PR TITLE
fix bug 1071083 - use assertRaiseMessage more instead of manually handling exception in tests.

### DIFF
--- a/apps/devmo/tests/test_helpers.py
+++ b/apps/devmo/tests/test_helpers.py
@@ -26,7 +26,7 @@ class TestUrlEncode(test_utils.TestCase):
             s = u"Someguy Dude\xc3\xaas Lastname"
             urlencode(s)
         except KeyError:
-            ok_(False, "There should be no KeyError")
+            self.fail("There should be no KeyError")
 
 
 class TestSoapbox(test_utils.TestCase):

--- a/apps/search/tests/test_indexes.py
+++ b/apps/search/tests/test_indexes.py
@@ -89,12 +89,7 @@ class TestIndexes(ElasticTestCase):
         # then create it again and see if it blows up
         es = get_indexing_es()
 
-        try:
-            es.indices.create(index.prefixed_name)
-        except RequestError:
-            pass
-        else:
-            assert False
+        self.assertRaises(RequestError, es.indices.create, index.prefixed_name)
 
         # then delete it and check if recreating works without blowing up
         index.delete()

--- a/apps/sumo/tests/test_form_fields.py
+++ b/apps/sumo/tests/test_form_fields.py
@@ -42,19 +42,11 @@ class TypedMultipleChoiceFieldTestCase(test_utils.TestCase):
     """TypedMultipleChoiceField is just like MultipleChoiceField
     except, instead of validating, it coerces types."""
 
-    def assertRaisesErrorWithMessage(self, error, message, callable, *args,
-                                     **kwargs):
-        self.assertRaises(error, callable, *args, **kwargs)
-        try:
-            callable(*args, **kwargs)
-        except error, e:
-            eq_(message, str(e))
-
     def test_typedmultiplechoicefield_71(self):
         f = TypedMultipleChoiceField(choices=[(1, "+1"), (-1, "-1")],
                                      coerce=int)
         eq_([1], f.clean(['1']))
-        self.assertRaisesErrorWithMessage(
+        self.assertRaisesMessage(
             ValidationError,
             "[u'Select a valid choice. 2 is not one of the available choices."
             "']", f.clean, ['2'])
@@ -77,12 +69,12 @@ class TypedMultipleChoiceFieldTestCase(test_utils.TestCase):
         # Don't do this!
         f = TypedMultipleChoiceField(choices=[('A', 'A'), ('B', 'B')],
                                      coerce=int)
-        self.assertRaisesErrorWithMessage(
+        self.assertRaisesMessage(
             ValidationError,
             "[u'Select a valid choice. B is not one of the available choices."
             "']", f.clean, ['B'])
         # Required fields require values
-        self.assertRaisesErrorWithMessage(
+        self.assertRaisesMessage(
             ValidationError, "[u'This field is required.']", f.clean, [])
 
     def test_typedmultiplechoicefield_75(self):

--- a/kuma/demos/tests/test_models.py
+++ b/kuma/demos/tests/test_models.py
@@ -2,7 +2,6 @@
 
 # This Python file uses the following encoding: utf-8
 # see also: http://www.python.org/dev/peps/pep-0263/
-import logging
 from os import unlink
 from os.path import dirname, isfile, isdir
 from shutil import rmtree
@@ -31,7 +30,6 @@ from .. import models
 from . import make_users, build_submission, build_hidden_submission
 
 models.DEMO_MAX_FILESIZE_IN_ZIP = 1 * 1024 * 1024
-
 
 
 def save_valid_submission(title='hello world',
@@ -87,11 +85,9 @@ class DemoPackageTest(TestCase):
         zf.close()
         s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-        try:
-            s.clean()
-            ok_(False, "There should be a validation exception")
-        except ValidationError, e:
-            ok_('ZIP file contains no acceptable files' in e.messages)
+        self.assertRaisesMessage(ValidationError,
+                                 'ZIP file contains no acceptable files',
+                                 s.clean)
 
         unlink(s.demo_package.path)
 
@@ -105,12 +101,9 @@ class DemoPackageTest(TestCase):
         zf.close()
         s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-        try:
-            s.clean()
-            ok_(False, "There should be a validation exception")
-        except ValidationError, e:
-            ok_('HTML index not found in ZIP' in e.messages)
-
+        self.assertRaisesMessage(ValidationError,
+                                 'HTML index not found in ZIP',
+                                 s.clean)
         unlink(s.demo_package.path)
 
     def test_demo_package_no_index(self):
@@ -123,11 +116,9 @@ class DemoPackageTest(TestCase):
         zf.close()
         s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-        try:
-            s.clean()
-            ok_(False, "There should be a validation exception")
-        except ValidationError, e:
-            ok_('HTML index not found in ZIP' in e.messages)
+        self.assertRaisesMessage(ValidationError,
+                                 'HTML index not found in ZIP',
+                                 s.clean)
 
         unlink(s.demo_package.path)
 
@@ -142,11 +133,9 @@ class DemoPackageTest(TestCase):
         zf.close()
         s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-        try:
-            s.clean()
-            ok_(False, "There should be a validation exception")
-        except ValidationError, e:
-            ok_('ZIP file contains no acceptable files' in e.messages)
+        self.assertRaisesMessage(ValidationError,
+                                 'ZIP file contains no acceptable files',
+                                 s.clean)
 
         unlink(s.demo_package.path)
 
@@ -162,9 +151,8 @@ class DemoPackageTest(TestCase):
 
         try:
             s.clean()
-            ok_(True, "This last one should be okay")
         except:
-            ok_(False, "The last zip file should have been okay")
+            self.fail("The last zip file should have been okay")
 
         unlink(s.demo_package.path)
 
@@ -180,9 +168,8 @@ class DemoPackageTest(TestCase):
 
         try:
             s.clean()
-            ok_(True, "This last one should be okay")
         except:
-            ok_(False, "The last zip file should have been okay")
+            self.fail("The last zip file should have been okay")
 
         unlink(s.demo_package.path)
 
@@ -377,12 +364,9 @@ class DemoPackageTest(TestCase):
         zf.close()
         s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-        try:
-            s.clean()
-            ok_(False, "There should be a validation exception")
-        except ValidationError, e:
-            ok_('ZIP file contains a file that is too large: bigfile.txt'
-                in e.messages)
+        self.assertRaisesMessage(ValidationError,
+                                 'ZIP file contains a file that is too large: bigfile.txt',
+                                 s.clean)
 
         unlink(s.demo_package.path)
 
@@ -418,11 +402,9 @@ class DemoPackageTest(TestCase):
 
             s.demo_package.save('play_demo.zip', ContentFile(fout.getvalue()))
 
-            try:
-                s.clean()
-                ok_(False, "There should be a validation exception")
-            except ValidationError, e:
-                ok_('ZIP file contains an unacceptable file: badfile' in e.messages)
+            self.assertRaisesMessage(ValidationError,
+                                     'ZIP file contains an unacceptable file: badfile',
+                                     s.clean)
 
     def test_hidden_demo_next_prev(self):
         """Ensure hidden demos do not display when next() or previous() are called"""
@@ -432,7 +414,6 @@ class DemoPackageTest(TestCase):
         eq_(s.next(), None)
 
     def test_hidden_demo_shows_to_creator_and_admin(self):
-        """Demo package with at least index.html in root is valid"""
         s = self.submission
         s.hidden = True
 
@@ -442,7 +423,6 @@ class DemoPackageTest(TestCase):
         ok_(s.allows_hiding_by(self.admin_user))
 
     def test_censored_demo_shows_only_in_admin_interface(self):
-        """Demo package with at least index.html in root is valid"""
         s = self.submission
         s.censor()
 

--- a/kuma/demos/tests/test_views.py
+++ b/kuma/demos/tests/test_views.py
@@ -387,13 +387,13 @@ class DemoViewsTest(UserTestCase):
         # Ensure the new screenshot and thumbnail URL code works when there's a
         # screenshot present.
         try:
-            r = self.client.get(reverse('demos_all'))
-            r = self.client.get(reverse('demos_tag', args=['tech:javascript']))
-            r = self.client.get(reverse('demos_detail', args=[s.slug]))
-            r = self.client.get(reverse('demos_feed_recent', args=['atom']))
-            r = self.client.get(reverse('demos_feed_featured', args=['json']))
+            self.client.get(reverse('demos_all'))
+            self.client.get(reverse('demos_tag', args=['tech:javascript']))
+            self.client.get(reverse('demos_detail', args=[s.slug]))
+            self.client.get(reverse('demos_feed_recent', args=['atom']))
+            self.client.get(reverse('demos_feed_featured', args=['json']))
         except:
-            ok_(False, "No exceptions should have been thrown")
+            self.fail("No exceptions should have been thrown")
 
         # Forcibly delete the screenshot - should not be possible from
         # user-facing UI per form validation, but we should at least not throw
@@ -404,13 +404,13 @@ class DemoViewsTest(UserTestCase):
 
         # Big bucks, no whammies...
         try:
-            r = self.client.get(reverse('demos_all'))
-            r = self.client.get(reverse('demos_tag', args=['tech:javascript']))
-            r = self.client.get(reverse('demos_detail', args=[s.slug]))
-            r = self.client.get(reverse('demos_feed_recent', args=['atom']))
-            r = self.client.get(reverse('demos_feed_featured', args=['json']))
+            self.client.get(reverse('demos_all'))
+            self.client.get(reverse('demos_tag', args=['tech:javascript']))
+            self.client.get(reverse('demos_detail', args=[s.slug]))
+            self.client.get(reverse('demos_feed_recent', args=['atom']))
+            self.client.get(reverse('demos_feed_featured', args=['json']))
         except:
-            ok_(False, "No exceptions should have been thrown")
+            self.fail("No exceptions should have been thrown")
 
     @attr('bug745902')
     def test_long_slug(self):

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -1,5 +1,5 @@
 from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import eq_, ok_
 
 from django.contrib.auth.models import User
 from django.contrib import messages as django_messages
@@ -64,8 +64,8 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
                                         uid='noone@inexistant.com')
         persona_login = SocialLogin(account=persona_account)
 
-        assert_raises(ImmediateHttpResponse,
-                      self.adapter.pre_social_login, request, persona_login)
+        self.assertRaises(ImmediateHttpResponse,
+                          self.adapter.pre_social_login, request, persona_login)
         queued_messages = list(messages)
         eq_(len(queued_messages), 1)
         eq_(django_messages.ERROR, queued_messages[0].level)

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -79,7 +79,7 @@ class TestUserProfile(UserTestCase):
             profile = UserProfile.objects.get(user=user)
             profile.gravatar
         except UnicodeEncodeError:
-            ok_(False, "There should be no UnicodeEncodeError")
+            self.fail("There should be no UnicodeEncodeError")
 
     def test_locale_timezone_fields(self):
         """We've added locale and timezone fields. Verify defaults."""

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -169,7 +169,7 @@ class ProfileViewsTest(UserTestCase):
         try:
             self.client.get(url, follow=True)
         except PageNotAnInteger:
-            ok_(False, "Non-numeric page number should not cause an error")
+            self.fail("Non-numeric page number should not cause an error")
 
     @mock.patch('basket.lookup_user')
     @mock.patch('basket.subscribe')

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -625,7 +625,7 @@ class ContentSectionToolTests(UserTestCase):
             result = kuma.wiki.content.filter_out_noinclude(doc_src)
             eq_('', result)
         except:
-            ok_(False, "There should not have been an exception")
+            self.fail("There should not have been an exception")
 
     def test_sample_code_extraction(self):
         sample_html = u"""

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -141,10 +141,10 @@ class DocumentTests(UserTestCase):
             try:
                 d.delete()
                 if active:
-                    ok_(False, 'Exception on delete when active')
+                    self.fail('Exception on delete when active')
             except Exception:
                 if not active:
-                    ok_(False, 'No exception on delete when not active')
+                    self.fail('No exception on delete when not active')
 
     def test_delete_tagged_document(self):
         """Make sure deleting a tagged doc deletes its tag relationships."""
@@ -827,7 +827,7 @@ class DumpAndLoadJsonTests(UserTestCase):
             # The original primary key should have gone away.
             try:
                 d_curr = Document.objects.get(pk=d_orig.pk)
-                ok_(False, "This should have been an error")
+                self.fail("This should have been an error")
             except Document.DoesNotExist:
                 pass
 
@@ -940,8 +940,8 @@ class DeferredRenderingTests(UserTestCase):
         self.d1.save()
         try:
             self.d1.render('', 'http://testserver/')
-            ok_(False, "An attempt to render while another appears to be in "
-                       "progress should be disallowed")
+            self.fail("An attempt to render while another appears to be in "
+                      "progress should be disallowed")
         except DocumentRenderingInProgress:
             pass
 
@@ -959,8 +959,8 @@ class DeferredRenderingTests(UserTestCase):
         try:
             self.d1.render('', 'http://testserver/')
         except DocumentRenderingInProgress:
-            ok_(False, "A timed-out rendering should not be considered as "
-                       "still in progress")
+            self.fail("A timed-out rendering should not be considered as "
+                      "still in progress")
 
     @mock.patch('kuma.wiki.kumascript.get')
     def test_long_render_sets_deferred(self, mock_kumascript_get):
@@ -1055,8 +1055,8 @@ class DeferredRenderingTests(UserTestCase):
         self.d1.save()
         try:
             result_rendered, _ = self.d1.get_rendered(None, 'http://testserver/')
-            ok_(False, "We should have gotten a "
-                       "DocumentRenderedContentNotAvailable exception")
+            self.fail("We should have gotten a "
+                      "DocumentRenderedContentNotAvailable exception")
         except DocumentRenderedContentNotAvailable:
             pass
         ok_(mock_render_document_delay.called)
@@ -1730,12 +1730,10 @@ class PageMoveTests(UserTestCase):
         grandchild_doc.parent_topic = child_doc
         grandchild_doc.save()
 
-        conflict = revision(title='Conflict page for page-move error handling',
-                            slug='test-move-error-messaging/moved/grandchild',
-                            is_approved=True,
-                            save=True)
-        conflict_doc = conflict.document
-
+        revision(title='Conflict page for page-move error handling',
+                 slug='test-move-error-messaging/moved/grandchild',
+                 is_approved=True,
+                 save=True)
         # TODO: Someday when we're on Python 2.7, we can use
         # assertRaisesRegexp. Until then, we have to manually catch
         # and inspect the exception.

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -116,9 +116,9 @@ class LocaleRedirectTests(UserTestCase, WikiTestCase):
         try:
             self.client.get(url, follow=True)
         except Http404, e:
-            ok_(True)
+            pass
         except Exception, e:
-            ok_(False, "The only exception should be a 404, not this: %s" % e)
+            self.fail("The only exception should be a 404, not this: %s" % e)
 
     def _create_en_and_de_docs(self):
         en = settings.WIKI_DEFAULT_LANGUAGE
@@ -812,7 +812,7 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         try:
             trap['data'].decode('utf8')
         except UnicodeDecodeError:
-            ok_(False, "Data wasn't posted as utf8")
+            self.fail("Data wasn't posted as utf8")
 
 
 class DocumentSEOTests(UserTestCase, WikiTestCase):


### PR DESCRIPTION
Also uses the fail testcase method for false positives in a few places.
