### PR TITLE
Fix bug 1124199: Page buttons sticky by default

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -22,7 +22,7 @@
   {% endif %}
 
 
-  <ul class="page-buttons" data-sticky="false">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
+  <ul class="page-buttons">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
 
         <div class="submenu" id="languages-menu-submenu">
           <div class="submenu-column">

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -329,16 +329,14 @@
                 }
             }
 
-            // Check if page buttons need to be sticky
-            if($pageButtons.attr('data-sticky') === 'true'){
-                pageButtonsHeight = $pageButtons.innerHeight();
-                if(scroll > pageButtonsOffset.top) {
-                    $pageButtons.css('min-width', $pageButtons.css('width'));
-                    $pageButtons.css(buttonDirection, pageButtonsOffset[buttonDirection]);
-                    $pageButtons.addClass(fixedClass);
-                } else {
-                    $pageButtons.removeClass(fixedClass);
-                }
+            // Make page buttons (Language, Edit, etc.) sticky
+            pageButtonsHeight = $pageButtons.innerHeight();
+            if(scroll > pageButtonsOffset.top) {
+                $pageButtons.css('min-width', $pageButtons.css('width'));
+                $pageButtons.css(buttonDirection, pageButtonsOffset[buttonDirection]);
+                $pageButtons.addClass(fixedClass);
+            } else {
+                $pageButtons.removeClass(fixedClass);
             }
 
             // If there is no ToC on the page
@@ -366,7 +364,7 @@
         }, 10);
 
         // Set it forth!
-        if($toc.length || $pageButtons.attr('data-sticky') === 'true'){
+        if($toc.length) {
             scrollFn();
             $(win).on('scroll resize', scrollFn);
         }


### PR DESCRIPTION
Our research shows that more people click the edit button, view the edit
page, and submit completed edits when the page buttons are sticky [1].

Even with this change, page buttons will only be sticky on pages with
tables of content due to bug 1124215 [2].

[1] https://groups.google.com/forum/#!msg/mozilla.dev.mdn/MV1rPgAfTnI/MkC1WAn9JMcJ
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=1124215