### PR TITLE
bug 1087015 - Ensure screenshot nav arrows display on tablet on detail page

### DIFF
--- a/kuma/demos/templates/demos/detail.html
+++ b/kuma/demos/templates/demos/detail.html
@@ -373,8 +373,9 @@
         <script type="text/javascript">
         $(".screenshots").ready(function(){
             if ($('.screenshots .panel').length > 1) {
+
                   // Set up the carousel
-                  $(".screenshots").show().addClass("js").jCarouselLite({
+                  $(".screenshots").show().addClass("js multi-images").jCarouselLite({
                       btnNext: ".nav-next a",
                       btnPrev: ".nav-prev a",
                       visible: 1
@@ -382,16 +383,18 @@
 
                   $(".nav-next a, .nav-prev a").show();
 
-                  $(".screenshots, .flag").hover(
-                    function() {
-                      $(".nav-next a").animate({ right: "6px" },{ queue:false });
-                      $(".nav-prev a").animate({ left: "6px" },{ queue:false });
-                    },
-                    function() {
-                      $(".nav-next a").animate({ right: "-65px" },{ queue:false });
-                      $(".nav-prev a").animate({ left: "-65px" },{ queue:false });
-                    }
-                  );
+                  $(".screenshots, .flag")
+                    .on('touchstart mouseenter', function() {
+                        showElement('6px');
+                    })
+                    .on('mouseleave', function() {
+                        showElement('-65px');
+                    });
+
+                function showElement(position) {
+                    $(".nav-next a").animate({ right: position },{ queue: false });
+                    $(".nav-prev a").animate({ left: position },{ queue: false });
+                }
             }
         });
         </script>

--- a/media/redesign/stylus/demos_10th.styl
+++ b/media/redesign/stylus/demos_10th.styl
@@ -173,6 +173,27 @@
     }
 }
 
+@media $media-query-tablet {
+    #demobox .screenshots.multi-images .nav-slide {
+        .next, .prev {
+            transform: scale(0.5);
+            -webkit-transform: scale(0.5);
+            display: block !important;
+            outline: 0;
+            background-color: transparent;
+            -webkit-tap-highlight-color: rgba(0,0,0,0);
+        }
+
+        .prev {
+            left: -10px !important; /* overriding the JS widget :/ */
+        }
+
+        .next {
+            right: -10px !important; /* overriding the JS widget :/ */
+        }
+    }
+}
+
 @media $media-query-mobile {
     #featured-demos header h2 {
         font-size: 24px;


### PR DESCRIPTION
You can't cycle through the screenshots on mobile without first tapping the image, which isn't intuitive.  This ensures the buttons stay in place.
