### PR TITLE
Bug 1145793: Remove .htaccess redesign redirect

### DIFF
--- a/configs/htaccess
+++ b/configs/htaccess
@@ -113,9 +113,6 @@ RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn/css /$1Learn/CSS [R=301,L]
 RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn/javascript /$1Learn/JavaScript [R=301,L]
 RewriteRule ^(\w{2,3}(?:-\w{2})?/)?learn /$1Learn [R=301,L]
 
-# Handle any outdated hotlinks to assets in /media/redesign
-RewriteRule ^media/redesign(.*) /media$1 [L,R=301]
-
 # Off-site redirects
 RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
 RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]


### PR DESCRIPTION
We added this redirect to .htaccess experimentally. We knew it had no
effect locally and were wondering if it would have any effect on our
stage and production servers.

This ultimately had no effect on our servers, so we asked WebOps [1] to
define this redirect in our main Apache config instead.

[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1145793