### PR TITLE
Experiment with lazyloading Tabzilla

### DIFF
--- a/media/js/main.js
+++ b/media/js/main.js
@@ -221,11 +221,17 @@
         Tabzilla
     */
     if($('#tabzilla').length) {
-        $.ajax({
-            url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
-            dataType: 'script',
-            cache: true
-        });
+        $('<link />').attr({
+            href: '//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css',
+            type: 'text/css',
+            rel: 'stylesheet'
+        }).on('load', function() {
+            $.ajax({
+                url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
+                dataType: 'script',
+                cache: true
+            });
+        }).prependTo(doc.head);
     }
 
 })(window, document, jQuery);

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,6 @@
   <link rel="home" href="{{ url('home') }}">
   <link rel="copyright" href="#copyright">
 
-  <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" type="text/css" rel="stylesheet">
   {% block site_css %}
     {{ css('mdn', 'all') }}
 


### PR DESCRIPTION
@stephaniehobson:  This is the best course for lazy loading Tabzilla from a logical perspective.  A few things:

1.  Appending the stylesheet to the `head` tag would give Tabzilla priority over our styles so it seems a bad idea

2.  I've used `prependTo` to put the stylesheet at the top of the head, but I think that's causing another repaint.

Let me know what you think of this.  Obviously not ready to merge, but just wanted to put this out there.