### PR TITLE
Bug 1082798: Split out header and footer tests

### DIFF
--- a/tests/ui/_tests.js
+++ b/tests/ui/_tests.js
@@ -5,10 +5,12 @@ define({
 
     // Functional test suite(s) to run in each browser once non-functional tests are completed
     functionalSuites: [
-        'tests/env',
-        'tests/homepage',
         'tests/auth',
-        'tests/demos'
+        'tests/demos',
+        'tests/env',
+        'tests/footer',
+        'tests/header',
+        'tests/homepage'
     ]
 
 });

--- a/tests/ui/tests/footer.js
+++ b/tests/ui/tests/footer.js
@@ -1,0 +1,33 @@
+define([
+    'intern!object',
+    'intern/chai!assert',
+    'intern/dojo/node!leadfoot/keys',
+    'base/lib/config',
+    'base/lib/assert'
+], function(registerSuite, assert, keys, config, libAssert) {
+
+    registerSuite({
+
+        name: 'footer',
+
+        beforeEach: function() {
+            return this.remote.get(config.homepageUrl);
+        },
+
+        'Changing the footer\'s language selector changes locale via URL': function() {
+
+            return this.remote
+                        .findById('language')
+                        .moveMouseTo(5, 5)
+                        .click()
+                        .type(['e', keys.RETURN])
+                        .getCurrentUrl()
+                        .then(function(url) {
+                            assert.isTrue(url.indexOf('/es/') != -1);
+                        })
+                        .goBack(); // Cleanup to go back to default locale
+        }
+
+    });
+
+});

--- a/tests/ui/tests/header.js
+++ b/tests/ui/tests/header.js
@@ -1,0 +1,58 @@
+define([
+    'intern!object',
+    'intern/chai!assert',
+    'base/lib/config',
+    'base/lib/assert',
+    'base/lib/poll'
+], function(registerSuite, assert, config, libAssert, poll) {
+
+    registerSuite({
+
+        name: 'header',
+
+        beforeEach: function() {
+            return this.remote.get(config.homepageUrl);
+        },
+
+        'Hovering over Zones menu displays submenu': function() {
+
+            return this.remote
+                        .findByCssSelector('#main-nav a')
+                        .moveMouseTo(5, 5)
+                        .end()
+                        .findById('nav-zones-submenu')
+                        .then(function(element) {
+                            return poll.until(element, 'isDisplayed').then(function() {
+                                // Polling proves it's true :)
+                                assert.isTrue(true);
+                            });
+                        });
+
+        },
+
+        'Focusing on the header search box expands the input': function() {
+
+            var searchBoxId = 'main-q';
+            var originalSize;
+
+            return this.remote
+                            .findById(searchBoxId)
+                            .getSize()
+                            .then(function(size) {
+                                originalSize = size;
+                            })
+                            .click()
+                            .end()
+                            .sleep(2000) // wait for animation
+                            .findById(searchBoxId)
+                            .getSize()
+                            .then(function(newSize) {
+                                assert.isTrue(newSize.width > originalSize.width);
+                            });
+        },
+
+        'Tabzilla loads properly': libAssert.elementExistsAndDisplayed('#tabzilla')
+
+    });
+
+});

--- a/tests/ui/tests/homepage.js
+++ b/tests/ui/tests/homepage.js
@@ -72,60 +72,6 @@ define([
 
         },
 
-        'Hovering over Zones menu displays submenu': function() {
-
-            return this.remote
-                        .findByCssSelector('#main-nav a')
-                        .moveMouseTo(5, 5)
-                        .end()
-                        .findById('nav-zones-submenu')
-                        .then(function(element) {
-                            return poll.until(element, 'isDisplayed').then(function() {
-                                // Polling proves it's true :)
-                                assert.isTrue(true);
-                            });
-                        });
-
-        },
-
-        'Focusing on the header search box expands the input': function() {
-
-            var searchBoxId = 'main-q';
-            var originalSize;
-
-            return this.remote
-                            .findById(searchBoxId)
-                            .getSize()
-                            .then(function(size) {
-                                originalSize = size;
-                            })
-                            .click()
-                            .end()
-                            .sleep(2000) // wait for animation
-                            .findById(searchBoxId)
-                            .getSize()
-                            .then(function(newSize) {
-                                assert.isTrue(newSize.width > originalSize.width);
-                            });
-        },
-
-        'Changing the footer\'s language selector changes locale via URL': function() {
-
-            return this.remote
-                        .findById('language')
-                        .moveMouseTo(5, 5)
-                        .click()
-                        .type(['e', keys.RETURN])
-                        .getCurrentUrl()
-                        .then(function(url) {
-                            assert.isTrue(url.indexOf('/es/') != -1);
-                        })
-                        .goBack(); // Cleanup to go back to default locale
-
-        },
-
-        'Tabzilla loads properly': libAssert.elementExistsAndDisplayed('#tabzilla')
-
     });
 
 });


### PR DESCRIPTION
We still load the homepage to run these tests, but we organize them into
more specific categories. This will help us find and update tests,
enable/disable related tests, determine which parts of the interface are
most problematic, and more.
