### PR TITLE
fix bug 1080001 - Address New Relic-reported JS Errors

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -408,6 +408,6 @@
 
 {% block js %}
   <script type="text/javascript">
-      jQuery('.from-search-toc').mozSearchResults('{{ search_url|safe }}');
+      if(window.jQuery) jQuery('.from-search-toc').mozSearchResults('{{ search_url|safe }}');
   </script>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -197,7 +197,7 @@
 
     {% if waffle.flag('ga_outbound_links') %}
       <script>
-        mdn.analytics.trackOutboundLinks();
+        if(window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
       </script>
     {% endif %}
 


### PR DESCRIPTION
Ensuring we have a few objects before they're used will save a few error reports in NR from IE8.
