### PR TITLE
fix bug 920314 - tweak template & css for sphinx

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -321,7 +321,7 @@ class ContentSectionTool(object):
 
 class URLAbsolutionFilter(html5lib_Filter):
     """Filter which turns relative links into absolute links.
-       Originally created for teh purpose of sphinx templates."""
+       Originally created for generating sphinx templates."""
 
     def __init__(self, source, base_url, tag_attributes):
         html5lib_Filter.__init__(self, source)

--- a/media/redesign/stylus/components/wiki/customcss.styl
+++ b/media/redesign/stylus/components/wiki/customcss.styl
@@ -83,10 +83,6 @@ table#fullwidth-table td.thirdColumn {
     .landing {
         display: table-row;
     }
-    .section {
-        display: table-cell;
-        width: 50%;
-    }
 }
 /* For Landing page boxes; these are boxes displayed within columns on landing
      pages, such as the Community and Related boxes. */

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
     {% include "includes/google_analytics.html" %}
   {% endif %}
 </head>
-<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}"{% if request.user.is_authenticated() %} data-login-service="{{ request.session.sociallogin_provider }}"{% endif %}>
+<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}"{% if request.user and request.user.is_authenticated() %} data-login-service="{{ request.session.sociallogin_provider }}"{% endif %}>
 
   {% include "includes/config.html" %}
 


### PR DESCRIPTION
Note: I'm removing the broad `.section` declarations from `customcss.styl` to fix sphinx-generated `class = "section"` markup. The same `.section` declarations are already [defined specifically in `topicpage-table.styl`](https://github.com/groovecoder/kuma/blob/update-sphinx-template-920314/media/redesign/stylus/components/wiki/topicpage-table.styl#L48-50).

Spot-check of the sphinx template works almost exactly the same as [the last time we cleaned this up](https://github.com/mozilla/kuma/pull/1316). I.e.,

Get the MDN sphinx theme and update its `layout.html` with the management command:

```
vagrant ssh
git clone https://github.com/lmorchard/mozilla-mdn-sphinx-theme.git
./manage.py generate_sphinx_template > mozilla-mdn-sphinx-theme/mdn_theme/mdn/layout.html
```

Change our own sphinx `docs/conf.py` to use the MDN sphinx theme:

```
html_theme_path = ['/home/vagrant/src/mozilla-mdn-sphinx-theme/mdn_theme',]
html_theme = 'mdn'
```

Re-build our sphinx docs:

```
sphinx-build docs docs/_build/html
```

From your host machine, open the resulting `docs/_build/html/index.html` file in your browser and see the beautiful new MDN theme. (Tabzilla asset loading is expected to fail when accessing the docs via `file:///`)
