### PR TITLE
bug 957802 - import actioncounters.utils from kuma

### DIFF
--- a/kuma/actioncounters/migrations/0003_update_unique_hashes.py
+++ b/kuma/actioncounters/migrations/0003_update_unique_hashes.py
@@ -20,7 +20,7 @@ class Migration(DataMigration):
             .delete())
 
         # Update all remaining counters with a unique hash.
-        from actioncounters.utils import get_unique
+        from kuma.actioncounters.utils import get_unique
         counters = orm.ActionCounterUnique.objects.all()
         for counter in counters:
             try:


### PR DESCRIPTION
Spot-check == `vagrant provision` should work without errors.