### PR TITLE
bug 1124419 - waffle user signup

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -1,0 +1,65 @@
+Feature Toggles
+===============
+
+MDN uses `feature toggles`_ to integrate un-finished feature changes as early
+as possible, and to control the behavior of finished features.
+
+Some site features are controlled using `django-waffle`_. You control these
+features in the django admin site's `waffle section`_.
+
+Some site features are controlled using `constance`_. You control these
+features in the django admin site's `constance section`_.
+
+Waffle Features
+---------------
+
+Switches
+~~~~~~~~
+
+`Waffle switches`_ are simple booleans - they are either on or off.
+
+* ``welcome_email`` - send welcome email to new user registrations
+* ``wiki_force_immediate_rendering`` - force wiki pages to render immediately in
+  the same http request in which they are saved (not in a background process)
+* ``wiki_error_on_delete`` - throw an error if a user tries to delete a page
+* ``render_stale_document_async`` - render stale documents in a background
+  sub-task
+
+Flags
+~~~~~
+
+`Waffle flags`_ control behavior by specific users, groups, percentages, and
+other advanced criteria.
+
+* ``events_map`` - show the map on the events page
+* ``search_explanation`` - show search results scoring details
+* ``search_doc_navigator`` - show the search doc navigator feature
+* ``search_drilldown_faceting`` - treat search filters as "drill-down" filters
+  - i.e., combine them with "AND" logic
+* ``search_suggestions`` - show the advanced search filter suggestions
+  interface
+* ``registration_disabled`` - enable/disable new user registration
+* ``social_account_research`` - enable/disable social account research on the
+  "Sign in to Edit" page
+* ``github_login`` - enable/disable sign in via github
+* ``kumaediting`` - enable/disable wiki editing
+* ``kumabanned`` - (deprecated) added to users to mark them as banned
+* ``enable_customcss`` - enable/disable Template:CustomCSS styles in wiki pages
+* ``top_contributors`` - enable/disable the "Top Contributors" feature on wiki
+  pages
+* ``page_move`` - enable/disable page move feature
+
+Constance Features
+------------------
+
+Constance configs let us set operational *values* for certain features in the
+database - so we can control them without changing code. They are all listed
+and documented in the admin site's `constance section`_.
+
+.. _feature toggles: https://en.wikipedia.org/wiki/Feature_toggle
+.. _django-waffle: http://waffle.readthedocs.org/en/latest/
+.. _waffle section: https://developer-local.allizom.org/admin/waffle/
+.. _constance: https://github.com/comoga/django-constance
+.. _constance section: https://developer-local.allizom.org/admin/constance/config/
+.. _Waffle switches: http://waffle.readthedocs.org/en/latest/types/switch.html
+.. _Waffle flags: http://waffle.readthedocs.org/en/latest/types/flag.html

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,6 +15,7 @@ Contents:
 
    development
    migrations
+   feature-toggles
    localization
    ckeditor
    tests

--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -105,14 +105,8 @@ You will want to make yourself an admin user to enable important site features.
 
 Enable Important Site Features
 ------------------------------
-
-Some site features are controlled using `django-waffle <http://waffle.readthedocs.org/en/latest/>`_.
-You control these features in the `waffle admin
-<https://developer-local.allizom.org/admin/waffle/>`_.
-
-Some site features are controlled using `constance
-<https://github.com/comoga/django-constance>`_. You control these features in
-the `constance config admin panel`_.
+You'll need to use :doc:`feature toggles <feature-toggles>` to enable some
+basic features.
 
 .. _GitHub Auth:
 

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -10,6 +10,7 @@ from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
 from tower import ugettext_lazy as _
+from waffle import flag_is_active
 
 from kuma.core.urlresolvers import reverse
 
@@ -103,7 +104,8 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         because the default adapter uses the account adpater above
         as the default.
         """
-        return True
+        # Check if profile creation is disabled via waffle
+        return not flag_is_active(request, 'registration_disabled')
 
     def validate_disconnect(self, account, accounts):
         """

--- a/kuma/users/templates/account/signup_closed.html
+++ b/kuma/users/templates/account/signup_closed.html
@@ -1,12 +1,12 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Sign Up Closed")) }}{% endblock %}
+{% block title %}{{ page_title(_("Profile Creation Disabled")) }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">
-  <h1>{{ _("Sign Up Closed") }}</h1>
+  <h1>{{ _("Profile Creation Disabled") }}</h1>
 
-  <p>{{ _("We are sorry, but the sign up is currently closed.") }}</p>
+  <p>{{ _("We are sorry, but profile creation is currently disabled.") }}</p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
Supersedes https://github.com/mozilla/kuma/pull/3055 with new docs for all feature toggles, including the new `registration_disabled` flag.