### PR TITLE
Fix bug 1119348 - Moved rendering of first edit email to Celery task

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2385,7 +2385,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         def _check_message_for_headers(message, username):
             ok_("%s made their first edit" % username in message.subject)
-            eq_({'X-Kuma-Document-Url': "dev.mo.org%s" % doc.get_absolute_url(),
+            eq_({'X-Kuma-Document-Url': "https://dev.mo.org%s" % doc.get_absolute_url(),
                  'X-Kuma-Editor-Username': username}, message.extra_headers)
 
         testuser_message = mail.outbox[0]


### PR DESCRIPTION
This fixes a bad isolation of the send_first_edit_email task that was introduced in bug 1115767.

This prevents passing in the pre-made email object which may contain stateful information.