### PR TITLE
Bug - 1125803 - Good & bad code examples.

### DIFF
--- a/media/redesign/stylus/components/components.styl
+++ b/media/redesign/stylus/components/components.styl
@@ -99,24 +99,13 @@
     reverse-link-decoration();
 }
 
-/* hoping to one day use these colours to generate most colours we use on MDN but just here for now */
+/*
+Notifications
+====================================================================== */
 
-$red = #ea3b28;
-$yellow = #ffcb00;
-$green = #70a300;
-$blue = #0095dd;
-$grey = #c7ccce;
 
-$negative = $red;
-$warning = $yellow;
-$positive = $green;
-$neutral = $blue;
-$default = $grey;
-
-$text-dark = $text-color;
-$text-light = #fff;
-
-/* functions to transform the base colours into variations of themselves */
+/* functions to transform the base colors into variations of themselves
+-------------------------------------------------------------- */
 
 theme-pale-light($color) {
     return tint($color, 80%);
@@ -132,7 +121,8 @@ theme-pale-dark($color) {
     return darken($color, 20%);
 }
 
-/* functions to get correct text colours for variations of theme colours */
+/* functions to get correct text colors for variations of theme colors
+-------------------------------------------------------------- */
 
 theme-pale-text($color) {
     $color = theme-pale-light($color);
@@ -154,7 +144,8 @@ theme-pale-contrast-text($color){
     return $color;
 }
 
-/* function to apply all the generated colours to a notification to theme it */
+/* function to apply all the generated colors to a notification to theme it
+-------------------------------------------------------------- */
 
 notification-theme($color) {
     background-color: theme-pale-light($color);
@@ -185,7 +176,8 @@ notification-theme($color) {
 
 }
 
-/* style notifications */
+/* style notifications
+-------------------------------------------------------------- */
 
 .notification {
     @extends .media;
@@ -234,7 +226,7 @@ notification-theme($color) {
     &.warning {
         notification-theme($warning);
 
-        /* warning clashes with a class in CustomCSS so we have to re-assert border-width and link colour
+        /* warning clashes with a class in CustomCSS so we have to re-assert border-width and link color
            the CustomCSS class might be changeable in the future but we can't change the notifier class
            because it is part of a django module . See also .notification-button. */
         border-width: @border-width;

--- a/media/redesign/stylus/components/syntax/example.styl
+++ b/media/redesign/stylus/components/syntax/example.styl
@@ -1,0 +1,74 @@
+$bg-good = blend(rgba($positive, 0.05), #fff);
+$bg-bad = blend(rgba($negative, 0.05), #fff);
+
+/*
+Pseudo element for icons
+-------------------------------------------------------------- */
+
+:not(pre)>code.example-good[class*='language-']:before,
+pre.example-good[class*='language-']:before,
+:not(pre)>code.example-bad[class*='language-']:before,
+pre.example-bad[class*='language-']:before {
+    border-radius: 100%; /* make it into a circle so bgcolor doesn't show */
+    font-family: 'FontAwesome';
+    font-size: $larger-font-size ;
+    position: absolute;
+    top: 14px;
+    left: 6px;
+    z-index: 10;
+    speak: none;
+}
+
+:not(pre)>code.example-good[class*='language-']:before,
+pre.example-good[class*='language-']:before {
+    background: $bg-good;
+    color: $positive;
+    content: '\f118';
+}
+
+:not(pre)>code.example-bad[class*='language-']:before,
+pre.example-bad[class*='language-']:before {
+    background: $bg-bad;
+    color:  $negative;
+    content: '\f119';
+}
+
+/*
+Background colouration
+-------------------------------------------------------------- */
+
+:not(pre)>code.example-good[class*='language-'],
+pre.example-good[class*='language-'] {
+    background: $bg-good;
+    background:
+        linear-gradient(rgba(0,0,0,0) 9px, rgba(0,0,0,0.02) 9px, rgba(0,0,0,0.02) 10px),
+        linear-gradient(90deg, rgba(0,0,0,0) 9px, rgba(0,0,0,0.02) 9px, rgba(0,0,0,0.02) 10px),
+        linear-gradient(rgba(0,0,0,0) 29px, rgba(0,0,0,0.02) 29px, rgba(0,0,0,0.02) 30px),
+        linear-gradient(90deg, rgba(0,0,0,0) 29px, rgba(0,0,0,0.02) 29px, rgba(0,0,0,0.02) 30px),
+        linear-gradient($bg-good, $bg-good);
+    background-size:
+        10px 10px,
+        10px 10px,
+        30px 30px,
+        30px 30px,
+        cover;
+    border-left: $code-block-border-width $code-block-border-style $positive;
+}
+
+:not(pre)>code.example-bad[class*='language-'],
+pre.example-bad[class*='language-'] {
+    background: $bg-bad;
+    background:
+        linear-gradient(45deg, rgba(0,0,0,0) 45%, rgba(0,0,0,0.01) 45%, rgba(0,0,0,0.01) 55%, rgba(0,0,0,0) 55%),
+        linear-gradient(135deg, rgba(0,0,0,0) 45%, rgba(0,0,0,0.01) 45%, rgba(0,0,0,0.01) 55%, rgba(0,0,0,0) 55%),
+        linear-gradient(45deg, rgba(0,0,0,0) 20px, rgba(0,0,0,0.01) 20px, rgba(0,0,0,0.01) 21px, rgba(0,0,0,0) 21px),
+        linear-gradient(135deg, rgba(0,0,0,0) 20px, rgba(0,0,0,0.01) 20px, rgba(0,0,0,0.01) 21px, rgba(0,0,0,0) 21px),
+        linear-gradient($bg-bad, $bg-bad);
+    background-size:
+        10px 10px,
+        10px 10px,
+        30px 30px,
+        30px 30px,
+        cover;
+    border-left: $code-block-border-width $code-block-border-style $negative;
+}

--- a/media/redesign/stylus/includes/mixins.styl
+++ b/media/redesign/stylus/includes/mixins.styl
@@ -537,7 +537,7 @@ $right-icons {
 /* Styles for code blocks - used for wiki document and WYSIWYG editor */
 $code-block {
     background: $code-block-background-color;
-    border-left: 6px solid $code-block-border-color;
+    border-left: $code-block-border-width $code-block-border-style $code-block-border-color;
     background-image:  url($media-url-dir + 'blueprint-dark.png');
     background-position: top center;
     background-repeat: repeat;

--- a/media/redesign/stylus/includes/vars.styl
+++ b/media/redesign/stylus/includes/vars.styl
@@ -21,6 +21,23 @@ $code-block-background-color = #fafbfc;
 $code-block-background-alt-color = #dde4e9;
 $code-block-border-color = #558abb;
 $code-block-padding = 15px;
+$code-block-border-width = 6px;
+$code-block-border-style = solid;
+
+$red = #ea3b28;
+$yellow = #ffcb00;
+$green = #70a300;
+$blue = #0095dd;
+$grey = #c7ccce;
+
+$negative = $red;
+$warning = $yellow;
+$positive = $green;
+$neutral = $blue;
+$default = $grey;
+
+$text-dark = $text-color;
+$text-light = #fff;
 
 /* typography */
 $light-font-weight = 200;

--- a/media/redesign/stylus/wiki-syntax.styl
+++ b/media/redesign/stylus/wiki-syntax.styl
@@ -6,3 +6,4 @@
 @import 'components/syntax/base';
 @import 'components/syntax/syntaxbox';
 @import 'components/syntax/error';
+@import 'components/syntax/example';


### PR DESCRIPTION
Add styling for good and bad code examples.

Colour blind friendly but not screen reader friendly. Needs to be used in combination with headings.

- added .example-good and .example-bad to be used on code examples
- made some code-block stuff into variables for reuse in new classes
- moved colours from components.styl into vars.styl
- polished comments

Testing: add .example-good or .example-bad to a `<pre>` or `<code>` tag that also has `class="brush:html"` declared on it (needs both the example class AND the prism styling to work).