### PR TITLE
fix bug 1119545 - hide website fields for "new" users

### DIFF
--- a/kuma/users/fixtures/test_users.json
+++ b/kuma/users/fixtures/test_users.json
@@ -45,6 +45,7 @@
             "deki_user_id": 0,
             "fullname": "Test User",
             "homepage": "http://testuser.com/",
+            "misc": "{\"websites\": {\"website\": \"http://testuser.com\"} }",
             "irc_nickname": "testuser",
             "locale": "en-US",
             "location": "Testville",

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -23,6 +23,9 @@ from .helpers import gravatar_url
 from .tasks import send_welcome_email
 
 
+LOW_ACTIVITY_THRESHOLD = 10
+
+
 class UserBan(models.Model):
     user = models.ForeignKey(User,
                              related_name="bans",
@@ -187,9 +190,12 @@ class UserProfile(ModelBase):
         return (Revision.objects.filter(creator=self.user)
                                 .order_by('-created')[:5])
 
-    @property
+    @cached_property
     def num_wiki_revisions(self):
         return Revision.objects.filter(creator=self.user).count()
+
+    def has_low_activity(self):
+        return self.num_wiki_revisions < LOW_ACTIVITY_THRESHOLD
 
 
 @receiver(models.signals.post_save, sender=User)

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -187,6 +187,10 @@ class UserProfile(ModelBase):
         return (Revision.objects.filter(creator=self.user)
                                 .order_by('-created')[:5])
 
+    @property
+    def num_wiki_revisions(self):
+        return Revision.objects.filter(creator=self.user).count()
+
 
 @receiver(models.signals.post_save, sender=User)
 def create_user_profile(sender, instance, created, **kwargs):

--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -123,6 +123,24 @@
         <figure>
           <img src="{{ profile.gravatar() }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
         </figure>
+        {# https://bugzil.la/1119545 - hide website until user makes 10 revisions #}
+        {% set low_activity = False %}
+        {% set low_activity_threshold = config.WIKI_LOW_ACTIVITY_THRESHOLD %}
+        {% set show_sites = True %}
+        {% if profile.num_wiki_revisions < low_activity_threshold %}
+          {% set low_activity = True %}
+        {% endif %}
+        {% if low_activity %}
+          {% if request.user == profile.user %}
+          {{ _('Until you have made {threshold} revisions, these fields are hidden from others.') | f(threshold=low_activity_threshold) }}
+          {% elif request.user.is_superuser %}
+          {{ _('Until this user has made {threshold} revisions, these fields are hidden from others.') | f(threshold=low_activity_threshold) }}
+          {% else %}
+            {% set show_sites = False %}
+          {% endif %}
+        {% endif %}
+
+        {% if show_sites %}
 
         <ul class="profile-links">
         {% for site_name, site_meta in profile.website_choices %}
@@ -139,6 +157,9 @@
           {% endif %}
         {% endfor %}
         </ul>
+
+        {% endif %}
+
       </div>
     </section>
 

--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -123,20 +123,11 @@
         <figure>
           <img src="{{ profile.gravatar() }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
         </figure>
-        {# https://bugzil.la/1119545 - hide website until user makes 10 revisions #}
-        {% set low_activity = False %}
-        {% set low_activity_threshold = config.WIKI_LOW_ACTIVITY_THRESHOLD %}
-        {% set show_sites = True %}
-        {% if profile.num_wiki_revisions < low_activity_threshold %}
-          {% set low_activity = True %}
-        {% endif %}
-        {% if low_activity %}
+        {% if show_hidden %}
           {% if request.user == profile.user %}
           {{ _('Until you have made {threshold} revisions, these fields are hidden from others.') | f(threshold=low_activity_threshold) }}
           {% elif request.user.is_superuser %}
           {{ _('Until this user has made {threshold} revisions, these fields are hidden from others.') | f(threshold=low_activity_threshold) }}
-          {% else %}
-            {% set show_sites = False %}
           {% endif %}
         {% endif %}
 

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -24,7 +24,7 @@ class TestUserProfile(UserTestCase):
 
         # Property should start off as an empty dict()
         sites = profile.websites
-        eq_({}, sites)
+        eq_({u'website': u'http://testuser.com'}, sites)
 
         # Assemble a set of test sites.
         test_sites = dict(

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.contrib.auth.models import User
 
 from kuma.core.helpers import urlparams
-from kuma.core.tests import override_constance_settings
 from kuma.core.urlresolvers import reverse
 from .test_views import TESTUSER_PASSWORD
 from . import (verify_strings_in_response, verify_strings_not_in_response,
@@ -22,14 +21,15 @@ class ProfileTests(UserTestCase):
         r = self.client.get(url, follow=True)
         ok_("testuser.com" not in r.content)
 
-    @override_constance_settings(WIKI_LOW_ACTIVITY_THRESHOLD=1)
-    @mock.patch_object(UserProfile, 'num_wiki_revisions')
-    def test_show_websites_for_higher_activity_users(self, mock_num_wiki_revisions):
-        mock_num_wiki_revisions.return_value = 2
+    @mock.patch_object(UserProfile, 'has_low_activity')
+    def test_show_websites_for_higher_activity_users(self,
+                                                     mock_low_activity):
+        mock_low_activity.return_value = False
         profile = UserProfile.objects.get(user__username='testuser')
-        url = reverse('users.profile', args=(profile.user.username,))
-        r = self.client.get(url, follow=True)
-        ok_("testuser.com" in r.content)
+        with mock.patch_object(profile, 'has_low_activity', False):
+            url = reverse('users.profile', args=(profile.user.username,))
+            r = self.client.get(url, follow=True)
+            ok_("testuser.com" in r.content)
 
 
 class SignupTests(UserTestCase):

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -94,6 +94,10 @@ def profile_view(request, username):
         page_number = 1
     show_hidden = (user == request.user) or user.is_superuser
 
+    show_sites = True
+    if profile.has_low_activity() and not show_hidden:
+        show_sites = False
+
     demos = (Submission.objects.all_sorted(sort_order)
                                .filter(creator=profile.user))
     if not show_hidden:
@@ -117,6 +121,8 @@ def profile_view(request, username):
 
     context = {
         'profile': profile,
+        'show_sites': show_sites,
+        'show_hidden': show_hidden,
         'demos': demos,
         'demos_paginator': demos_paginator,
         'demos_page': demos_page,

--- a/settings.py
+++ b/settings.py
@@ -1047,11 +1047,6 @@ CONSTANCE_CONFIG = dict(
         'Allowed file types for wiki file attachments',
     ),
 
-    WIKI_LOW_ACTIVITY_THRESHOLD = (
-        10,
-        'Number of edits a user must make to cross the "Low Activity" threshold',
-    ),
-
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS = (
         '^https?\:\/\/(developer-local.allizom.org|developer-dev.allizom.org|developer.allizom.org|mozillademos.org|testserver|localhost\:8000|(www.)?youtube.com\/embed\/(\.*))',
         'Regex comprised of domain names that are allowed for IFRAME SRCs'

--- a/settings.py
+++ b/settings.py
@@ -1047,6 +1047,11 @@ CONSTANCE_CONFIG = dict(
         'Allowed file types for wiki file attachments',
     ),
 
+    WIKI_LOW_ACTIVITY_THRESHOLD = (
+        10,
+        'Number of edits a user must make to cross the "Low Activity" threshold',
+    ),
+
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS = (
         '^https?\:\/\/(developer-local.allizom.org|developer-dev.allizom.org|developer.allizom.org|mozillademos.org|testserver|localhost\:8000|(www.)?youtube.com\/embed\/(\.*))',
         'Regex comprised of domain names that are allowed for IFRAME SRCs'


### PR DESCRIPTION
This approach simply hides the website fields. We can re-visit this if we decide instead to use `rel="nofollow"` in [bug 820555](https://bugzilla.mozilla.org/show_bug.cgi?id=820555)