### PR TITLE
Bug 1070001 reorg wikiedit

### DIFF
--- a/kuma/wiki/templates/wiki/edit_document.html
+++ b/kuma/wiki/templates/wiki/edit_document.html
@@ -86,7 +86,7 @@
         <header id="article-head">
 
           <div class="title">
-            <h1>{{ _('<span class="action">Editing</span> <em>{title}</em>')|fe(title=revision.title) }}</h1>
+            <h1>{{ _('<span class="title-prefix">Editing</span> <em>{title}</em>')|fe(title=revision.title) }}</h1>
             <p class="save-state" id="draft-status">
               {% if not section_id %}
                 <a href="" id="btn-properties">{{ _('Edit Page Title and Properties') }}</a><br />

--- a/kuma/wiki/templates/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/templates/wiki/includes/kumascript_errors.html
@@ -1,4 +1,4 @@
-<div class="warning" id="kumascript-errors">
+<div class="warning" id="kserrors">
 <p>
 {{ ngettext(
   'There was a scripting error on this page. While it is being addressed by site editors, you can view partial content below.',
@@ -8,14 +8,14 @@
 
 </p>
 {% if request.user.is_authenticated() %}
-  <button type="button" class="kumascript-error-detail-toggle" data-alternate-message="{{ _('Hide error information') }}">
+  <button type="button" class="kserrors-details-toggle" data-alternate-message="{{ _('Hide error information') }}">
     {{ ngettext(
       'More information about this error',
       'More information about these errors',
       kumascript_errors|count)
     }}
   </button>
-  <div class="kumascript-error-details hidden">
+  <div class="kserrors-details hidden">
       <p>{% trans %}
         Anyone with an MDN profile can edit a document to fix an error. Use the <a href="/docs/MDN/Kuma/Troubleshooting_KumaScript_errors">KumaScript troubleshooting guide</a> as a starting point.
       {% endtrans %}</p>

--- a/kuma/wiki/templates/wiki/move_document.html
+++ b/kuma/wiki/templates/wiki/move_document.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% set title = _('Move "{t}"')|f(t=document.title) %}
+{% set title = _('Move Article | {document}')|f(document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
 {% set meta = [('robots', 'noindex, nofollow')] %}
 {% block bodyclass %}move-page{% endblock %}
@@ -12,7 +12,9 @@
 
 {% block content %}
 
-      <h1>{{ title }}</h1>
+      <div class="title">
+        <h1>{{ _('<span class="title-prefix">Moving</span> <em>{title}</em>')|fe(title=document.title) }}</h1>
+      </div>
       <p>{{ _('Please provide a new slug for this page using the field below.') }}</p>
 
       {% if conflicts: %}
@@ -35,7 +37,7 @@
       </div>
       {% endif %}
 
-      <form action="" method="post">
+      <form action="" method="post" class="editing">
         {{ csrf() }}
         <ul class="description">
           <li>

--- a/kuma/wiki/templates/wiki/new_document.html
+++ b/kuma/wiki/templates/wiki/new_document.html
@@ -27,7 +27,7 @@
         {{ document_form.category|safe }}
 
         <div class="title">
-            <h1><span class="action">{{ ('Create a ') }}</span><em>{{ _('New Document') }}</em></h1>
+            <h1><span class="title-prefix">{{ ('Create a ') }}</span><em>{{ _('New Document') }}</em></h1>
         </div>
 
         <ul class="metadata">

--- a/kuma/wiki/templates/wiki/translate.html
+++ b/kuma/wiki/templates/wiki/translate.html
@@ -28,7 +28,7 @@
       <div id="localize-document" class="editing">
         <header id="article-head">
           <div class="title">
-           <h1>{{ _('<span class="action">Translating</span> <em>{title}</em>')|fe(title=parent.title) }}</h1>
+           <h1>{{ _('<span class="title-prefix">Translating</span> <em>{title}</em>')|fe(title=parent.title) }}</h1>
           </div>
 
           <div class="change-locale">

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -427,9 +427,9 @@
     /*
         Toggle kumascript error detail pane
     */
-    $('.kumascript-error-detail-toggle').toggleMessage({
+    $('.kserrors-details-toggle').toggleMessage({
         toggleCallback: function() {
-            $('.kumascript-error-details').toggleClass('hidden');
+            $('.kserrors-details').toggleClass('hidden');
         }
     });
 

--- a/media/redesign/stylus/components/syntax/base.styl
+++ b/media/redesign/stylus/components/syntax/base.styl
@@ -1,4 +1,3 @@
-@require '../../includes/mixins';
 /*
     Updates in this file modify or enhance the code provided by Prism.js
     Modifies <pre> and <code> with classses added by prism.js

--- a/media/redesign/stylus/components/syntax/syntaxbox.styl
+++ b/media/redesign/stylus/components/syntax/syntaxbox.styl
@@ -1,5 +1,3 @@
-@require 'includes/vars';
-@require 'includes/mixins';
 /*
     Syntax boxes are used for short, non-functional code snippets.
     .syntaxbox is used anywhere (DOM, JS, CSS, ...)
@@ -34,8 +32,6 @@ pre.twopartsyntaxbox code[class*="language-"] {
     overflow: hidden;
     position: relative;
     text-align: center;
-
-
 
     /* show on hover and focus, and when triggered by JS adding class */
     &.isOpaque,

--- a/media/redesign/stylus/components/wiki/article-head.styl
+++ b/media/redesign/stylus/components/wiki/article-head.styl
@@ -2,3 +2,9 @@
 .article-meta{
     min-height: 41px;
 }
+
+#edit-document {
+    #article-head {
+        position: relative;
+    }
+}

--- a/media/redesign/stylus/components/wiki/customcss.styl
+++ b/media/redesign/stylus/components/wiki/customcss.styl
@@ -1276,7 +1276,6 @@ div.warning {
 .page-content dd {
     margin: 0.5em;
 }
-/* [dir="rtl"] .translate #page-buttons { } */
 [dir="rtl"] .hasJS #nav-main #nav-sub-docs,
 [dir="rtl"] #nav-main .menu:hover #nav-sub-docs {
     margin-left: -300px;

--- a/media/redesign/stylus/components/wiki/edit/ace-content.styl
+++ b/media/redesign/stylus/components/wiki/edit/ace-content.styl
@@ -1,0 +1,10 @@
+#ace_content {
+    height: 500px;
+    position: relative;
+    width: 100%;
+
+    .ace_warning,
+    .ace_error {
+        background-image: none;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/cke.styl
+++ b/media/redesign/stylus/components/wiki/edit/cke.styl
@@ -1,4 +1,3 @@
-
 /* ckeditor / content area styles */
 .ckeditor-container {
     padding: 6px;

--- a/media/redesign/stylus/components/wiki/edit/description.styl
+++ b/media/redesign/stylus/components/wiki/edit/description.styl
@@ -1,0 +1,33 @@
+#translate-document,
+.move-page {
+    .description {
+        li {
+            clearfix();
+            margin: 0 0 7px;
+        }
+
+        dl {
+            margin: 0;
+        }
+
+        dt {
+            display: inline-block;
+            font-style: normal;
+            font-weight: bold;
+            margin-right: 10px;
+        }
+
+        dd {
+            display: inline-block;
+        }
+    }
+}
+
+
+#translate-document {
+
+    .description {
+        margin: $summary-margin;
+        padding: $summary-padding;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/duration-container.styl
+++ b/media/redesign/stylus/components/wiki/edit/duration-container.styl
@@ -1,0 +1,21 @@
+/* series of 3 number inputs which set rendering max age of a page */
+.duration-container {
+    display: inline-block;
+    float: left;
+    margin-left: 5px;
+
+    input {
+        display: inline-block;
+        width: 50px;
+    }
+
+    div {
+        display: inline-block;
+        margin-right: 5px;
+    }
+
+    label {
+        float: right;
+        margin-left: 5px;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/editing.styl
+++ b/media/redesign/stylus/components/wiki/edit/editing.styl
@@ -1,0 +1,42 @@
+/* editing is the class applied to the forms on the edit, translate, move and create
+   document pages. */
+
+.editing {
+    position: relative;
+
+    h1 {
+        letter-spacing: normal;
+        line-height: 40px;
+        margin-bottom: $grid-spacing;
+
+        em {
+            color: #333;
+            font-style: normal;
+            margin-left: -3px;
+            text-transform: none;
+        }
+    }
+
+    h2 {
+        margin-bottom: $grid-spacing;
+        text-transform: none;
+    }
+
+    summary h2 {
+        display: inline-block;
+        margin-bottom: 0;
+    }
+
+    h2 {$selector-icon},
+    h3 {$selector-icon} {
+        @extend $right-icons;
+    }
+
+    summary {
+        clearfix();
+        set-font-size(20px);
+        cursor: pointer;
+        margin: $summary-margin;
+        padding: $summary-padding;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/first-contrib-welcome.styl
+++ b/media/redesign/stylus/components/wiki/edit/first-contrib-welcome.styl
@@ -1,0 +1,17 @@
+/* welcome message put up first time someone edits a doc */
+
+.first-contrib-welcome {
+    background: $light-background-color;
+    border: 5px solid $header-background-color;
+    padding: 15px 15px 10px;
+    margin: 20px 0;
+
+    h2 {
+        margin: 0 0 10px;
+        font: bold 18px/1.5 'Open Sans', sans-serif;
+    }
+
+    p {
+        margin-bottom: 8px;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/guide-links.styl
+++ b/media/redesign/stylus/components/wiki/edit/guide-links.styl
@@ -1,0 +1,7 @@
+/* link to editor and style guide editor that appear above text editor */
+.guide-links{
+    float: right;
+    margin-top: $grid-spacing;
+    padding: 0 4px 2px 0;
+    color: #999;
+}

--- a/media/redesign/stylus/components/wiki/edit/metadata.styl
+++ b/media/redesign/stylus/components/wiki/edit/metadata.styl
@@ -1,0 +1,45 @@
+.metadata {
+    display: none;
+    float: none;
+    margin-top: ($grid-spacing / 2);
+    margin-bottom: @margin-top;
+    width: auto;
+
+    .new & {
+        display: block;
+    }
+
+    .metadataDisplay {
+        display: inline-block;
+        padding: 8px 0 0 3px;
+    }
+
+    &.metadata-choose-parent {
+        display: none;
+        set-font-size($small-bump-font-size);
+    }
+
+    input, input#id_title {
+        float: left;
+        margin: 2px 0px;
+        padding: 6px 8px;
+        width: 70%;
+    }
+
+    select {
+        float: left;
+        margin: 5px 0;
+    }
+
+    label, legend {
+        color: #888;
+        display: block;
+        float: left;
+        font-weight: bold;
+        line-height: 2.5;
+        padding-right: 5px;
+        text-align: right;
+        width: auto;
+    }
+
+}

--- a/media/redesign/stylus/components/wiki/edit/move-page.styl
+++ b/media/redesign/stylus/components/wiki/edit/move-page.styl
@@ -1,0 +1,17 @@
+.move-page {
+    dl {
+        width: auto;
+    }
+
+    dt {
+        width: 120px;
+    }
+
+    input[type=text] {
+        width: 400px;
+    }
+
+    .warning {
+        color: #fff;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/page-attachments.styl
+++ b/media/redesign/stylus/components/wiki/edit/page-attachments.styl
@@ -48,10 +48,10 @@
         .attachment-required {
             border: 1px solid #900;
         }
+    }
 
-        textarea {
-            height: 40px;
-        }
+    textarea {
+        height: 40px;
     }
 }
 

--- a/media/redesign/stylus/components/wiki/edit/page-comment.styl
+++ b/media/redesign/stylus/components/wiki/edit/page-comment.styl
@@ -1,0 +1,7 @@
+#page-comment {
+    input {
+        padding-top: 10px;
+        padding-bottom: @padding-top;
+        width: 98%;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/save-and-edit-target.styl
+++ b/media/redesign/stylus/components/wiki/edit/save-and-edit-target.styl
@@ -1,0 +1,3 @@
+iframe#save-and-edit-target {
+    offscreen();
+}

--- a/media/redesign/stylus/components/wiki/edit/save-state.styl
+++ b/media/redesign/stylus/components/wiki/edit/save-state.styl
@@ -1,0 +1,6 @@
+.save-state {
+    set-smaller-font-size();
+    clear: both;
+    color: #888;
+    margin: 0;
+}

--- a/media/redesign/stylus/components/wiki/edit/title.styl
+++ b/media/redesign/stylus/components/wiki/edit/title.styl
@@ -1,0 +1,9 @@
+/* small writing above the page title that says what action the user is
+   performing on it Editing/Moving/Translating */
+
+.title-prefix {
+    set-larger-font-size();
+    display: block;
+    line-height: 20px;
+    color: #888;
+}

--- a/media/redesign/stylus/components/wiki/edit/translate/approved-localized.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/approved-localized.styl
@@ -1,0 +1,20 @@
+/* puts approved and localized content side by side on translation pages */
+.approved,
+.localized {
+    box-sizing: border-box;
+    width: 50%;
+    bidi-value(float, left, right);
+
+    /* when approved version hideden from view translated version fill full width of page */
+    .translate-only & {
+        width: 100%;
+        float: none;
+        padding: 0;
+    }
+}
+.approved {
+    bidi-style(padding-right, $grid-spacing / 2, padding-left, 0);
+}
+.localized {
+    bidi-style(padding-left, $grid-spacing / 2, padding-right, 0);
+}

--- a/media/redesign/stylus/components/wiki/edit/translate/change-locale.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/change-locale.styl
@@ -1,0 +1,7 @@
+.change-locale {
+    margin-top: ($grid-spacing * -1);
+    margin-bottom: ($grid-spacing / 2);
+    bidi-value(clear, left, right);
+    bidi-value(float, left, right);
+    set-smaller-font-size();
+}

--- a/media/redesign/stylus/components/wiki/edit/translate/content-fields.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/content-fields.styl
@@ -1,0 +1,13 @@
+/* content-fields is the block which contains the english and translated article on translation edit pages */
+#content-fields {
+    clearfix();
+
+    header {
+        clearfix();
+        display: block;
+        margin-bottom: ($grid-spacing / 2);
+        padding: 7px 0 0 0;
+        position: relative;
+        z-index: 10;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/translate/translate-buttons.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/translate-buttons.styl
@@ -1,0 +1,18 @@
+.translate-buttons {
+    margin-top: 19px; /* Margin to level buttons with CKEditor top */
+    text-align: right;
+
+    button {
+        margin-bottom: 10px; /* Margin when buttons are stacked */
+    }
+}
+
+/* changes to bring buttons inline when original article is hidden from view */
+.translate-only {
+
+    .translate-buttons {
+        margin-top: 0;
+        margin-left: 10px;
+        display: inline-block;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/translate/translate-document.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/translate-document.styl
@@ -1,0 +1,34 @@
+#translate-document {
+
+    /* approved version of the article content */
+    .translate-rendered {
+        overflow-x: hidden;
+
+        pre {
+            white-space: normal;
+        }
+    }
+
+    /* translation interface has a number of headings that do not have icons
+       so we hide the icon on this heading to make them all match */
+    #page-comment .icon-comment {
+        display: none;
+    }
+
+    /* when approved version hidden from view translated version fills full width of page */
+    .translate-only {
+
+        .boxed,
+        .doc-mode-btn {
+            display: none;
+        }
+
+        .approved-title {
+            display: inline-block;
+            float: left;
+        }
+
+    }
+
+}
+

--- a/media/redesign/stylus/components/wiki/edit/translate/translate-source.styl
+++ b/media/redesign/stylus/components/wiki/edit/translate/translate-source.styl
@@ -1,0 +1,11 @@
+.translate-source {
+    textarea {
+        width: 100%;
+        box-sizing: border-box;
+        border: 0;
+        /* Same formatting as CKEditor source view */
+        font-family: 'Courier New', Monospace;
+        set-smaller-font-size();
+        white-space: pre;
+    }
+}

--- a/media/redesign/stylus/components/wiki/edit/vars.styl
+++ b/media/redesign/stylus/components/wiki/edit/vars.styl
@@ -1,0 +1,6 @@
+/* Space needed to account for the absolutely-positioned #page-buttons element. */
+$space-for-buttons = 40px;
+
+/* Space around the <summary> element. Store these to align other elements with <summary>. */
+$summary-margin = 0 ($grid-spacing / 2) ($grid-spacing / 2);
+$summary-padding = 5px;

--- a/media/redesign/stylus/components/wiki/kserrors.styl
+++ b/media/redesign/stylus/components/wiki/kserrors.styl
@@ -1,11 +1,11 @@
 /* kumascript errors block at the top of an article */
-#kumascript-errors {
+#kserrors {
     ul {
         list-style-type: none;
         padding-left: 0 !important;
     }
 }
 
-.kumascript-error-details {
+.kserrors-details {
     padding: $grid-spacing 0;
 }

--- a/media/redesign/stylus/components/wiki/move-decendants.styl
+++ b/media/redesign/stylus/components/wiki/move-decendants.styl
@@ -1,6 +1,6 @@
 /* used on page move page */
 
-/* TODO: this does not need its own styles, find a grey box class to re-use here */
+/* TODO: this does not need its own styles, create a grey box class to re-use here */
 
 .move-descendants {
     border: 1px solid #dfe6eb;

--- a/media/redesign/stylus/components/wiki/no-details.styl
+++ b/media/redesign/stylus/components/wiki/no-details.styl
@@ -5,7 +5,6 @@ accessibility) */
     summary {
         display: block;
     }
-
     summary:before {
         set-font-size(1.25em);
         bidi-value(float, left, right);
@@ -13,7 +12,6 @@ accessibility) */
         margin-top: -.15em;
         bidi-style(margin-left, -15px, margin-right, 0);
     }
-
     &.open summary:before {
         content: '–';
         margin-top: -.2em;

--- a/media/redesign/stylus/components/wiki/page-buttons.styl
+++ b/media/redesign/stylus/components/wiki/page-buttons.styl
@@ -53,3 +53,55 @@
         display: none;
     }
 }
+
+
+.move-page {
+
+    #page-buttons {
+        right: auto;
+        top: auto;
+        text-align: left;
+        float: none;
+        margin: $grid-spacing 0;
+        position: relative;
+    }
+}
+
+#translate-document {
+
+    header .page-buttons {
+        clear: both;
+        margin-bottom: 0;
+    }
+}
+
+#new-document,
+#edit-document,
+#translate-document {
+
+    .page-buttons {
+        z-index: 1; /* Move above the .title and .metadata classes to be clickable. */
+    }
+}
+
+#new-document,
+#edit-document,
+#translate-document,
+.move-page {
+    .page-buttons {
+        bidi-value(text-align, right, left);
+        float: none;
+        padding: 0;
+        margin-bottom: -10px;
+
+        li {
+            margin-bottom: 10px;
+        }
+
+        a, button {
+            border: 0;
+            display: inline-block;
+            box-shadow: 1px 1px 0 rgba(0,0,0,.25);
+        }
+    }
+}

--- a/media/redesign/stylus/wiki-edit.styl
+++ b/media/redesign/stylus/wiki-edit.styl
@@ -4,417 +4,45 @@
 @require 'includes/vars';
 @require 'includes/mixins';
 @require 'components/tagit';
+
+@require 'components/wiki/edit/vars';
+@require 'components/wiki/edit/editing';
 @require 'components/wiki/edit/cke';
 @require 'components/wiki/edit/page-attachments';
+@require 'components/wiki/edit/save-and-edit-target';
+@require 'components/wiki/edit/title';
+@require 'components/wiki/edit/guide-links';
+@require 'components/wiki/edit/ace-content';
+@require 'components/wiki/edit/save-state';
+@require 'components/wiki/edit/first-contrib-welcome';
+@require 'components/wiki/edit/page-comment';
+@require 'components/wiki/edit/description';
+
+
+/*
+Meta data for pages
+====================================================================== */
+
+@require 'components/wiki/edit/metadata';
+@require 'components/wiki/edit/duration-container';
+
+
+/*
+Move page
+====================================================================== */
+
+@require 'components/wiki/edit/move-page.styl';
+
+
+/*
+Translate interface.
+====================================================================== */
 
 @require 'components/wiki/edit/translate/structure';
-
-/* Space needed to account for the absolutely-positioned #page-buttons element. */
-$space-for-buttons = 40px;
-
-/* Space around the <summary> element. Store these to align other elements with <summary>. */
-$summary-margin = 0 ($grid-spacing / 2) ($grid-spacing / 2);
-$summary-padding = 5px;
-
-#new-document,
-#edit-document,
-#translate-document,
-.move-page {
-    .page-buttons {
-        bidi-value(text-align, right, left);
-        float: none;
-        padding: 0;
-        margin-bottom: -10px;
-
-        li {
-            margin-bottom: 10px;
-        }
-
-        a, button {
-            border: 0;
-            display: inline-block;
-            box-shadow: 1px 1px 0 rgba(0,0,0,.25);
-        }
-    }
-    iframe#save-and-edit-target {
-        offscreen();
-    }
-}
-
-#new-document,
-#edit-document,
-#translate-document {
-    .editing {
-        position: relative;
-    }
-
-    h1 {
-        letter-spacing: normal;
-        line-height: 40px;
-        margin-bottom: ($grid-spacing);
-
-        .action {
-            set-larger-font-size();
-            display: block;
-            line-height: 20px;
-        }
-
-        em {
-            color: #333;
-            font-style: normal;
-            margin-left: -3px;
-            text-transform: none;
-        }
-    }
-
-    h2 {
-        margin-bottom: $grid-spacing;
-        text-transform: none;
-    }
-
-    summary h2 {
-        display: inline-block;
-        margin-bottom: 0;
-    }
-
-    h2 {$selector-icon}, h3 {$selector-icon} {
-        @extend $right-icons;
-    }
-
-    .title {
-        h1 {
-            color: #888;
-            bidi-value(float, left, right);
-        }
-    }
-
-    #page-attachments-new-table {
-        textarea {
-            height: 40px;
-        }
-    }
-
-    summary {
-        clearfix();
-        set-font-size(20px);
-        cursor: pointer;
-        margin: $summary-margin;
-        padding: $summary-padding;
-    }
-
-    .page-buttons {
-        z-index: 1; /* Move above the .title and .metadata classes to be clickable. */
-    }
-}
-
-/* link to editor and style guide editor that appear above text editor */
-.guide-links{
-    float: right;
-    margin-top: $grid-spacing;
-    padding: 0 4px 2px 0;
-    color: #999;
-}
-
-#new-document,
-#edit-document {
-    ul.metadata {
-        display: none;
-        float: none;
-        margin-top: ($grid-spacing / 2);
-        margin-bottom: ($grid-spacing / 2);
-        width: auto;
-
-        .new & {
-            display: block;
-        }
-
-        li {
-            .metadataDisplay {
-                display: inline-block;
-                padding: 8px 0 0 3px;
-            }
-
-            &.metadata-choose-parent {
-                display: none;
-                set-font-size($small-bump-font-size);
-            }
-
-            input, input#id_title {
-                float: left;
-                margin: 2px 0px;
-                padding: 6px 8px;
-                width: 70%;
-            }
-
-            select {
-                float: left;
-                margin: 5px 0;
-            }
-
-            label, legend {
-                color: #888;
-                display: block;
-                float: left;
-                font-weight: bold;
-                line-height: 2.5;
-                padding-right: 5px;
-                text-align: right;
-                width: auto;
-            }
-        }
-    }
-
-    .metadata .duration-container {
-        display: inline-block;
-        float: left;
-        margin-left: 5px;
-
-        input {
-            display: inline-block;
-            width: 50px;
-        }
-
-        div {
-            display: inline-block;
-            margin-right: 5px;
-        }
-
-        label {
-            float: right;
-            margin-left: 5px;
-        }
-    }
-
-    #ace_content {
-        height: 500px;
-        position: relative;
-        width: 100%;
-
-        .ace_warning, .ace_error {
-            background-image: none;
-        }
-    }
-}
-
-#edit-document {
-    #article-head {
-        position: relative;
-    }
-
-    h1{
-        margin-top: 0;
-    }
-}
-
-.save-state {
-    set-smaller-font-size();
-    clear: both;
-    color: #888;
-    margin: 0;
-}
-
-
-.first-contrib-welcome {
-    background: $light-background-color;
-    border: 5px solid $header-background-color;
-    padding: 15px 15px 10px;
-    margin: 20px 0;
-
-    h2 {
-        margin: 0 0 10px;
-        font: bold 18px/1.5 'Open Sans', sans-serif;
-    }
-
-    p {
-        margin-bottom: 8px;
-    }
-}
-
-
-#page-comment {
-    input {
-        padding-top: 10px;
-        padding-bottom: @padding-top;
-        width: 98%;
-    }
-}
-
-#translate-document, .move-page {
-    .description {
-        li {
-            clearfix();
-            margin: 0 0 7px;
-        }
-
-        dl {
-            margin: 0;
-        }
-
-        dt {
-            display: inline-block;
-            font-style: normal;
-            font-weight: bold;
-            margin-right: 10px;
-        }
-
-        dd {
-            display: inline-block;
-        }
-    }
-}
-
-#translate-document {
-
-    .description {
-        margin: $summary-margin;
-        padding: $summary-padding;
-    }
-
-    .approved, .localized {
-            width: 50%;
-            bidi-value(float, left, right);
-    }
-
-    .approved {
-        header{
-            height: auto;
-            padding-right: 25px;
-            padding-bottom: 0;
-        }
-    }
-
-    .translate-rendered {
-        overflow-x: hidden;
-
-        pre {
-            white-space: normal;
-        }
-    }
-
-    .change-locale {
-        margin-top: ($grid-spacing * -1);
-        margin-bottom: ($grid-spacing / 2);
-        bidi-value(clear, left, right);
-        bidi-value(float, left, right);
-        set-font-size($smaller-font-size);
-    }
-
-    header .page-buttons {
-        clear: both;
-        margin-bottom: 0;
-    }
-
-
-    #page-comment .icon-comment-alt {
-        display: none;
-    }
-
-    .translate-only {
-
-        .localized, .approved {
-            width: 100%;
-            float: none;
-        }
-
-        .boxed, .doc-mode-btn {
-            display: none;
-        }
-
-        .translate-buttons {
-            margin-top: 0;
-            margin-left: 10px;
-            display: inline-block;
-        }
-
-        .approved header {
-            padding-right: 0;
-        }
-
-        .approved-title {
-            display: inline-block;
-            float: left;
-        }
-
-    }
-
-}
-
-/* content-fields is the block which contains the english and translated article on translation edit pages */
-#content-fields {
-    clearfix();
-
-    .approved, .localized {
-        width: 49%;
-    }
-
-    .approved {
-        bidi-value(float, left, right);
-
-        .boxed {
-            padding-right: 25px;
-        }
-    }
-
-    .localized {
-        bidi-value(float, right, left);
-    }
-
-    header {
-        clearfix();
-        display: block;
-        height: 16px;
-        margin-bottom: ($grid-spacing / 2);
-        padding: 7px 0 14px;
-        position: relative;
-        z-index: 10;
-    }
-}
-
-.move-page {
-    dl {
-        width: auto;
-    }
-
-    dt {
-        width: 120px;
-    }
-
-    input[type=text] {
-        width: 400px;
-    }
-
-    #page-buttons {
-        right: auto;
-        top: auto;
-        text-align: left;
-        float: none;
-        margin: $grid-spacing 0;
-        position: relative;
-    }
-
-    .warning {
-        color: #fff;
-    }
-}
-
-.translate-source {
-    textarea {
-        width: 100%;
-        vendorize(box-sizing, border-box);
-        border: 0;
-        /* Same formatting as CKEditor source view */
-        font-family: 'Courier New', Monospace;
-        font-size: small;
-        white-space: pre;
-    }
-}
-
-.translate-buttons {
-    margin-top: 19px; /* Margin to level buttons with CKEditor top */
-    text-align: right;
-
-    button {
-        margin-bottom: 10px; /* Margin when buttons are stacked */
-    }
-}
+@require 'components/wiki/edit/translate/translate-document.styl';
+@require 'components/wiki/edit/translate/content-fields.styl';
+@require 'components/wiki/edit/translate/translate-source.styl';
+@require 'components/wiki/edit/translate/translate-buttons.styl';
+@require 'components/wiki/edit/translate/approved-localized.styl';
+@require 'components/wiki/edit/translate/change-locale.styl';
 

