### PR TITLE
Bug 1150118 - Lazy load fonts

### DIFF
--- a/media/stylus/base/elements/typography.styl
+++ b/media/stylus/base/elements/typography.styl
@@ -17,7 +17,7 @@ h1, h2, h3, h4 {
 }
 
 h2, h3 {
-    font-family: 'Open Sans', sans-serif;
+    font-family: $site-font-family;
 }
 
 h2, h3, h4 {
@@ -40,12 +40,12 @@ h2 {
 
 h3 {
     set-font-size(24px);
-    letter-spacing: -0.5px;
+    letter-spacing: -0.021em;
 }
 
 h4 {
     set-font-size(18px);
-    letter-spacing: -0.25px;
+    letter-spacing: -0.014em;
 }
 
 /*

--- a/media/stylus/components/content.styl
+++ b/media/stylus/components/content.styl
@@ -28,7 +28,7 @@ $table-blue = #d4dde4;
                 border: @border;
                 border-bottom: 2px solid rgba-fallback(rgba($table-blue, 1));
                 background: rgba-fallback(rgba($table-blue, 0.5));
-                font-family: 'Open Sans Light', sans-serif;
+                font-family: $heading-font-family;
                 font-size: 14px;
                 padding: 2px 8px 4px;
                 font-weight: bold;

--- a/media/stylus/components/fellowship/cta.styl
+++ b/media/stylus/components/fellowship/cta.styl
@@ -30,11 +30,10 @@ Call to action button
         width: 100%;
         padding: 0.75rem;
         margin: 0px;
-        font-size: 1.6rem;
+        set-font-size(22px);
         line-height: 1;
         text-transform: uppercase;
         text-align: center;
-        font-family: "Open Sans",sans-serif;
         opacity: 1;
         visibility: visible;
         transition: opacity 0.2s ease-in-out 0s;

--- a/media/stylus/components/fellowship/pullquote.styl
+++ b/media/stylus/components/fellowship/pullquote.styl
@@ -8,7 +8,7 @@ The quote on the fellowship page
         position: relative;
         background-color: inherit;
         border: none;
-        font-family: 'Open Sans Light', Arial, Helvetica, sans-serif;
+        font-family: $heading-font-family;
         font-style: italic;
         font-size: $larger-font-size;
         color: $neutral;

--- a/media/stylus/components/wiki/customcss.styl
+++ b/media/stylus/components/wiki/customcss.styl
@@ -781,7 +781,7 @@ table.compat-table td.header {
     border: 1px solid rgba-fallback(rgba(212,221,228,0));
     background: none;
     font-weight: 200;
-    font-family: 'Open Sans Light', sans-serif;
+    font-family: $heading-font-family;
     font-size: 16px;
     line-height: 100%;
     padding: 2px 4px 8px;
@@ -874,7 +874,7 @@ ul.card-grid li {
     }
     .card-grid > li span {
         display: block;
-        font-family: 'Open Sans Light', Arial, Helvetica, sans-serif;
+        font-family: $heading-font-family;
         font-size: 22px;
         letter-spacing: -1px;
         line-height: 22px;
@@ -1553,7 +1553,7 @@ dd.landingPageList {
             display: inline;
             font-size: 14px;
             font-weight: 200;
-            font-family: 'Open Sans Light', sans-serif;
+            font-family: $heading-font-family;
             height: 32px;
             list-style-type: none;
             margin: auto;
@@ -1821,7 +1821,7 @@ a.addpage-button .right-align {
     border-right: none;
     vertical-align: top;
     padding: 6px;
-    font-family: "Open Sans", sans-serif;
+    font-family: $site-font-family;
     font-weight: bold;
     text-align: right;
 }

--- a/media/stylus/components/wiki/edit/first-contrib-welcome.styl
+++ b/media/stylus/components/wiki/edit/first-contrib-welcome.styl
@@ -8,7 +8,7 @@
 
     h2 {
         margin: 0 0 10px;
-        font: bold 18px/1.5 'Open Sans', sans-serif;
+        font: bold 18px/1.5 $site-font-family;
     }
 
     p {

--- a/media/stylus/components/wiki/topicpage-table.styl
+++ b/media/stylus/components/wiki/topicpage-table.styl
@@ -20,7 +20,7 @@ body .topicpage-table {
 /* styles for elements inside .topicpage-table */
 .topicpage-table {
     h2 {
-        font-family: 'Open Sans Light', sans-serif;
+        font-family: $heading-font-family;
     }
 
     ul {

--- a/media/stylus/includes/vars.styl
+++ b/media/stylus/includes/vars.styl
@@ -41,8 +41,8 @@ $text-light = #fff;
 
 /* typography */
 $light-font-weight = 200;
-$site-font-family = 'Open Sans', sans-serif;
-$heading-font-family = 'Open Sans Light', sans-serif;
+$site-font-family = 'Open Sans', Arial, sans-serif;
+$heading-font-family = 'Open Sans Light', 'Helvetica', Arial, sans-serif;
 
 /* sizes */
 $larger-font-size = 20px;

--- a/media/stylus/wiki-wysiwyg.styl
+++ b/media/stylus/wiki-wysiwyg.styl
@@ -9,7 +9,7 @@ html.maximized {
     overflow-y: auto !important;
 }
 body {
-    font: 14px/1.5 'Open Sans', sans-serif;
+    font: 14px/1.5 $site-font-family;
     padding: $grid-spacing;
 }
 


### PR DESCRIPTION
Some clean up in anticipation of changes to font stuff:

- Use variable to set font family
- Use mixin to set font size
- Added Arial to fallback list (more size appropriate than Helvetia which is Mac sans-serif default)
- Line-height and letter-spacing should be relative to font-size not pixels