### PR TITLE
Fix bug 1104119 - Cache refill instead of invalidation for document zone remaps.

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -192,8 +192,6 @@ KUMASCRIPT_TIMEOUT_ERROR = [
 ]
 SLUG_CLEANSING_REGEX = '^\/?(([A-z-]+)?\/?docs\/)?'
 
-URL_REMAPS_CACHE_KEY_TMPL = 'DocumentZoneUrlRemaps:%s'
-
 # TODO: Put this under the control of Constance / Waffle?
 # Flags used to signify revisions in need of review
 REVIEW_FLAG_TAGS = (

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -44,7 +44,7 @@ from kuma.search.decorators import register_live_index
 from . import kumascript
 from .constants import (DEKI_FILE_URL, DOCUMENT_LAST_MODIFIED_CACHE_KEY_TMPL,
                         KUMA_FILE_URL, REDIRECT_CONTENT, REDIRECT_HTML,
-                        TEMPLATE_TITLE_PREFIX, URL_REMAPS_CACHE_KEY_TMPL)
+                        TEMPLATE_TITLE_PREFIX)
 from .content import parse as parse_content
 from .content import (extract_code_sample, extract_css_classnames,
                       extract_html_attributes, extract_kumascript_macro_names,
@@ -1532,11 +1532,15 @@ class DocumentZone(models.Model):
         return u'DocumentZone %s (%s)' % (self.document.get_absolute_url(),
                                           self.document.title)
 
+    @staticmethod
+    def cache_key(locale):
+        return 'wiki:zones:remaps:%s' % locale
+
     def save(self, *args, **kwargs):
         super(DocumentZone, self).save(*args, **kwargs)
 
-        # Invalidate URL remap cache for this zone
-        memcache.delete(URL_REMAPS_CACHE_KEY_TMPL % self.document.locale)
+        # Reset URL cache for the locale of this zone's attached document
+        DocumentZone.objects.reset_url_remaps(self.document.locale)
 
 
 class ReviewTag(TagBase):

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -24,7 +24,7 @@ from kuma.search.models import Index
 from .events import context_dict
 from .exceptions import PageMoveError, StaleDocumentsRenderingInProgress
 from .helpers import absolutify
-from .models import Document, Revision, RevisionIP
+from .models import Document, Revision, RevisionIP, DocumentZone
 from .search import WikiDocumentType
 from .signals import render_done
 
@@ -112,11 +112,7 @@ def build_json_data_for_document_task(pk, stale):
 
 @receiver(render_done)
 def build_json_data_handler(sender, instance, **kwargs):
-    try:
-        build_json_data_for_document_task.delay(instance.pk, stale=False)
-    except:
-        logging.error('JSON metadata build task failed',
-                      exc_info=True)
+    build_json_data_for_document_task.delay(instance.pk, stale=False)
 
 
 @task
@@ -352,3 +348,17 @@ def unindex_documents(ids, index_pk):
     index = Index.objects.get(pk=index_pk)
 
     cls.bulk_delete(ids, es=es, index=index.prefixed_name)
+
+
+@task
+def invalidate_zone_cache(pk):
+    document = Document.objects.get(pk=pk)
+    # if the document is a document zone
+    if document.zones.exists():
+        # reset the cached list of zones of the document's locale
+        DocumentZone.objects.reset_url_remaps(document.locale)
+
+
+@receiver(render_done)
+def invalidate_zone_cache_handler(sender, instance, **kwargs):
+    invalidate_zone_cache.delay(instance.pk)


### PR DESCRIPTION
This resets the cached document zone remaps when saving documents instead just deleting them when saving the zone.