### PR TITLE
Fix bug 1084503: extend UserAdmin to allow sorting in admin/auth/user view

### DIFF
--- a/kuma/users/admin.py
+++ b/kuma/users/admin.py
@@ -6,6 +6,20 @@ from taggit.forms import TagWidget
 from kuma.core.managers import NamespacedTaggableManager
 from .models import UserBan, UserProfile
 
+from django.contrib.auth.admin import UserAdmin
+from django.contrib.auth.models import User
+
+
+class ExtendedUserAdmin(UserAdmin):
+    # extend the admin view of users to show date_joined field; add a filter on the field too
+    list_display = ('username', 'email', 'first_name', 'last_name', 'date_joined', 'is_staff', 'is_active')
+    list_filter = ('is_staff', 'is_superuser', 'is_active', 'date_joined',)
+    ordering = ('-date_joined',)
+
+
+admin.site.unregister(User)
+admin.site.register(User, ExtendedUserAdmin)
+
 
 class UserBanAdmin(admin.ModelAdmin):
     fields = ('user', 'by', 'reason', 'is_active')


### PR DESCRIPTION
I *think* that this does what is expected in the main bug description. It adds a field Date Joined to the admin display of users, along with a Filter to narrow the result down by date. The details are in https://bugzilla.mozilla.org/show_bug.cgi?id=1084503