### PR TITLE
bug 1113260 - use django-ratelimit for ip bans

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -148,6 +148,3 @@
 [submodule "vendor/src/django-ratelimit"]
 	path = vendor/src/django-ratelimit
 	url = git://github.com/jsocol/django-ratelimit.git
-[submodule "vendor/src/django-cacheback"]
-    path = vendor/src/django-cachebackk
-    url = https://github.com/codeinthehole/django-cacheback.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -148,3 +148,6 @@
 [submodule "vendor/src/django-ratelimit"]
 	path = vendor/src/django-ratelimit
 	url = git://github.com/jsocol/django-ratelimit.git
+[submodule "vendor/src/django-cacheback"]
+    path = vendor/src/django-cachebackk
+    url = https://github.com/codeinthehole/django-cacheback.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -136,9 +136,6 @@
 [submodule "vendor/src/django-celery"]
 	path = vendor/src/django-celery
 	url = git://github.com/celery/django-celery.git
-[submodule "vendor/src/django-banish"]
-	path = vendor/src/django-banish
-	url = git://github.com/yourabi/django-banish.git
 [submodule "vendor/src/django-honeypot"]
 	path = vendor/src/django-honeypot
 	url = git://github.com/sunlightlabs/django-honeypot.git
@@ -148,3 +145,6 @@
 [submodule "vendor/src/django-cacheback"]
 	path = vendor/src/django-cacheback
 	url = https://github.com/codeinthehole/django-cacheback.git
+[submodule "vendor/src/django-ratelimit"]
+	path = vendor/src/django-ratelimit
+	url = git://github.com/jsocol/django-ratelimit.git

--- a/kuma/actioncounters/utils.py
+++ b/kuma/actioncounters/utils.py
@@ -1,40 +1,6 @@
-import re
 import hashlib
 
