### PR TITLE
"Google +" to "Google+"

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -233,7 +233,7 @@
         <ul>
             <li><a href="{{ twitter_url }}" target="_blank" data-url="{{short_share_url_twitter}}" data-title="{{ share_text }}" class="share-link twitter"><i aria-hidden="true" class="icon-twitter"></i>{{ _('Twitter') }}</a></li>
             <li><a href="{{ facebook_url }}" target="_blank" data-url="{{short_share_url_facebook}}" data-title="{{ share_text }}" class="share-link facebook"><i aria-hidden="true" class="icon-facebook"></i>{{ _('Facebook') }}</a></li>
-            <li><a href="{{ gplus_url }}" target="_blank" data-url="{{short_share_url_gplus}}" data-title="{{ share_text }}" class="share-link gplus"><i aria-hidden="true" class="icon-google-plus"></i>{{ _('Google +') }}</a></li>
+            <li><a href="{{ gplus_url }}" target="_blank" data-url="{{short_share_url_gplus}}" data-title="{{ share_text }}" class="share-link gplus"><i aria-hidden="true" class="icon-google-plus"></i>{{ _('Google+') }}</a></li>
         </ul>
     </div>
 


### PR DESCRIPTION
I think this "Google +" is strange, usually "Google+" or "Google Plus".

Related pull requests: #3124, #3142.