### PR TITLE
Bug 1109267 - Indicators in Headings

### DIFF
--- a/media/redesign/stylus/wiki-customcss.styl
+++ b/media/redesign/stylus/wiki-customcss.styl
@@ -1155,6 +1155,15 @@ dl {
 /* ----------------------------
         Styles for Indicator
 */
+
+.headingWithIndicator {
+    clearfix();
+
+    h1, h2, h3, h4, h5, h6 {
+        float:left;
+    }
+}
+
 .inlineIndicator,
 .indicatorInHeadline,
 .blockIndicator,


### PR DESCRIPTION
Previously when an indicator and heading were intended to share the same line this was accomplished by putting the indicator first in the source and floating it left. This was not the right order for the content but we noticed because it is causing problems for visual users when the content column is narrow and the indicator long because the content would reflows to  display the indicator ahead of the heading.

I have created the class headingWithIndicator. Merging this change will not affect anything already on the site, however, once it is pushed we can edit the macro templates to add this class to the wrapper div and move the indicator second in the source.

Macros which need to be edited: h1_gecko_minversion, h2_gecko_minversion, h3_gecko_minversion, method_gecko_minversion, obsoleteGeneric. Templates are updated on staging if you want to grab them for testing.

Used camelCase for the class name because all the associated classes use it. #twitch
