### PR TITLE
Fixes bug 931377: Adding button to toggle <pre> wrapped code samples

### DIFF
--- a/media/redesign/js/main.js
+++ b/media/redesign/js/main.js
@@ -212,6 +212,19 @@
         mdn.Notifier.discover();
     })();
 
+
+    /*
+        Inject Toggle Code button before <pre> elements
+        TODO: Make it translatable into any detected browser language
+    */
+    (function() {
+        $.each($('pre'), function() {
+            var $pre = $(this);
+            $pre.before('<button class="button toggle-pre">Toggle code <i class="icon-caret-down" aria-hidden="true"></i></button>');
+        });
+    })();
+
+
     /*
         Tabzilla
     */

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -579,6 +579,17 @@
     });
 
 
+    /*
+        Toggle <pre> visibility and button caret glyph
+    */
+    $('button.toggle-pre').on('click', function(e) {
+        e.preventDefault();
+        var $button = $(this);
+        $button.children('i').toggleClass('icon-caret-down icon-caret-right');
+        $button.next('pre').toggle();
+    });
+
+
     function debounce(func, wait, immediate) {
         var timeout;
         return function() {

--- a/media/redesign/stylus/components/wiki/customcss.styl
+++ b/media/redesign/stylus/components/wiki/customcss.styl
@@ -72,6 +72,11 @@ table#fullwidth-table td.thirdColumn {
 #wikiArticle {$selector-icon} {
     margin-left: 0px;
 }
+/* make injected toggle button a consistent width
+     since icon-caret* glyphs varies in size */
+#wikiArticle button.toggle-pre i {
+    width: 1px;
+}
 /* Iframe for live sample centered (Test) */
 .centered iframe {
     display: block;


### PR DESCRIPTION
I chatted a bit with @jezdez about this - JavaScript seems to be the lowest barrier to implementing this show/hide pre code sample functionality. Here's a basic patch to do that.

It only works in English, and the button appears above each and every pre element, so it may not be quite ready to merge.

My Dev Kuma doesn't have a large enough sample of pages in it to be sure this behaves exactly as expected so some testing/review would be welcome.