### PR TITLE
Bug 1086519 - Leave new title and slug for cloned pages blank [take 2]

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1776,8 +1776,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
     def test_clone(self):
         self.client.login(username='admin', password='testpass')
-        slug = 'my_doc'
-        title = 'My Doc'
+        slug = None 
+        title = None
         content = '<p>Hello!</p>'
 
         test_revision = revision(save=True, title=title, slug=slug,
@@ -1790,7 +1790,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         page = pq(response.content)
 
         eq_(page.find('input[name=title]')[0].value, title)
-        eq_(page.find('input[name=slug]')[0].value, slug + '_clone')
+        eq_(page.find('input[name=slug]')[0].value, slug)
         eq_(page.find('textarea[name=content]')[0].value, content)
 
     def test_localized_based_on(self):

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -891,7 +891,6 @@ def new_document(request):
                 initial_title = clone_doc.title
                 initial_html = clone_doc.html
                 initial_tags = clone_doc.tags.all()
-                initial_slug = _split_slug(clone_doc.slug)['specific'] + '_clone'
                 if clone_doc.current_revision:
                     initial_toc = clone_doc.current_revision.toc_depth
                 else:


### PR DESCRIPTION
The initial title and slug for a new cloned page should not default to "original_title" and "original_title_clone," respectively, but instead remain blank (requiring manual user entry) to avoid the accidental creation of confusing, seemingly duplicate entries.

See https://bugzilla.mozilla.org/show_bug.cgi?id=1086519.
