### PR TITLE
Bug 1151523 - intrinsic ratio youtube iframes

### DIFF
--- a/media/stylus/components/wiki/intrinsic.styl
+++ b/media/stylus/components/wiki/intrinsic.styl
@@ -1,0 +1,31 @@
+/*
+Creates container that preserves aspect ratio, and fills container with iframe
+http://alistapart.com/article/creating-intrinsic-ratios-for-video
+https://css-tricks.com/NetMag/FluidWidthVideo/Article-FluidWidthVideo.php
+====================================================================== */
+.intrinsic-wrapper {
+    max-width: 640px;
+    margin: 0 auto;
+}
+
+.intrinsic-container {
+    position: relative;
+    height: 0;
+    overflow: hidden;
+
+    /* 16x9 Aspect Ratio */
+    padding-bottom: 56.25%;
+
+    /* 4x3 Aspect Ratio */
+    &-4x3{
+        padding-bottom: 75%;
+    }
+
+    iframe {
+        position: absolute;
+        top:0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+    }
+}

--- a/media/stylus/wiki.styl
+++ b/media/stylus/wiki.styl
@@ -33,6 +33,7 @@ Components that may appear on most wiki pages
 @require 'components/wiki/offline-dialog-content';
 @require 'components/share';
 @require 'components/share-link';
+@require 'components/wiki/intrinsic';
 
 
 /*


### PR DESCRIPTION
Using the switch to the macro for youtube imbeds to take this opportunity to improve how the videos display at different screen sizes.

Works in concert with https://developer.mozilla.org/en-US/docs/Template:EmbedYouTube
Here's some content with videos you can alter to test: https://developer.mozilla.org/en-US/docs/Tools/Page_Inspector/How_to/Work_with_animations

Testing:
- create the macro on your local test environment
- fire up kumascript
- embed some videos like so `{{ EmbedYouTube('mDHtLK88ZW4') }}`
- resize your browser window and watch the ratio be maintained