### PR TITLE
Reduce test envs

### DIFF
--- a/tests/ui/intern-sauce-labs.js
+++ b/tests/ui/intern-sauce-labs.js
@@ -7,17 +7,12 @@ define(['./_base', './_cli', 'intern'], function(config, cli, intern) {
     // OnDemand. Options that will be permutated are browserName, version, platform, and platformVersion; any other
     // capabilities options specified for an environment will be copied as-is
     config.environments = [
-        { browserName: 'internet explorer', version: '11', platform: 'Windows 8.1' },
-        { browserName: 'internet explorer', version: '10', platform: 'Windows 8' },
-        { browserName: 'internet explorer', version: '9', platform: 'Windows 7' },
-        { browserName: 'firefox', version: '28', platform: [ 'OS X 10.9', 'Windows 7', 'Linux' ] },
-        { browserName: 'chrome', version: '34', platform: [ 'OS X 10.9', 'Windows 7', 'Linux' ] },
-        { browserName: 'safari', version: '6', platform: 'OS X 10.8' },
-        { browserName: 'safari', version: '7', platform: 'OS X 10.9' }
+        { browserName: 'firefox', version: '32', platform: [ 'OS X 10.9', 'Windows 7'] }
     ];
 
-    // Name of the tunnel class to use for WebDriver tests
-    config.tunnel = 'SauceLabsTunnel';
+     // Prevent collisions with port :4444, configure SauceConnect to use port :4445
+     config.tunnel = 'SauceLabsTunnel';
+     config.tunnelOptions.port = 4445;
 
     return cli.mixinArgs(intern.args, config);
 });


### PR DESCRIPTION
Reducing the test matrix for saucelabs jobs. Later we can up the number of envs once we decide what should be supported. For now though I would like jobs to run quicker, which means fewer concurrent jobs run.
pr also includes a tweak to the port SauceConnect uses. This will prevent intern jobs from colliding with our Python jobs that also use Sauce
