### PR TITLE
Bug 1145630: Social Sharing A/B tests

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -1,7 +1,7 @@
 {% extends "wiki/base.html" %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 
-{% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, get_document_buttons, get_document_subnav, get_approvals_html, document_watch with context %}
+{% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, get_document_buttons, get_document_subnav, get_approvals_html, document_watch, share_links with context %}
 
 {% if fallback_reason == 'no_translation' %}
   {% set help_link = url('wiki.translate', document_path=document.full_path, locale=document.locale)|urlparams(tolocale=request.locale) %}
@@ -174,6 +174,10 @@
 
         <h1>{{ document.title }}</h1>
 
+        {% if waffle.flag('share_links') %}
+          {{ share_links(document) }}
+        {% endif %}
+
         {% if waffle.flag('top_contributors') %}
             {% set contributors = document.get_contributors() %}
             {% set contrib_limit = 13 %}
@@ -231,6 +235,9 @@
                 <ol class="toggle-container">
                   {{ toc_html|safe }}
                 </ol>
+                {% if waffle.flag('share_links') %}
+                  {{ share_links(document) }}
+                {% endif %}
               </div>
               {% endif %}
               </div>
@@ -337,28 +344,7 @@
               </article>
 
             {% if waffle.flag('share_links') %}
-                {% set full_url = request.build_absolute_uri(document.get_absolute_url()) %}
-
-                {% set share_url_twitter = full_url|urlparams(utm_campaign='share', utm_source='twitter.com', utm_medium='doc share link') %}
-                {% set share_url_facebook = full_url|urlparams(utm_campaign='share', utm_source='facebook.com', utm_medium='doc share link')%}
-                {% set share_url_gplus = full_url|urlparams(utm_campaign='share', utm_source='plus.google.com', utm_medium='doc share link')%}
-
-                {% set short_share_url_twitter = share_url_twitter | bitly_shorten %}
-                {% set short_share_url_facebook = share_url_facebook | bitly_shorten %}
-                {% set short_share_url_gplus = share_url_gplus | bitly_shorten %}
-
-                {% set twitter_url = 'http://twitter.com/share'|urlparams(url=short_share_url_twitter, text=share_text) %}
-                {% set facebook_url = 'http://facebook.com/sharer.php?s=100&p[url]='+short_share_url_facebook+'&p[images][0]=/media/redesign/img/favicon144.png&p[title]=' + share_text %}
-                {% set gplus_url = 'https://plus.google.com/share'|urlparams(url=short_share_url_gplus) %}
-
-                <div class="share">
-                    <strong><i class="icon-share" aria-hidden="true"></i> {{ _('Share:') }}</strong>
-                    <ul>
-                        <li><a href="{{ twitter_url }}" target="_blank" data-url="{{short_share_url_twitter}}" data-title="{{ share_text }}" class="share-link twitter"><i aria-hidden="true" class="icon-twitter"></i>{{ _('Twitter') }}</a></li>
-                        <li><a href="{{ facebook_url }}" target="_blank" data-url="{{short_share_url_facebook}}" data-title="{{ share_text }}" class="share-link facebook"><i aria-hidden="true" class="icon-facebook"></i>{{ _('Facebook') }}</a></li>
-                        <li><a href="{{ gplus_url }}" target="_blank" data-url="{{short_share_url_gplus}}" data-title="{{ share_text }}" class="share-link gplus"><i aria-hidden="true" class="icon-google-plus"></i>{{ _('Google +') }}</a></li>
-                    </ul>
-                </div>
+              {{ share_links(document) }}
             {% endif %}
 
 

--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -210,3 +210,31 @@
 
 
 {%- endmacro %}
+
+
+
+{% macro share_links(document) -%}
+    {% set full_url = request.build_absolute_uri(document.get_absolute_url()) %}
+
+    {% set share_url_twitter = full_url|urlparams(utm_campaign='share', utm_source='twitter.com', utm_medium='doc share link') %}
+    {% set share_url_facebook = full_url|urlparams(utm_campaign='share', utm_source='facebook.com', utm_medium='doc share link')%}
+    {% set share_url_gplus = full_url|urlparams(utm_campaign='share', utm_source='plus.google.com', utm_medium='doc share link')%}
+
+    {% set short_share_url_twitter = share_url_twitter | bitly_shorten %}
+    {% set short_share_url_facebook = share_url_facebook | bitly_shorten %}
+    {% set short_share_url_gplus = share_url_gplus | bitly_shorten %}
+
+    {% set twitter_url = 'http://twitter.com/share'|urlparams(url=short_share_url_twitter, text=share_text) %}
+    {% set facebook_url = 'http://facebook.com/sharer.php?s=100&p[url]='+short_share_url_facebook+'&p[images][0]=/media/redesign/img/favicon144.png&p[title]=' + share_text %}
+    {% set gplus_url = 'https://plus.google.com/share'|urlparams(url=short_share_url_gplus) %}
+
+    <div class="share">
+        <strong><i class="icon-share" aria-hidden="true"></i> {{ _('Share:') }}</strong>
+        <ul>
+            <li><a href="{{ twitter_url }}" target="_blank" data-url="{{short_share_url_twitter}}" data-title="{{ share_text }}" class="share-link twitter"><i aria-hidden="true" class="icon-twitter"></i>{{ _('Twitter') }}</a></li>
+            <li><a href="{{ facebook_url }}" target="_blank" data-url="{{short_share_url_facebook}}" data-title="{{ share_text }}" class="share-link facebook"><i aria-hidden="true" class="icon-facebook"></i>{{ _('Facebook') }}</a></li>
+            <li><a href="{{ gplus_url }}" target="_blank" data-url="{{short_share_url_gplus}}" data-title="{{ share_text }}" class="share-link gplus"><i aria-hidden="true" class="icon-google-plus"></i>{{ _('Google +') }}</a></li>
+        </ul>
+    </div>
+
+{%- endmacro %}

--- a/media/stylus/components/share-link.styl
+++ b/media/stylus/components/share-link.styl
@@ -1,0 +1,124 @@
+/*
+share-link
+====================================================================== */
+.share-link {
+    border: 1px solid rgba-fallback(rgba(255,255,255,0.2));
+    border-radius: 2px;
+    box-shadow: none;
+    color: #fff;
+    bidi-value(margin, 0 6px 6px 0, 0 0 6px 6px);
+    padding: 3px;
+
+    &.facebook {
+        background-color: rgb(59, 89, 152);
+    }
+    &.twitter {
+        background-color: rgb(0, 172, 237);
+    }
+    &.gplus {
+        background-color: rgb(221, 75, 57);
+    }
+
+    {$selector-icon} {
+        bidi-style(margin-left, 0, margin-right, 4px);
+        bidi-style(margin-right, 4px, margin-left, 0);
+    }
+
+
+    /*
+    share-thin (can be removed if we decid not to use the share-thin style)
+    ====================================================================== */
+
+    .share-thin & {
+        display: inline-block;
+        width: 0;
+        height: 20px;
+        bidi-value(padding, 0 0 0 25px, 0 25px 0 0);
+        overflow: hidden;
+        vertical-align: middle;
+        position: relative;
+        border: 2px solid transparent;
+
+        &:focus,
+        &:hover {
+            border: 2px solid rgba(255,255,255, 0.5);
+        }
+
+        {$selector-icon} {
+            position: absolute;
+            top: 4px;
+            left: 50%;
+            bidi-value(margin-left, -0.4em, -0.4em); /* using ems because relative to text size */
+        }
+
+        &.facebook {$selector-icon} {
+            bidi-value(margin-left, -0.25em, -0.25em); /* using ems because relative to text size */
+        }
+
+        &.gplus {$selector-icon} {
+            bidi-value(margin-left, -0.35em, -0.35em); /* using ems because relative to text size */
+        }
+
+
+        @media $media-query-small-desktop {
+            height: 40px;
+            bidi-style(padding-left, 40px, padding-right, 0);
+            font-size: 24px;
+
+            {$selector-icon} {
+                top: 10px;
+            }
+        }
+    }
+
+
+    /*
+    share-group (can be removed if we decide not to use the share-group style)
+    ====================================================================== */
+    $share-group-link-border-width = 2px;
+
+
+    .share-group & {
+        display: inline-block;
+        width: 0;
+        height: 30px;
+        bidi-value(padding, 0 0 0 30px, 0 30px 0 0);
+        overflow: hidden;
+        vertical-align: middle;
+        position: relative;
+        font-size: 18px;
+        bidi-value(margin, 0, 0);
+        border-radius: 0;
+        border: $share-group-link-border-width solid rgba-fallback(rgba(255,255,255,0.5), $text-color);
+        background-color: $link-color;
+
+        &:hover,
+        &:focus {
+            color: $text-color;
+        }
+
+        {$selector-icon} {
+            position: absolute;
+            top: 7px;
+            left: 50%;
+            bidi-value(margin-left, -0.4em, -0.4em); /* using ems because relative to text size */
+        }
+
+        &.twitter {
+            bidi-value(border-radius, 10px 0 0 10px, 0 10px 10px 0);
+            bidi-style(border-right-width, 0, border-left-width, $share-group-link-border-width);
+        }
+
+        &.facebook {
+            border-left-width: 0;
+            border-right-width: 0;
+        }
+
+        &.gplus {
+            bidi-value(border-radius, 0 10px 10px 0, 10px 0 0 10px);
+            bidi-style(border-left-width, 0, border-right-width, $share-group-link-border-width);
+        }
+    }
+}
+
+

--- a/media/stylus/components/share.styl
+++ b/media/stylus/components/share.styl
@@ -1,4 +1,5 @@
 .share {
+    display: none; /* hide by default, needs to be shown by optimizely */
     set-smaller-font-size();
     bidi-value(text-align, right, left);
     position: relative;
@@ -12,32 +13,83 @@
     li {
         display: inline-block;
         margin: 0;
-        padding: 0;
+        bidi-value(padding, 0, 0); /* to over-ride default bidi-value) */
+    }
+
+    &.show {
+        display: block;
+    }
+
+
+    /*
+    Inside TOC
+    - can be removed if we decide not to put share links here
+    -------------------------------------------------------------- */
+    .toc & {
+        background-color: #fff;
+        margin: 0 -15px -5px;
+        padding: 5px 0 15px 0;
+        top: 15px;
+
+        @media $media-query-tablet {
+            background-color: transparent;
+            top: 0;
+        }
+
+        /* hide title if there isn't enough space for it in TOC */
+        /* stylus does not evaluate variables in the MQ correctly, can't switch :( */
+        @media all and (min-width:1025px) and (max-width: $max-width-default),
+        all and (max-width: 480px) {
+            & strong {
+                offscreen();
+            }
+        }
+    }
+
+    .toggle-container + &.show {
+        display: block;
+    }
+
+    .toggle-container[aria-expanded="true"] + &.show {
+        display: block;
+    }
+
+    .toggle-container[aria-expanded="false"] + &.show {
+        display: none;
+    }
+
+
+    /*
+    Inside doument-head
+    - can be removed if we decide not to put share links here
+    -------------------------------------------------------------- */
+
+    .document-head & {
+        top: -($grid-spacing / 2);
+        margin-bottom: $grid-spacing;
+        bidi-value(text-align, left, right);
+
+        strong {$selector-icon} {
+            display: none;
+        }
     }
 }
 
-.share-link {
-    border: 1px solid rgba-fallback(rgba(255,255,255,0.2));
-    border-radius: 2px;
-    box-shadow: none;
-    color: #fff;
-    bidi-value(margin, 0px 6px 6px 0px, 0px 0px 6px 6px);
-    padding: 3px;
-
-    &.facebook {
-        background-color: rgb(59, 89, 152);
-    }
-    &.twitter {
-        background-color: rgb(0, 172, 237);
-    }
-    &.gplus {
-        background-color: rgb(221, 75, 57);
-    }
-
-    {$selector-icon} {
-        bidi-style(margin-left, 0px, margin-right, 4px);
-        bidi-style(margin-right, 4px, margin-left, 0px);
-    }
-
+/* can be removed if we decide not to use .share-thin style */
+.share-thin strong {
+    offscreen();
 }
 
+/* can be removed if we decide not to use .share-thin style or not put them in .toc */
+.toc .share-thin ul {
+    bidi-style(margin-right, 15px, margin-left, 0);
+}
+
+/* can be removed if we decide not to use .share-group style */
+.share-group {
+    font-size: 0;
+
+    strong {
+        display: none;
+    }
+}

--- a/media/stylus/wiki.styl
+++ b/media/stylus/wiki.styl
@@ -32,6 +32,7 @@ Components that may appear on most wiki pages
 @require 'components/wiki/edit-section';
 @require 'components/wiki/offline-dialog-content';
 @require 'components/share';
+@require 'components/share-link';
 
 
 /*


### PR DESCRIPTION
Styling for 3 different types of buttons going in 3 different places.

Classes:
.share
.share.share-group
.share.share-thin

All hidden by default at the moment, show by adding class `show` to the element with class `share`

Here's a screen shot of the `share.share-thin` positioned under the title, `share.share-group` positioned in the TOC, and the default `.share` under the article.
![screen shot 2015-03-30 at 15 47 49](https://cloud.githubusercontent.com/assets/854701/6908721/343d0cb2-d6f4-11e4-9fbc-5558f4488a03.png)
