### PR TITLE
Bug 1150118: Lazyload Tabzilla

### DIFF
--- a/media/js/main.js
+++ b/media/js/main.js
@@ -221,11 +221,17 @@
         Tabzilla
     */
     if($('#tabzilla').length) {
-        $.ajax({
-            url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
-            dataType: 'script',
-            cache: true
-        });
+        $('<link />').attr({
+            href: '//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css',
+            type: 'text/css',
+            rel: 'stylesheet'
+        }).on('load', function() {
+            $.ajax({
+                url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
+                dataType: 'script',
+                cache: true
+            });
+        }).prependTo(doc.head);
     }
 
 })(window, document, jQuery);

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -53,7 +53,18 @@ draw-grid();
 }
 
 #tabzilla {
+    /* below copied from https://github.com/mozilla/bedrock/blob/master/media/css/tabzilla/tabzilla.less#L51-L60 */
     bidi-value(float, right, left);
+    display: block;
+    height: 44px;
+    width: 150px;
+    overflow: hidden;
+}
+
+#tabzilla-panel {
+    /* in case the javascript loads before the CSS */
+    height: 0;
+    overflow: hidden;
 }
 
 #nav-access {

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,6 @@
   <link rel="home" href="{{ url('home') }}">
   <link rel="copyright" href="#copyright">
 
-  <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" type="text/css" rel="stylesheet">
   {% block site_css %}
     {{ css('mdn', 'all') }}
 


### PR DESCRIPTION
Lazyloading tabzilla is the first step to lazy loading web fonts. (The font declarations in tabzilla.css will load the fonts when it loads).  

David's PR lazyloads the files. My PR adds the necessary CSS to MDN sheets to prevent repaints as tabzilla js and css load.

Supersedes #3161