### PR TITLE
Fix Bug Bug 1154283: Use summary box on tables

### DIFF
--- a/media/stylus/components/wiki/customcss.styl
+++ b/media/stylus/components/wiki/customcss.styl
@@ -321,122 +321,8 @@ div.index ol {
     padding-left: 0;
     list-style-type: none;
 }
-/* Stuff used for the syntax information about CSS, HTML, and so forth */
-/* ul.cssprop    box used by each CSS Property reference page*/
-.cssprop {
-    background-color: rgba-fallback(rgba(255,203,0,0.1));
-}
-[dir="ltr"] .cssprop {
-    clear: left;
-    margin: 0 0 $grid-spacing 0;
-    padding: 14px 0 14px 40px;
-    border-left: 6px solid rgba-fallback(rgba(255,203,0,0.5));
-}
-[dir="rtl"] .cssprop {
-    clear: right;
-    margin: 0 0 $grid-spacing 0;
-    padding: 14px 40px 14px 0;
-    border-right: 6px solid rgba-fallback(rgba(255,203,0,0.5));
-}
 
-.cssprop li {
-    display: table-row;
-    padding: 3px;
-    margin: 0;
-}
-.cssprop li dfn {
-    display: table-cell;
-    padding: 0 5px;
-    border-bottom: none;
-    white-space: pre;
-    cursor: inherit;
-}
-.cssprop li dfn:after {
-    content: ":";
-}
-.cssprop li li {
-    display: list-item;
-    list-style-type: disc;
-    line-height: 1;
-}
-/* ul.htmlelt box used by each HTML Element reference page */
-.htmlelt {
-    display: table;
-    padding: 11px 22px;
-    background-color: rgba-fallback(rgba(255,149,0,0.1));
-}
-[dir="ltr"] .htmlelt {
-    clear: left;
-    border-left: 6px solid rgba-fallback(rgba(255,149,0,0.5));
-}
-[dir="rtl"] .htmlelt {
-    clear: right;
-    border-right: 6px solid rgba-fallback(rgba(255,149,0,0.5));
-}
-.htmlelt li {
-    display: table-row;
-    padding: 3px;
-    margin: 0;
-    text-align: left;
-}
-.htmlelt li dfn {
-    display: table-cell;
-    padding: 0 5px;
-    border-bottom: none;
-    white-space: pre;
-    cursor: inherit;
-}
-.htmlelt li dfn:after {
-    content: ":";
-}
-.htmlelt li li {
-    display: list-item;
-    list-style-type: disc;
-    line-height: 1;
-}
-/* ul.audionodebox used by each AudioNode object reference page*/
-.audionodebox {
-    display: table;
-    padding: 11px 22px;
-    background-color: rgba-fallback(rgba(117,195,165,0.1));
-}
-[dir="ltr"] .audionodebox {
-    clear: left;
-    border-left: 6px solid rgba-fallback(rgba(117,195,165,0.5));
-}
-[dir="rtl"] .audionodebox {
-    clear: right;
-    border-right: 6px solid rgba-fallback(rgba(117,195,165,0.5));
-}
-.audionodebox li,
-.summary-box-js li,
-.summary-box-events li {
-    display: table-row;
-    padding: 3px;
-    margin: 0;
-    text-align: left;
-}
-.audionodebox li dfn,
-.summary-box-js li dfn,
-.summary-box-events li dfn {
-    display: table-cell;
-    padding: 0 5px;
-    border-bottom: none;
-    white-space: pre;
-    cursor: inherit;
-}
-.audionodebox li dfn:after,
-.summary-box-js li dfn:after,
-.summary-box-events li dfn:after {
-    content: ":";
-}
-.audionodebox li li,
-.summary-box-js li li,
-.summary-box-events li li {
-    display: list-item;
-    list-style-type: disc;
-    line-height: 1;
-}
+
 /* https://developer.mozilla.org/en-US/docs/Template:HTML:Element_Navigation */
 table.HTMLElmNav {
     margin: 1em auto;
@@ -1610,34 +1496,6 @@ dd.landingPageList {
     text-decoration: underline;
 }
 
-
-/* new modules */
-.summary-box-events {
-    display: table;
-    background-color: rgba-fallback(rgba(0,150,221,0.1));
-    padding: 11px 22px;
-}
-.redesign[dir="ltr"] .summary-box-events {
-    clear: left;
-    border-left: 6px solid rgba-fallback(rgba(0,150,221,0.5));
-}
-.redesign[dir="rtl"] .summary-box-events {
-    clear: right;
-    border-right: 6px solid rgba-fallback(rgba(0,150,221,0.5));
-}
-.summary-box-js {
-    display: table;
-    background-color: rgba-fallback(rgba(230,96,0,0.1));
-    padding: 11px 22px;
-}
-.redesign[dir="ltr"] .summary-box-js {
-    clear: left;
-    border-left: 6px solid rgba-fallback(rgba(230,96,0,0.5));
-}
-.redesign[dir="rtl"] .summary-box-js {
-    clear: right;
-    border-right: 6px solid rgba-fallback(rgba(230,96,0,0.5));
-}
 .redesign .standardNote,
 .redesign .optional,
 .renamed {

--- a/media/stylus/components/wiki/summary-box.styl
+++ b/media/stylus/components/wiki/summary-box.styl
@@ -1,0 +1,88 @@
+
+/*
+Summary boxes
+====================================================================== */
+
+/* item-spacing matches border and text-content li and td padding
+but no global varible becuase we should really pick 6 or 8 and
+just use $list-item-spacing everywhere */
+$summary-box-item-spacing = 6px;
+$summary-box-spacing = ($grid-spacing) - $summary-box-item-spacing;
+$summary-box-indent = ($grid-spacing * 2) - $summary-box-item-spacing;
+
+.cssprop,
+.htmlelt,
+.audionodebox,
+.summary-box-js,
+.summary-box-events {
+    display: table;
+    margin: 0 0 $grid-spacing 0;
+    border: 0 solid transparent;
+    bidi-value(clear, left, right);
+
+    .text-content & { /* need to override default text-content styles */
+        border-collapse: separate;
+        bidi-value(padding, $summary-box-spacing $summary-box-indent $summary-box-spacing $summary-box-spacing, $summary-box-spacing $summary-box-spacing $summary-box-spacing $summary-box-indent);
+        bidi-value(border-width, 0 0 0 $summary-box-item-spacing, 0 $summary-box-item-spacing 0 0);
+
+        @media $media-query-small-mobile {
+            bidi-value(padding, $summary-box-item-spacing, $summary-box-item-spacing);
+        }
+    }
+
+   li {
+        display: table-row;
+        margin: 0;
+    }
+
+    li dfn {
+        display: table-cell;
+        bidi-value(padding, $summary-box-item-spacing ($summary-box-item-spacing * 2) $summary-box-item-spacing $summary-box-item-spacing, $summary-box-item-spacing $summary-box-item-spacing $summary-box-item-spacing ($summary-box-item-spacing* 2 ));
+        border-bottom: none;
+        font-weight: bold;
+        white-space: pre;
+        cursor: inherit;
+    }
+
+    li li {
+        display: list-item;
+        list-style-type: disc;
+        line-height: 1;
+    }
+
+    th {
+        font-weight: bold;
+    }
+
+    th,
+    td {
+        border-width: 0;
+        vertical-align: top;
+    }
+}
+
+.text-content .cssprop {
+    background-color: rgba-fallback(rgba(255,203,0,0.1));
+    border-color: rgba-fallback(rgba(255,203,0,0.5));
+}
+
+.text-content .htmlelt {
+    background-color: rgba-fallback(rgba(255,149,0,0.1));
+    border-color: rgba-fallback(rgba(255,149,0,0.5));
+}
+
+.text-content .audionodebox {
+    background-color: rgba-fallback(rgba(117,195,165,0.1));
+    border-color: rgba-fallback(rgba(117,195,165,0.5));
+}
+
+.text-content .summary-box-js {
+    background-color: rgba-fallback(rgba(230,96,0,0.1));
+    border-color: rgba-fallback(rgba(230,96,0,0.5));
+}
+
+.text-content .summary-box-events {
+    background-color: rgba-fallback(rgba(0,150,221,0.1));
+    border-color: rgba-fallback(rgba(0,150,221,0.5));
+}
+

--- a/media/stylus/wiki.styl
+++ b/media/stylus/wiki.styl
@@ -34,6 +34,7 @@ Components that may appear on most wiki pages
 @require 'components/share';
 @require 'components/share-link';
 @require 'components/wiki/intrinsic';
+@require 'components/wiki/summary-box';
 
 
 /*


### PR DESCRIPTION
- made styles applicable to both ul and table for all colours of summary box
- standardized styles for both ul and table to match
- moved summary box classes into separate .styl file
- converted declarations to pre-processor syntax (variables! nesting! FTW!)
- RTL bugs

Supersedes #3179

Testing: 
Old style summary box made on a list: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/b
New style summary box made on a table: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr
Testing page with both side by side: https://developer.allizom.org/en-US/docs/User:stephaniehobson:summary-box