### PR TITLE
fix bug 1149282 - Ensure proper paren placement in locales list

### DIFF
--- a/kuma/wiki/templates/wiki/select_locale.html
+++ b/kuma/wiki/templates/wiki/select_locale.html
@@ -10,7 +10,7 @@
     <ul class="locales">
       {% for locale in settings.LANGUAGES %}
         {% if locale[0] != settings.WIKI_DEFAULT_LANGUAGE %}
-          <li><a href="{{ url('wiki.translate', document_path=document.full_path)|urlparams(tolocale=locale[0]) }}">{{ locale[1] }} ({{ locale[0] }})</a></li>
+          <li><a href="{{ url('wiki.translate', document_path=document.full_path)|urlparams(tolocale=locale[0]) }}"><bdi>{{ locale[1] }} ({{ locale[0] }})</bdi></a></li>
         {% endif %}
       {% endfor %}
     </ul>


### PR DESCRIPTION
The parens look wonky in RTL in this list.  Fixing it.