### PR TITLE
fix bug 1093348 - add 'author' demo license

### DIFF
--- a/kuma/demos/__init__.py
+++ b/kuma/demos/__init__.py
@@ -625,6 +625,12 @@ DEMO_LICENSES = dict((x['name'], x) for x in getattr(settings, 'DEMO_LICENSES', 
         'link': _('http://creativecommons.org/publicdomain/zero/1.0/'),
         'icon': '',
     },
+    {
+        'name': "author",
+        'title': _("Author's"),
+        'link': '',
+        'icon': '',
+    },
 )))
 
 

--- a/kuma/demos/templates/demos/detail.html
+++ b/kuma/demos/templates/demos/detail.html
@@ -262,17 +262,7 @@
                 {# TODO: Show "hosted by {{domain}}?" #}
                 {% if false %}<span class="note">Hosted on GitHub</span>{% endif %}</a></p>
             {% endif %}
-            {% if submission.license_name == 'mpl' %}
-                {% set license_class = 'mpl' %}
-            {% elif submission.license_name == 'gpl' %}
-                {% set license_class = 'gpl' %}
-            {% elif submission.license_name == 'bsd' %}
-                {% set license_class = 'bsd' %}
-            {% elif submission.license_name == 'apache' %}
-                {% set license_class = 'apache' %}
-            {% else %}
-                {% set license_class = 'publicdomain' %}
-            {% endif %}
+            {% set license_class = submission.license_name %}
             <p class="license {{ license_class }}">
                 {% trans link=license_link(submission.license_name)|e, title=license_title(submission.license_name)|e %}
                     This demo is released under the <a href="{{link}}">{{title}}</a> license.


### PR DESCRIPTION
An alternative, simpler implementation to https://github.com/mozilla/kuma/pull/2881. It won't let us condition the license on the waffle flag, but it's much easier to merge sooner.
