### PR TITLE
fix bug 1082034 - fix url_redirect for '/' path

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1305,8 +1305,15 @@ Full traceback:
                 url = anchors[0].get('href')
                 # allow explicit domain and *not* '//'
                 # i.e allow "https://developer...." and "/en-US/docs/blah"
-                if url.startswith(settings.SITE_URL) or (url[0] == '/' and url[1] != '/'):
+                if len(url) > 1:
+                    if url.startswith(settings.SITE_URL):
+                        return url
+                    elif (url[0] == '/' and url[1] != '/'):
+                        return url
+                elif (len(url) == 1 and url[0] == '/'):
                     return url
+                else:
+                    return None
 
     def redirect_document(self):
         """If I am a redirect to a Document, return that Document.

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -19,6 +19,7 @@ from waffle.models import Switch
 
 from devmo.utils import MemcacheLock
 from devmo.tests import override_constance_settings
+from kuma.wiki.constants import REDIRECT_CONTENT
 from kuma.wiki.cron import calculate_related_documents
 from kuma.wiki.exceptions import (PageMoveError,
                                   DocumentRenderedContentNotAvailable,
@@ -304,6 +305,38 @@ class DocumentTests(UserTestCase):
         d3.save()
         ok_(d3.parents == [d1, d2])
 
+    @attr('redirect')
+    def test_redirect_url_allows_site_url(self):
+        href = "%s/en-US/Mozilla" % settings.SITE_URL
+        title = "Mozilla"
+        html = REDIRECT_CONTENT % {'href': href, 'title': title}
+        d = document(is_redirect=True, html=html)
+        eq_(href, d.redirect_url())
+
+    @attr('redirect')
+    def test_redirect_url_allows_domain_relative_url(self):
+        href = "/en-US/Mozilla"
+        title = "Mozilla"
+        html = REDIRECT_CONTENT % {'href': href, 'title': title}
+        d = document(is_redirect=True, html=html)
+        eq_(href, d.redirect_url())
+
+    @attr('redirect')
+    def test_redirect_url_rejects_protocol_relative_url(self):
+        href = "//evilsite.com"
+        title = "Mozilla"
+        html = REDIRECT_CONTENT % {'href': href, 'title': title}
+        d = document(is_redirect=True, html=html)
+        eq_(None, d.redirect_url())
+
+    @attr('bug1082034')
+    @attr('redirect')
+    def test_redirect_url_works_for_home_path(self):
+        href = "/"
+        title = "Mozilla"
+        html = REDIRECT_CONTENT % {'href': href, 'title': title}
+        d = document(is_redirect=True, html=html)
+        eq_(href, d.redirect_url())
 
 class PermissionTests(test_utils.TestCase):
 


### PR DESCRIPTION
There's probably a more pythonic way to re-write this `redirect_url` logic ...
