### PR TITLE
fix bug 1076863 - Add CSSLint to dev box

### DIFF
--- a/puppet/manifests/classes/csslint.pp
+++ b/puppet/manifests/classes/csslint.pp
@@ -1,0 +1,13 @@
+# Get stylus
+class csslint {
+    exec { 'csslint-install':
+        command => '/usr/bin/npm install -g csslint@0.10.0',
+        creates => '/usr/local/bin/csslint',
+        require => [
+            Package['nodejs'],
+        ]
+    }
+    file { '/usr/local/bin/csslint':
+        require => Exec['csslint-install'],
+    }
+}

--- a/puppet/manifests/dev-vagrant.pp
+++ b/puppet/manifests/dev-vagrant.pp
@@ -76,6 +76,7 @@ class dev {
         stylus: stage => extras;
         cleancss: stage => extras;
         uglify: stage => extras;
+        csslint: stage => extras;
 
         site_config: stage => main;
         dev_hacks_post: stage => hacks_post;


### PR DESCRIPTION
@stephaniehobson Mentioned wanting a CSS validator so I think this is our best bet.  This PR doesn't contain any usage settings yet, but we can figure that out as we go along, like:
-  Should we add it to compile-stylesheets?  (I vote no, but...)
-  Should each of us add it as a pre-commit hook?
-  Should we add individual lint settings?

To check, do `vagrant provision` from the host and then ssh into the box, type "css" and then press tab;  "csslint" should be there.
