### PR TITLE
bug 1113260 - add django-banish to ban by IP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -139,3 +139,6 @@
 [submodule "vendor/src/django-celery"]
 	path = vendor/src/django-celery
 	url = git://github.com/celery/django-celery.git
+[submodule "vendor/src/django-banish"]
+	path = vendor/src/django-banish
+	url = git://github.com/yourabi/django-banish.git

--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -11,7 +11,7 @@
                 <td class="dashboard-revision">Revision</td>
                 <td class="dashboard-title">Title</td>
                 <td class="dashboard-comment">Comment</td>
-                <td class="dashboard-author">Author</td>
+                <td class="dashboard-author">Author{% if show_ips %} <button id="show_ips_btn">Toggle IPs</button>{% endif %}</td>
             </tr>
         </thead>
         <tbody>
@@ -42,15 +42,20 @@
                     </td>
                     <td class="dashboard-comment">{{ format_comment(revision) }}</td>
                     <td class="dashboard-author"><a href="{{ revision.creator.get_absolute_url() }}">{{ revision.creator }}</a>
-                    {% if show_ips %}
-                    <br/><a class="dashboard-ip-link" href="{{ url('admin:wiki_revisionip_changelist') }}?revision={{revision.id}}" target="_blank">{{ _('View IP') }}</a>
+                    {% if show_ips and revision.revisionip_set.all() %}
+                    {% set revision_ip = revision.revisionip_set.all()[0].ip %}
+                    <span class="revision_ip">
+                    <br/>IP: {{ revision_ip }}
+                    {% set ban_ip_url = '%s?%s' % (url('admin:banish_banishment_add'), 'condition=%s' % revision_ip) %}
+                    <br/><a class="dashboard-ban-ip-link" href="{{ ban_ip_url }}" target="_blank">{{ _('Ban IP') }}</a>
+                    </span>
                     {% endif %}
                     {% if request.user.is_superuser and revision.creator.get_profile().is_banned %}
                         {% set active_ban = revision.creator.get_profile().active_ban() %}
                         <div class="banned">
                             banned {{ datetimeformat(active_ban.date, format='date') }}
                             by {{ active_ban.by }}
-                        </div> 
+                        </div>
                     {% endif %}
                     </td>
                 </tr>

--- a/kuma/dashboards/templates/dashboards/revisions.html
+++ b/kuma/dashboards/templates/dashboards/revisions.html
@@ -60,6 +60,7 @@
     var $localeInput = $('#id_locale');
     var $filterForm = $('#revision-filter');
     var $pageInput = $('#revision-page');
+    var $showIPsButton = $('#show_ips_btn');
     var currentLocale = '{{ request.locale }}';
     var controlsTemplate = '\
     <div class="action-bar">\
@@ -101,6 +102,12 @@
             $(item).trigger('mdn:click');
         },
         alwaysCollectItems: true
+    });
+
+    // Hide IPs & wire Toggle IPs button, if present
+    $('.revision_ip').toggle();
+    $showIPsButton.click(function(e) {
+        $('.revision_ip').toggle();
     });
 
     // Focus on the first item, if there

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -48,8 +48,8 @@ class RevisionsDashTest(UserTestCase):
         eq_(200, response.status_code)
 
         page = pq(response.content)
-        ip_col_header = page.find('a.ip-link')
-        eq_([], ip_col_header)
+        ip_button = page.find('button#show_ips_btn')
+        eq_([], ip_button)
 
         Switch.objects.create(name='store_revision_ips', active=True).save()
         self.client.login(username='admin', password='testpass')
@@ -58,8 +58,8 @@ class RevisionsDashTest(UserTestCase):
         eq_(200, response.status_code)
 
         page = pq(response.content)
-        ip_col_header = page.find('a.dashboard-ip-link')
-        ok_(len(ip_col_header) > 0)
+        ip_button = page.find('button#show_ips_btn')
+        ok_(len(ip_button) > 0)
 
     @attr('dashboards')
     def test_locale_filter(self):

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -54,6 +54,8 @@ oauthlib==0.6.3
 -e git://github.com/countergram/pytidylib.git@15f8f734e761485d79556c03266353534c987601#egg=pytidylib
 # 2013-11-01 (Current.)
 -e git://github.com/mozilla/django-badger.git@1a41701179df11df8ca8ca44898b70b6352623d3#egg=django-badger
+# 2014-12-29
+-e git://github.com/yourabi/django-banish.get@f0a36d1ffe6ad32a5969ec742152dfb541f4108c#egg=django-banish
 
 ## Formerly vendor/src - converted to versions from git refs
 python-magic==0.4.6

