### PR TITLE
bug 1121918 - put authkeys behind permission

### DIFF
--- a/kuma/authkeys/migrations/0003_remove_authkeys.py
+++ b/kuma/authkeys/migrations/0003_remove_authkeys.py
@@ -8,7 +8,9 @@ class Migration(DataMigration):
 
     def forwards(self, orm):
         "Write your forwards methods here."
-        orm.Key.objects.all().delete()
+        (orm.Key.objects.all().exclude(
+            id__in=orm.KeyAction.objects.values_list('key_id', flat=True))
+         .delete())
 
     def backwards(self, orm):
         "Write your backwards methods here."

--- a/kuma/authkeys/migrations/0003_remove_authkeys.py
+++ b/kuma/authkeys/migrations/0003_remove_authkeys.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        orm.Key.objects.all().delete()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+        # No way to go back
+
+    models = {
+        'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        'auth.permission': {
+            'Meta': {'ordering': "('content_type__app_label', 'content_type__model', 'codename')", 'unique_together': "(('content_type', 'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        'authkeys.key': {
+            'Meta': {'object_name': 'Key'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {}),
+            'hashed_secret': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.CharField', [], {'max_length': '64', 'db_index': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['auth.User']"})
+        },
+        'authkeys.keyaction': {
+            'Meta': {'object_name': 'KeyAction'},
+            'action': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'history'", 'to': "orm['authkeys.Key']"}),
+            'notes': ('django.db.models.fields.TextField', [], {'null': 'True'}),
+            'object_id': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        }
+    }
+
+    complete_apps = ['authkeys']
+    symmetrical = True

--- a/kuma/authkeys/templates/authkeys/list.html
+++ b/kuma/authkeys/templates/authkeys/list.html
@@ -24,10 +24,6 @@
                 <a class="button"
                    title="{{ _('View key usage history') }}"
                    href="{{ url('authkeys.history', pk=key.pk) }}">{{ _('History ({count})') | f(count=key.history.count()) }}</a>
-                <a class="button transparent only-icon"
-                   href="{{ url('authkeys.delete', pk=key.pk) }}">
-                   <span>{{ _('Delete key') }}</span><i aria-hidden="true" class="icon-trash"></i>
-                </a>
             </span>
 
         </li>

--- a/kuma/authkeys/templates/authkeys/list.html
+++ b/kuma/authkeys/templates/authkeys/list.html
@@ -32,9 +32,9 @@
 {% endif %}
 
 {% else %}
-<p>{% trans %}
+<p>{% trans bugzilla_url="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Mozilla Developer Network&component=User management" %}
   You need a special permission to use API keys.
-  You may request permission by <a href="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Mozilla Developer Network&component=User management">filing a bug</a>.
+  You may request permission by <a href="{{ bugzilla_url }}">filing a bug</a>.
 {% endtrans %}
 </p>
 

--- a/kuma/authkeys/templates/authkeys/list.html
+++ b/kuma/authkeys/templates/authkeys/list.html
@@ -3,6 +3,8 @@
 {% block intro %}{{ _("API Keys: <b>Your Keys</b>" | safe) }}{% endblock %}
 
 {% block subcontent %}
+
+{% if request.user.has_perm('authkeys.add_key') %}
 <p>{% trans %}
     These are your API keys. They're useful for building applications that
     perform tasks on MDN on your behalf. If you have stopped using any of
@@ -32,4 +34,15 @@
         {% endfor %}
     </table>
 {% endif %}
+
+{% else %}
+<p>{% trans %}
+  You need a special permission to use API keys.
+  You may request permission by <a href="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Mozilla Developer Network&component=User management">filing a bug</a>.
+{% endtrans %}
+</p>
+
+{% endif %}
+
+
 {% endblock %}

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -1,10 +1,10 @@
-from django.test import TestCase
-
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
-from kuma.core.urlresolvers import reverse
+from django.contrib.auth.models import Permission, User
+from django.test import TestCase
 
+from kuma.core.urlresolvers import reverse
 from kuma.users.tests import user
 
 from ..models import Key
