### PR TITLE
fix bug 1112676 - show deleted docs on rev dashboard

### DIFF
--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -37,6 +37,7 @@
                         <br />
                         <span class="locale">{{ revision.document.locale }}</span>
                         {% if not previous_id %}<span class="new">{{ _('new') }}</span>{% endif %}
+                        {% if revision.document.deleted %}<span class="deleted">{{ _('deleted') }}</span>{% endif %}
                     </td>
                     <td class="dashboard-title">
                         <a href="{{ revision_url }}">{{ revision.title }}</a>

--- a/media/redesign/stylus/dashboards.styl
+++ b/media/redesign/stylus/dashboards.styl
@@ -37,7 +37,7 @@
             }
         }
 
-        .new, .locale {
+        .new, .locale, .deleted {
             set-font-size(11px);
             border-radius: 8px;
             color: #fff;
@@ -50,6 +50,9 @@
         }
         .locale {
             background: rgba-fallback(rgba(#777, 0.6));
+        }
+        .deleted {
+            background: rgba-fallback(rgba(#f00, 0.6));
         }
     }
 


### PR DESCRIPTION
Show "deleted" marker on the revisions dashboard when the document has been deleted. To spot check:
- [x] Compile stylus
- [x] Edit a wiki page
- [x] Delete the wiki page
- [x] Check the [revision dashboards](https://developer-local.allizom.org/en-US/dashboards/revisions)
- [x] Should see "deleted" on the row

![mdn_rev_dashboard_deleted](https://cloud.githubusercontent.com/assets/71928/5511379/6a71491c-8792-11e4-8ebb-d1a8da4f5cfe.png)
