### PR TITLE
bug 1151523 - Disallow IFRAMEs from CKEditor

### DIFF
--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -78,15 +78,7 @@
 
     // Disable the Advanced Content Filter because too many pages
     // use unlimited HTML.
-    config.allowedContent = {
-        $1: {
-            // Use the ability to specify elements as an object.
-            elements: CKEDITOR.dtd,
-            attributes: true,
-            styles: true,
-            classes: true
-        }
-    };
+    config.allowedContent = '{{ allowed_tags }}';
     config.disallowedContent = 'iframe; *[on*]';
 
     // Don't use HTML entities in the output except basic ones (config.basicEntities).

--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -56,7 +56,7 @@
       'mdn-redirect,mdn-sample-finder,mdn-sampler,mdn-syntaxhighlighter,mdn-system-integration,mdn-table-customization,' +
       'mdn-toggle-block,mdn-wrapstyle,' +
       // Other plugins.
-      'descriptionlist,tablesort,texzilla,youtube';
+      'descriptionlist,tablesort,texzilla';
 
     config.removeButtons = 'Cut,Copy,PasteFromWord,Language';
     config.toolbarGroups = [

--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -78,7 +78,16 @@
 
     // Disable the Advanced Content Filter because too many pages
     // use unlimited HTML.
-    config.allowedContent = true;
+    config.allowedContent = {
+        $1: {
+            // Use the ability to specify elements as an object.
+            elements: CKEDITOR.dtd,
+            attributes: true,
+            styles: true,
+            classes: true
+        }
+    };
+    config.disallowedContent = 'iframe; *[on*]';
 
     // Don't use HTML entities in the output except basic ones (config.basicEntities).
     config.entities = false;

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -59,7 +59,7 @@ from . import kumascript
 from .constants import (DOCUMENTS_PER_PAGE, TEMPLATE_TITLE_PREFIX,
                         SLUG_CLEANSING_REGEX, REVIEW_FLAG_TAGS_DEFAULT,
                         DOCUMENT_LAST_MODIFIED_CACHE_KEY_TMPL,
-                        REDIRECT_CONTENT)
+                        REDIRECT_CONTENT, ALLOWED_TAGS)
 from .decorators import (check_readonly, process_document_path,
                          allow_CORS_GET, prevent_indexing)
 from .events import EditDocumentEvent
@@ -1326,7 +1326,9 @@ def ckeditor_config(request):
         code = default_config[0].code
     else:
         code = ''
-    context = {'editor_config': code, 'redirect_pattern': REDIRECT_CONTENT}
+
+    context = {'editor_config': code, 'redirect_pattern': REDIRECT_CONTENT,
+                        'allowed_tags': ' '.join(ALLOWED_TAGS)}
     return render(request, 'wiki/ckeditor_config.js', context,
                   content_type="application/x-javascript")
 


### PR DESCRIPTION
The first step in preventing IFRAMEs in CKEditor per the bug in the title.

Relevant:  http://docs.ckeditor.com/#!/guide/dev_disallowed_content