--- a/settings.py
+++ b/settings.py
@@ -1269,6 +1269,6 @@ SOCIALACCOUNT_PROVIDERS = {
 # django-banish defaults; listing here to be explicit
 BANISH_ENABLED = True
 BANISH_EMPTY_UA = True
-BANISH_ABUSE_THRESHOLD = 75
+BANISH_ABUSE_THRESHOLD = 9999999 # TODO: https://bugzil.la/1122658
 BANISH_USE_HTTP_X_FORWARDED_FOR = True
 BANISH_MESSAGE = _("This connection has been banned for suspicious activity.")

--- a/settings.py
+++ b/settings.py
@@ -1270,4 +1270,5 @@ SOCIALACCOUNT_PROVIDERS = {
 BANISH_ENABLED = True
 BANISH_EMPTY_UA = True
 BANISH_ABUSE_THRESHOLD = 75
+BANISH_USE_HTTP_X_FORWARDED_FOR = True
 BANISH_MESSAGE = _("This connection has been banned for suspicious activity.")

--- a/settings.py
+++ b/settings.py
@@ -1,9 +1,10 @@
 # Django settings for kuma project.
+from collections import namedtuple
+import json
 import logging
 import os
 import platform
-import json
-from collections import namedtuple
+import sys
 
 from django.utils.functional import lazy
 from django.utils.translation import ugettext_lazy as _
@@ -1269,6 +1270,6 @@ SOCIALACCOUNT_PROVIDERS = {
 # django-banish defaults; listing here to be explicit
 BANISH_ENABLED = True
 BANISH_EMPTY_UA = True
-BANISH_ABUSE_THRESHOLD = 9999999 # TODO: https://bugzil.la/1122658
+BANISH_ABUSE_THRESHOLD = sys.maxint # TODO: https://bugzil.la/1122658
 BANISH_USE_HTTP_X_FORWARDED_FOR = True
 BANISH_MESSAGE = _("This connection has been banned for suspicious activity.")

--- a/settings.py
+++ b/settings.py
@@ -426,6 +426,7 @@ MIDDLEWARE_CLASSES = (
     'kuma.core.anonymous.AnonymousIdentityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'kuma.users.middleware.BanMiddleware',
+    'banish.middleware.BanishMiddleware',
 
     'badger.middleware.RecentBadgeAwardsMiddleware',
     'kuma.wiki.badges.BadgeAwardingMiddleware',
@@ -519,6 +520,7 @@ INSTALLED_APPS = (
     'djcelery',
     'taggit',
     'dbgettext',
+    'banish',
 
     'kuma.dashboards',
     'statici18n',
@@ -1263,3 +1265,9 @@ SOCIALACCOUNT_PROVIDERS = {
         }
     }
 }
+
+# django-banish defaults; listing here to be explicit
+BANISH_ENABLED = True
+BANISH_EMPTY_UA = True
+BANISH_ABUSE_THRESHOLD = 75
+BANISH_MESSAGE = _("This connection has been banned for suspicious activity.")

--- a/settings_test.py
+++ b/settings_test.py
@@ -7,3 +7,4 @@ INSTALLED_APPS += (
     'kuma.core.tests.taggit_extras',
     'kuma.actioncounters.tests',
 )
+BANISH_ENABLED = False

--- a/vendor/kuma.pth
+++ b/vendor/kuma.pth
@@ -95,3 +95,4 @@ src/celery
 src/kombu
 src/py-amqp
 src/django-celery
+src/django-banish


### PR DESCRIPTION
:disappointed: to add another dependency via submodule, but ...

This will help us fight spammers more efficiently. We can ban IP addresses ourselves with the django admin site interface rather than filing a NetOps bug every time.

To check:

1. `git submodule update --init` to get `django-banish` into `vendor/src`
2. `vagrant provision` to run `syncdb` to create the `banish` models
3. Activate the `store_revision_ips` [waffle switch](https://developer-local.allizom.org/admin/waffle/switch/)
4. Make a revision
5. Go to [the revision dashboard](https://developer-local.allizom.org/en-US/dashboards/revisions)
6. [ ] Click the "Toggle IPs" button
7. [ ] Click "Ban IP"
8. [ ] Enter a reason for the ban
9. [ ] Click Save
10. You should get "Permission Denied" errors for every request

Now, to un-banish yourself:

1. Set `BANISH_ENABLED = False` in `settings.py`
2. Go back to [the banishments admin interface](https://developer-local.allizom.org/admin/banish/banishment/) and delete the banishment record