### PR TITLE
Fix Bug 1087020: Demo detail page mobile view

### DIFF
--- a/kuma/demos/templates/demos/detail.html
+++ b/kuma/demos/templates/demos/detail.html
@@ -60,246 +60,251 @@
 
   <section id="content-main" role="main" class="full">
 
-    <section id="demobox">
-      <div class="demo-info">
-        <h1 class="page-title">{{submission.title}}</h1>
-        <p class="byline">
-          {% trans creator_link=submission_creator(submission), create_date=datetimeformat(submission.created, 'date')|e %}
-            By {{ creator_link }} on {{ create_date }}
-          {% endtrans %}
-        </p>
+    <section id="demobox" class="media media-mobile-stack media-reverse">
+      <div class="media-img">
+          <div class="demo-preview">
+            <div class="screenshots">
+              <ul class="nav-slide">
+                  <li class="nav-prev"><a href="#" class="prev" title="{{_('See the previous image')}}">{{_('Previous')}}</a></li>
+                  <li class="nav-next"><a href="#" class="next" title="{{_('See the next image')}}">{{_('Next')}}</a></li>
+              </ul>
 
-        {# This should only be added for derby winners #}
-        {# <p class="flag"><strong>{{_('You Like')}}</strong></p> #}
-
-
-        <div class="demo-desc">
-          <p>{{ submission.summary }}</p>
-        </div>
-      </div>
-
-      <ul class="tools">
-        <li class="launch"><a href="{{ url('demos_launch', slug=submission.slug) }}" target="{{ "_blank" if submission.navbar_optout }}" class="button"><strong>{{_('Launch Demo')}}</strong></a></li>
-        <li>
-            {% set likes = submission.likes.get_total_for_request(request) %}
-            <form id="demo-unlike" target="like_receiver" method="post"
-                action="{{ url('demos_unlike', slug=submission.slug) }}?iframe=1"
-                style="{{ likes > 0 and ' ' or 'display: none' }}">
-                {{ csrf() }}
-                <button type="submit" class="unlike" title="{{_('You like this demo. Undo?')}}"><span>{{_('You Like')}}</button>
-              </form>
-              <form id="demo-like" target="like_receiver" method="post"
-                  action="{{ url('demos_like', slug=submission.slug) }}?iframe=1"
-                  style="{{ likes > 0 and 'display: none' or ' ' }}">
-                {{ csrf() }}
-                <button type="submit" class="like" title="{{_('Do you like this demo?')}}"><span>{{_('Like It')}}</span></button>
-              </form>
-              <iframe style="display: none" id="like_receiver" name="like_receiver"></iframe>
-        </li>
-
-        <li class="share"><a href="#share-opts" id="sharetoggle" title="{{_('Share this demo with your social network')}}">{{_("Share It")}}</a>
-          <ul id="share-opts">
-            <li class="sharetitle">{{_('Share It')}}</li>
-            <li class="twitter"><a href="{{ 'http://twitter.com/share'|urlparams(url=short_url, text=submission.title.encode('utf-8'), via="mozhacks") }}">{{_('Share on Twitter')}}</a></li>
-            <li class="facebook"><a href="{{ 'http://www.facebook.com/sharer.php'|urlparams(u=full_url, t=submission.title.encode('utf-8')) }}">{{_('Share on Facebook')}}</a></li>
-            <li class="link"><input id="shorturl" type="text" readonly="readonly" value="{{ short_url }}"></li>
-          </ul>
-          <script type="text/javascript">
-              var so = document.getElementById('share-opts');
-              so.className = 'js';
-              so.style.display = 'none';
-            </script>
-        </li>
-      </ul>
-
-      <div class="demo-meta">
-        {% if tech_tags_for_object(submission)|length > 0 %}
-        <p class="tags">
-            {{_('Built using')}}
-            {% for tag in tags_for_object(submission) %}
-                {% if tag.name.startswith('tech:') %}
-                    <a title="{{_('See more demos made with {tag_title}') | f(tag_title=tag_title(tag)) }}" href="{{ url('demos_tag', tag=tag.name) }}">{{ tag_title(tag) }}</a>{% if not loop.last %}, {% endif %}
+              <ul class="slider">
+                {% if submission.video_url %}
+                    <li class="panel">{{ submission.video_url.embed_html }}</li>
                 {% endif %}
-            {% endfor %}
-        </p>
-        {% endif %}
+                {% for idx in range(1, 6) %}
+                  {% set screenshot_url = submission.screenshot_url(idx) %}
+                  {% if screenshot_url %}
+                    <li class="panel">
+                      <img src="{{ screenshot_url }}" alt="" width="434" height="325">
+                    </li>
+                  {% endif %}
+                {% endfor %}
+              </ul>
 
-        <ul class="stats">
-            {% set launches = submission.launches.total %}
-            {% set likes = submission.likes.total %}
-            {% set comments = submission.comments_total %}
-            <li class="views" title="{{ ngettext('This demo has been viewed {count} time', 'This demo has been viewed {count} times', launches) | f(count=launches) }}">{{ngettext('{count} view', '{count} views', launches) | f(count=launches) }}</li>
-            <li class="likes" title="{{ ngettext('{count} person liked this demo', '{count} people liked this demo', likes) | f(count=likes) }}">{{ngettext('{count} like', '{count} likes', likes) | f(count=likes) }}</li>
-            <li class="comments" title="{{ ngettext('There is {count} comment for this demo', 'There are {count} comments for this demo', comments) | f(count=comments) }}">{{ _('{comment_count} comments') | f(comment_count=comments) }}</li>
-        </ul>
-      </div>
-
-    <div class="screenshots">
-      <ul class="nav-slide">
-          <li class="nav-prev"><a href="#" class="prev" title="{{_('See the previous image')}}">{{_('Previous')}}</a></li>
-          <li class="nav-next"><a href="#" class="next" title="{{_('See the next image')}}">{{_('Next')}}</a></li>
-      </ul>
-
-      <ul class="slider">
-        {% if submission.video_url %}
-            <li class="panel">{{ submission.video_url.embed_html }}</li>
-        {% endif %}
-        {% for idx in range(1, 6) %}
-          {% set screenshot_url = submission.screenshot_url(idx) %}
-          {% if screenshot_url %}
-            <li class="panel">
-              <img src="{{ screenshot_url }}" alt="" width="434" height="325">
-            </li>
-          {% endif %}
-        {% endfor %}
-      </ul>
-
-    </div><!-- /.screenshots -->
-        <script type="text/javascript">
-            var els = document.getElementsByTagName('div');
-            for (var i=0,el; el=els[i]; i++) {
-                if (el.className == 'screenshots') {
-                    el.className += ' js';
-                    el.parentNode.style.overflow = 'hidden';
+            </div><!-- /.screenshots -->
+            <script type="text/javascript">
+                var els = document.getElementsByTagName('div');
+                for (var i=0,el; el=els[i]; i++) {
+                    if (el.className == 'screenshots') {
+                        el.className += ' js';
+                        el.parentNode.style.overflow = 'hidden';
+                    }
                 }
-            }
-        </script>
+            </script>
+          </div>
+      </div>
+      <div class="media-body">
+          <div class="demo-info">
+            <h1 class="page-title">{{submission.title}}</h1>
+            <p class="byline">
+              {% trans creator_link=submission_creator(submission), create_date=datetimeformat(submission.created, 'date')|e %}
+                By {{ creator_link }} on {{ create_date }}
+              {% endtrans %}
+            </p>
 
+            {# This should only be added for derby winners #}
+            {# <p class="flag"><strong>{{_('You Like')}}</strong></p> #}
+
+
+            <div class="demo-desc">
+              <p>{{ submission.summary }}</p>
+            </div>
+          </div>
+
+          <ul class="tools">
+            <li class="launch"><a href="{{ url('demos_launch', slug=submission.slug) }}" target="{{ "_blank" if submission.navbar_optout }}" class="button"><strong>{{_('Launch Demo')}}</strong></a></li>
+            <li>
+                {% set likes = submission.likes.get_total_for_request(request) %}
+                <form id="demo-unlike" target="like_receiver" method="post"
+                    action="{{ url('demos_unlike', slug=submission.slug) }}?iframe=1"
+                    style="{{ likes > 0 and ' ' or 'display: none' }}">
+                    {{ csrf() }}
+                    <button type="submit" class="unlike" title="{{_('You like this demo. Undo?')}}"><span>{{_('You Like')}}</button>
+                  </form>
+                  <form id="demo-like" target="like_receiver" method="post"
+                      action="{{ url('demos_like', slug=submission.slug) }}?iframe=1"
+                      style="{{ likes > 0 and 'display: none' or ' ' }}">
+                    {{ csrf() }}
+                    <button type="submit" class="like" title="{{_('Do you like this demo?')}}"><span>{{_('Like It')}}</span></button>
+                  </form>
+                  <iframe style="display: none" id="like_receiver" name="like_receiver"></iframe>
+            </li>
+
+            <li class="share"><a href="#share-opts" id="sharetoggle" title="{{_('Share this demo with your social network')}}">{{_("Share It")}}</a>
+              <ul id="share-opts">
+                <li class="sharetitle">{{_('Share It')}}</li>
+                <li class="twitter"><a href="{{ 'http://twitter.com/share'|urlparams(url=short_url, text=submission.title.encode('utf-8'), via="mozhacks") }}">{{_('Share on Twitter')}}</a></li>
+                <li class="facebook"><a href="{{ 'http://www.facebook.com/sharer.php'|urlparams(u=full_url, t=submission.title.encode('utf-8')) }}">{{_('Share on Facebook')}}</a></li>
+                <li class="link"><input id="shorturl" type="text" readonly="readonly" value="{{ short_url }}"></li>
+              </ul>
+              <script type="text/javascript">
+                  var so = document.getElementById('share-opts');
+                  so.className = 'js';
+                  so.style.display = 'none';
+                </script>
+            </li>
+          </ul>
+
+          <div class="demo-meta">
+            {% if tech_tags_for_object(submission)|length > 0 %}
+            <p class="tags">
+                {{_('Built using')}}
+                {% for tag in tags_for_object(submission) %}
+                    {% if tag.name.startswith('tech:') %}
+                        <a title="{{_('See more demos made with {tag_title}') | f(tag_title=tag_title(tag)) }}" href="{{ url('demos_tag', tag=tag.name) }}">{{ tag_title(tag) }}</a>{% if not loop.last %}, {% endif %}
+                    {% endif %}
+                {% endfor %}
+            </p>
+            {% endif %}
+
+            <ul class="stats">
+                {% set launches = submission.launches.total %}
+                {% set likes = submission.likes.total %}
+                {% set comments = submission.comments_total %}
+                <li class="views" title="{{ ngettext('This demo has been viewed {count} time', 'This demo has been viewed {count} times', launches) | f(count=launches) }}">{{ngettext('{count} view', '{count} views', launches) | f(count=launches) }}</li>
+                <li class="likes" title="{{ ngettext('{count} person liked this demo', '{count} people liked this demo', likes) | f(count=likes) }}">{{ngettext('{count} like', '{count} likes', likes) | f(count=likes) }}</li>
+                <li class="comments" title="{{ ngettext('There is {count} comment for this demo', 'There are {count} comments for this demo', comments) | f(count=comments) }}">{{ _('{comment_count} comments') | f(comment_count=comments) }}</li>
+            </ul>
+          </div>
+      </div>
     </section><!-- /#demobox -->
 
-    <section class="demo-more">
+    <div class="column-container">
+        <section class="column-8 demo-more">
 
-      {# only shown to admins and the demo owner #}
-      {# TODO: The whole UL should be hidden if none of the conditions are met. Logged-out users get served an empty list, which is invalid HTML and can trigger layout weirdness. #}
-      {% set p_edit = submission.allows_editing_by(request.user) %}
-      {% set p_delete = submission.allows_deletion_by(request.user) %}
-      {% set p_hide = submission.allows_hiding_by(request.user) %}
-      {% set show_buttons = ( p_edit or p_delete or p_hide ) %}
+          {# only shown to admins and the demo owner #}
+          {# TODO: The whole UL should be hidden if none of the conditions are met. Logged-out users get served an empty list, which is invalid HTML and can trigger layout weirdness. #}
+          {% set p_edit = submission.allows_editing_by(request.user) %}
+          {% set p_delete = submission.allows_deletion_by(request.user) %}
+          {% set p_hide = submission.allows_hiding_by(request.user) %}
+          {% set show_buttons = ( p_edit or p_delete or p_hide ) %}
 
-      {% if show_buttons %}
-      <ul id="demo-manage">
+          {% if show_buttons %}
+          <ul id="demo-manage">
 
-        {% if p_edit %}
-            <li><a href="{{ url('demos_edit', slug=submission.slug) }}"
-                class="button edit">{{_('Edit Demo')}}</a></li>
-        {% endif %}
+            {% if p_edit %}
+                <li><a href="{{ url('demos_edit', slug=submission.slug) }}"
+                    class="button edit">{{_('Edit Demo')}}</a></li>
+            {% endif %}
 
-        {% if p_delete %}
-            <li><a href="{{ url('demos_delete', slug=submission.slug) }}"
-                class="button remove modal">{{_("Remove demo")}}</a></li>
-        {% endif %}
-        {% if p_hide %}
-            {% if submission.hidden %}
-                <li><form id="demo-show" method="post" action="{{ url('demos_show', slug=submission.slug) }}">{{ csrf() }}
-                    <button type="submit"><span class="button remove">{{_("Show demo")}}</span></button></form></li>
+            {% if p_delete %}
+                <li><a href="{{ url('demos_delete', slug=submission.slug) }}"
+                    class="button remove modal">{{_("Remove demo")}}</a></li>
+            {% endif %}
+            {% if p_hide %}
+                {% if submission.hidden %}
+                    <li><form id="demo-show" method="post" action="{{ url('demos_show', slug=submission.slug) }}">{{ csrf() }}
+                        <button type="submit"><span class="button remove">{{_("Show demo")}}</span></button></form></li>
+                {% else %}
+                    <li><form id="demo-hide" method="post" action="{{ url('demos_hide', slug=submission.slug) }}">{{ csrf() }}
+                        <button type="submit"><span class="button remove">{{_("Hide demo")}}</span></button></form></li>
+                {% endif %}
+            {% endif %}
+
+          </ul>
+          {% endif %}
+
+          {% if submission.description %}
+          <section class="moreabout">
+            <h1>{{_('More About This Demo From The Author')}}</h1>
+            <p>{{ submission.description | nl2br }}</p>
+          </section>
+          {% endif %}
+
+          <section id="comments">
+            <header>
+              {% if submission.comments_total == 0 %}
+                  <h1>{{_('No comments yet.')}}</h1>
+              {% else %}
+                  <h1>{{ ngettext('{comments_total} comment so far', '{comments_total} comments so far', submission.comments_total) | f(comments_total=submission.comments_total) }}</h1>
+              {% endif %}
+              {% if request.user.is_authenticated() %}
+                  {% trans %}
+                      <p>Why not <a href="#comment-post">Add your own</a>?</p>
+                  {% endtrans %}
+              {% else %}
+                  {% trans login_url=url('account_login') %}
+                  <p><a href="{{ login_url }}">Log in</a> to add your own.</p>
+                  {% endtrans %}
+              {% endif %}
+            </header>
+
+            <ol id="comments-list" class="hfeed">
+                {{ comments_tree(request, submission, get_threaded_comment_tree(submission)) }}
+            </ol>
+            <script type="text/javascript">
+                document.getElementById('comments-list').className += ' js';
+            </script>
+
+            {% if request.user.is_authenticated() %}
+                <form id="comment-post" class="comment_form" method="POST" action="{{ url('demos_new_comment', slug=submission.slug) }}">
+                  {{ csrf() }}
+                  <fieldset>
+                      <legend><span>{{_('Add your comment')}}</span></legend>
+                      <div><textarea id="your-comment" name="comment" rows="6" cols="60"></textarea></div>
+                      <p><button type="submit">{{_('Comment')}}</button></p>
+                  </fieldset>
+                </form>
+            {% endif %}
+
+          </section>
+        </section>
+
+        <section id="demo-sub" class="column-4">
+
+          <div class="module" id="source">
+            <h3 class="mod-title">{{_('Get the Source Code')}}</h3>
+            <p class="download"><a href="{{ url('demos_download', slug=submission.slug) }}">{% trans file_ksize=(submission.demo_package.size/1024)|round(2,'ceil')|e %}Download the Source <span class="note">{{file_ksize}} KB &middot; ZIP File</span>{% endtrans %}</a></p>
+            {% if submission.source_code_url %}
+            <p class="browse"><a href="{{ submission.source_code_url }}">Browse the Source
+                {# TODO: Show "hosted by {{domain}}?" #}
+                {% if false %}<span class="note">Hosted on GitHub</span>{% endif %}</a></p>
+            {% endif %}
+            {% if submission.license_name == 'mpl' %}
+                {% set license_class = 'mpl' %}
+            {% elif submission.license_name == 'gpl' %}
+                {% set license_class = 'gpl' %}
+            {% elif submission.license_name == 'bsd' %}
+                {% set license_class = 'bsd' %}
+            {% elif submission.license_name == 'apache' %}
+                {% set license_class = 'apache' %}
             {% else %}
-                <li><form id="demo-hide" method="post" action="{{ url('demos_hide', slug=submission.slug) }}">{{ csrf() }}
-                    <button type="submit"><span class="button remove">{{_("Hide demo")}}</span></button></form></li>
+                {% set license_class = 'publicdomain' %}
             {% endif %}
-        {% endif %}
+            <p class="license {{ license_class }}">
+                {% trans link=license_link(submission.license_name)|e, title=license_title(submission.license_name)|e %}
+                    This demo is released under the <a href="{{link}}">{{title}}</a> license.
+                {% endtrans %}
+            </p>
+          </div>
 
-      </ul>
-      {% endif %}
-
-      {% if submission.description %}
-      <section class="moreabout">
-        <h1>{{_('More About This Demo From The Author')}}</h1>
-        <p>{{ submission.description | nl2br }}</p>
-      </section>
-      {% endif %}
-
-      <section id="comments">
-        <header>
-          {% if submission.comments_total == 0 %}
-              <h1>{{_('No comments yet.')}}</h1>
-          {% else %}
-              <h1>{{ ngettext('{comments_total} comment so far', '{comments_total} comments so far', submission.comments_total) | f(comments_total=submission.comments_total) }}</h1>
+          {% if more_by | length > 1 %}
+          <div class="module" id="moreby">
+            <h3 class="mod-title">{{ _('More by {creator}')|fe(creator=submission_creator(submission)) }}</h3>
+            <ul class="gallery">
+              {% for more_submission in more_by %}
+                {% if more_submission.id != submission.id %}
+                    <li><a href="{{ more_submission.get_absolute_url() }}"><img src="{{ more_submission.thumbnail_url(1) }}" alt="{{ more_submission.title }}" title="{{ more_submission.title }}" width="80" height="60"></a></li>
+                {% endif %}
+              {% endfor %}
+            </ul>
+          </div>
           {% endif %}
-          {% if request.user.is_authenticated() %}
-              {% trans %}
-                  <p>Why not <a href="#comment-post">Add your own</a>?</p>
-              {% endtrans %}
-          {% else %}
-              {% trans login_url=url('account_login') %}
-              <p><a href="{{ login_url }}">Log in</a> to add your own.</p>
-              {% endtrans %}
-          {% endif %}
-        </header>
 
-        <ol id="comments-list" class="hfeed">
-            {{ comments_tree(request, submission, get_threaded_comment_tree(submission)) }}
-        </ol>
-        <script type="text/javascript">
-            document.getElementById('comments-list').className += ' js';
-        </script>
+          <div id="demo-report">
+            <h3>{{ _("Report a Problem") }}</h3>
+            <ul>
+                <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=notworking" title="{{_('Flag Content')}}">{{_('Demo is not working')}}</a></li>
+                <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=inappropriate" title="{{_('Flag Content')}}">{{_('Demo is inappropriate')}}</a></li>
+                <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=plagarised" title="{{_('Flag Content')}}">{{_('Demo is not by this author')}}</a></li>
+            </ul>
+          </div>
 
-        {% if request.user.is_authenticated() %}
-            <form id="comment-post" class="comment_form" method="POST" action="{{ url('demos_new_comment', slug=submission.slug) }}">
-              {{ csrf() }}
-              <fieldset>
-                  <legend><span>{{_('Add your comment')}}</span></legend>
-                  <div><textarea id="your-comment" name="comment" rows="6" cols="60"></textarea></div>
-                  <p><button type="submit">{{_('Comment')}}</button></p>
-              </fieldset>
-            </form>
-        {% endif %}
-
+        </section>
       </section>
-    </section>
-
-    <section id="demo-sub">
-
-      <div class="module" id="source">
-        <h3 class="mod-title">{{_('Get the Source Code')}}</h3>
-        <p class="download"><a href="{{ url('demos_download', slug=submission.slug) }}">{% trans file_ksize=(submission.demo_package.size/1024)|round(2,'ceil')|e %}Download the Source <span class="note">{{file_ksize}} KB &middot; ZIP File</span>{% endtrans %}</a></p>
-        {% if submission.source_code_url %}
-        <p class="browse"><a href="{{ submission.source_code_url }}">Browse the Source
-            {# TODO: Show "hosted by {{domain}}?" #}
-            {% if false %}<span class="note">Hosted on GitHub</span>{% endif %}</a></p>
-        {% endif %}
-        {% if submission.license_name == 'mpl' %}
-            {% set license_class = 'mpl' %}
-        {% elif submission.license_name == 'gpl' %}
-            {% set license_class = 'gpl' %}
-        {% elif submission.license_name == 'bsd' %}
-            {% set license_class = 'bsd' %}
-        {% elif submission.license_name == 'apache' %}
-            {% set license_class = 'apache' %}
-        {% else %}
-            {% set license_class = 'publicdomain' %}
-        {% endif %}
-        <p class="license {{ license_class }}">
-            {% trans link=license_link(submission.license_name)|e, title=license_title(submission.license_name)|e %}
-                This demo is released under the <a href="{{link}}">{{title}}</a> license.
-            {% endtrans %}
-        </p>
-      </div>
-
-      {% if more_by | length > 1 %}
-      <div class="module" id="moreby">
-        <h3 class="mod-title">{{ _('More by {creator}')|fe(creator=submission_creator(submission)) }}</h3>
-        <ul class="gallery">
-          {% for more_submission in more_by %}
-            {% if more_submission.id != submission.id %}
-                <li><a href="{{ more_submission.get_absolute_url() }}"><img src="{{ more_submission.thumbnail_url(1) }}" alt="{{ more_submission.title }}" title="{{ more_submission.title }}" width="80" height="60"></a></li>
-            {% endif %}
-          {% endfor %}
-        </ul>
-      </div>
-      {% endif %}
-
-      <div id="demo-report">
-        <h3>{{ _("Report a Problem") }}</h3>
-        <ul>
-            <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=notworking" title="{{_('Flag Content')}}">{{_('Demo is not working')}}</a></li>
-            <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=inappropriate" title="{{_('Flag Content')}}">{{_('Demo is inappropriate')}}</a></li>
-            <li><a class="modal" href="{{ url('demos_flag', slug=submission.slug) }}?flag_type=plagarised" title="{{_('Flag Content')}}">{{_('Demo is not by this author')}}</a></li>
-        </ul>
-      </div>
-
-    </section>
-
-  </section>
+    </div>
 
 </div>
 </section>

--- a/media/redesign/stylus/base/utilities.styl
+++ b/media/redesign/stylus/base/utilities.styl
@@ -52,7 +52,9 @@
 
 /*  media block
     for use when you want an item of defined width on the left and some stuff on the right of it
-    http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/ */
+    http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/
+    add .media-reverse to .media if you want the defined width stuff on the right (it still has to come first in the source)
+    add .media-mobile-stack or .media-small-mobile-stack to stack the stuff on mobile */
 .media,
 .media-body {
     overflow: hidden;
@@ -61,15 +63,53 @@
 }
 
 .media-img {
-    float: left;
-    margin-right: ($grid-spacing / 2);
+    bidi-value(float, left, right);
+    bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
 
     img {
         display: block;
     }
+
+    .media-reverse & {
+        bidi-value(float, right, left);
+        bidi-style(margin-left, ($grid-spacing / 2), margin-right, 0);
+    }
 }
 
-.media-imgExt {
-    float: right;
-    margin-left: ($grid-spacing / 2);
+/* declaration for stacking the two items */
+media-stack() {
+    .media-body,
+    .media-img {
+        float: none;
+        margin-left: 0;
+        margin-right: 0;
+    }
+
+    &.media-reverse {
+        display: table;
+        caption-side: top;
+        width: 100%;
+
+        .media-img {
+            display: table-cell;
+        }
+        .media-body {
+            display: table-caption;
+        }
+    }
+
 }
+
+/* triggers for stacking */
+.media-mobile-stack {
+    @media $media-query-mobile {
+        media-stack();
+    }
+}
+
+.media-small-mobile-stack {
+    @media $media-query-small-mobile {
+        media-stack();
+    }
+}
+

--- a/media/redesign/stylus/components/demos/backgrounds.styl
+++ b/media/redesign/stylus/components/demos/backgrounds.styl
@@ -1,3 +1,5 @@
+@require '../../includes/vars';
+
 /* Background */
 .section-demos {
   background: url("/media/img/demos/bg-demostudio.jpg") center 50px no-repeat;
@@ -14,6 +16,11 @@
   -moz-box-shadow: 1px 1px 4px rgba(0,0,0,0.25);
   -webkit-box-shadow: 1px 1px 4px rgba(0,0,0,0.25);
   box-shadow: 1px 1px 4px rgba(0,0,0,0.25);
+
+  @media $media-query-small-mobile {
+    margin: 20px 0;
+    padding: 20px 0 10px;
+  }
 }
 #demostudio.detail {
   background: url("/media/img/demos/bg-demodetail.jpg") center 55px no-repeat;
@@ -24,6 +31,10 @@
   -moz-box-shadow: none;
   -webkit-box-shadow: none;
   box-shadow: none;
+
+  @media $media-query-small-mobile {
+    padding: 0;
+  }
 }
 #demostudio.landing {
   background: url("/media/img/demos/bg-demolanding.jpg") center 50px no-repeat;

--- a/media/redesign/stylus/components/demos/demo-manage.styl
+++ b/media/redesign/stylus/components/demos/demo-manage.styl
@@ -1,4 +1,12 @@
+@require '../../includes/vars';
+
 /* edit/remove/hide buttons on demo detail page */
+#demo-manage {
+    @media $media-query-mobile {
+        display: none;
+    }
+}
+
 #demo-manage li {
   font-size: 1.142em;
   display: inline;

--- a/media/redesign/stylus/components/demos/demo-more.styl
+++ b/media/redesign/stylus/components/demos/demo-more.styl
@@ -1,10 +1,7 @@
 /* Author description of demo on demo details page */
 .demo-more {
   font-size: 0.928em;
-  width: 610px;
-  float: left;
   color: #666;
-  padding: 20px 0 0;
 }
 .moreabout {
   padding: 20px 30px;

--- a/media/redesign/stylus/components/demos/demobox.styl
+++ b/media/redesign/stylus/components/demos/demobox.styl
@@ -1,13 +1,13 @@
+@require '../../includes/vars';
+
 /* Demo Detail */
 #demobox {
   position: relative;
   margin-top: -10px;
   min-height: 420px;
-  padding: 10px 585px 0 0;
   color: #fff;
   font-size: 0.928em;
   text-shadow: 1px 1px 0 rgba(0,0,0,0.6);
-  background: url("/media/img/demos/bg-mainscreen.png") right 10px no-repeat;
 }
 #demobox a {
   color: #fff;
@@ -16,6 +16,9 @@
   margin-top: 10px;
   padding: 15px 30px 0;
   border-top: 2px solid #6b7684;
+  @media $media-query-small-mobile {
+    padding: 15px 0 0;
+  }
 }
 #demobox h1 {
   font-size: 1.695em;
@@ -36,6 +39,9 @@
   min-height: 40px;
   border: solid #6b7684;
   border-width: 2px 0;
+  @media $media-query-small-mobile {
+    padding: 15px 0 15px;
+  }
 }
 #demobox .tools:after {
   content: ".";
@@ -52,6 +58,12 @@
   position: absolute;
   left: 30px;
   top: 15px;
+  @media $media-query-small-mobile {
+    position: static;
+    padding-right: 15px;
+    margin-bottom: 15px;
+    width: 100%;
+  }
 }
 #demobox .launch .button {
   font-size: 1.539em;
@@ -101,6 +113,10 @@
   position: relative;
   z-index: 99;
   margin-top: 8px;
+
+  @media $media-query-small-mobile {
+    margin-top: 4px;
+  }
 }
 #share-opts {
   margin: 0.75em 0;
@@ -131,6 +147,10 @@
   font-size: 0.857em;
   list-style: none;
   margin: 15px 0 0 30px;
+
+  @media $media-query-small-mobile {
+    margin: 15px 0 0 0;
+  }
 }
 #demobox .stats li {
   float: left;
@@ -150,6 +170,9 @@
 #demobox .tags {
   font-size: 0.857em;
   margin: 10px 30px;
+  @media $media-query-small-mobile {
+    margin: 10px 0;
+  }
 }
 #demobox #share-opts li {
   float: none;
@@ -232,18 +255,54 @@
   -o-transform: rotate(-35deg);
   transform: rotate(-35deg);
 }
-#demobox .screenshots {
-  width: 434px;
-  position: absolute;
-  right: 58px;
-  top: 21px;
-  overflow: hidden;
+
+$demo-preview-width = 434px;
+$demo-preview-height = 325px;
+
+#demobox .demo-preview{
+    padding: 11px 58px 72px;
+    margin: 0 auto;
+    background:url("/media/img/demos/bg-mainscreen.png") center top;
+    background-size: contain;
+    width: $demo-preview-width;
+    @media $media-query-tablet {
+        padding: (11px / 2 ) (58px / 2 ) (72px / 2);
+        margin-top: 48px;
+        width: ($demo-preview-width / 2);
+    }
+
+    @media $media-query-mobile {
+        margin-top: $grid-spacing;
+        margin-bottom: $grid-spacing;
+    }
 }
+
+#demobox .screenshots{
+    margin:0 auto;
+    position:relative;
+    width: $demo-preview-width;
+    @media $media-query-tablet {
+        width: ($demo-preview-width / 2);
+    }
+}
+
+#demobox img {
+    width: $demo-preview-width;
+    @media $media-query-tablet {
+        width: ($demo-preview-width / 2);
+    }
+}
+
 #demobox .slider {
   margin: 0;
