### PR TITLE
Fix Bug 1148752 - Main heading of wiki articles creates horizontal scroll with small viewports

### DIFF
--- a/media/stylus/components/wiki/document-head.styl
+++ b/media/stylus/components/wiki/document-head.styl
@@ -3,6 +3,9 @@
     clear: both;
 
     h1 {
-        margin-bottom: 20px;
+        word-break: break-all;
+        line-height: 1.2;
+        margin-top: 7px;
+        margin-bottom: 27px;
     }
 }


### PR DESCRIPTION
- Breaks all words in wiki articles main heading. The long API method names create ugly horizontal scrollbars when pages are viewed from tablets or mobiles. Broken words are ugly but horizontal scrolls are too inconvenient.
- Reduce `line-height` as so much spaces between each lines of the same word was confusing.
- Keep whitespace in design by increasing margin's sizes
- Switch margin's length to em so they will stay coherent with the font size even if `font-size` changes

I look around in the Style code and `em` doesn't seem to be used. I think margins which contribute to vertical rhythm should be in `em` to stay coherent with the text size.

Before | After
------------ | -------------
![main-heading-horizontal-scroll](https://cloud.githubusercontent.com/assets/188748/6881201/92e36aae-d555-11e4-9380-32f694218886.png) | ![fixed-main-heading-horizontal-scroll](https://cloud.githubusercontent.com/assets/188748/6881204/9b755466-d555-11e4-858f-4c9126a80aef.png)

