### PR TITLE
fix bug 1115767 - SMTP headers for url & username

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2385,8 +2385,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         def _check_message_for_headers(message, username):
             ok_("%s made their first edit" % username in message.subject)
-            eq_({'X-Article-Url': "dev.mo.org%s" % doc.get_absolute_url(),
-                 'X-Editor-Username': username}, message.extra_headers)
+            eq_({'X-Kuma-Document-Url': "dev.mo.org%s" % doc.get_absolute_url(),
+                 'X-Kuma-Editor-Username': username}, message.extra_headers)
 
         testuser_message = mail.outbox[0]
         admin_message = mail.outbox[1]

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -2190,8 +2190,8 @@ def _make_first_edit_email(new_rev, request):
     article_url = "%s%s" % (Site.objects.get_current().domain,
                             doc.get_absolute_url())
     email = EmailMessage(subject, message, settings.DEFAULT_FROM_EMAIL,
-                         headers = {'X-Article-Url': article_url,
-                                    'X-Editor-Username': user.username})
+                         headers={'X-Kuma-Document-Url': article_url,
+                                  'X-Kuma-Editor-Username': user.username})
     return email
 
 

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -17,6 +17,7 @@ from tower import ugettext_lazy as _lazy, ugettext as _
 
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
 from django.core.cache import cache
 from django.core.mail import EmailMessage
@@ -2186,7 +2187,11 @@ def _make_first_edit_email(new_rev, request):
     template = 'wiki/email/edited.ltxt'
     context = context_dict(new_rev)
     message = render_to_string(request, template, context)
-    email = EmailMessage(subject, message, settings.DEFAULT_FROM_EMAIL)
+    article_url = "%s%s" % (Site.objects.get_current().domain,
+                            doc.get_absolute_url())
+    email = EmailMessage(subject, message, settings.DEFAULT_FROM_EMAIL,
+                         headers = {'X-Article-Url': article_url,
+                                    'X-Editor-Username': user.username})
     return email
 
 


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1115767

Spot-check instructions are the same as https://github.com/mozilla/kuma/pull/2966, but check for the custom SMTP headers too.

I'm not super-happy with this code so I could use a critical review on it.