### PR TITLE
fix bug 1115738 - (again) with dashboard-col class

### DIFF
--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -8,10 +8,10 @@
     <table class="dashboard-table" width="100%">
         <thead>
             <tr>
-                <td class="dashboard-revision">Revision</td>
-                <td class="dashboard-title">Title</td>
-                <td class="dashboard-comment">Comment</td>
-                <td class="dashboard-author">Author</td>
+                <td class="dashboard-col">Revision</td>
+                <td class="dashboard-col dashboard-col-title">Title</td>
+                <td class="dashboard-col">Comment</td>
+                <td class="dashboard-col dashboard-col-author">Author</td>
             </tr>
         </thead>
         <tbody>
@@ -29,19 +29,19 @@
                     data-compare-url="{{ url('wiki.compare_revisions', revision.document.full_path, locale=revision.document.locale) }}?from={{ previous_id if previous_id else revision.id }}&to={{ revision.id }}&raw=1"
                     data-revert-url="{{ url('wiki.revert_document', revision.document.full_path, revision.id, locale=revision.document.locale) }}"
                     data-history-url="{{ url('wiki.document_revisions', revision.document.full_path, locale=revision.document.locale) }}">
-                    <td class="dashboard-revision">
+                    <td class="dashboard-col">
                         <a href="{{ url('wiki.revision', revision.document.full_path, revision.id) }}">{{ datetimeformat(revision.created, format='datetime') }}</a>
                         <br />
                         <span class="locale">{{ revision.document.locale }}</span>
                         {% if not previous_id %}<span class="new">{{ _('new') }}</span>{% endif %}
                         {% if revision.document.deleted %}<span class="deleted">{{ _('deleted') }}</span>{% endif %}
                     </td>
-                    <td class="dashboard-title">
+                    <td class="dashboard-col dashboard-col-title">
                         <a href="{{ revision_url }}">{{ revision.title }}</a>
                         <span class="dashboard-slug">{{ revision.document.slug }}</span>
                     </td>
-                    <td class="dashboard-comment">{{ format_comment(revision) }}</td>
-                    <td class="dashboard-author"><a href="{{ revision.creator.get_absolute_url() }}">{{ revision.creator }}</a>
+                    <td class="dashboard-col">{{ format_comment(revision) }}</td>
+                    <td class="dashboard-col dashboard-col-author"><a href="{{ revision.creator.get_absolute_url() }}">{{ revision.creator }}</a>
                     {% if show_ips %}
                     <br/><a class="dashboard-ip-link" href="{{ url('admin:wiki_revisionip_changelist') }}?revision={{revision.id}}" target="_blank">{{ _('View IP') }}</a>
                     {% endif %}

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -103,7 +103,7 @@ class RevisionsDashTest(UserTestCase):
         eq_(2, revisions.length)
 
         for revision in revisions:
-            author = pq(revision).find('.dashboard-author').text()
+            author = pq(revision).find('.dashboard-col-author').text()
             ok_('testuser01' in author)
             ok_('testuser2' not in author)
 
@@ -118,7 +118,7 @@ class RevisionsDashTest(UserTestCase):
         revisions = page.find('.dashboard-row')
 
         for revision in revisions:
-            slug = pq(revision).find('.dashboard-title').html()
+            slug = pq(revision).find('.dashboard-col-title').html()
             ok_('lorem' in slug)
             ok_('article' not in slug)
 
@@ -134,4 +134,4 @@ class RevisionsDashTest(UserTestCase):
 
         eq_(6, revisions.length)
         for revision in revisions:
-            ok_('lorem' not in pq(revision).find('.dashboard-title').html())
+            ok_('lorem' not in pq(revision).find('.dashboard-col-title').html())

--- a/media/redesign/stylus/dashboards.styl
+++ b/media/redesign/stylus/dashboards.styl
@@ -50,7 +50,7 @@
         }
     }
 
-    td {
+    .dashboard-col {
         @extend $column-strip;
         padding: 6px;
         display: inline-block;


### PR DESCRIPTION
[The blanket `td` style caused issues with the diff table inside the dashboard](https://bugzilla.mozilla.org/show_bug.cgi?id=1115738#c8). :(

So, I'm back to `dashboard-col` classes, and also `dashboard-col-title` and `dashboard-col-author` for identifying the special columns. And now I understand how Twitter Bootstrap class naming conventions evolved. :frowning: 