### PR TITLE
Fix Bug 1148738 - Syntax boxes should wrap

### DIFF
--- a/media/stylus/components/syntax/syntaxbox.styl
+++ b/media/stylus/components/syntax/syntaxbox.styl
@@ -8,17 +8,12 @@ pre.syntaxbox,
 pre.twopartsyntaxbox {
     background: $code-block-background-alt-color;
     @extend $code-block;
+    white-space: pre-wrap;
+    text-overflow: ellipsis ellipsis;
 }
 
 pre.twopartsyntaxbox {
     margin-bottom: 0;
-}
-
-/* Allow the content of the syntax box to wrap, to prevent horizontal scrolling */
-
-pre.syntaxbox code[class*="language-"],
-pre.twopartsyntaxbox code[class*="language-"] {
-    white-space: pre-line;
 }
 
 .syntaxbox-help {


### PR DESCRIPTION
White-space declaration wasn't being applied because the selector was too specific. This moves it up to a more general selector.

Supersedes #3143.