-# this is not intended to be an all-knowing IP address regex
-IP_RE = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
-
-
-def get_ip(request):
-    """
-    Retrieves the remote IP address from the request data.  If the user is
-    behind a proxy, they may have a comma-separated list of IP addresses, so
-    we need to account for that.  In such a case, only the first IP in the
-    list will be retrieved.  Also, some hosts that use a proxy will put the
-    REMOTE_ADDR into HTTP_X_FORWARDED_FOR.  This will handle pulling back the
-    IP from the proper place.
-
-    **NOTE** This function was taken from django-tracking (MIT LICENSE)
-             http://code.google.com/p/django-tracking/
-    """
-
-    # if neither header contain a value, just use local loopback
-    ip_address = request.META.get('HTTP_X_FORWARDED_FOR',
-                                  request.META.get('REMOTE_ADDR', '127.0.0.1'))
-    if ip_address:
-        # make sure we have one and only one IP
-        try:
-            ip_address = IP_RE.match(ip_address)
-            if ip_address:
-                ip_address = ip_address.group(0)
-            else:
-                # no IP, probably from some dirty proxy or other device
-                # throw in some bogus IP
-                ip_address = '10.0.0.1'
-        except IndexError:
-            pass
-
-    return ip_address
+from kuma.core.utils import get_ip
 
 
 def get_unique(content_type, object_pk, name,

--- a/kuma/contentflagging/utils.py
+++ b/kuma/contentflagging/utils.py
@@ -1,40 +1,6 @@
-import re
 import hashlib
 
-# this is not intended to be an all-knowing IP address regex
-IP_RE = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
-
-
-def get_ip(request):
-    """
-    Retrieves the remote IP address from the request data.  If the user is
-    behind a proxy, they may have a comma-separated list of IP addresses, so
-    we need to account for that.  In such a case, only the first IP in the
-    list will be retrieved.  Also, some hosts that use a proxy will put the
-    REMOTE_ADDR into HTTP_X_FORWARDED_FOR.  This will handle pulling back the
-    IP from the proper place.
-
-    **NOTE** This function was taken from django-tracking (MIT LICENSE)
-             http://code.google.com/p/django-tracking/
-    """
-
-    # if neither header contain a value, just use local loopback
-    ip_address = request.META.get('HTTP_X_FORWARDED_FOR',
-                                  request.META.get('REMOTE_ADDR', '127.0.0.1'))
-    if ip_address:
-        # make sure we have one and only one IP
-        try:
-            ip_address = IP_RE.match(ip_address)
-            if ip_address:
-                ip_address = ip_address.group(0)
-            else:
-                # no IP, probably from some dirty proxy or other device
-                # throw in some bogus IP
-                ip_address = '10.0.0.1'
-        except IndexError:
-            pass
-
-    return ip_address
+from kuma.core.utils import get_ip
 
 
 def get_unique(content_type, object_pk, request=None, ip=None, user_agent=None, user=None):

--- a/kuma/core/admin.py
+++ b/kuma/core/admin.py
@@ -3,4 +3,8 @@ from django.contrib import admin
 from kuma.core.models import IPBan
 
 
-admin.site.register(IPBan, admin.ModelAdmin)
+class IPBanAdmin(admin.ModelAdmin):
+    list_display = ('ip', 'created', 'deleted')
+
+
+admin.site.register(IPBan, IPBanAdmin)

--- a/kuma/core/admin.py
+++ b/kuma/core/admin.py
@@ -1,0 +1,6 @@
+from django.contrib import admin
+
+from kuma.core.models import IPBan
+
+
+admin.site.register(IPBan, admin.ModelAdmin)

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -31,4 +31,4 @@ class IPBanJob(KumaJob):
         return "60/m"
 
     def empty(self):
-        return []
+        return "60/m"

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -20,7 +20,7 @@ class KumaJob(Job):
         return hashlib.md5(six.b(':').join(value)).hexdigest()
 
 
-class IPBanJob(Job):
+class IPBanJob(KumaJob):
     lifetime = 60 * 60 * 3
     refresh_timeout = 60
 
@@ -29,11 +29,6 @@ class IPBanJob(Job):
         if IPBan.objects.active(ip=ip).exists():
             return "0/s"
         return "60/m"
-
-    def key(self, ip):
-        # override the default way to make sure we handle unicode,
-        # bytestring and integer versions of the pk the same
-        return 'kuma:core:ipban:%s' % ip
 
     def empty(self):
         return []

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -18,3 +18,22 @@ class KumaJob(Job):
         if isinstance(value, tuple):
             value = tuple(to_bytestring(v) for v in value)
         return hashlib.md5(six.b(':').join(value)).hexdigest()
+
+
+class IPBanJob(Job):
+    lifetime = 60 * 60 * 3
+    refresh_timeout = 60
+
+    def fetch(self, ip):
+        from .models import IPBan
+        if IPBan.objects.active(ip=ip).exists():
+            return "0/s"
+        return "60/m"
+
+    def key(self, ip):
+        # override the default way to make sure we handle unicode,
+        # bytestring and integer versions of the pk the same
+        return 'kuma:core:ipban:%s' % ip
+
+    def empty(self):
+        return []

--- a/kuma/core/management/commands/delete_old_ip_bans.py
+++ b/kuma/core/management/commands/delete_old_ip_bans.py
@@ -1,0 +1,19 @@
+"""
+Delete old revision IPs
+"""
+from optparse import make_option
+
+from django.core.management.base import BaseCommand
+from .tasks import delete_old_ip_bans
+
+
+class Command(BaseCommand):
+    help = "Delete old IP Bans"
+    option_list = BaseCommand.option_list + (
+        make_option('--days', dest="days", default=30, type=int,
+                    help="How many days 'old' (Default 30)"),
+    )
+
+    def handle(self, *args, **options):
+        self.options = options
+        delete_old_ip_bans(days=options['days'])

--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -7,9 +7,11 @@ TODO:
 - Permissions for tag namespaces (eg. system:* is superuser-only)
 - Machine tag assists
 """
+from datetime import date, timedelta
 import operator
-from django.db import router
 
+from django.db import router
+from django.db import models
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.contrib.auth.models import AnonymousUser
 
@@ -239,6 +241,16 @@ def resolve_allowed_tags(model_obj, tags_curr, tags_new,
             tags_out.extend(ns_tags_curr[ns])
 
     return tags_out
+
+
+class IPBanManager(models.Manager):
+    def active(self, ip):
+        return super(IPBanManager, self).filter(ip=ip, deleted__isnull=True)
+
+    def delete_old(self, days=30):
+        cutoff_date = date.today() - timedelta(days=days)
+        old_ip_bans = self.get_query_set().filter(created__lte=cutoff_date)
+        old_ip_bans.delete()
 
 
 # Tell South to ignore our fields, if present.

--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -245,11 +245,11 @@ def resolve_allowed_tags(model_obj, tags_curr, tags_new,
 
 class IPBanManager(models.Manager):
     def active(self, ip):
-        return super(IPBanManager, self).filter(ip=ip, deleted__isnull=True)
+        return self.filter(ip=ip, deleted__isnull=True)
 
     def delete_old(self, days=30):
         cutoff_date = date.today() - timedelta(days=days)
-        old_ip_bans = self.get_query_set().filter(created__lte=cutoff_date)
+        old_ip_bans = self.filter(created__lte=cutoff_date)
         old_ip_bans.delete()
 
 

--- a/kuma/core/migrations/0002_auto__add_ipban.py
+++ b/kuma/core/migrations/0002_auto__add_ipban.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+import datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding model 'IPBan'
+        db.create_table('core_ipban', (
+            ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
+            ('ip', self.gf('django.db.models.fields.GenericIPAddressField')(max_length=39)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, db_index=True)),
+            ('deleted', self.gf('django.db.models.fields.DateTimeField')(null=True, blank=True)),
+        ))
+        db.send_create_signal('core', ['IPBan'])
+
+
+    def backwards(self, orm):
+        # Deleting model 'IPBan'
+        db.delete_table('core_ipban')
+
+
+    models = {
+        'core.ipban': {
+            'Meta': {'object_name': 'IPBan'},
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'deleted': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ip': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39'})
+        }
+    }
+
+    complete_apps = ['core']

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -48,7 +48,7 @@ class IPBan(models.Model):
     def delete(self, *args, **kwargs):
         self.deleted = timezone.now()
         self.save()
-        IPBanJob.delete(self.ip)
+        IPBanJob().invalidate(self.ip)
 
     def __unicode__(self):
         return u'%s banned on %s' % (self.ip, self.created)

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -1,11 +1,10 @@
-from datetime import datetime
-
 from django.db import models
 from django.utils import timezone
 
 from south.modelsinspector import add_introspection_rules
 
 from .managers import IPBanManager
+from .jobs import IPBanJob
 
 
 class ModelBase(models.Model):
@@ -49,6 +48,7 @@ class IPBan(models.Model):
     def delete(self, *args, **kwargs):
         self.deleted = timezone.now()
         self.save()
+        IPBanJob.delete(self.ip)
 
     def __unicode__(self):
         return u'%s banned on %s' % (self.ip, self.created)

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -1,6 +1,9 @@
+from datetime import datetime
 from django.db import models
 
 from south.modelsinspector import add_introspection_rules
+
+from .managers import IPBanManager
 
 
 class ModelBase(models.Model):
@@ -32,6 +35,21 @@ class ModelBase(models.Model):
         if signal:
             models.signals.post_save.send(sender=cls, instance=self,
                                           created=False)
+
+
+class IPBan(models.Model):
+    ip = models.GenericIPAddressField()
+    created = models.DateTimeField(default=datetime.now, db_index=True)
+    deleted = models.DateTimeField(null=True, blank=True)
+
+    objects = IPBanManager()
+
+    def delete(self, *args, **kwargs):
+        self.deleted = datetime.now()
+        self.save()
+
+    def __unicode__(self):
+        return u'%s banned on %s' % (self.ip, self.created)
 
 
 add_introspection_rules([], [

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -1,5 +1,7 @@
 from datetime import datetime
+
 from django.db import models
+from django.utils import timezone
 
 from south.modelsinspector import add_introspection_rules
 
@@ -39,13 +41,13 @@ class ModelBase(models.Model):
 
 class IPBan(models.Model):
     ip = models.GenericIPAddressField()
-    created = models.DateTimeField(default=datetime.now, db_index=True)
+    created = models.DateTimeField(default=timezone.now, db_index=True)
     deleted = models.DateTimeField(null=True, blank=True)
 
     objects = IPBanManager()
 
     def delete(self, *args, **kwargs):
-        self.deleted = datetime.now()
+        self.deleted = timezone.now()
         self.save()
 
     def __unicode__(self):

--- a/kuma/core/tasks.py
+++ b/kuma/core/tasks.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 import constance.config
 
 from kuma.core.cache import memcache
+from .models import IPBan
 
 
 LOCK_ID = 'clean-sessions-lock'
@@ -51,3 +52,8 @@ def clean_sessions():
     else:
         logger.error('The clean_sessions task is already running since %s' %
                      memcache.get(LOCK_ID))
+
+
+@task
+def delete_old_ip_bans(immediate=False, days=30):
+    IPBan.objects.delete_old(days=days)

--- a/kuma/core/tasks.py
+++ b/kuma/core/tasks.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 
 import constance.config
 
-from kuma.core.cache import memcache
+from .cache import memcache
 from .models import IPBan
 
 
@@ -55,5 +55,5 @@ def clean_sessions():
 
 
 @task
-def delete_old_ip_bans(immediate=False, days=30):
+def delete_old_ip_bans(days=30):
     IPBan.objects.delete_old(days=days)

--- a/kuma/core/tests/test_models.py
+++ b/kuma/core/tests/test_models.py
@@ -4,23 +4,23 @@ from nose.tools import eq_
 
 from django.test import TestCase
 
-from kuma.core.models import IPBan
+from ..models import IPBan
 
 
 class RevisionIPTests(TestCase):
     def test_delete_older_than_default_30_days(self):
         old_date = date.today() - timedelta(days=31)
-        IPBan.objects.create(ip='127.0.0.1', created=old_date).save()
-        eq_(1, IPBan.objects.all().count())
+        IPBan(ip='127.0.0.1', created=old_date).save()
+        eq_(1, IPBan.objects.count())
         IPBan.objects.delete_old()
-        eq_(0, IPBan.objects.all().count())
+        eq_(0, IPBan.objects.count())
 
     def test_delete_older_than_days_argument(self):
         ban_date = date.today() - timedelta(days=5)
         IPBan(ip='127.0.0.1', created=ban_date).save()
-        eq_(1, IPBan.objects.all().count())
+        eq_(1, IPBan.objects.count())
         IPBan.objects.delete_old(days=4)
-        eq_(0, IPBan.objects.all().count())
+        eq_(0, IPBan.objects.count())
 
     def test_delete_older_than_only_deletes_older_than(self):
         oldest_date = date.today() - timedelta(days=31)
@@ -31,6 +31,6 @@ class RevisionIPTests(TestCase):
 
         now_date = date.today()
         IPBan(ip='127.0.0.3', created=now_date).save()
-        eq_(3, IPBan.objects.all().count())
+        eq_(3, IPBan.objects.count())
         IPBan.objects.delete_old()
-        eq_(2, IPBan.objects.all().count())
+        eq_(2, IPBan.objects.count())

--- a/kuma/core/tests/test_models.py
+++ b/kuma/core/tests/test_models.py
@@ -1,0 +1,36 @@
+from datetime import date, timedelta
+
+from nose.tools import eq_
+
+from django.test import TestCase
+
+from kuma.core.models import IPBan
+
+
+class RevisionIPTests(TestCase):
+    def test_delete_older_than_default_30_days(self):
+        old_date = date.today() - timedelta(days=31)
+        IPBan.objects.create(ip='127.0.0.1', created=old_date).save()
+        eq_(1, IPBan.objects.all().count())
+        IPBan.objects.delete_old()
+        eq_(0, IPBan.objects.all().count())
+
+    def test_delete_older_than_days_argument(self):
+        ban_date = date.today() - timedelta(days=5)
+        IPBan(ip='127.0.0.1', created=ban_date).save()
+        eq_(1, IPBan.objects.all().count())
+        IPBan.objects.delete_old(days=4)
+        eq_(0, IPBan.objects.all().count())
+
+    def test_delete_older_than_only_deletes_older_than(self):
+        oldest_date = date.today() - timedelta(days=31)
+        IPBan(ip='127.0.0.1', created=oldest_date).save()
+
+        old_date = date.today() - timedelta(days=29)
+        IPBan(ip='127.0.0.2', created=old_date).save()
+
+        now_date = date.today()
+        IPBan(ip='127.0.0.3', created=now_date).save()
+        eq_(3, IPBan.objects.all().count())
+        IPBan.objects.delete_old()
+        eq_(2, IPBan.objects.all().count())

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -2,6 +2,7 @@ import functools
 import logging
 import os
 import random
+import re
 import tempfile
 import time
 from itertools import islice
@@ -19,12 +20,47 @@ from django.utils.http import urlencode
 
 from taggit.utils import split_strip
 
-from kuma.actioncounters.utils import get_ip
 from .cache import memcache
 from .jobs import IPBanJob
 
 
+# this is not intended to be an all-knowing IP address regex
+IP_RE = re.compile('\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}')
+
+
 log = commonware.log.getLogger('kuma.core.utils')
+
+
+def get_ip(request):
+    """
+    Retrieves the remote IP address from the request data.  If the user is
+    behind a proxy, they may have a comma-separated list of IP addresses, so
+    we need to account for that.  In such a case, only the first IP in the
+    list will be retrieved.  Also, some hosts that use a proxy will put the
+    REMOTE_ADDR into HTTP_X_FORWARDED_FOR.  This will handle pulling back the
+    IP from the proper place.
+
+    **NOTE** This function was taken from django-tracking (MIT LICENSE)
+             http://code.google.com/p/django-tracking/
+    """
+
+    # if neither header contain a value, just use local loopback
+    ip_address = request.META.get('HTTP_X_FORWARDED_FOR',
+                                  request.META.get('REMOTE_ADDR', '127.0.0.1'))
+    if ip_address:
+        # make sure we have one and only one IP
+        try:
+            ip_address = IP_RE.match(ip_address)
+            if ip_address:
+                ip_address = ip_address.group(0)
+            else:
+                # no IP, probably from some dirty proxy or other device
+                # throw in some bogus IP
+                ip_address = '10.0.0.1'
+        except IndexError:
+            pass
+
+    return ip_address
 
 
 def paginate(request, queryset, per_page=20):

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -19,7 +19,9 @@ from django.utils.http import urlencode
 
 from taggit.utils import split_strip
 
+from kuma.actioncounters.utils import get_ip
 from .cache import memcache
+from .models import IPBan
 
 
 log = commonware.log.getLogger('kuma.core.utils')
@@ -284,3 +286,9 @@ def chord_flow(pre_task, tasks, post_task):
         return chain(*tasks)
     else:
         return chain(pre_task, chord(header=tasks, body=post_task))
+
+
+def limit_banned_ip_to_0(group, request):
+    if IPBan.objects.active(ip=get_ip(request)).count() > 0:
+        return "0/s"
+    return "60/m"

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -21,7 +21,7 @@ from taggit.utils import split_strip
 
 from kuma.actioncounters.utils import get_ip
 from .cache import memcache
-from .models import IPBan
+from .jobs import IPBanJob
 
 
 log = commonware.log.getLogger('kuma.core.utils')
@@ -289,6 +289,5 @@ def chord_flow(pre_task, tasks, post_task):
 
 
 def limit_banned_ip_to_0(group, request):
-    if IPBan.objects.active(ip=get_ip(request)).exists():
-        return "0/s"
-    return "60/m"
+    ip = get_ip(request)
+    return IPBanJob().get(ip)

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -289,6 +289,6 @@ def chord_flow(pre_task, tasks, post_task):
 
 
 def limit_banned_ip_to_0(group, request):
-    if IPBan.objects.active(ip=get_ip(request)).count() > 0:
+    if IPBan.objects.active(ip=get_ip(request)).exists():
         return "0/s"
     return "60/m"

--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -46,8 +46,8 @@
                     {% set revision_ip = revision.revisionip_set.all()[0].ip %}
                     <span class="revision_ip">
                     <br/>IP: {{ revision_ip }}
-                    {% set ban_ip_url = '%s?%s' % (url('admin:banish_banishment_add'), 'condition=%s' % revision_ip) %}
-                    <br/><a class="dashboard-ban-ip-link" href="{{ ban_ip_url }}" target="_blank">{{ _('Ban IP') }}</a>
+                    {% set ban_ip_url = '%s?%s' % (url('admin:core_ipban_add'), 'ip=%s' % revision_ip) %}
+                    <br/><a class="dashboard-ban-ip-link" href="{{ ban_ip_url }}" target="_blank">{{ _('Ban IP from Editing') }}</a>
                     </span>
                     {% endif %}
                     {% if request.user.is_superuser and revision.creator.get_profile().is_banned %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -230,6 +230,5 @@ class TaggedDocumentManager(models.Manager):
 class RevisionIPManager(models.Manager):
     def delete_old(self, days=30):
         cutoff_date = date.today() - timedelta(days=days)
-        old_rev_ips = self.get_query_set().filter(
-            revision__created__lte=cutoff_date)
+        old_rev_ips = self.filter(revision__created__lte=cutoff_date)
         old_rev_ips.delete()

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -257,7 +257,7 @@ def update_community_stats():
 
 
 @task
-def delete_old_revision_ips(immediate=False, days=30):
+def delete_old_revision_ips(days=30):
     RevisionIP.objects.delete_old(days=days)
 
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -566,17 +566,20 @@ class BannedIPTests(UserTestCase, WikiTestCase):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
         eq_(403, response.status_code)
+        cache.clear()
 
     def test_banned_ip_cant_post_edit(self):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
         eq_(403, response.status_code)
+        cache.clear()
 
     def test_banned_ip_can_still_get_articles(self):
         response = self.client.get(self.doc.get_absolute_url(),
                                    REMOTE_ADDR=self.ip
                                   )
         eq_(200, response.status_code)
+        cache.clear()
 
 class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
     """

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2354,6 +2354,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         rev_ip = RevisionIP.objects.get(revision=rev)
         eq_('127.0.0.1', rev_ip.ip)
 
+    def test_banned_ip(self):
+        pass
+
     @mock.patch.object(Site.objects, 'get_current')
     def test_email_for_first_edits(self, get_current):
         get_current.return_value.domain = 'dev.mo.org'

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -559,27 +559,26 @@ class BannedIPTests(UserTestCase, WikiTestCase):
         self.ip_ban = IPBan.objects.create(ip=self.ip)
         self.doc, rev = doc_rev()
         self.edit_url = reverse('wiki.edit_document',
-                                args=[self.doc.full_path]
-                               )
+                                args=[self.doc.full_path])
+
+    def tearDown(self):
+        cache.clear()
 
     def test_banned_ip_cant_get_edit(self):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
         eq_(403, response.status_code)
