### PR TITLE
bug 1093979 - Add waffle for demo homepage image preloading

### DIFF
--- a/kuma/demos/templates/demos/home.html
+++ b/kuma/demos/templates/demos/home.html
@@ -271,8 +271,8 @@
 
 
         // Update the main demo from the current index demo.
-        function updateMainFeaturedDemo (to) {
-            var demo = demos[to != undefined ?  to : currentIndex];
+        function updateMainFeaturedDemo() {
+            var demo = demos[currentIndex];
             $('#demo-main')
                 .find('.preview img').attr('src', demo.screenshot).end()
                 .find('.preview a').attr('href', demo.link).end()
@@ -317,6 +317,16 @@
         }
 
 
+        // Preload images for sake of smoothness
+        if(window.waffle && waffle.flag_is_active('demos_10th_preload')) {
+            $.each(demos, function() {
+                $('<img>').attr({
+                    'src': this.screenshot,
+                    'aria-hidden': 'true',
+                    'class': 'offscreen'
+                }).appendTo(document.body);
+            });
+        }
 
     });
 


### PR DESCRIPTION
This is just an experimental snippet to preload main demo box images; having images preloaded may improve the visual user experience.  I'm open to thoughts on this.
