### PR TITLE
FIX BUG 1084110: Upgrade Stylus & Clean CSS

### DIFF
--- a/media/redesign/stylus/font-awesome.styl
+++ b/media/redesign/stylus/font-awesome.styl
@@ -11,9 +11,7 @@
 icon-lookup = {
     'icon-fixed-width': 'icon-fw',
     'icon-large': 'icon-lg',
-    'icons-ul': 'icon-ul',
-    'icon-li': 'icon-li',
-    'icon-spin': 'icon-spin'
+    'icons-ul': 'icon-ul'
 }
 
 icon-pseudo-lookup = {

--- a/puppet/manifests/classes/cleancss.pp
+++ b/puppet/manifests/classes/cleancss.pp
@@ -1,7 +1,7 @@
 # Get clean-css
 class cleancss {
     exec { 'cleancss-install':
-        command => '/usr/bin/npm install -g clean-css@2.2.3',
+        command => '/usr/bin/npm install -g clean-css@2.2.16',
         creates => '/usr/local/bin/cleancss',
         require => [
             Package['nodejs'],

--- a/puppet/manifests/classes/stylus.pp
+++ b/puppet/manifests/classes/stylus.pp
@@ -1,7 +1,7 @@
 # Get stylus
 class stylus {
     exec { 'stylus-install':
-        command => '/usr/bin/npm install -g stylus@0.43.1',
+        command => '/usr/bin/npm install -g stylus@0.49.2',
         creates => '/usr/local/bin/stylus',
         require => [
             Package['nodejs'],


### PR DESCRIPTION
 Clean CSS 2.2.16 and Stylus 49.2.

Always good to have most recent versions of things. Both updates include bug fixes and the Clean CSS one saves us yet more white space.

Small change to the font-awesome.styl file to remove an unnecessary call that was throwing new Stylus into an infinite loop.

To test:
- Before switching to this branch save a copy of media/redesign/css/ outside of kuma
- Halt and provision vagrant to get most recent versions of clean css and stylus
- Start your webserver however you normally do
- Run ./scripts/compile-stylesheets 
- Watch process to make sure there are no errors
- Hit up a couple pages on the site to make sure nothing broke
- Do a diff on the contents of /media/redesign/css and compare. There will be a few small changes. Mostly whitespace compression and the font-awesome fix.

Ack, ops deployed the new versions on prod, if this breaks anything locally for you we will have to ask them to roll back that change.
