### PR TITLE
fix bug 1148738 - Formal syntax box may be longer than the screen

### DIFF
--- a/media/stylus/components/syntax/syntaxbox.styl
+++ b/media/stylus/components/syntax/syntaxbox.styl
@@ -18,7 +18,8 @@ pre.twopartsyntaxbox {
 
 pre.syntaxbox code[class*="language-"],
 pre.twopartsyntaxbox code[class*="language-"] {
-    white-space: pre-line;
+    white-space: pre-wrap;
+    text-overflow: ellipsis ellipsis;
 }
 
 .syntaxbox-help {


### PR DESCRIPTION
- Switching `.syntaxbox`'s `white-space` property from `pre-line` to `pre-wrap`. A quick solution until we find a more advanced solution. (an expandable box triggered by the user?)
- Adding ellipsis at the start and the end of line when text is cut off.

I checked with @teoli2003. This is one of the expected changes for the new CSS Reference article template . It also improves JavaScript articles when viewed through a small viewport.