### PR TITLE
Fix Bug 1137652:  Add padding for current page in quick links

### DIFF
--- a/media/redesign/stylus/components/wiki/quick-links.styl
+++ b/media/redesign/stylus/components/wiki/quick-links.styl
@@ -36,7 +36,10 @@
     }
 }
 
-.quick-links li.toggleable a, .quick-links .title, #quick-links-toggle {
+.quick-links li.toggleable a,
+.quick-links li.toggleable em,
+.quick-links .title,
+#quick-links-toggle {
     bidi-style(padding-left, 20px, padding-right, 0);
     color: $text-color;
     display: inline-block;


### PR DESCRIPTION
I had a heck of a time testing this one, the macro that generates the quick-links has changed since the last database dump and I was getting timeouts once I updated the macro templates.

1) get everything up and running with the new style sheet compiled and being served (so, a hard refresh).
2) find/create a page with a left sidebar (maybe https://developer-local.allizom.org/en-US/docs/Web/API/AnimationEvent but don't do your hard refresh on this page or you lose the sidebar)
3) copy the HTML for #quick-links as generated on prod on https://developer.mozilla.org/en-US/docs/Web/API/AnimationEvent/pseudoElement
4) using dev tools paste the #quick-links HTML in.