### PR TITLE
fix bug 1136293 - move persona host to settings.py

### DIFF
--- a/kuma/users/templates/persona/auth.html
+++ b/kuma/users/templates/persona/auth.html
@@ -1,4 +1,4 @@
-<script src="https://login.persona.org/include.js"></script>
+<script src="{{ settings.PERSONA_INCLUDE_URL }}"></script>
 <form id="_persona_login" method="post" action="{{ url('persona_login') }}" data-csrf-token-url="{{ url('persona_csrf_token') }}" data-request='{{ request_parameters|safe }}'>
   <input type="hidden" name="csrfmiddlewaretoken" value="" id="_persona_csrf_token" />
   <input type="hidden" name="next" value="" id="_persona_next_url"/>

--- a/settings.py
+++ b/settings.py
@@ -1261,6 +1261,8 @@ SOCIALACCOUNT_PROVIDERS = {
         }
     }
 }
+PERSONA_VERIFIER_URL = 'https://verifier.login.persona.org/verify'
+PERSONA_INCLUDE_URL = 'https://login.persona.org/include.js'
 
 # django-banish defaults; listing here to be explicit
 BANISH_ENABLED = False # TODO: https://bugzil.la/1126412


### PR DESCRIPTION
To spot-check using the Persona stage server, add this to your `settings_local.py` file:
```
PERSONA_VERIFIER_URL = 'https://verifier.login.anosrep.org/verify'
PERSONA_INCLUDE_URL = 'https://login.anosrep.org/include.js'
```
Then, when you sign in with Persona, make sure the `include.js` asset is coming from `login.anosrep.org`. When you sign in with Persona, you'll probably need to make a new account on the stage server. And if you use a gmail account, you'll be using the new OAuth bridge.