### PR TITLE
Bug 1137020: Track homepage search with Optimizely

### DIFF
--- a/media/redesign/js/home.js
+++ b/media/redesign/js/home.js
@@ -10,4 +10,12 @@
         $list.css('height', 'auto');
     }
 
+    // Track search submissions with Optimizely
+    var $centerSearchBox = $('#home-search-form');
+    if ($centerSearchBox) {
+        $centerSearchBox.submit(function() {
+            mdn.optimizely.push(['trackEvent', 'submit-homepage-search-form']);
+        });
+    }
+
 })(jQuery);


### PR DESCRIPTION
The easiest way to test this is to insert an `alert()` between lines 16 and 17. I can never seem to figure out how to test `trackEvent` locally, but I'm also not worried about it since it's just like other `trackEvent` calls.