-  width: 434px;
-  height: 325px;
+  width: $demo-preview-width;
+  height: $demo-preview-height;
   overflow: hidden;
+
+    @media $media-query-tablet {
+        width: ($demo-preview-width / 2);
+        height: ($demo-preview-height / 2);
+    }
 }
 #demobox .slider .panel {
   margin: 0;

--- a/media/redesign/stylus/components/demos/header.styl
+++ b/media/redesign/stylus/components/demos/header.styl
@@ -1,8 +1,14 @@
+@require '../../includes/vars';
+
 /* Header */
 #demos-head {
   position: relative;
   padding: 40px 0 0 260px;
   min-height: 40px;
+
+  @media $media-query-small-mobile {
+    padding: 0;
+  }
 }
 .landing #demos-head {
   padding: 40px 240px 0 360px;
@@ -16,6 +22,10 @@
   text-indent: -999em;
   overflow: hidden;
   background: url("/media/img/demos/logo-demostudio-lt.png") 0 0 no-repeat;
+
+  @media $media-query-small-mobile {
+    position: static;
+  }
 }
 .landing #demos-head h1 {
   left: 100px;

--- a/media/redesign/stylus/components/demos/paging.styl
+++ b/media/redesign/stylus/components/demos/paging.styl
@@ -5,6 +5,12 @@
   text-transform: uppercase;
   font-size: 0.857em;
   text-shadow: 1px 1px 0 rgba(0,0,0,0.6);
