### PR TITLE
Bug 1086519 - Leave new title and slug for cloned pages blank

### DIFF
--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -891,7 +891,6 @@ def new_document(request):
                 initial_title = clone_doc.title
                 initial_html = clone_doc.html
                 initial_tags = clone_doc.tags.all()
-                initial_slug = _split_slug(clone_doc.slug)['specific'] + '_clone'
                 if clone_doc.current_revision:
                     initial_toc = clone_doc.current_revision.toc_depth
                 else:


### PR DESCRIPTION
The initial title and slug for a new cloned page should not default to "original_title" and "original_title_clone," respectively, but instead remain blank (requiring manual user entry) to avoid the accidental creation of confusing, seemingly duplicate entries.  

Creating pull request for testing purposes per suggestion of @groovecoder. 

See https://bugzilla.mozilla.org/show_bug.cgi?id=1086519. 