### PR TITLE
Fixes bug 1108474: Make compare revisions button on history page sticky

### DIFF
--- a/kuma/wiki/templates/wiki/document_revisions.html
+++ b/kuma/wiki/templates/wiki/document_revisions.html
@@ -73,11 +73,6 @@
             </li>
             {% if loop.last %}</ul>{% endif %}
           {% endfor %}
-          {% if revision_count > 1 %}
-            <div class="revision-list-controls revision-list-controls-bottom">
-              <input type="submit" class="link-btn" value="{% if document.parent %}{{ _('Compare Selected Translations') }}{% else %}{{ _('Compare Selected Revisions') }}{% endif %}" />
-            </div>
-          {% endif %}
         </form>
       {% else %}
         {{ _('This document has no revisions.') }}

--- a/media/redesign/js/wiki.js
+++ b/media/redesign/js/wiki.js
@@ -578,6 +578,18 @@
         }
     });
 
+    /*
+      Make Compare selected revisions button sticky when scrolling history page
+    */
+    (function() {
+        var button = $('.revision-list-controls .link-btn');
+        var revisionButtonOffset = $(button).offset().top;
+        $(window).on('scroll', function() {
+            var $compareButton = $(button);
+            var scroll = $(this).scrollTop();
+            $compareButton.toggleClass('fixed', scroll >= revisionButtonOffset);
+        });
+    })();
 
     function debounce(func, wait, immediate) {
         var timeout;

--- a/media/redesign/stylus/components/wiki/revision-list.styl
+++ b/media/redesign/stylus/components/wiki/revision-list.styl
@@ -97,3 +97,7 @@ html[dir=rtl] .revision-list-controls:before {
     width: 460px;
 }
 
+/* make the Compare selected revisions button align to layout */
+.revision-list-controls .fixed {
+    bidi-style(left, 24px, right, auto);
+}


### PR DESCRIPTION
This is to address the feature requested in https://bugzilla.mozilla.org/show_bug.cgi?id=1108474 - make the compare revisions button sticky when scrolling the page.