### PR TITLE
fix bug 1140436: add period url param & select box to revisions dashboard

### DIFF
--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -6,7 +6,12 @@ from kuma.core.form_fields import StrippedCharField
 
 
 LANG_CHOICES = [('', _('All Locales'))] + settings.LANGUAGES
-
+PERIOD_CHOICES = [('', _('None')),
+                  ('hour', _('Hour')),
+                  ('day', _('Day')),
+                  ('week',_('Week')),
+                  ('month',_('30 days')
+               )]
 
 class RevisionDashboardForm(forms.Form):
 
@@ -31,3 +36,8 @@ class RevisionDashboardForm(forms.Form):
     end_date = forms.DateField(required=False, label=_(u'End Date:'),
                     input_formats=['%m/%d/%Y'],
                     widget=forms.TextInput(attrs={'pattern': '\d{1,2}/\d{1,2}/\d{4}'}))
+
+    preceding_period = forms.ChoiceField(choices=PERIOD_CHOICES,
+                    required=False,
+                    label=_(u'Preceding Period:'))
+                    

--- a/kuma/dashboards/templates/dashboards/revisions.html
+++ b/kuma/dashboards/templates/dashboards/revisions.html
@@ -36,6 +36,11 @@
                 {{ form.end_date }}
             </div>
 
+            <div class="revision-field">
+                <label for="id_preceding_period">{{ _('Preceding Period:') }}</label>
+                {{ form.preceding_period }}
+            </div>
+
             <button type="submit">{{ _('Filter') }}</button>
             <input type="hidden" name="page" id="revision-page" value="{{ page }}" />
         </form>


### PR DESCRIPTION
I think that this needs some i18n polish (because I don't know how that system works in Kuma), but it filters by hour/day/week/month per @a2sheppy's feature request.