### PR TITLE
bug 957802 - update whatsdeployed link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Development
 :IRC:           irc://irc.mozilla.org/mdndev
 
                 http://logs.glob.uno/?c=mozilla%23mdndev (logs)
-:Servers:       http://mzl.la/deployed-mdn (What's Deployed)
+:Servers:       http://mzl.la/whats-deployed (What's Deployed)
 
                 https://developer-dev.allizom.org/ (dev)
 


### PR DESCRIPTION
Small fix to the "What's Deployed" link now that we've dropped the dev server.