### PR TITLE
Fix Bug 1078597: Bug with bidi-value-vendorize() mixin

### DIFF
--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -240,12 +240,15 @@ bidi-value(prop, ltr, rtl, make-important = false) {
 }
 
 bidi-value-vendorize(prop, ltr, rtl, make-important = false) {
-    for prefix in VENDOR-PREFIXES {
-        bidi-style(unquote(prefix + prop), ltr, prop, rtl, make-important);
-    }
-    bidi-style(prop, ltr, prop, rtl, make-important);
-}
+    make-important = make-important ? unquote('!important') : unquote('');
 
+    vendorize(prop, ltr make-important);
+
+    html[dir='rtl'] & {
+        vendorize(prop, rtl make-important);
+    }
+
+}
 
 /*
     MIXINS LIKE CLASSES


### PR DESCRIPTION
As part of looking at feature settings for CSSLint I turned up the fact that this mixin was producing code that would triggers warnings in CSSLint.

Test:
- a LTR and and RTL zone landing page and look at the little arrows in the sub menu.
