### PR TITLE
fix bug 632204 - Removed captcha field from demo submission form

### DIFF
--- a/kuma/demos/forms.py
+++ b/kuma/demos/forms.py
@@ -178,9 +178,9 @@ class SubmissionEditForm(MyModelForm):
 class SubmissionNewForm(SubmissionEditForm):
 
     class Meta(SubmissionEditForm.Meta):
-        fields = SubmissionEditForm.Meta.fields + ( 'accept_terms', )
+        fields = SubmissionEditForm.Meta.fields + ('accept_terms', )
 
     accept_terms = forms.BooleanField(initial=False, required=True)
 
     def __init__(self, *args, **kwargs):
-        super(SubmissionNewForm, self).__init__(*args, **kwargs)        
+        super(SubmissionNewForm, self).__init__(*args, **kwargs)

--- a/kuma/demos/forms.py
+++ b/kuma/demos/forms.py
@@ -178,12 +178,9 @@ class SubmissionEditForm(MyModelForm):
 class SubmissionNewForm(SubmissionEditForm):
 
     class Meta(SubmissionEditForm.Meta):
-        fields = SubmissionEditForm.Meta.fields + ( 'captcha', 'accept_terms', )
+        fields = SubmissionEditForm.Meta.fields + ( 'accept_terms', )
 
-    captcha = ReCaptchaField(label=_("Show us you're human"))
     accept_terms = forms.BooleanField(initial=False, required=True)
 
     def __init__(self, *args, **kwargs):
-        super(SubmissionNewForm, self).__init__(*args, **kwargs)
-        if not settings.RECAPTCHA_PRIVATE_KEY:
-            del self.fields['captcha']
+        super(SubmissionNewForm, self).__init__(*args, **kwargs)        

--- a/kuma/demos/templates/demos/submit.html
+++ b/kuma/demos/templates/demos/submit.html
@@ -155,7 +155,6 @@
         {% if not edit %}
         <fieldset class="section notitle">
           <ul>
-            {{ li_field(form, 'captcha') }}
             <li id="field_accept_terms" class="check field{{ ' error' if form.accept_terms.errors }}">
             <strong class="label">
               <label>

--- a/kuma/demos/tests/test_views.py
+++ b/kuma/demos/tests/test_views.py
@@ -115,7 +115,6 @@ class DemoViewsTest(UserTestCase):
         assert d('li#field_screenshot_1 ul.errorlist')
         assert d('li#field_demo_package ul.errorlist')
         assert d('li#field_license_name ul.errorlist')
-        assert d('li#field_captcha ul.errorlist')
         assert d('li#field_accept_terms ul.errorlist')
 
     @logged_in


### PR DESCRIPTION
Removed captcha field from demo submission form and from the corresponding template. Also removed the assertion for captcha in test_views.py