### PR TITLE
bug 1080617 - update l10n docs re: verbatim perms

### DIFF
--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -293,6 +293,8 @@ localizers will have merge head-aches.
         $ git commit -m "MDN string update YYYY-MM-DD"
         $ git svn dcommit
 
+.. note:: You need verbatim permissions for the following. If you don't have permissions, email `groovecoder <mailto:lcrouch@mozilla.com>`_ or `mathjazz <mailto:matjaz.horvat@gmail.com>`_ to do the following ...
+
 4.  Go to the `MDN templates on Verbatim
     <https://localize.mozilla.org/templates/mdn/>`_
 


### PR DESCRIPTION
Doesn't fix the l10n story, but at least it documents the roadblock that both @jezdez and @stephaniehobson hit going thru it.
