### PR TITLE
Fix Bug 931377: Add a class to hide when viewing article but show in editor

### DIFF
--- a/media/redesign/stylus/base/utilities.styl
+++ b/media/redesign/stylus/base/utilities.styl
@@ -24,6 +24,26 @@
 /* simple hiding of elements */
 .hidden {
     display: none;
+
+    body[contenteditable] & {
+        position: relative;
+        display: block;
+        border: 2px dotted #000;
+        padding: 3px;
+
+        &:before {
+            set-font-size(10px);
+            content: 'hidden';
+            position: absolute;
+            top: -17px;
+            left: -2px;
+            z-index: 10;
+            display: block;
+            padding: 0 2px;
+            background: #000;
+            color: #fff;
+        }
+    }
 }
 
 .title {


### PR DESCRIPTION
Altered current .hidden class to display in editor and have a dotted black border around it and floating label.

This page already has some instances of .hidden on it and it helpful for testing: https://developer-local.allizom.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations

I had trouble getting the editor to pull the newly generated stylesheets. Sometimes running `./manage.py compress_assets` helped.