### PR TITLE
bug 1072493 - Allow customizable domain runner via command line

### DIFF
--- a/docs/ui-tests.rst
+++ b/docs/ui-tests.rst
@@ -64,9 +64,9 @@ Running Tests
 
     node_modules/.bin/intern-runner config=intern-local
 
-The above runs the entire suite of tests. Custom functionality has been added to allow for command line arguments to be passed to modify configuration, namely `b` to set which browsers to run in and `t` for which test suites to run::
+The above runs the entire suite of tests. Custom functionality has been added to allow for command line arguments to be passed to modify configuration, namely `b` to set which browsers to run in, `t` for which test suites to run, and `d` for which domain to run on::
 
-    node_modules/.bin/intern-runner config=intern-local b=firefox,chrome t=auth,homepage
+    node_modules/.bin/intern-runner config=intern-local b=firefox,chrome t=auth,homepage d=developer-local.allizom.org
 
 =========================
 Identifying Test Failures

--- a/tests/ui/tests/_config.js
+++ b/tests/ui/tests/_config.js
@@ -1,20 +1,30 @@
-define({
+define(['intern'], function(intern) {
 
-    // URLs
-    homepageUrl: 'http://developer-local.allizom.org/',
+    var domain = intern.args.d || 'developer-local.allizom.org';
+    var httpsAddress = 'https://' + domain + '/';
+    var defaultLocale = 'en-US';
 
-    // Locales
-    defaultLocale: 'en-US',
+    return {
 
-    // Important media queries
-    mediaQueries: {
-        smallDesktop: 1200,
-        tablet: 1024,
-        mobile: 768,
-        smallMobile: 480
-    },
+        // URLs
+        domain: domain,
+        url: httpsAddress,
+        homepageUrl: httpsAddress + defaultLocale,
 
-    // Async testing in milliseconds
-    testTimeout: 22000,
+        // Locales
+        defaultLocale: defaultLocale,
+
+        // Important media queries
+        mediaQueries: {
+            smallDesktop: 1200,
+            tablet: 1024,
+            mobile: 768,
+            smallMobile: 480
+        },
+
+        // Async testing in milliseconds
+        testTimeout: 22000
+
+    };
 
 });


### PR DESCRIPTION
Now we can add "d" to the command line to specify a domain, which will be super helpful with SauceLabs and testing on dev, stage, and prod :)

To test, run tests without the "d" option and with "d=developer.mozilla.org"
