### PR TITLE
fix bug 1095004 - Don't show download link on author license demos

### DIFF
--- a/kuma/demos/templates/demos/detail.html
+++ b/kuma/demos/templates/demos/detail.html
@@ -255,12 +255,16 @@
         <section id="demo-sub" class="column-4">
 
           <div class="module" id="source">
-            <h3 class="mod-title">{{_('Get the Source Code')}}</h3>
-            <p class="download"><a href="{{ url('demos_download', slug=submission.slug) }}">{% trans file_ksize=(submission.demo_package.size/1024)|round(2,'ceil')|e %}Download the Source <span class="note">{{file_ksize}} KB &middot; ZIP File</span>{% endtrans %}</a></p>
-            {% if submission.source_code_url %}
-            <p class="browse"><a href="{{ submission.source_code_url }}">Browse the Source
-                {# TODO: Show "hosted by {{domain}}?" #}
-                {% if false %}<span class="note">Hosted on GitHub</span>{% endif %}</a></p>
+
+            <h3 class="mod-title">{{_('About this Demo')}}</h3>
+
+            {% if submission.license_name != 'author' %}
+                <p class="download"><a href="{{ url('demos_download', slug=submission.slug) }}">{% trans file_ksize=(submission.demo_package.size/1024)|round(2,'ceil')|e %}Download the Source <span class="note">{{file_ksize}} KB &middot; ZIP File</span>{% endtrans %}</a></p>
+                {% if submission.source_code_url %}
+                <p class="browse"><a href="{{ submission.source_code_url }}">Browse the Source
+                    {# TODO: Show "hosted by {{domain}}?" #}
+                    {% if false %}<span class="note">Hosted on GitHub</span>{% endif %}</a></p>
+                {% endif %}
             {% endif %}
             {% set license_class = submission.license_name %}
             <p class="license {{ license_class }}">


### PR DESCRIPTION
Changed the title and added the conditional check for author license which hides source link
