### PR TITLE
Fix Bug 1149205 - Add <wbr> to article headings

### DIFF
--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -24,6 +24,8 @@ from .constants import DIFF_WRAP_COLUMN
 from .jobs import DocumentZoneStackJob
 from .models import Document, memcache
 
+BREAKS_RE = re.compile(r'(?<=[a-z,A-Z])\.(?=[a-z,A-Z])')
+
 register.function(build_policy_admin_links)
 
 
@@ -355,3 +357,12 @@ def wiki_url(context, path):
     # finally cache the reversed document URL for a bit
     memcache.set(u'wiki_url:%s:%s' % (locale, path), url, 60 * 5)
     return url
+
+
+@register.filter
+def addbreaks(title):
+    """
+    adds <wbr> tags before . that appear between letters
+    no numbers should be split
+    """
+    return BREAKS_RE.sub('<wbr>.', title)

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -172,7 +172,8 @@
             <a class="button from-search-next only-icon disabled" title="{{ _('Next Search Result') }}" data-empty-title="{{ _('No Previous Search Result') }}"><i aria-hidden="true" class="icon-chevron-right"></i></a>
           </span>
 
-        <h1>{{ document.title }}</h1>
+        {% set safe_title = document.title|forceescape %}
+        <h1>{{ safe_title|addbreaks|safe }}</h1>
 
         {% if waffle.flag('share_links') %}
           {{ share_links(document) }}

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -7,7 +7,7 @@ from django.contrib.sites.models import Site
 from kuma.core.cache import memcache
 from kuma.users.tests import UserTestCase
 from kuma.wiki.helpers import (absolutify, document_zone_management_links,
-                               revisions_unified_diff, tojson)
+                               revisions_unified_diff, tojson, addbreaks)
 from kuma.wiki.models import DocumentZone
 from kuma.wiki.tests import revision, WikiTestCase
 
@@ -17,6 +17,9 @@ class HelpTests(WikiTestCase):
     def test_tojson(self):
         eq_(tojson({'title': '<script>alert("Hi!")</script>'}),
             '{"title": "&lt;script&gt;alert(&quot;Hi!&quot;)&lt;/script&gt;"}')
+
+    def test_addbreaks(self):
+        eq_(addbreaks('this.is.a.test.1.1'), 'this<wbr>.is<wbr>.a<wbr>.test.1.1')
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_absolutify(self, get_current):


### PR DESCRIPTION
In which I write python code which is probably not suitable for publication but does at least come with a test.

We need to add intelligent line breaks to really long article headings, especially on smaller screens. Inserting <wbr> tags before periods seems like a good option.

Two things that likely have to change:
1) I used safe on the document titles assuming that what we do to them on the way into the database makes them safe. I could be wrong. Maybe there is a better way to do this?
2) I assumed there will never be any "." in code in the document titles. The find replace is at least smart enough not to break up decimal numbers but not smart enough to leave something like a url in a src attribute alone.