### PR TITLE
fix bug 1082030 - remove the old URL pattern for the devderby rules.

### DIFF
--- a/kuma/demos/templates/demos/devderby_tag.html
+++ b/kuma/demos/templates/demos/devderby_tag.html
@@ -4,7 +4,7 @@
 {% block bodyclass %}section-demos devderby plain{% endblock %}
 {% block title %}{{ page_title(_('{subtitle} | Demo Studio') | f(subtitle=tag_title(tag))) }}{% endblock %}
 {% block extrahead %}
-  <link rel="alternate" type="application/atom+xml" 
+  <link rel="alternate" type="application/atom+xml"
       title="{{_('Demos tagged {tag}') | f(tag=tag_title(tag)) }}"
       href="{{ url('demos_feed_tag', format='atom', tag=tag.name) }}" />
     {{ css('devderby') }}
@@ -20,7 +20,6 @@
       <ul>
         <li><a href="{{url('demos_devderby_landing')}}">{{_("Home")}}</a></li>
         <li><a href="{{url('demos_devderby_landing')}}#upcoming">{{_("Challenges")}}</a></li>
-        <li><a href="{{url('demos_devderby_rules')}}">{{_("Rules")}}</a></li>
         <li><a href="{{url('demos_devderby_landing')}}#tab-judging">{{_("Judging")}}</a></li>
         <li><a href="{{url('demos_devderby_landing')}}#challenge-prizes">{{_("Prizes")}}</a></li>
         <li><a href="{{url('demos_devderby_landing')}}#resources">{{_("Resources")}}</a></li>
@@ -34,9 +33,9 @@
       <h1><a href="{{url('demos_devderby_landing')}}">{{_("Dev Derby")}}</a></h1>
       <h2><span>{{ tag_meta(tag, 'dateline') }}</span> {{ tag_meta(tag, 'short_title') }}</h2>
     </header>
-    
+
     <p>{{ tag_description(tag) }}</p>
-    
+
     {% if winner_demos | count > 0 %}
     <section id="derby-winners">
       <h1>{{_("Derby Winners")}}</h1>
@@ -49,7 +48,7 @@
       </ul>
     </section>
     {% endif %}
-    
+
     <h2>{{_("Submissions")}}</h2>
     {{ submission_listing(
         request, submission_list, is_paginated, paginator, page_obj,

--- a/kuma/demos/urls.py
+++ b/kuma/demos/urls.py
@@ -23,7 +23,6 @@ urlpatterns = patterns('kuma.demos.views',
         DevDerbyByDate.as_view(), name='demos_devderby_by_date'),
     url(r'^devderby/tag/(?P<tag>[^/]+)/?$', DevDerbyTagView.as_view(),
         name='demos_devderby_tag'),
-    url(r'^devderby/rules/?$', 'devderby_rules', name='demos_devderby_rules'),
 
     url(r'^terms', 'terms', name='demos_terms'),
 


### PR DESCRIPTION
This is related to bug #1045796 and was forgotten in 0b0c1412b4df9a28fe2496d32142950d1b5b317f.

(Supersedes https://github.com/mozilla/kuma/pull/2816 with a rebase to fix Travis)
