### PR TITLE
Fix Bug 1102508: Link syntaxboxes to Syntax Help Article

### DIFF
--- a/media/js/syntax-prism.js
+++ b/media/js/syntax-prism.js
@@ -10,7 +10,7 @@
     var defaultBrush = 'html';
 
     // Treat and highlight PRE elements!
-    $('article pre').each(function() {
+    $('article pre:not(.twopartsyntaxbox):not(.syntaxbox)').each(function() {
         var $pre = $(this);
         var klass = $.trim($pre.attr('class'));
 

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -196,7 +196,7 @@
         var syntaxSections = {
             css:  {
                 link: 'docs/Web/CSS/Value_definition_syntax',
-                title: 'How to read CSS syntax.', // how do I localize this
+                title: gettext('How to read CSS syntax.'),
                 urlTest: '/docs/Web/CSS/',
                 classTest: 'brush:css'
             },

--- a/media/redesign/stylus/base/elements/typography.styl
+++ b/media/redesign/stylus/base/elements/typography.styl
@@ -117,10 +117,11 @@ blockquote {
 
 pre,
 code {
-    font-family: 'Courier New', 'Andale Mono', monospace;
+    font-family: Consolas, Monaco, 'Andale Mono', monospace; /* match Prism */
     margin-bottom: $content-block-margin;
 }
 
+/* pre is a block element so it gets a bit more fancy styling */
 pre {
     set-font-size($base-font-size);
     line-height: 19px;
@@ -130,10 +131,10 @@ pre {
     overflow: auto;
 }
 
+/* code may appear inline in headings, we want to match the font weight of the element its nested in */
 code {
     font-weight: inherit;
 }
-
 
 @media $media-query-mobile {
     h1, h2, h3, h4, h5, h6 {

--- a/media/redesign/stylus/wiki-syntax-syntaxbox.styl
+++ b/media/redesign/stylus/wiki-syntax-syntaxbox.styl
@@ -1,4 +1,5 @@
 @require 'includes/vars';
+@require 'includes/mixins';
 /*
     Syntax boxes are used for short, non-functional code snippets.
     .syntaxbox is used anywhere (DOM, JS, CSS, ...)
@@ -8,6 +9,7 @@
 pre.syntaxbox,
 pre.twopartsyntaxbox {
     background: $code-block-background-alt-color;
+    @extend $code-block;
 }
 
 pre.twopartsyntaxbox {
@@ -25,14 +27,17 @@ pre.twopartsyntaxbox code[class*="language-"] {
     height: 1.2em;
     float: left;
     font-size: $larger-font-size;
-    margin-left: -1.1em; /* width of icon */
+    width: 1.1em;
+    margin-left: @width * -1;
     margin-top: -4px;
     opacity: 0;
     overflow: hidden;
     position: relative;
     text-align: center;
-    width: 1.1em;
 
+
+
+    /* show on hover and focus, and when triggered by JS adding class */
     &.isOpaque,
     &:hover,
     &:focus {
@@ -40,5 +45,4 @@ pre.twopartsyntaxbox code[class*="language-"] {
     }
 }
 
-/* show on hover */
-/* show when tabbed to, make focusable */
+


### PR DESCRIPTION
Added javascript to detect syntaxbox and twopartsyntaxbox and create a link to help articles based on if there is a CSS class identifying the language, falling back to the language the section is in if there is not.

Prevented prism from styling syntaxbox and twopartysyntaxbox so that we can link the syntax to articles explaining it.

Added CSS to support new help link and to style the syntaxboxes without the help of prism.
