### PR TITLE
Bug 1124199: Revert default sticky buttons

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -22,7 +22,7 @@
   {% endif %}
 
 
-  <ul class="page-buttons">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
+  <ul class="page-buttons" data-sticky="false">{% if not document.is_template %}<li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
 
         <div class="submenu" id="languages-menu-submenu">
           <div class="submenu-column">

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -329,14 +329,16 @@
                 }
             }
 
-            // Make page buttons (Language, Edit, etc.) sticky
-            pageButtonsHeight = $pageButtons.innerHeight();
-            if(scroll > pageButtonsOffset.top) {
-                $pageButtons.css('min-width', $pageButtons.css('width'));
-                $pageButtons.css(buttonDirection, pageButtonsOffset[buttonDirection]);
-                $pageButtons.addClass(fixedClass);
-            } else {
-                $pageButtons.removeClass(fixedClass);
+            // Check if page buttons need to be sticky
+            if($pageButtons.attr('data-sticky') === 'true'){
+                pageButtonsHeight = $pageButtons.innerHeight();
+                if(scroll > pageButtonsOffset.top) {
+                    $pageButtons.css('min-width', $pageButtons.css('width'));
+                    $pageButtons.css(buttonDirection, pageButtonsOffset[buttonDirection]);
+                    $pageButtons.addClass(fixedClass);
+                } else {
+                    $pageButtons.removeClass(fixedClass);
+                }
             }
 
             // If there is no ToC on the page
@@ -364,7 +366,7 @@
         }, 10);
 
         // Set it forth!
-        if($toc.length) {
+        if($toc.length || $pageButtons.attr('data-sticky') === 'true'){
             scrollFn();
             $(win).on('scroll resize', scrollFn);
         }


### PR DESCRIPTION
This reverts commit d9369db700f2f1e1e226b5fb57936582fe5c418c.

After turning sticky page buttons on by default, a number of bugs were
discovered. This commit turns the sticky page buttons back off by
default so that the bugs can be fixed.