### PR TITLE
Bug 957802: Removed link to GitHub issues.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,9 +37,8 @@ Contributing Code
 What to work on
 ===============
 
-Good starting projects are listed on [GitHub][github] and [Bugzilla][bugzilla]. If you have any questions, just ask in the #mdndev IRC channel on irc.mozilla.org!
+Good starting projects are listed on [Bugzilla][bugzilla]. If you have any questions, just ask in the #mdndev IRC channel on irc.mozilla.org!
 
-[github]: https://github.com/mozilla/kuma/issues?labels=good+first+issue&milestone=&page=1&state=open
 [bugzilla]: https://bugzilla.mozilla.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&columnlist=short_desc%2Ccomponent%2Cchangeddate&list_id=9799718&product=Mozilla%20Developer%20Network&query_format=advanced&status_whiteboard=[good%20first%20bug]&status_whiteboard_type=allwordssubstr&query_based_on=
 
 How to submit code


### PR DESCRIPTION
Having a link to GitHub issues on "What to work on" leads possible
contributors to a page that just says "Bummer, we couldn't find
anything.".
