### PR TITLE
Add indentation to toc sub items.

### DIFF
--- a/media/redesign/stylus/components/wiki/toc.styl
+++ b/media/redesign/stylus/components/wiki/toc.styl
@@ -7,10 +7,6 @@
         set-smaller-font-size();
     }
 
-    ol ol {
-        padding-left: $grid-spacing;
-    }
-
     li {
         padding-top: ($grid-spacing / 2);
         position: relative;
@@ -21,6 +17,10 @@
             position: absolute;
             color: #484848;
         }
+    }
+
+    li li {
+        padding-left: $grid-spacing;
     }
 
     .toggler {


### PR DESCRIPTION
Switched from `ol ol` to `li li` to make any type of list item indented (MDN uses `ol` but readthedocs/sphinx uses `ul`). 