### PR TITLE
Make edit button dark blue

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -413,11 +413,6 @@
   <script type="text/javascript">
       if(window.jQuery) jQuery('.from-search-toc').mozSearchResults('{{ search_url|safe }}');
 
-      {# This can be removed once the edit button background color A/B test is completed. #}
-      {% if not is_zone_root %}
-          mdn.optimizely.push(['activate', 2706700712]);
-      {% endif %}
-
       {# This can be removed once the social network button multivariate test is completed. #}
       mdn.optimizely.push(['activate', 2796520257]);
   </script>

--- a/media/stylus/components/wiki/page-buttons.styl
+++ b/media/stylus/components/wiki/page-buttons.styl
@@ -34,6 +34,15 @@
     }
 }
 
+/* Use a dark blue background color for all document edit buttons except those
+   that appear on zone landing pages. Superusers can customize zone landing page
+   style and we can't be sure that dark blue will look good on the background
+   colors they choose. */
+body:not(.zone-landing) #edit-button {
+    background-color: $blue;
+    color: $blue-background-text-color;
+}
+
 @media $media-query-small-desktop {
 
     .page-buttons, #page-buttons {


### PR DESCRIPTION
A recent A/B test showed that around 31% more people click the edit
button when it's a darker shade of blue.

Full results: http://optimize.ly/~KSOEmr?token=63f0bef5c746e00caa31#view=2
Analysis: https://groups.google.com/d/msg/mozilla.dev.mdn/98GP_Vh30Cc/GSL_L-f-pJYJ