### PR TITLE
fix bug 866542 - Hide attachment table on document display page

### DIFF
--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -3,6 +3,7 @@ from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
 import constance.config
+from django.conf import settings
 
 from kuma.users.tests import UserTestCase
 from kuma.wiki.tests import revision, WikiTestCase
@@ -45,7 +46,8 @@ class AttachmentTests(UserTestCase, WikiTestCase):
                       save=True)
 
         # view it and verify markup is escaped
-        response = self.client.get(rev.document.get_absolute_url())
+        response = self.client.get(reverse('wiki.edit_document', args=(rev.slug,),
+                                    locale=settings.WIKI_DEFAULT_LANGUAGE))
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_('%s xss' % title,

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -336,11 +336,6 @@
 
               {% if not is_zone_root %}
 
-                <!-- attachments list -->
-                {% if document.attachments.all().exists() %}
-                  {% include 'attachments/includes/attachment_list.html' %}
-                {% endif %}
-
                 <!-- contributors -->
                 <div class="wiki-block contributors">
                   <h2 class="offscreen">{{ _('Document Tags and Contributors') }}</h2>


### PR DESCRIPTION
No test included because checking for not-an-attachments-table doesn't seem logical.
