### PR TITLE
bug 1087015 - Adding the demo detail to the main demo so that users know what it is

### DIFF
--- a/media/redesign/stylus/components/demos/studio.styl
+++ b/media/redesign/stylus/components/demos/studio.styl
@@ -179,8 +179,16 @@ html {
     }
 
     #demo-main .demo-details {
-        top: 20px;
-        bottom: auto;
+        bottom: 20px;
+        left: 20px;
+        right: 20px;
+        display: block !important; /* overrides the javascript functionality */
+        padding: 6px;
+        text-align: center;
+
+        .desc, .byline {
+            display: none;
+        }
     }
 
     #featured-demos .nav-slide .prev,


### PR DESCRIPTION
Result looks something like this:

http://screencast.com/t/co0qVjxUDZ

Otherwise right now we just have a screenshot and that has no value, really.
