### PR TITLE
fix bug 1088403 - add bn-IN locale

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -116,6 +116,7 @@ MDN_LANGUAGES = (
                  'en-US',
                  'ar',
                  'bn-BD',
+                 'bn-IN',
                  'de',
                  'el',
                  'es',


### PR DESCRIPTION
To spot-check, do steps 3, 5, and 6 from [the Kuma docs for "Adding a New Locale"](http://kuma.readthedocs.org/en/latest/localization.html#adding-a-new-locale), i.e.:

```
(kuma)lcrouch-14912:kuma lcrouch$ cd locale/
(kuma)lcrouch-14912:locale lcrouch$ svn up
Updating '.':
At revision 133691.
(kuma)lcrouch-14912:locale lcrouch$ vagrant ssh
...
(env)vagrant@precise32:~/src$ cd locale/
(env)vagrant@precise32:~/src/locale$ podebug --rewrite=bracket templates/LC_MESSAGES/messages.pot bn_IN/LC_MESSAGES/messages.po
processing 1 files...
[###########################################] 100%
(env)vagrant@precise32:~/src/locale$ ./compile-mo.sh .
```
1. Restart your django `runserver` (either manually or via `foreman`) to have it reload the binary gettext strings.
2. Go to https://developer-local.allizom.org/bn-IN/
3. [x] Make sure you get the home page (no errors)
4. [x] Make sure strings are wrapped in `[` and `]` characters to show translations are working