-        cache.clear()
 
     def test_banned_ip_cant_post_edit(self):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
         eq_(403, response.status_code)
-        cache.clear()
 
     def test_banned_ip_can_still_get_articles(self):
         response = self.client.get(self.doc.get_absolute_url(),
-                                   REMOTE_ADDR=self.ip
-                                  )
+                                   REMOTE_ADDR=self.ip)
         eq_(200, response.status_code)
-        cache.clear()
+
 
 class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
     """

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -557,24 +557,26 @@ class BannedIPTests(UserTestCase, WikiTestCase):
         super(BannedIPTests, self).setUp()
         self.ip = '127.0.0.1'
         self.ip_ban = IPBan.objects.create(ip=self.ip)
-        self.d, r = doc_rev()
-        self.edit_url = reverse('wiki.edit_document', args=[self.d.full_path])
+        self.doc, rev = doc_rev()
+        self.edit_url = reverse('wiki.edit_document',
+                                args=[self.doc.full_path]
+                               )
 
     def test_banned_ip_cant_get_edit(self):
         self.client.login(username='testuser', password='testpass')
-        resp = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
-        eq_(403, resp.status_code)
+        response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
+        eq_(403, response.status_code)
 
     def test_banned_ip_cant_post_edit(self):
         self.client.login(username='testuser', password='testpass')
-        resp = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
-        eq_(403, resp.status_code)
+        response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
+        eq_(403, response.status_code)
 
     def test_banned_ip_can_still_get_articles(self):
-        resp = self.client.get(reverse('wiki.document',
-                                       args=[self.d.full_path]),
-                               REMOTE_ADDR=self.ip)
-        eq_(200, resp.status_code)
+        response = self.client.get(self.doc.get_absolute_url(),
+                                   REMOTE_ADDR=self.ip
+                                  )
+        eq_(200, response.status_code)
 
 class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
     """
