### PR TITLE
Fix bug 1152191: Properly serve error json for non-existent docs in children api

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -301,6 +301,13 @@ class ViewTests(UserTestCase, WikiTestCase):
         json_obj = json.loads(resp.content)
         eq_(json_obj['subpages'][0]['title'], 'A Child')
 
+        # Test if we are serving an error json if document does not exist
+        no_doc_url = reverse('wiki.get_children', args=['nonexistentDocument'],
+            locale=settings.WIKI_DEFAULT_LANGUAGE)
+        resp = self.client.get(no_doc_url)
+        result = json.loads(resp.content)
+        eq_(result, {'error': 'Document does not exist.'})
+
     def test_summary_view(self):
         """The ?summary option should restrict document view to summary"""
         d, r = doc_rev("""

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -1399,10 +1399,11 @@ def get_children(request, document_slug, document_locale):
     try:
         doc = Document.objects.get(locale=document_locale,
                                    slug=document_slug)
+        result = _make_doc_structure(doc, 0, expand, depth)
     except Document.DoesNotExist:
         result = {'error': 'Document does not exist.'}
 
-    result = json.dumps(_make_doc_structure(doc, 0, expand, depth))
+    result = json.dumps(result)
     return HttpResponse(result, mimetype='application/json')
 
 


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1152191#c1