### PR TITLE
fix bug 1133585 - use prod server for sphinx template

### DIFF
--- a/kuma/wiki/management/commands/generate_sphinx_template.py
+++ b/kuma/wiki/management/commands/generate_sphinx_template.py
@@ -27,6 +27,7 @@ class Command(NoArgsCommand):
         # Create a mock request for the sake of rendering the template
         request = RequestFactory().get('/')
         request.locale = settings.LANGUAGE_CODE
+        request.META['SERVER_NAME'] = 'developer.mozilla.org'
 
         # Load the page with sphinx template
         content = render(request, 'wiki/sphinx.html', {'is_sphinx': True,


### PR DESCRIPTION
Spot-check:
1. `./manage.py generate_sphinx_template > layout.html`
2. `git clone git@github.com:mozilla/mdn-sphinx-theme.git`
3. `cp layout.html /path/to/mdn-sphinx-theme/mdn_theme/mdn/`
4. `pip install -e /path/to/mdn-sphinx-theme`
5. `cd docs`
6. `make html`
7. `open _build/html/index.html`

* [ ] Check the docs render correctly and have the right favicon.