### PR TITLE
Fix bug 1098194 - Move config_lazy helper to demo models module to prevent circular import.

### DIFF
--- a/apps/devmo/utils.py
+++ b/apps/devmo/utils.py
@@ -7,19 +7,12 @@ import os
 import tempfile
 
 import commonware.log
-import constance.config
-from constance.admin import FIELDS
 import lockfile
 from polib import pofile
 
 from django.conf import settings
 from django.core.cache import get_cache
 from django.shortcuts import _get_queryset
-from django.utils.functional import lazy
-
-
-LAZY_CONSTANCE_TYPES = list(FIELDS.keys())
-LAZY_CONSTANCE_TYPES.remove(unicode)  # because we already have str in the list
 
 
 log = commonware.log.getLogger('mdn.devmo.utils')
@@ -132,27 +125,6 @@ class MemcacheLock(object):
 def entity_decode(str):
     """Turn HTML entities in a string into unicode."""
     return htmlparser.unescape(str)
-
-
-def config(name, default=None):
-    """
-    Just a silly wrapper arround the constance's config object.
-    """
-    return getattr(constance.config, name, default)
-
-"""
-A function to use constance's config object in an environment in which
-one requires lazy values such a model field parameters.
-
-E.g. something that is a pretty stupid idea but should show the risk as well::
-
-    class Entry(models.Model):
-        title = models.CharField(max_length=config_lazy('ENTRY_MAX_LENGTH'))
-
-.. where ``ENTRY_MAX_LENGTH`` is the name of the constance config value.
-
-"""
-config_lazy = lazy(config, *LAZY_CONSTANCE_TYPES)
 
 
 def get_object_or_none(klass, *args, **kwargs):


### PR DESCRIPTION
This happens since the utility requires importing the FIELD list from the constance app, which triggers the population of the Django app cache, which imports other models and voila you have a circular implicite import error.

This would not happen when using modern Django.
