### PR TITLE
Bug 1093762: Set equal width for mobile buttons

### DIFF
--- a/media/redesign/stylus/components/demos/studio.styl
+++ b/media/redesign/stylus/components/demos/studio.styl
@@ -259,6 +259,7 @@ html {
     #demo-tags .button, .demo-mobile-list .button {
         margin-top: 12px;
         font-size: 1.2em !important;
+        width: 70%;
     }
 
     .section-demos-home {


### PR DESCRIPTION
Before:

<img src="https://camo.githubusercontent.com/db1eff65f32604bc32b1d03a6ef97889995467c1/687474703a2f2f692e696d6775722e636f6d2f7762586f514e342e706e67" alt="A vertical column of buttons, each with a different width." />

After:

<img src="http://i.imgur.com/ABNz12o.png" alt="A vertical column of buttons with equal widths." />
