### PR TITLE
bug 1110863 - remove username from deletion log

### DIFF
--- a/kuma/wiki/templates/wiki/deletion_log.html
+++ b/kuma/wiki/templates/wiki/deletion_log.html
@@ -7,7 +7,7 @@
     <h1>{{ _('Document Deleted') }}</h1>
     <p>
     {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  %}
-      This document was deleted by <a href="{{ url }}">{{ username }}</a> on {{ when }}.
+      This document was deleted on {{ when }}.
     {% endtrans %}
     </p>
 


### PR DESCRIPTION
Removing username from deletion log so, e.g., spammers can't find other users who delete their spam.
