### PR TITLE
Bug 756533 - Slightly revert logging changes from 96d0d221bb3d297b4af1bcb9e66ebe614f351533.

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -1165,6 +1165,11 @@ SYSLOG_TAG = 'http_app_kuma'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse',
+        },
+    },
     'formatters': {
         'default': {
             'format': '{0}: %(asctime)s %(name)s:%(levelname)s %(message)s: '
@@ -1179,6 +1184,7 @@ LOGGING = {
         },
         'mail_admins': {
             'class': 'django.utils.log.AdminEmailHandler',
+            'filters': ['require_debug_false'],
             'level': logging.ERROR,
         },
     },
@@ -1186,18 +1192,16 @@ LOGGING = {
         'kuma': {
             'handlers': ['console'],
             'propagate': True,
-            # Use the most permissive setting. It is filtered in the handlers.
-            'level': logging.DEBUG,
+            'level': logging.ERROR,
         },
         'django.request': {
             'handlers': ['console'],
             'propagate': True,
-            # Use the most permissive setting. It is filtered in the handlers.
-            'level': logging.DEBUG,
+            'level': logging.ERROR,
         },
         'elasticsearch': {
-            'level': logging.ERROR,
             'handlers': ['console'],
+            'level': logging.ERROR,
         },
     },
 }


### PR DESCRIPTION
This increases the logging threadshold to just errors and reintroduces
the RequireDebugFalse filter for the admin email log handler.