### PR TITLE
fix bug 1115071 - Ensure correct addresses for context menu items

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -424,8 +424,8 @@
     </div> <!-- ends "main-content" -->
 
   <menu type="context" id="edit-history-menu">
-    <menuitem data-action="$edit" label="{{_('Edit page')}}"></menuitem>
-    <menuitem data-action="$history" label="{{_('View page history')}}"></menuitem>
+    <menuitem data-action="{{ url('wiki.edit_document', document.full_path, locale=document.locale) }}" label="{{_('Edit page')}}"></menuitem>
+    <menuitem data-action="{{ url('wiki.document_revisions', document.full_path) }}" label="{{_('View page history')}}"></menuitem>
   </menu>
 {% endblock %}
 

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -413,14 +413,12 @@
             var isLinkTargeted = ($(target).is('a') || $(target).parents().is('a'));
             var isImageTargeted = $(target).is('img');
 
-            $body.attr('contextmenu', 'edit-history-menu');
-
             if(isLinkTargeted || isTextSelected || isImageTargeted) {
                 $body.attr('contextmenu', '');
             }
 
             $contextMenu.on('click', function(e) {
-                location.href = (target.href || location.href) + $(e.target).data('action') + '?src=context';
+                location.href = $(e.target).data('action') + '?src=context';
             });
     });
 


### PR DESCRIPTION
Should've just used the full URL in the `data-` attribute in the first place.