### PR TITLE
bug 957802 - pin puppetlabs-apt module version

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
                       apt-get --assume-yes install facter=1.7.6-1puppetlabs1 puppet=2.7.26-1puppetlabs1 puppet-common=2.7.26-1puppetlabs1;
                       mkdir -p /etc/puppet/modules;
                       puppet module install -f puppetlabs-stdlib;
-                      puppet module install -f puppetlabs-apt;
+                      puppet module install -f --version 1.8.0 puppetlabs-apt;
                       puppet module install -f --version 0.4.0 elasticsearch-elasticsearch"
     end
 


### PR DESCRIPTION
Spot-check:
```
vagrant halt
vagrant destroy
vagrant up
```
Should work as documented in [the vagrant docs](http://kuma.readthedocs.org/en/latest/installation-vagrant.html).