### PR TITLE
Fix bug 1132962: Use <mark> for matched terms

### DIFF
--- a/kuma/search/fields.py
+++ b/kuma/search/fields.py
@@ -34,7 +34,7 @@ class DocumentExcerptField(serializers.Field):
     """
     A serializer field that given a wiki DocumentType object returns
     a cleaned version of the excerpt fields with the highlighting
-    <em> tag intact.
+    <mark> tag intact.
     """
     def to_native(self, value):
         if not getattr(value, 'highlight', False):

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -53,7 +53,7 @@ class FilterTests(ElasticTestCase):
         view = HighlightView.as_view()
         request = self.get_request('/en-US/search?q=article')
         response = view(request)
-        ok_('<em>article</em>' in response.data['documents'][0]['excerpt'])
+        ok_('<mark>article</mark>' in response.data['documents'][0]['excerpt'])
 
     def test_language_filter(self):
         class LanguageView(SearchView):

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -47,10 +47,10 @@ class FieldTests(ElasticTestCase):
 
         class FakeValue(WikiDocumentType):
             summary = 'just a summary'
-            highlight = {'content': ['this is <em>matching</em> text']}
+            highlight = {'content': ['this is <mark>matching</mark> text']}
 
         field = DocumentExcerptField()
-        eq_(field.to_native(FakeValue()), 'this is <em>matching</em> text')
+        eq_(field.to_native(FakeValue()), 'this is <mark>matching</mark> text')
 
         class FakeValue(WikiDocumentType):
             summary = 'just a summary'

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -218,7 +218,8 @@ class WikiDocumentType(document.DocType):
 
         # Add highlighting.
         sq = sq.highlight(*cls.excerpt_fields)
-        sq = sq.highlight_options(order='score')
+        sq = sq.highlight_options(order='score', pre_tags=['<mark>'],
+                                  post_tags=['</mark>'])
 
         return sq
 

--- a/media/redesign/stylus/search.styl
+++ b/media/redesign/stylus/search.styl
@@ -49,6 +49,11 @@ h3 {$selector-icon}, fieldset {$selector-icon} {
     h3 {
         margin-bottom: $grid-spacing;
     }
+
+    mark {
+        background: none;
+        font-weight: bold;
+    }
 }
 
 .result-list {


### PR DESCRIPTION
Quoting MDN...

    The HTML <mark> Element represents highlighted text, i.e., a run of
    text marked for reference purpose, due to its relevance in a
    particular context. For example it can be used in a page showing
    search results to highlight every instance of the searched for word.

-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark