### PR TITLE
Fix for incorrect link to troubleshooting page.

### DIFF
--- a/docs/installation-vagrant.rst
+++ b/docs/installation-vagrant.rst
@@ -256,4 +256,4 @@ since the current puppet configurations do not currently support
 ``nfs: false``.
 
 If you have other problems during ``vagrant up``, please check
-:ref:`Troubleshooting`.
+:doc:`Troubleshooting <troubleshooting>`.


### PR DESCRIPTION
On installation-vagrant page there is an invalid link to troubleshooting page,
this patch fixes that.