### PR TITLE
Bug 1082798: Update test name to be consistent

### DIFF
--- a/tests/ui/tests/homepage.js
+++ b/tests/ui/tests/homepage.js
@@ -16,7 +16,7 @@ define([
             return this.remote.get(config.homepageUrl);
         },
 
-        'Ensure homepage is displaying search form and accepts text': function() {
+        'Homepage search form displays and accepts text': function() {
 
             var term = 'Hello';
 


### PR DESCRIPTION
Update the name of the homepage search box test to be declarative like
other test names.
