### PR TITLE
Fix bug 1110863 - Commit the db transaction before completing signup.

### DIFF
--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -383,7 +383,8 @@ class SignupView(BaseSignupView):
                 get_adapter().stash_verified_email(self.request,
                                                    email_address['email'])
 
-        form.save(self.request)
+        with transaction.commit_on_success():
+            form.save(self.request)
         return helpers.complete_social_signup(self.request,
                                               self.sociallogin)
 


### PR DESCRIPTION
This is a regression from bug 1104864 and relateds to the abysymal
behavior of the Django 1.4 transaction middleware. Celery is just a
pawn in its game. God damnit.
