### PR TITLE
bug 1082798 - Remove unwarranted sleep() call, add detail to test failure

### DIFF
--- a/tests/ui/tests/auth.js
+++ b/tests/ui/tests/auth.js
@@ -68,7 +68,7 @@ define([
                                     .getCurrentUrl()
                                     .then(function(url) {
                                         assert.isTrue(url.indexOf('/account/signup') != -1);
-                                        return libLogin.completePersonaLogout(remote).sleep(4000).then(dfd.resolve);
+                                        return libLogin.completePersonaLogout(remote).then(dfd.resolve);
                                     });
                         });
                 });

--- a/tests/ui/tests/footer.js
+++ b/tests/ui/tests/footer.js
@@ -37,7 +37,7 @@ define([
                         .type(['e', keys.RETURN])
                         .getCurrentUrl()
                         .then(function(url) {
-                            assert.isTrue(url.indexOf('/es/') != -1);
+                            assert.ok(url.indexOf('/es/') != -1, 'The URL after language selector changed in the footer is: ' + url);
                         })
                         .goBack(); // Cleanup to go back to default locale
         }


### PR DESCRIPTION
This will (1) get rid of a bad practice and (2) provide detail in the event of a test failure for the URL comparison
