### PR TITLE
bug 1113252 - send edited notification email for users' first edits

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -10,6 +10,7 @@ from django.dispatch import receiver
 from django.db import connection
 from django.core.cache import get_cache
 
+from constance import config
 import waffle
 
 from devmo.utils import MemcacheLock
@@ -215,3 +216,9 @@ def update_community_stats():
 @task
 def delete_old_revision_ips(immediate=False, days=30):
     RevisionIP.objects.delete_old(days=days)
+
+
+@task
+def send_first_edit_email(email):
+    email.to = [config.EMAIL_LIST_FOR_FIRST_EDITS,]
+    email.send()

--- a/kuma/wiki/templates/wiki/email/edited.ltxt
+++ b/kuma/wiki/templates/wiki/email/edited.ltxt
@@ -28,4 +28,4 @@ Edit Article:
 Article History:
 {% endtrans %}
  https://{{ host }}{{ history_url }}
-{{ unsubscribe_text(watch) }}{% endautoescape %}
+{% if watch %}{{ unsubscribe_text(watch) }}{% endif %}{% endautoescape %}

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -517,14 +517,22 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         eq_(self.d.current_revision, new_rev.based_on)
 
         # Assert notifications fired and have the expected content:
-        eq_(1, len(mail.outbox)) # Regression check:
+        # 1 email for the first time edit notification
+        # 1 email for the EditDocumentEvent to sam@example.com
+        eq_(2, len(mail.outbox)) # Regression check:
                                  # messing with context processors can
                                  # cause notification emails to error
                                  # and stop being sent.
+        first_edit_email = mail.outbox[0]
+        expected_to = [constance.config.EMAIL_LIST_FOR_FIRST_EDITS]
+        expected_subject = u'[MDN] %(username)s made their first edit, to: %(title)s' % ({'username': new_rev.creator.username, 'title': self.d.title})
+        eq_(expected_subject, first_edit_email.subject)
+        eq_(expected_to, first_edit_email.to)
+
+        edited_email = mail.outbox[1]
         expected_to = [u'sam@example.com']
         expected_subject = u'[MDN] Page "%s" changed by %s' % (self.d.title,
                                                      new_rev.creator)
-        edited_email = mail.outbox[0]
         eq_(expected_subject, edited_email.subject)
         eq_(expected_to, edited_email.to)
         ok_('%s changed %s.' % (unicode(self.username), unicode(self.d.title))

--- a/settings.py
+++ b/settings.py
@@ -1146,6 +1146,11 @@ CONSTANCE_CONFIG = dict(
         'Email address from which welcome emails will be sent',
     ),
 
+    EMAIL_LIST_FOR_FIRST_EDITS = (
+        "mdn-first-edits@mozilla.org",
+        "Email address to which emails will be sent for users' first edits",
+    ),
+
     FACEBOOK_RESEARCH_APP_ID = (
         '',
         'ID of the Facebook application used to determine whether an MDN user is logged in with Facebook',


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1113252

To spot-check:
- [ ] Create a new user
- [ ] Make a first edit (or a new page) with the new user
- [ ] Should see [the edited notification email](https://github.com/mozilla/kuma/blob/master/kuma/wiki/templates/wiki/email/edited.ltxt) in the console output
- [ ] Make another edit with the new user
- [ ] Should see no email in the console output
