### PR TITLE
Lazyload Tabzilla Stylesheet

### DIFF
--- a/media/js/main.js
+++ b/media/js/main.js
@@ -220,18 +220,24 @@
     /*
         Tabzilla
     */
-    if($('#tabzilla').length) {
+    (function($tabzilla) {
+        if(!$tabzilla.length) return;
+
         $('<link />').attr({
             href: '//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css',
             type: 'text/css',
             rel: 'stylesheet'
         }).on('load', function() {
+
+            $('#tabzilla').addClass('loaded');
+
             $.ajax({
                 url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
                 dataType: 'script',
                 cache: true
             });
         }).prependTo(doc.head);
-    }
+
+    })($('#tabzilla'));
 
 })(window, document, jQuery);

--- a/media/js/main.js
+++ b/media/js/main.js
@@ -221,11 +221,17 @@
         Tabzilla
     */
     if($('#tabzilla').length) {
-        $.ajax({
-            url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
-            dataType: 'script',
-            cache: true
-        });
+        $('<link />').attr({
+            href: '//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css',
+            type: 'text/css',
+            rel: 'stylesheet'
+        }).on('load', function() {
+            $.ajax({
+                url: '//mozorg.cdn.mozilla.net/en-US/tabzilla/tabzilla.js',
+                dataType: 'script',
+                cache: true
+            });
+        }).prependTo(doc.head);
     }
 
 })(window, document, jQuery);

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -53,7 +53,18 @@ draw-grid();
 }
 
 #tabzilla {
+    /* below copied from https://github.com/mozilla/bedrock/blob/master/media/css/tabzilla/tabzilla.less#L51-L60 */
     bidi-value(float, right, left);
+    display: block;
+    height: 44px;
+    width: 150px;
+    overflow: hidden;
+}
+
+#tabzilla-panel {
+    /* in case the javascript loads before the CSS */
+    height: 0;
+    overflow: hidden;
 }
 
 #nav-access {

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -59,6 +59,13 @@ draw-grid();
     height: 44px;
     width: 150px;
     overflow: hidden;
+
+    /* Prevents the "mozilla" link from displaying before tabzilla is loaded */
+    opacity: 0;
+
+    &.loaded {
+        opacity: 1;
+    }
 }
 
 #tabzilla-panel {

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,6 @@
   <link rel="home" href="{{ url('home') }}">
   <link rel="copyright" href="#copyright">
 
-  <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" type="text/css" rel="stylesheet">
   {% block site_css %}
     {{ css('mdn', 'all') }}
 


### PR DESCRIPTION
Supercedes https://github.com/mozilla/kuma/pull/3181

Added a change so that the link doesn't display until tabzilla has loaded.