### PR TITLE
bug 1152386 - Add comments to warn about command line conditions

### DIFF
--- a/tests/ui/_cli.js
+++ b/tests/ui/_cli.js
@@ -30,15 +30,21 @@ define({
         // If we weren't provided username and password, let's set a grep to avoid login tests
         if(args.u == undefined && args.p == undefined) {
             greps.push('requires-login');
+            console.log('No username (-u) and password (-p) provided.  Tests requiring login will be skipped.');
         }
 
         // Set a document for wiki testing
         if(args.wd == undefined) {
             greps.push('requires-doc');
+            console.log('No wiki document (-wd) provided.  Most wiki tests will be skipped.');
         }
 
         // Set the final GREP value
         args.grep = greps.length ? ('^(?!.*?\\[' + greps.join('|') + '\\])') : '';
+
+        if(args.grep) {
+            console.log('Command line arguments have forced a grep to skip tests:  ' + args.grep);
+        }
 
         return config;
     }


### PR DESCRIPTION
These would be helpful for those running tests, wondering why wiki or login tests aren't working.