### PR TITLE
Bug 1093762: Restore size/space of #search-browse

### DIFF
--- a/media/redesign/stylus/components/demos/search-browse.styl
+++ b/media/redesign/stylus/components/demos/search-browse.styl
@@ -2,22 +2,18 @@
 #search-browse {
   background: url("/media/img/demos/bg-darts.png") center center no-repeat;
   text-align: center;
-  padding: 1em 15%;
+  padding: $grid-spacing 0;
   margin: 0 0 60px;
-}
-#search-browse .demo-search {
-  width: 45%;
-  float: left;
-}
-#search-browse #demo-tags {
-  width: 45%;
-  float: right;
-  position: relative;
+
+  #demo-tags {
+      position: relative;
+  }
 }
 #demo-tags .button {
   font-size: 1.2em;
   position: relative;
   z-index: 11;
+  text-align: center;
 }
 #search-browse b {
   color: #fff;
@@ -27,4 +23,42 @@
   -moz-transform: rotate(-20deg);
   -webkit-transform: rotate(-20deg);
   transform: rotate(-20deg);
+}
+
+/* Spacing and sizing for the widgets in the #search-browse element (the search
+   box and the "Browse by technology" dropdown) */
+#search-browse {
+    /* Widget containers */
+    .demo-search, #demo-tags {
+        width: 45%;
+    }
+
+    /* Widgets */
+    $button-mobile-width = 70%;
+    #search-demos, #demo-tags .button, #tags-list {
+        width: 40%;
+
+        @media $media-query-tablet {
+            width: $button-mobile-width;
+        }
+    }
+
+    /* The other "Browse by..." buttons, which should have the same width at
+       mobile sizes as the "Browse by technology" button. */
+    .demo-mobile-list a {
+        width: $button-mobile-width;
+    }
+}
+#search-browse .demo-search {
+    float: left;
+    text-align: right;
+}
+#search-browse #demo-tags, #tags-list {
+    float: right;
+    text-align: left;
+}
+#search-browse #tags-list {
+    @media $media-query-small-mobile {
+        width: 100%;
+    }
 }

--- a/media/redesign/stylus/components/demos/studio.styl
+++ b/media/redesign/stylus/components/demos/studio.styl
@@ -246,13 +246,24 @@ html {
         height: 98%;
     }
 
-    .landing #search-browse #demo-tags {
-        float: none;
-        width: auto;
-    }
+    .landing #search-browse {
+        #demo-tags, .demo-search, b {
+            display: block;
+            float: none;
+            text-align: center;
+        }
 
-    .landing #search-browse .demo-search {
-        width: auto;
+        #demo-tags, .demo-search {
+            width: auto;
+        }
+
+        p {
+            margin-bottom: 12px;
+        }
+
+        b {
+            transform: none;
+        }
     }
 
     .landing #featured-demos {
@@ -267,7 +278,6 @@ html {
     #demo-tags .button, .demo-mobile-list .button {
         margin-top: 12px;
         font-size: 1.2em !important;
-        width: 70%;
     }
 
     .section-demos-home {
@@ -277,5 +287,9 @@ html {
         .demo-landing-gallery {
             display: none;
         }
+    }
+
+    #search-browse #demo-tags {
+        text-align: center;
     }
 }

--- a/media/redesign/stylus/components/demos/tags-list.styl
+++ b/media/redesign/stylus/components/demos/tags-list.styl
@@ -4,13 +4,11 @@
 }
 #tags-list {
   display: none;
-  width: 210px;
-  margin: -5px auto 1em -112px;
   padding: 20px 5px 10px;
   overflow: hidden;
   font-size: 11px;
   position: absolute;
-  left: 50%;
+  left: 0;
   z-index: 30;
   -moz-border-radius: 6px;
   -webkit-border-radius: 6px;
@@ -47,7 +45,6 @@
   color: #eee;
 }
 #search-demos {
-  width: 70%;
   border-radius: 0.99em;
   padding: 5px 10px 5px 30px;
   border: 0;


### PR DESCRIPTION
The search box and the Browse button were nearer in the original design.
They were moved around when the redesign launched.

http://ternowaydesigns.com/wordpress/wp-content/uploads/2012/03/mozilla_demoStudio.jpg
