### PR TITLE
Bug 1100643: integrate custom CSS - remove .b2g-button

### DIFF
--- a/media/redesign/stylus/wiki-customcss.styl
+++ b/media/redesign/stylus/wiki-customcss.styl
@@ -1570,39 +1570,6 @@ div.fxosLiveSampleWrapper {
 * Buttons
 * ---------------------------------- */
 
-.b2g-button {
-    width: 100%;
-    height: 3.8rem;
-    margin: 0 0 1rem;
-    padding: 0 1.5rem;
-    vendorize(box-sizing, border-box);
-    display: inline-block;
-    vertical-align: middle;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    overflow: hidden;
-    background: #fafafa url("https://developer.mozilla.org/media/gaia/shared/style/buttons/images/ui/default.png") repeat-x left bottom;
-    border: 0.1rem solid #a6a6a6;
-    border-radius: 0.2rem;
-    font: 500 1.6rem/3.8rem 'MozTT', Sans-serif;
-    color: #333;
-    text-align: center;
-    text-shadow: 0.1rem 0.1rem 0 rgba(255,255,255,0.3);
-    text-decoration: none;
-}
-/* Press (default & recommend) */
-.b2g-button:active,
-.b2g-button.recommend:active,
-.b2g-button:hover,
-.b2g-button.recommend:hover
-.b2g-button:focus,
-.b2g-button.recommend:focus  {
-    border-color: #008aaa;
-    background: #008aaa;
-    text-decoration: none;
-    color: #333;
-    outline: none;
-}
 /* For styling bug links */
 .bug-resolved {
     text-decoration: line-through;


### PR DESCRIPTION
Remove.b2g-button class from styles as it is no longer in use (corresponding macro template has been removed).