+
+  @media $media-query-small-mobile {
+    float:none;
+    width: auto;
+  }
+
 }
 #demos-head .paging a {
   display: block;

--- a/media/redesign/stylus/components/demos/sidebar.styl
+++ b/media/redesign/stylus/components/demos/sidebar.styl
@@ -1,7 +1,4 @@
 #demo-sub {
-  width: 295px;
-  float: right;
-  padding: 20px 0 0 20px;
 }
 #demo-sub .module {
   background: #fff;

--- a/media/redesign/stylus/components/demos/studio.styl
+++ b/media/redesign/stylus/components/demos/studio.styl
@@ -117,6 +117,10 @@ html {
 
 @media $media-query-mobile {
 
+    #demostudio main > .center {
+        padding-top: 0;
+    }
+
     #demo-prev, #demo-next {
         display: none;
     }

--- a/media/redesign/stylus/includes/mixin_draw-grid.styl
+++ b/media/redesign/stylus/includes/mixin_draw-grid.styl
@@ -114,6 +114,7 @@ draw-grid() {
      @media $media-query-mobile {
         .column-1, .column-2, .column-3, .column-4, .column-5, .column-6, .column-7, .column-8, .column-9, .column-10, .column-11, .column-12,
         .column-strip, .column-quarter, .column-third, .column-half, .column-9, .column-all, .column-container {$grid-column-selector} {
+            clearfix();
             width: auto !important;
             margin-left: 0 !important;
             margin-right: 0 !important;


### PR DESCRIPTION
Lots of overrides to make demo detail page more mobile friendly.
- Added clearfix() to mobile column declaration, this could break stuff site wide (though it is more likely to fix stuff...)
- Added some stuff to make .media RTL friendly and to display the media below the content if .media-reversed is added.
- Solved most of the problems by switching from the demos grid to the MDN grid (added column-container)
