### PR TITLE
fixes bug 1142203: refactor datetime.now into django.utils timezone.now

### DIFF
--- a/kuma/actioncounters/migrations/0003_update_unique_hashes.py
+++ b/kuma/actioncounters/migrations/0003_update_unique_hashes.py
@@ -1,6 +1,7 @@
 # encoding: utf-8
 import datetime
 from django.db import IntegrityError
+from django.utils import timezone
 from south.v2 import DataMigration
 
 
@@ -82,7 +83,7 @@ class Migration(DataMigration):
         },
         'auth.user': {
             'Meta': {'object_name': 'User'},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -90,7 +91,7 @@ class Migration(DataMigration):
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),

--- a/kuma/attachments/models.py
+++ b/kuma/attachments/models.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import models
+from django.utils import timezone
 
 import jingo
 from kuma.core.urlresolvers import reverse
@@ -121,7 +122,7 @@ class AttachmentRevision(models.Model):
 
     description = models.TextField(blank=True)  # Does not allow wiki markup
 
-    created = models.DateTimeField(default=datetime.now)
+    created = models.DateTimeField(default=timezone.now)
     comment = models.CharField(max_length=255, blank=True)
     creator = models.ForeignKey(User,
                                 related_name='created_attachment_revisions')

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -6,6 +6,7 @@ from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.files.base import ContentFile
 from django.core.files import temp as tempfile
+from django.utils import timezone
 from django.utils.http import parse_http_date_safe
 
 import constance.config
@@ -62,7 +63,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
             a = Attachment(title=f['title'], slug=f['slug'],
                            mindtouch_attachment_id=f['file_id'])
             a.save()
-            now = datetime.datetime.now()
+            now = timezone.now()
             r = AttachmentRevision(
                 attachment=a,
                 mime_type='text/plain',
@@ -204,7 +205,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
             slug=a.slug,
             description='',
             comment='Initial revision.',
-            created=datetime.datetime.now() - datetime.timedelta(seconds=30),
+            created=timezone.now() - datetime.timedelta(seconds=30),
             creator=test_user,
             is_approved=True)
         r.file.save('get_previous_test_file.txt',
@@ -219,7 +220,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
             slug=a.slug,
             description='',
             comment='First edit..',
-            created=datetime.datetime.now(),
+            created=timezone.now(),
             creator=test_user,
             is_approved=True)
         r2.file.save('get_previous_test_file.txt',
@@ -246,7 +247,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
             slug=a.slug,
             description='',
             comment='Initial revision.',
-            created=datetime.datetime.now() - datetime.timedelta(seconds=30),
+            created=timezone.now() - datetime.timedelta(seconds=30),
             creator=test_user,
             is_approved=True)
         r.file.save('mime_type_filter_test_file.txt',

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -46,7 +46,7 @@ def revisions(request):
         start_date = filter_form.cleaned_data['start_date']
         if start_date:
             end_date = (filter_form.cleaned_data['end_date'] or
-                        datetime.datetime.now())
+                        timezone.now())
             query_kwargs['created__range'] = [start_date, end_date]
 
         preceding_period = filter_form.cleaned_data['preceding_period']

--- a/kuma/demos/helpers.py
+++ b/kuma/demos/helpers.py
@@ -7,6 +7,7 @@ from babel import localedata
 import jinja2
 
 from django.conf import settings
+from django.utils import timezone
 from django.utils.tzinfo import LocalTimezone
 
 import jingo
@@ -374,7 +375,7 @@ def timesince(d, now=None):
         if d.tzinfo:
             now = datetime.datetime.now(LocalTimezone(d))
         else:
-            now = datetime.datetime.now()
+            now = timezone.now()
 
     # Ignore microsecond part of 'd' since we removed it from 'now'
     delta = now - (d - datetime.timedelta(0, 0, d.microsecond))

--- a/kuma/demos/tests/__init__.py
+++ b/kuma/demos/tests/__init__.py
@@ -1,6 +1,7 @@
 import datetime
 
 from django.contrib.auth.models import User
+from django.utils import timezone
 
 from ..models import Submission
 
@@ -16,7 +17,7 @@ def make_users():
 
 
 def build_submission(creator):
