### PR TITLE
Bug 1106059: Disable admin Document deletion.

### DIFF
--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -292,6 +292,14 @@ class DocumentAdmin(admin.ModelAdmin):
             del actions['delete_selected']
         return actions
 
+    def has_delete_permission(self, request, obj=None):
+        """
+        Disable deletion of individual Documents, by always returning
+        False for the permission check.
+        
+        """
+        return False
+
     def queryset(self, request):
         """
         The Document class has multiple managers which perform


### PR DESCRIPTION
We already have the delete-from-object-list action disabled; this
simply completes that process by disabling the delete button on
individual Documents, by hard-wiring a lack of delete permission for
every user.

As a result, all Document deletion will be forced through the custom
kuma deletion infrastructure, which ensures we have an auditable trail
of who has deleted a Document and why.
