### PR TITLE
Fix bug 1035569 - Clean out query parameters that are empty.

### DIFF
--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -43,6 +43,12 @@ class URLTests(test_utils.TestCase):
         eq_(url.merge_query_param('foo', [None]),
             'http://example.com/?foo=&foo=bar&spam=eggs')
 
+    def test_clean_params(self):
+        for url in ['http://example.com/?spam=',
+                    'http://example.com/?spam']:
+            url_object = QueryURLObject(url)
+            eq_(url_object.clean_params(url_object.query_dict), {})
+
     def test_referer_bad_encoding(self):
         class _TestRequest(object):
             # In order to test this we just need an object that has


### PR DESCRIPTION
This prevents a hard exception on the search page when given a query parameter that doesn't have a value.