### PR TITLE
bug 1065965 - Ensure save buttons enable when CKEditor source is edited.

### DIFF
--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -936,8 +936,9 @@
       $form.on('change input', metaSelector, function() {
         var $this = $(this);
         var value = $this.val();
+        var typeAttr = $this.attr('type');
 
-        if($this.attr('type').toLowerCase() == 'checkbox') {
+        if(typeAttr && typeAttr.toLowerCase() == 'checkbox') {
             value = this.checked;
         }
 


### PR DESCRIPTION
Right now there's a warning because the attribute isn't on the textarea of CKEditor's source textarea.

To test:
1.  Go to the new document page
2.  Fill in _nothing_
3.  Click the "source" button of CKEditor
4.  Add some raw HTML
5.  See that the save buttons are enabled.
