### PR TITLE
Fix bug 1104112: Revert demo heading text change

### DIFF
--- a/kuma/demos/templates/demos/home.html
+++ b/kuma/demos/templates/demos/home.html
@@ -39,11 +39,7 @@
   {% if featured_submission_list | length >= 3 %}
   <section id="featured-demos">
     <header>
-        {% if waffle.flag("demos_10th") %}
-            <h2>{{_("Firefox 10th Anniversary Demos")}}</h2>
-        {% else %}
-            <h2>{{_("Featured Demos")}}</h2>
-        {% endif %}
+      <h2>{{_("Featured Demos")}}</h2>
     </header>
 
     <ul class="nav-slide">

--- a/media/redesign/stylus/demos_10th.styl
+++ b/media/redesign/stylus/demos_10th.styl
@@ -205,12 +205,7 @@
 
 
 @media $media-query-mobile {
-
     #demostudio.landing {
       background-image: url("/media/img/demos/10th/bg-demolanding-low.jpg");
-    }
-
-    #featured-demos header h2 {
-        font-size: 24px;
     }
 }


### PR DESCRIPTION
This reverts commit 1aef4025a415de5a54dd12531a885f6c5a79962c.

Conflicts:
    media/redesign/stylus/demos_10th.styl
