### PR TITLE
Fix bug 1093783: Make Demo Studio logo a link

### DIFF
--- a/kuma/demos/templates/demos/home.html
+++ b/kuma/demos/templates/demos/home.html
@@ -18,7 +18,7 @@
 <div class="wrap">
 
   <header id="demos-head">
-    <h1>{{_("Mozilla Demo Studio")}}</h1>
+    <h1><a href="{{ url('demos') }}">{{_("Mozilla Demo Studio")}}</a></h1>
     <ul class="demo-buttons">
       <li class="submit"><a href="{{ url('demos_submit') }}" class="button positive"><b></b>{{_("Submit a Demo")}}</a></li>
       <li class="learnmore menu"><a href="#learn-pop" class="button">{{ _('Learn More') }}</a>


### PR DESCRIPTION
Steps to reproduce in [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1093783).
