### PR TITLE
Fix Bug 1083481 -  <details> fallback JavaScript and CSS is not #a11y

### DIFF
--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -212,7 +212,10 @@
         if ($body.is('.new')) {
             initPrepopulatedSlugs();
         }
-        initDetailsTags();
+
+        if($('details').length){
+            initDetailsTags();
+        }
 
         if ($body.is('.edit, .new, .translate')) {
             initMetadataEditButton();
@@ -251,15 +254,44 @@
     // Make <summary> and <details> tags work even if the browser doesn't support them.
     // From http://mathiasbynens.be/notes/html5-details-jquery
     function initDetailsTags() {
-        var supportsDetails = ('open' in doc.createElement('details'));
+        // test for browser support of details from http://mathiasbynens.be/notes/html5-details-jquery
+        var supportsDetails = (function(doc) {
+            var el = doc.createElement('details')
+            var isFake;
+            var root;
+            var diff;
+            if (!('open' in el)) {
+                return false;
+            }
+            root = doc.body || (function() {
+                var de = doc.documentElement;
+                isFake = true;
+                return de.insertBefore(doc.createElement('body'), de.firstElementChild || de.firstChild);
+            }());
+            el.innerHTML = '<summary>a</summary>b';
+            el.style.display = 'block';
+            root.appendChild(el);
+            diff = el.offsetHeight;
+            el.open = true;
+            diff = diff != el.offsetHeight;
+            root.removeChild(el);
+            if (isFake) {
+                root.parentNode.removeChild(root);
+            }
+            return diff;
+        }(document));
+
+        var $allDetails = $('details');
+        // need to know if it's opera to avoid a bug later
+        var isOpera = Object.prototype.toString.call(window.opera) == '[object Opera]';
 
         // Execute the fallback only if there's no native `details` support
         if (!supportsDetails) {
             // Note <details> tag support. Modernizr doesn't do this properly as of 1.5; it thinks Firefox 4 can do it, even though the tag has no "open" attr.
-            $('details').addClass('no-details');
+            $allDetails.addClass('no-details');
 
             // Loop through all `details` elements
-            $('details').each(function() {
+            $allDetails.each(function() {
                 // Store a reference to the current `details` element in a variable
                 var $details = $(this),
                     // Store a reference to the `summary` element of the current `details` element (if any) in a variable
@@ -294,28 +326,27 @@
                     $detailsNotSummary.hide();
                 }
 
-                // Set the `tabindex` attribute of the `summary` element to 0 to make it keyboard accessible
-                $detailsSummary.attr('tabindex', 0).on('click', function() {
+                // add ARIA, tabindex, listeners and events
+                $detailsSummary.attr('tabindex', 0).attr('role', 'button').on('click', function() {
                     // Focus on the `summary` element
                     $detailsSummary.focus();
                     // Toggle the `open` attribute of the `details` element
                     if (typeof $details.attr('open') !== 'undefined') {
                         $details.removeAttr('open');
-                    }
-                    else {
+                        $detailsSummary.attr('aria-expanded', 'false');
+                    } else {
                         $details.attr('open', 'open');
+                        $detailsSummary.attr('aria-expanded', 'true');
                     }
                     // Toggle the additional information in the `details` element
                     $detailsNotSummary.slideToggle();
                     $details.toggleClass('open');
                 }).on('keyup', function(event) {
-                    if (13 === event.keyCode || 32 === event.keyCode) {
+                    if (32 == event.keyCode || (13 == event.keyCode && !isOpera)) {
                         // Enter or Space is pressed -- trigger the `click` event on the `summary` element
                         // Opera already seems to trigger the `click` event when Enter is pressed
-                        if (!($.browser.opera && 13 === event.keyCode)) {
-                            event.preventDefault();
-                            $detailsSummary.click();
-                        }
+                        event.preventDefault();
+                        $detailsSummary.click();
                     }
                 });
             });

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -1103,8 +1103,9 @@ details {
    <details> is not natively supported. Add focus styles (for keyboard
    accessibility) */
 .no-details {
-    summary:hover, summary:focus {
-        outline: 0; /* csslint - see bug #1083481 */
+
+    summary {
+        display: block;
     }
 
     summary:before {


### PR DESCRIPTION
Existing code was good but was throwing an error. Updated test for Opera to be stand alone and not rely on something we probably removed.

Added ARIA roles.

Tweaked CSS.

Testing:
- test both FireFox and Chrome since Chrome does support details and FF doesn't
- details should expand on both space and enter