@@ -2382,9 +2384,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         rev = doc.revisions.order_by('-id').all()[0]
         rev_ip = RevisionIP.objects.get(revision=rev)
         eq_('127.0.0.1', rev_ip.ip)
-
-    def test_banned_ip(self):
-        pass
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_email_for_first_edits(self, get_current):

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -40,7 +40,6 @@ from smuggler.forms import ImportFileForm
 from teamwork.shortcuts import get_object_or_404_or_403
 import waffle
 
-from kuma.actioncounters.utils import get_ip
 from kuma.authkeys.decorators import accepts_auth_key
 from kuma.contentflagging.models import ContentFlag, FLAG_NOTIFICATIONS
 
@@ -53,7 +52,7 @@ from kuma.core.decorators import (never_cache, login_required,
 from kuma.core.helpers import urlparams
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import (get_object_or_none, paginate, smart_int,
-                             limit_banned_ip_to_0)
+                             get_ip, limit_banned_ip_to_0)
 from kuma.search.store import referrer_url
 from kuma.users.models import UserProfile
 

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -34,6 +34,7 @@ from django.views.decorators.clickjacking import (xframe_options_exempt,
 from django.views.decorators.csrf import csrf_exempt
 
 import constance.config
+from ratelimit.decorators import ratelimit
 from smuggler.utils import superuser_required
 from smuggler.forms import ImportFileForm
 from teamwork.shortcuts import get_object_or_404_or_403
@@ -51,7 +52,8 @@ from kuma.core.decorators import (never_cache, login_required,
                                   permission_required)
 from kuma.core.helpers import urlparams
 from kuma.core.urlresolvers import reverse
-from kuma.core.utils import get_object_or_none, paginate, smart_int
+from kuma.core.utils import (get_object_or_none, paginate, smart_int,
+                             limit_banned_ip_to_0)
 from kuma.search.store import referrer_url
 from kuma.users.models import UserProfile
 
@@ -987,6 +989,7 @@ def new_document(request):
 
 @require_http_methods(['GET', 'POST'])
 @login_required  # TODO: Stop repeating this knowledge here and in Document.allows_editing_by.
+@ratelimit(key='user', rate=limit_banned_ip_to_0, block=True)
 @process_document_path
 @check_readonly
 @prevent_indexing

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -54,8 +54,6 @@ django-cacheback==0.9
 -e git://github.com/countergram/pytidylib.git@15f8f734e761485d79556c03266353534c987601#egg=pytidylib
 # 2013-11-01 (Current.)
 -e git://github.com/mozilla/django-badger.git@1a41701179df11df8ca8ca44898b70b6352623d3#egg=django-badger
-# 2014-12-29
--e git://github.com/yourabi/django-banish.git@f0a36d1ffe6ad32a5969ec742152dfb541f4108c#egg=django-banish
 # 2015-01-13
 -e git+https://github.com/elasticsearch/elasticsearch-dsl-py.git@97774f045c23d74253fe2f8794cb2111f7064285#egg=elasticsearch-dsl-py
 
@@ -85,6 +83,7 @@ django-recaptcha==0.0.9
 
 django-honeypot==0.4.0
 bitly_api==0.3
+django-ratelimit==0.5.0
 
 ## Formerly vendor/src - arbitrary commits not matched to versions
 # 2011-12-29

--- a/settings.py
+++ b/settings.py
@@ -426,7 +426,6 @@ MIDDLEWARE_CLASSES = (
     'kuma.core.anonymous.AnonymousIdentityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'kuma.users.middleware.BanMiddleware',
-    'banish.middleware.BanishMiddleware',
 
     'badger.middleware.RecentBadgeAwardsMiddleware',
     'kuma.wiki.badges.BadgeAwardingMiddleware',
@@ -520,7 +519,6 @@ INSTALLED_APPS = (
     'djcelery',
     'taggit',
     'dbgettext',
-    'banish',
     'honeypot',
 
     'kuma.dashboards',
@@ -1284,13 +1282,6 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 PERSONA_VERIFIER_URL = 'https://verifier.login.persona.org/verify'
 PERSONA_INCLUDE_URL = 'https://login.persona.org/include.js'
-
-# django-banish defaults; listing here to be explicit
-BANISH_ENABLED = False # TODO: https://bugzil.la/1126412
-BANISH_EMPTY_UA = True
-BANISH_ABUSE_THRESHOLD = sys.maxint # TODO: https://bugzil.la/1122658
-BANISH_USE_HTTP_X_FORWARDED_FOR = True
-BANISH_MESSAGE = _("This connection has been banned for suspicious activity.")
 
 HONEYPOT_FIELD_NAME = 'website'
 

--- a/settings.py
+++ b/settings.py
@@ -520,6 +520,7 @@ INSTALLED_APPS = (
     'taggit',
     'dbgettext',
     'honeypot',
+    'cacheback',
 
     'kuma.dashboards',
     'statici18n',
@@ -1215,7 +1216,6 @@ LOGGING = {
             'handlers': ['console'],
             'level': logging.ERROR,
         }
-
     },
 }
 

--- a/vendor/kuma.pth
+++ b/vendor/kuma.pth
@@ -98,3 +98,4 @@ src/django-honeypot
 src/bitly-api-python
 src/django-cacheback
 src/django-ratelimit
+src/django-cacheback

--- a/vendor/kuma.pth
+++ b/vendor/kuma.pth
@@ -94,7 +94,7 @@ src/celery
 src/kombu
 src/py-amqp
 src/django-celery
-src/django-banish
 src/django-honeypot
 src/bitly-api-python
 src/django-cacheback
+src/django-ratelimit


### PR DESCRIPTION
**DNM** Sanity-check PR. Here's the approach so far:

* Adding a new `IPBan` model to `kuma.core` (like `UserBan` in `kuma.users`)
* Decorate views with `ratelimit` of a new `limit_banned_ip_to_0` util function

Pro: Simpler code that uses `django-ratelimit` (a well-supported popular library) as its designed

Con: Have to decorate each view (or add mixin to CBV's)

Overall I'm liking this approach more than `django-banish` or any others we've tried so far.