-    now = str(datetime.datetime.now())
+    now = str(timezone.now())
 
     s = Submission(title='Hello world' + now, slug='hello-world' + now,
         description='This is a hello world demo', hidden=False,
@@ -27,7 +28,7 @@ def build_submission(creator):
 
 
 def build_hidden_submission(creator, slug='hidden-world'):
-    now = str(datetime.datetime.now())
+    now = str(timezone.now())
 
     s = Submission(title='Hidden submission 1' + now, slug=slug + now,
         description='This is a hidden demo', hidden=True,

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -10,7 +10,7 @@ import jsonpickle
 from django.conf import settings
 from django.core.management.base import NoArgsCommand
 from django.db import IntegrityError
-from django.utils import encoding, hashcompat
+from django.utils import encoding, hashcompat, timezone
 
 from kuma.core.utils import file_lock
 from kuma.feeder.models import Feed, Entry
@@ -232,7 +232,7 @@ class Command(NoArgsCommand):
                 last_publication = datetime.datetime(yr, mon, d, hr, min, sec)
             else:
                 log.warn("Entry has no updated field, faking it")
-                last_publication = datetime.datetime.now()
+                last_publication = timezone.now()
 
             new_entry = Entry(feed=feed, guid=entry_guid, raw=json_entry,
                               visible=True, last_published=last_publication)

--- a/kuma/search/migrations/0006_auto__add_index.py
+++ b/kuma/search/migrations/0006_auto__add_index.py
@@ -3,6 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from django.utils import timezone
 
 
 class Migration(SchemaMigration):
@@ -12,7 +13,7 @@ class Migration(SchemaMigration):
         db.create_table('search_index', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('name', self.gf('django.db.models.fields.CharField')(max_length=30, null=True, blank=True)),
-            ('created_at', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('created_at', self.gf('django.db.models.fields.DateTimeField')(default=django.utils.timezone.now)),
             ('promoted', self.gf('django.db.models.fields.BooleanField')(default=False)),
             ('populated', self.gf('django.db.models.fields.BooleanField')(default=False)),
         ))
@@ -49,7 +50,7 @@ class Migration(SchemaMigration):
         },
         'search.index': {
             'Meta': {'ordering': "['-created_at']", 'object_name': 'Index'},
-            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
             'populated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),

--- a/kuma/search/migrations/0007_auto__add_outdatedobject.py
+++ b/kuma/search/migrations/0007_auto__add_outdatedobject.py
@@ -3,6 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from django.utils import timezone
 
 
 class Migration(SchemaMigration):
@@ -12,7 +13,7 @@ class Migration(SchemaMigration):
         db.create_table('search_outdatedobject', (
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('index', self.gf('django.db.models.fields.related.ForeignKey')(related_name='outdated_objects', to=orm['search.Index'])),
-            ('created_at', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('created_at', self.gf('django.db.models.fields.DateTimeField')(default=django.utils.timezone.now)),
             ('content_type', self.gf('django.db.models.fields.related.ForeignKey')(to=orm['contenttypes.ContentType'])),
             ('object_id', self.gf('django.db.models.fields.PositiveIntegerField')()),
         ))
@@ -49,7 +50,7 @@ class Migration(SchemaMigration):
         },
         'search.index': {
             'Meta': {'ordering': "['-created_at']", 'object_name': 'Index'},
-            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'null': 'True', 'blank': 'True'}),
             'populated': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -58,7 +59,7 @@ class Migration(SchemaMigration):
         'search.outdatedobject': {
             'Meta': {'object_name': 'OutdatedObject'},
             'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['contenttypes.ContentType']"}),
-            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created_at': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
             'index': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'outdated_objects'", 'to': "orm['search.Index']"}),
             'object_id': ('django.db.models.fields.PositiveIntegerField', [], {})

--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -13,6 +13,7 @@ from celery import chain
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
+from django.utils import timezone
 
 from kuma.core.utils import chunked
 from kuma.wiki.helpers import absolutify
@@ -59,7 +60,7 @@ class Command(BaseCommand):
             # Query all documents, excluding those whose `last_rendered_at` is
             # within `min_render_age` or NULL.
             min_render_age = (
-                datetime.datetime.now() -
+                timezone.now() -
                 datetime.timedelta(seconds=self.options['min_age']))
             docs = Document.objects.filter(
                 Q(last_rendered_at__isnull=True) |

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -2,6 +2,7 @@ from datetime import date, datetime, timedelta
 
 from django.core import serializers
 from django.db import models
+from django.utils import timezone
 
 import bleach
 import constance.config
@@ -47,7 +48,7 @@ class BaseDocumentManager(models.Manager):
     def get_by_stale_rendering(self):
         """Find documents whose renderings have gone stale"""
         return (self.exclude(render_expires__isnull=True)
-                    .filter(render_expires__lte=datetime.now()))
+                    .filter(render_expires__lte=timezone.now()))
 
     def allows_add_by(self, user, slug):
         """Determine whether the user can create a document with the given
@@ -190,7 +191,7 @@ class BaseDocumentManager(models.Manager):
             # Don't do a type check here since that would require importing
             if actual._meta.object_name == 'Revision':
                 actual.creator = creator
-                actual.created = datetime.now()
+                actual.created = timezone.now()
 
             actual.save()
             counter += 1

--- a/kuma/wiki/migrations/0001_initial.py
+++ b/kuma/wiki/migrations/0001_initial.py
@@ -3,6 +3,7 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from django.utils import timezone
 
 class Migration(SchemaMigration):
 
@@ -39,7 +40,7 @@ class Migration(SchemaMigration):
             ('summary', self.gf('django.db.models.fields.TextField')()),
             ('content', self.gf('django.db.models.fields.TextField')()),
             ('keywords', self.gf('django.db.models.fields.CharField')(max_length=255, blank=True)),
-            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=django.utils.timezone.now)),
             ('reviewed', self.gf('django.db.models.fields.DateTimeField')(null=True)),
             ('significance', self.gf('django.db.models.fields.IntegerField')(null=True)),
             ('comment', self.gf('django.db.models.fields.CharField')(max_length=255)),
@@ -77,7 +78,7 @@ class Migration(SchemaMigration):
             ('id', self.gf('django.db.models.fields.AutoField')(primary_key=True)),
             ('document', self.gf('django.db.models.fields.related.ForeignKey')(related_name='poll_votes', to=orm['wiki.Document'])),
             ('helpful', self.gf('django.db.models.fields.BooleanField')(default=False)),
-            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now, db_index=True)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=django.utils.timezone.now, db_index=True)),
             ('creator', self.gf('django.db.models.fields.related.ForeignKey')(related_name='poll_votes', null=True, to=orm['auth.User'])),
             ('anonymous_id', self.gf('django.db.models.fields.CharField')(max_length=40, db_index=True)),
             ('user_agent', self.gf('django.db.models.fields.CharField')(max_length=1000)),
@@ -146,7 +147,7 @@ class Migration(SchemaMigration):
         },
         'auth.user': {
             'Meta': {'object_name': 'User'},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -154,7 +155,7 @@ class Migration(SchemaMigration):
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -214,7 +215,7 @@ class Migration(SchemaMigration):
         'wiki.helpfulvote': {
             'Meta': {'object_name': 'HelpfulVote'},
             'anonymous_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
-            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now', 'db_index': 'True'}),
             'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'null': 'True', 'to': "orm['auth.User']"}),
             'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'to': "orm['wiki.Document']"}),
             'helpful': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -239,7 +240,7 @@ class Migration(SchemaMigration):
             'based_on': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Revision']", 'null': 'True', 'blank': 'True'}),
             'comment': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'content': ('django.db.models.fields.TextField', [], {}),
-            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_revisions'", 'to': "orm['auth.User']"}),
             'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': "orm['wiki.Document']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),

--- a/kuma/wiki/migrations/0016_add_file_storage.py
+++ b/kuma/wiki/migrations/0016_add_file_storage.py
@@ -3,6 +3,8 @@ import datetime
 from south.db import db
 from south.v2 import SchemaMigration
 from django.db import models
+from django.utils import timezone
+
 
 class Migration(SchemaMigration):
 
@@ -17,7 +19,7 @@ class Migration(SchemaMigration):
             ('slug', self.gf('django.db.models.fields.CharField')(max_length=255, null=True, db_index=True)),
             ('mime_type', self.gf('django.db.models.fields.CharField')(max_length=255, db_index=True)),
             ('description', self.gf('django.db.models.fields.TextField')()),
-            ('created', self.gf('django.db.models.fields.DateTimeField')(default=datetime.datetime.now)),
+            ('created', self.gf('django.db.models.fields.DateTimeField')(default=django.utils.timezone.now)),
             ('comment', self.gf('django.db.models.fields.CharField')(max_length=255)),
             ('creator', self.gf('django.db.models.fields.related.ForeignKey')(related_name='created_attachment_revisions', to=orm['auth.User'])),
             ('is_approved', self.gf('django.db.models.fields.BooleanField')(default=True, db_index=True)),
@@ -63,7 +65,7 @@ class Migration(SchemaMigration):
         },
         'auth.user': {
             'Meta': {'object_name': 'User'},
-            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
             'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'groups': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Group']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -71,7 +73,7 @@ class Migration(SchemaMigration):
             'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
             'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
             'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
-            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
             'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
             'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': "orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'}),
@@ -97,7 +99,7 @@ class Migration(SchemaMigration):
             'Meta': {'object_name': 'AttachmentRevision', 'db_table': "'wiki_attachmentrevision'"},
             'attachment': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': "orm['attachments.Attachment']"}),
             'comment': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
-            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_attachment_revisions'", 'to': "orm['auth.User']"}),
             'description': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
             'file': ('django.db.models.fields.files.FileField', [], {'max_length': '500'}),
@@ -149,7 +151,7 @@ class Migration(SchemaMigration):
         'wiki.helpfulvote': {
             'Meta': {'object_name': 'HelpfulVote'},
             'anonymous_id': ('django.db.models.fields.CharField', [], {'max_length': '40', 'db_index': 'True'}),
-            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now', 'db_index': 'True'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now', 'db_index': 'True'}),
             'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'null': 'True', 'to': "orm['auth.User']"}),
             'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'poll_votes'", 'to': "orm['wiki.Document']"}),
             'helpful': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
@@ -186,7 +188,7 @@ class Migration(SchemaMigration):
             'based_on': ('django.db.models.fields.related.ForeignKey', [], {'to': "orm['wiki.Revision']", 'null': 'True', 'blank': 'True'}),
             'comment': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
             'content': ('django.db.models.fields.TextField', [], {}),
-            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'default': 'django.utils.timezone.now'}),
             'creator': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'created_revisions'", 'to': "orm['auth.User']"}),
             'document': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'revisions'", 'to': "orm['wiki.Document']"}),
             'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -22,6 +22,7 @@ from django.db import models
 from django.db.models import Count, signals
 from django.dispatch import receiver
 from django.http import Http404
+from django.utils import timezone
 from django.utils.decorators import available_attrs
 from django.utils.functional import cached_property
 
@@ -396,7 +397,7 @@ class Document(NotificationsMixin, models.Model):
         # failure, in this case, and allow another scheduling attempt.
         timeout = constance.config.KUMA_DOCUMENT_RENDER_TIMEOUT
         max_duration = timedelta(seconds=timeout)
-        duration = datetime.now() - self.render_scheduled_at
+        duration = timezone.now() - self.render_scheduled_at
         if duration > max_duration:
             return False
 
@@ -415,7 +416,7 @@ class Document(NotificationsMixin, models.Model):
         # Assume failure, in this case, and allow another rendering attempt.
         timeout = constance.config.KUMA_DOCUMENT_RENDER_TIMEOUT
         max_duration = timedelta(seconds=timeout)
-        duration = datetime.now() - self.render_started_at
+        duration = timezone.now() - self.render_started_at
         if duration > max_duration:
             return False
 
@@ -474,7 +475,7 @@ class Document(NotificationsMixin, models.Model):
 
         # Note when the rendering was scheduled. Kind of a hack, doing a quick
         # update and setting the local property rather than doing a save()
-        now = datetime.now()
+        now = timezone.now()
         Document.objects.filter(pk=self.pk).update(render_scheduled_at=now)
         self.render_scheduled_at = now
 
@@ -501,7 +502,7 @@ class Document(NotificationsMixin, models.Model):
 
         # Note when the rendering was started. Kind of a hack, doing a quick
         # update and setting the local property rather than doing a save()
-        now = datetime.now()
+        now = timezone.now()
         Document.objects.filter(pk=self.pk).update(render_started_at=now)
         self.render_started_at = now
 
@@ -519,7 +520,7 @@ class Document(NotificationsMixin, models.Model):
         self.regenerate_cache_with_fields()
 
         # Finally, note the end time of rendering and update the document.
-        self.last_rendered_at = datetime.now()
+        self.last_rendered_at = timezone.now()
 
         # If this rendering took longer than we'd like, mark it for deferred
         # rendering in the future.
@@ -534,7 +535,7 @@ class Document(NotificationsMixin, models.Model):
         # intervention to free docs from deferred jail.
         if self.render_max_age:
             # If there's a render_max_age, automatically update render_expires
-            self.render_expires = (datetime.now() +
+            self.render_expires = (timezone.now() +
                                    timedelta(seconds=self.render_max_age))
         else:
             # Otherwise, just clear the expiration time as a one-shot
@@ -802,7 +803,7 @@ class Document(NotificationsMixin, models.Model):
                             (revision.created, revision.creator))
         if comment:
             revision.comment += ': "%s"' % comment
-        revision.created = datetime.now()
+        revision.created = timezone.now()
         revision.creator = user
         revision.save()
         if old_review_tags:
@@ -981,7 +982,7 @@ class Document(NotificationsMixin, models.Model):
         moved_rev.id = None
 
         moved_rev.creator = user
-        moved_rev.created = datetime.now()
+        moved_rev.created = timezone.now()
         moved_rev.slug = new_slug
         if title:
             moved_rev.title = title
@@ -1689,7 +1690,7 @@ class Revision(models.Model):
     # Maximum age (in seconds) before this document needs re-rendering
     render_max_age = models.IntegerField(blank=True, null=True)
 
-    created = models.DateTimeField(default=datetime.now, db_index=True)
+    created = models.DateTimeField(default=timezone.now, db_index=True)
     comment = models.CharField(max_length=255)
     creator = models.ForeignKey(User, related_name='created_revisions')
     is_approved = models.BooleanField(default=True, db_index=True)
@@ -1841,7 +1842,7 @@ class Revision(models.Model):
 
     @property
     def translation_age(self):
-        return abs((datetime.now() - self.created).days)
+        return abs((timezone.now() - self.created).days)
 
 
 class RevisionIP(models.Model):
@@ -1857,7 +1858,7 @@ class HelpfulVote(models.Model):
     """Helpful or Not Helpful vote on Document."""
     document = models.ForeignKey(Document, related_name='poll_votes')
     helpful = models.BooleanField(default=False)
-    created = models.DateTimeField(default=datetime.now, db_index=True)
+    created = models.DateTimeField(default=timezone.now, db_index=True)
     creator = models.ForeignKey(User, related_name='poll_votes', null=True)
     anonymous_id = models.CharField(max_length=40, db_index=True)
     user_agent = models.CharField(max_length=1000)

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -3,6 +3,7 @@ import time
 
 from django.contrib.auth.models import User, Group, Permission
 from django.template.defaultfilters import slugify
+from django.utils import timezone
 
 from html5lib.filters._base import Filter as html5lib_Filter
 from nose.tools import nottest
@@ -31,7 +32,7 @@ def document(save=False, **kwargs):
     """Return an empty document with enough stuff filled out that it can be
     saved."""
     defaults = {'category': Document.CATEGORIES[0][0],
-                'title': str(datetime.now()),
+                'title': str(timezone.now()),
                 'is_redirect': 0}
     defaults.update(kwargs)
     if 'slug' not in kwargs:

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -10,6 +10,8 @@ import time
 from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
+from django.utils import timezone
+
 from kuma.users.tests import UserTestCase
 from kuma.wiki.tests import (WikiTestCase, document, revision,
                              make_translation, wait_add_rev)
@@ -61,7 +63,7 @@ class FeedTests(UserTestCase, WikiTestCase):
     def test_revisions_feed(self):
         d = document(title='HTML9')
         d.save()
-        now = datetime.datetime.now()
+        now = timezone.now()
         for i in xrange(1, 6):
             created = now + datetime.timedelta(seconds=5 * i)
             revision(save=True,
@@ -110,7 +112,7 @@ class FeedTests(UserTestCase, WikiTestCase):
         reflect proper document locale, regardless of requestor's locale"""
         d = document(title='HTML9', locale="fr")
         d.save()
-        now = datetime.datetime.now()
+        now = timezone.now()
         for i in xrange(1, 6):
             created = now + datetime.timedelta(seconds=5 * i)
             revision(save=True,
@@ -142,14 +144,14 @@ class FeedTests(UserTestCase, WikiTestCase):
                  comment='Revision 1',
                  content="First Content",
                  is_approved=True,
-                 created=datetime.datetime.now())
+                 created=timezone.now())
         r = revision(save=True,
                      document=d,
                      title='HTML9',
                      comment='Revision 2',
                      content="First Content",
                      is_approved=True,
-                     created=(datetime.datetime.now() +
+                     created=(timezone.now() +
                               datetime.timedelta(seconds=1)),
                      tags='"some", "more", "tags"')
         r.review_tags.set(*[u'editorial'])

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -12,6 +12,7 @@ from nose import SkipTest
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
+from django.utils import timezone
 
 import constance.config
 from waffle.models import Switch
@@ -733,7 +734,7 @@ class GetCurrentOrLatestRevisionTests(UserTestCase):
     def test_latest(self):
         """Return latest revision when no current exists."""
         r1 = revision(is_approved=False, save=True,
-                      created=datetime.now() - timedelta(days=1))
+                      created=timezone.now() - timedelta(days=1))
         r2 = revision(is_approved=False, save=True, document=r1.document)
         eq_(r2, r1.document.current_or_latest_revision())
 
@@ -937,7 +938,7 @@ class DeferredRenderingTests(UserTestCase):
     def test_one_render_at_a_time(self, mock_kumascript_get):
         """Only one in-progress rendering should be allowed for a Document"""
         mock_kumascript_get.return_value = (self.rendered_content, None)
-        self.d1.render_started_at = datetime.now()
+        self.d1.render_started_at = timezone.now()
         self.d1.save()
         try:
             self.d1.render('', 'http://testserver/')
@@ -954,7 +955,7 @@ class DeferredRenderingTests(UserTestCase):
         mock_kumascript_get.return_value = (self.rendered_content, None)
         timeout = 5.0
         constance.config.KUMA_DOCUMENT_RENDER_TIMEOUT = timeout
-        self.d1.render_started_at = (datetime.now() -
+        self.d1.render_started_at = (timezone.now() -
                                      timedelta(seconds=timeout + 1))
         self.d1.save()
         try:
@@ -1078,7 +1079,7 @@ class RenderExpiresTests(UserTestCase):
     """Tests for max-age and automatic document rebuild"""
 
     def test_find_stale_documents(self):
-        now = datetime.now()
+        now = timezone.now()
 
         # Fresh
         d1 = document(title='Aged 1')
@@ -1105,7 +1106,7 @@ class RenderExpiresTests(UserTestCase):
         mock_kumascript_get.return_value = ('MOCK CONTENT', None)
 
         max_age = 1000
-        now = datetime.now()
+        now = timezone.now()
 
         d1 = document(title='Aged 1')
         d1.render_max_age = max_age
@@ -1122,7 +1123,7 @@ class RenderExpiresTests(UserTestCase):
     def test_update_expires_without_max_age(self, mock_kumascript_get):
         mock_kumascript_get.return_value = ('MOCK CONTENT', None)
 
-        now = datetime.now()
+        now = timezone.now()
         d1 = document(title='Aged 1')
         d1.render_expires = now - timedelta(seconds=100)
         d1.save()
@@ -1137,7 +1138,7 @@ class RenderExpiresTests(UserTestCase):
                           mock_kumascript_get):
         mock_kumascript_get.return_value = ('MOCK CONTENT', None)
 
-        now = datetime.now()
+        now = timezone.now()
         earlier = now - timedelta(seconds=1000)
 
         d1 = document(title='Aged 3')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -19,6 +19,7 @@ from django.db.models import Q
 from django.test.client import (FakePayload, encode_multipart,
                                 BOUNDARY, CONTENT_TYPE_RE, MULTIPART_CONTENT)
 from django.http import Http404
+from django.utils import timezone
 from django.utils.encoding import smart_str
 
 import constance.config
@@ -3275,7 +3276,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
     def test_rendering_in_progress_warning(self):
         """Document view should serve up rendered content when available"""
         # Make the document look like there's a rendering in progress.
-        self.d.render_started_at = datetime.datetime.now()
+        self.d.render_started_at = timezone.now()
         self.d.save()
 
         resp = self.client.get(self.url, follow=False)
@@ -3305,7 +3306,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         # rendering is in progress.
         self.d.html = self.raw_content
         self.d.rendered_html = ''
-        self.d.render_started_at = datetime.datetime.now()
+        self.d.render_started_at = timezone.now()
         self.d.save()
 
         # Now, ensure that raw content is shown in the view.


### PR DESCRIPTION
Here's a first pass at converting datetime.now calls into timezone.now. I've deliberately avoided some of the pytz stuff, though I think it can be replaced with Django's timezone module as well. Tests appear to pass save for something related to email, and I'm not sure if that works on my local master branch either.

Thoughts? Anything I should add/remove? Should this be done on a smaller test scale first, e.g. on a per app basis?