### PR TITLE
bug 1113260 - manual IP ban & un-ban

### DIFF
--- a/kuma/core/admin.py
+++ b/kuma/core/admin.py
@@ -4,6 +4,9 @@ from kuma.core.models import IPBan
 
 
 class IPBanAdmin(admin.ModelAdmin):
+    # Remove list delete action to enforce model soft delete in admin site
+    actions = None
+    readonly_fields = ('deleted',)
     list_display = ('ip', 'created', 'deleted')
 
 


### PR DESCRIPTION
Spot check:
0. Make sure you're running the `python2.6 manage.py celery worker --events --beat --autoreload --concurrency=4` process
1. Activate [waffle switch](https://developer-local.allizom.org/admin/waffle/switch/) `store_revision_ips`
2. Make an edit
3. Go to [the revisions dashboard](https://developer-local.allizom.org/en-US/dashboards/revisions), click "Toggle IPs" and then click "Ban IP from Editing"
4. [ ] Go back to the edit page, verify you get permission denied error page
5. Go to [the IP Bans admin page](https://developer-local.allizom.org/admin/core/ipban/), click the IP Ban, click "Delete" and then "Yes, I'm sure"
6. [ ] Go back to the edit page, verify you get the edit page