--- a/media/redesign/stylus/wiki-syntax.styl
+++ b/media/redesign/stylus/wiki-syntax.styl
@@ -1,3 +1,6 @@
+@require 'includes/vars';
+@require 'includes/mixins';
+
 /* Styling for displaying blocks of code in wiki articles */
 
 @import 'components/syntax/base';

--- a/media/redesign/stylus/wiki.styl
+++ b/media/redesign/stylus/wiki.styl
@@ -27,7 +27,7 @@ Components that may appear on most wiki pages
 @require 'components/wiki/toc';
 @require 'components/wiki/topicpage-table';
 @require 'components/wiki/no-details';
-@require 'components/wiki/kumascript-errors';
+@require 'components/wiki/kserrors';
 @require 'components/wiki/page-print';
 @require 'components/wiki/edit-section';
 @require 'components/wiki/offline-dialog-content';


### PR DESCRIPTION
Renamed classes to make them more modular:
- documents -> document-list
- deleted move-decendatnts-list and changed elements to use document-list
- move-lookup-link -> parent-suggest-link
- contributor-sub -> contributors->sub
- choice-list -> revision-list-head
- revision-list -> revision-list-contain
- compare -> revision-list-controls
- various changes to more granualr class names inside revision-list
- action -> title-prefix
- kumascript-errors -> kserrors
- kumascript-details -> kserrors-details
- kumascript-detail-toggle -> kserrors-details-toggle

Move Page:
- changed title to match style of create/edit/translate pages
- removed move-decendatnts-list and changed occurances to document-list

Everything else was done to decrease specificity and redundancy, or move declarations into their own files for maintainability.

Wasn't sure what to do with the broadly defined elements declared at the beginning of wiki-edit so they're just hanging out there for now.
