### PR TITLE
fix bug 1082596 - fix removeUtms regex and replace

### DIFF
--- a/maintenance/index.html
+++ b/maintenance/index.html
@@ -27,30 +27,14 @@
     <!--[if lte IE 7]><link rel="stylesheet" type="text/css" media="all" href="media/css/ie7.css" /><![endif]-->
 
     <script type="text/javascript">
-      // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
-      var removeUtms  =   function(){
-          var l = window.location;
-          if( l.hash.indexOf( "utm" ) != -1 ){
-              if( window.history.replaceState ){
-                  history.replaceState({},'', l.pathname + l.search);
-              } else {
-                  l.hash = "";
-              }
-          };
-      };
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-36116321-5'],
-                ['_setAllowAnchor', true],
-                  ['_setCustomVar', 7, 'Signed-In', 'Yes', 1],
-                    ['_setCustomVar', 6, 'Redesign', 'Yes', 1],
-                  ['_trackPageview']);
-      _gaq.push( removeUtms );
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-      (function(a, d) {
-        var ga = d.createElement(a); ga.type = 'text/javascript'; ga.async = true;
-        ga.src = ('https:' == d.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-        var s = d.getElementsByTagName(a)[0]; s.parentNode.insertBefore(ga, s);
-      })('script', document);
+    ga('create', 'UA-36116321-5', 'mozilla.org');
+    ga('set', 'anonymizeIp', true);
+    ga('send', 'pageview');
     </script>
     <!--[if IE]><script src="media/js/libs/html5.js"></script><![endif]-->
   </head>

--- a/templates/includes/google_analytics.html
+++ b/templates/includes/google_analytics.html
@@ -80,18 +80,12 @@
         var win = window;
         var removeUtms = function(){
             var location = win.location;
-            if (location.hash.indexOf('utm') != -1) {
-                var anchor = location.hash.match(/#(?!utm)[^&]+/);
-                anchor = anchor ? anchor[0] : '';
-                if(!anchor && win.history.replaceState){
-                    history.replaceState({}, '', location.pathname + location.search);
-                } else {
-                    location.hash = anchor;
-                }
+            if (location.href.indexOf('utm') != -1 && win.history.replaceState) {
+                win.history.replaceState({}, '', location.pathname);
             }
         };
 
-        ga('send', 'pageview', removeUtms(win.location + ''));
+        ga('send', 'pageview', {'hitCallback': removeUtms});
     })();
 </script>
 {% endif %}


### PR DESCRIPTION
To spot-check, go to https://developer-local.allizom.org/en-US/?utm_campaign=test&utm_source=test.com&utm_medium=url and the location should update to https://developer-local.allizom.org/en-US/ after the `pageview` is sent to GA.

The code was looking for `#utm_` params, which we use for hacks.mozilla.org. We use regular `?utm_` params for MDN. In addition, the `ga('send'` call was trying to remove the parameters **before** the `pageview`, so it's a good thing it **wasn't** working.
