### PR TITLE
Fix Bug 1130026: Code styling in .warning messages

### DIFF
--- a/media/redesign/stylus/base/elements/typography.styl
+++ b/media/redesign/stylus/base/elements/typography.styl
@@ -115,7 +115,6 @@ pre/code/kbd
 pre,
 code {
     font-family: Consolas, Monaco, 'Andale Mono', monospace; /* match Prism */
-    margin-bottom: $content-block-margin;
 }
 
 /* pre is a block element so it gets a bit more fancy styling */
@@ -123,9 +122,11 @@ pre {
     set-font-size($base-font-size);
     line-height: 19px;
     border: 0;
-    background: #f6f6f2;
-    padding: 15px;
+    background: $light-background-color;
+    color: $text-color;
+    padding: $code-block-padding;
     overflow: auto;
+    margin: 0 0 $grid-spacing 0;
 }
 
 /* code may appear inline in headings, we want to match the font weight of the element its nested in */

--- a/media/redesign/stylus/components/syntax/base.styl
+++ b/media/redesign/stylus/components/syntax/base.styl
@@ -1,13 +1,19 @@
 /*
-    Updates in this file modify or enhance the code provided by Prism.js
-    Modifies <pre> and <code> with classses added by prism.js
+    This file modifies <pre> and <code> with the class 'language-' which is added by prism.js
+    This is complicated by the fact that we don't know the configuration of the HTML
+        - it could be <pre> or <code> or <pre><code> or or <pre><code><code> or <pre><em><code> (just to name a few)
 */
-code[class*='language-'],
-pre[class*='language-'] {
-    color: inherit;
-    text-shadow: none;
+
+/*
+prism.css problem fixing
+====================================================================== */
+
+/* prism.css incorrectly double styles code > code, but only with a backround color */
+code[class*='language-'] > code[class*='language-'] {
+    background-color: none;
 }
 
+/* prism.css overrides our gridspacing with its own margin, override it back */
 pre[class*='language-'] {
     margin: 0 0 $grid-spacing 0;
 
@@ -16,12 +22,22 @@ pre[class*='language-'] {
     }
 }
 
-:not(pre)>code[class*='language-'],
+/* prism.css overrides our text-color with black and adds a text-shadow, override it back */
+code[class*='language-'],
+pre[class*='language-'] {
+    color: $text-color;
+    text-shadow: none;
+}
+
+/*
+Enhamcements!
+====================================================================== */
+:not(pre):not(code)>code[class*='language-'],
 pre[class*='language-'] {
     @extend $code-block;
 }
 
-/*  Some places in the wiki feature <pre><em><code> */
+/*  we don't want <pre><em><code> to have the code-block styling  */
 pre em code[class*='language-'] {
     background: none;
     border-left: 0;

--- a/media/redesign/stylus/components/wiki/content/warning.styl
+++ b/media/redesign/stylus/components/wiki/content/warning.styl
@@ -9,10 +9,9 @@
     margin: 0 0 $grid-spacing 0;
     set-font-size($base-font-size);
 
-    pre {
-        color: $text-color;
-        padding: ($grid-spacing / 2) !important;
-        background: none repeat scroll 0 0 rgba-fallback(rgba(255, 255, 255, 0.7)) !important;
+    /* set-message-base strips this, we have to add it back because it looks funny with the bg-color */
+    pre:last-child {
+        padding-bottom: $code-block-padding;
     }
 
     &.warning-review {

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -541,6 +541,7 @@ $code-block {
     background-image:  url($media-url-dir + 'blueprint-dark.png');
     background-position: top center;
     background-repeat: repeat;
+    color: $text-color;
 
     vendorize(tab-size, 4);
     vendorize(hyphens, none);

--- a/media/redesign/stylus/includes/vars.styl
+++ b/media/redesign/stylus/includes/vars.styl
@@ -20,6 +20,7 @@ $light-background-color = #f4f7f8;
 $code-block-background-color = #fafbfc;
 $code-block-background-alt-color = #dde4e9;
 $code-block-border-color = #558abb;
+$code-block-padding = 15px;
 
 /* typography */
 $light-font-weight = 200;


### PR DESCRIPTION
- Beefed up comments in syntax/base.styl
- Added an explicit text-color declaration to the code-block mixin (it's good practice to declare text and bgcolor together)
- Switched to variables for a few things
- Moved margin-bottom declaration off code and moved it to just pre (as code sometimes appears as an inline element)

A page to help with testing: https://developer.mozilla.org/en-US/docs/User:stephaniehobson:code