@@ -16,15 +16,26 @@ class KeyViewsTest(TestCase):
     def setUp(self):
         username = 'tester23'
         password = 'trustno1'
-        self.email = 'tester23@example.com'
+        email = 'tester23@example.com'
 
-        self.user = user(username=username, email=self.email,
+        self.user = user(username=username, email=email,
                          password=password, save=True)
-
         self.client.login(username=username, password=password)
 
-        self.user2 = user(username='someone', email='someone@example.com',
-                          save=True)
+        # Give self.user (tester23) keys permissions
+        add_perm = Permission.objects.get(codename='add_key')
+        del_perm = Permission.objects.get(codename='delete_key')
+        self.user.user_permissions.add(add_perm)
+        self.user.user_permissions.add(del_perm)
+
+        _cache_bust_user_perms(self)
+
+        username2 = 'someone'
+        password2 = 'somepass'
+        email2 = 'someone@example.com'
+
+        self.user2 = user(username=username2, email=email2,
+                          password=password2, save=True)
 
         self.key1 = Key(user=self.user, description='Test Key 1')
         self.key1.save()
@@ -135,3 +146,52 @@ class KeyViewsTest(TestCase):
         ok_(302, resp.status_code)
 
         eq_(0, Key.objects.filter(pk=self.key1.pk).count())
+
+
+class KeyViewsPermissionTest(TestCase):
+
+    def setUp(self):
+        username = 'tester23'
+        password = 'trustno1'
+        email = 'tester23@example.com'
+
+        self.user = user(username=username, email=email,
+                         password=password, save=True)
+        self.client.login(username=username, password=password)
+
+    def test_new_key_requires_permission(self):
+        url = reverse('authkeys.new', locale='en-US')
+        resp = self.client.get(url)
+        eq_(403, resp.status_code)
+
+        perm = Permission.objects.get(codename='add_key')
+        self.user.user_permissions.add(perm)
+        _cache_bust_user_perms(self)
+
+        resp = self.client.get(url)
+        eq_(200, resp.status_code)
+
+    def test_delete_key_requires_separate_permission(self):
+        self.key1 = Key(user=self.user, description='Test Key 1')
+        self.key1.save()
+
+        url = reverse('authkeys.delete', locale='en-US', args=(self.key1.pk,))
+        resp = self.client.get(url)
+        eq_(403, resp.status_code)
+        _cache_bust_user_perms(self)
+
+        resp = self.client.get(url)
+        eq_(403, resp.status_code)
+
+        perm = Permission.objects.get(codename='delete_key')
+        self.user.user_permissions.add(perm)
+        _cache_bust_user_perms(self)
+
+        resp = self.client.get(url)
+        eq_(200, resp.status_code)
+
+
+def _cache_bust_user_perms(self):
+    # Need to cache-bust the user perms by re-fetching from DB
+    # https://docs.djangoproject.com/en/1.7/topics/auth/default/#permissions-and-authorization
+    self.user = User.objects.get(username=self.user.username)

--- a/kuma/authkeys/views.py
+++ b/kuma/authkeys/views.py
@@ -1,7 +1,6 @@
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, render, redirect
-from django.core.urlresolvers import reverse
-from django.contrib.auth.decorators import login_required
+from django.contrib.auth.decorators import login_required, permission_required
 
 from kuma.core.utils import paginate
 
@@ -12,7 +11,7 @@ from .forms import KeyForm
 ITEMS_PER_PAGE = 15
 
 
-@login_required
+@permission_required('authkeys.add_key')
 def new(request):
     context = {"key": None}
     if request.method != "POST":
@@ -49,7 +48,7 @@ def history(request, pk):
     return render(request, 'authkeys/history.html', context)
 
 
-@login_required
+@permission_required('authkeys.delete_key')
 def delete(request, pk):
     key = get_object_or_404(Key, pk=pk)
     if key.user != request.user:

--- a/kuma/authkeys/views.py
+++ b/kuma/authkeys/views.py
@@ -11,6 +11,7 @@ from .forms import KeyForm
 ITEMS_PER_PAGE = 15
 
 
+@login_required
 @permission_required('authkeys.add_key', raise_exception=True)
 def new(request):
     context = {"key": None}
@@ -48,6 +49,7 @@ def history(request, pk):
     return render(request, 'authkeys/history.html', context)
 
 
+@login_required
 @permission_required('authkeys.delete_key', raise_exception=True)
 def delete(request, pk):
     key = get_object_or_404(Key, pk=pk)

--- a/kuma/authkeys/views.py
+++ b/kuma/authkeys/views.py
@@ -11,7 +11,7 @@ from .forms import KeyForm
 ITEMS_PER_PAGE = 15
 
 
-@permission_required('authkeys.add_key')
+@permission_required('authkeys.add_key', raise_exception=True)
 def new(request):
     context = {"key": None}
     if request.method != "POST":
@@ -48,7 +48,7 @@ def history(request, pk):
     return render(request, 'authkeys/history.html', context)
 
 
-@permission_required('authkeys.delete_key')
+@permission_required('authkeys.delete_key', raise_exception=True)
 def delete(request, pk):
     key = get_object_or_404(Key, pk=pk)
     if key.user != request.user:

--- a/kuma/users/helpers.py
+++ b/kuma/users/helpers.py
@@ -55,7 +55,7 @@ def admin_link(context, user):
     """Returns a link to admin a user"""
     link = ''
     url = reverse('admin:auth_user_change', args=(user.id,))
-    link = '<a href="%s" class="button neutral">%s<i aria-hidden="true" class="icon-lock"></i></a>' % (url, _('Admin'))
+    link = '<a href="%s" class="button neutral">%s<i aria-hidden="true" class="icon-wrench"></i></a>' % (url, _('Admin'))
     return Markup(link)
 
 

--- a/kuma/users/helpers.py
+++ b/kuma/users/helpers.py
@@ -42,10 +42,20 @@ def ban_link(context, ban_user, banner_user):
             active_ban = ban_user.get_profile().active_ban()
             url = reverse('admin:users_userban_change', args=(active_ban.id,))
             title = _('Banned on {ban_date} by {ban_admin}.').format(ban_date=datetimeformat(context, active_ban.date, format='date', output='json'), ban_admin=active_ban.by )
-            link = '<a href="%s" class="button ban-link" title="%s">%s</a>' % (url, title, _('Banned'))
+            link = '<a href="%s" class="button ban-link" title="%s">%s<i aria-hidden="true" class="icon-ban"></i></a>' % (url, title, _('Banned'))
         else:
             url = '%s?user=%s&by=%s' % (reverse('admin:users_userban_add'), ban_user.id, banner_user.id)
-            link = '<a href="%s" class="button negative ban-link">%s</a>' % (url, _('Ban User'))
+            link = '<a href="%s" class="button negative ban-link">%s<i aria-hidden="true" class="icon-ban"></i></a>' % (url, _('Ban User'))
+    return Markup(link)
+
+
+@register.function
+@contextfunction
+def admin_link(context, user):
+    """Returns a link to admin a user"""
+    link = ''
+    url = reverse('admin:auth_user_change', args=(user.id,))
+    link = '<a href="%s" class="button neutral">%s<i aria-hidden="true" class="icon-lock"></i></a>' % (url, _('Admin'))
     return Markup(link)
 
 

--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -55,6 +55,11 @@
             {{ ban_link(profile.user, request.user) }}
           {% endif %}
 
+          {% if request.user.is_superuser %}
+            {{ admin_link(profile.user) }}
+          {% endif %}
+
+
           <!-- Only shown for the user and admins -->
           {% if profile.allows_editing_by(request.user) %}
               <a id="edit-profile" href="{{ url('users.profile_edit', username=profile.user.username) }}" class="button neutral">{{ _("Edit") }}<i aria-hidden="true" class="icon-pencil"></i></a>


### PR DESCRIPTION
This puts the Add & Delete auth keys views behind the respective permissions. It also includes a data migration to delete all existing authkeys.
![api-key-permission](https://cloud.githubusercontent.com/assets/71928/5910463/e975dc0e-a57f-11e4-88af-992c500d6d9b.gif)