### PR TITLE
fix bug 1118318 - return 410 for deleted docs

### DIFF
--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -404,7 +404,8 @@ def _document_deleted(request, deletion_logs):
 
     return render(request,
                   'wiki/deletion_log.html',
-                  {'deletion_log': deletion_log})
+                  {'deletion_log': deletion_log},
+                  status=404)
 
 
 @newrelic.agent.function_trace()


### PR DESCRIPTION
Spot-check: Delete a document, then go back to its url. Make sure net console shows 410.