### PR TITLE
Fix bug 1139947: Fix homepage Owl Carousel error

### DIFF
--- a/kuma/landing/templates/landing/homepage.html
+++ b/kuma/landing/templates/landing/homepage.html
@@ -181,7 +181,11 @@
 
 {% block js %}
   {{ super() }}
-  {{ js('home', async=True) }}
+  {% if settings.TEMPLATE_DEBUG %}
+      {{ js('home') }}
+  {% else %}
+      {{ js('home', async=True) }}
+  {% endif %}
   {% if waffle.flag('search_suggestions') %}
     {{ js('search-suggestions') }}
     <script>


### PR DESCRIPTION
This bug only manifests locally. The "home" bundle is attached to the
homepage asynchronously. The scripts in the bundle still need to be
loaded in order, however.

On production, the scripts *are* loaded in order because the are
concatenated before the whole thing is attached asynchronously.

Locally, each script within the bundle is individually attached
asynchronously, so they're sometimes loaded out of order, causing the
error.