### PR TITLE
Bug 1139508: Redirect media/redesign with htaccess

### DIFF
--- a/configs/htaccess
+++ b/configs/htaccess
@@ -113,6 +113,9 @@ RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn/css /$1Learn/CSS [R=301,L]
 RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn/javascript /$1Learn/JavaScript [R=301,L]
 RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn /$1Learn [R=301,L]
 
+# Handle any outdated hotlinks to assets in /media/redesign
+RewriteRule ^media/redesign(.*) /media$1 [L,R=301]
+
 # Off-site redirects
 RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
 RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]


### PR DESCRIPTION
We need to redirect from /media/redesign to /media. This htaccess
redirect won't have any affect locally (because we alias /media in
mozilla-kuma-apache.conf), but it might work on production where the
alias isn't active.

Unfortunately, the only way to know for sure is to try it out. If this
doesn't do the trick, we can revert this change and work with WebOps to
set up the redirects in whatever form their configuration requires.