### PR TITLE
Fix Bug 1158614 - "flag content" button hard to read

### DIFF
--- a/kuma/demos/templates/demos/flag.html
+++ b/kuma/demos/templates/demos/flag.html
@@ -18,7 +18,7 @@
 <section id="content">
 <div class="wrap">
 
-  <section id="content-main" role="main" class="full">
+  <main id="content-main" role="main" class="full">
 
     <form id="flag-confirm" enctype="multipart/form-data" action="" method="POST" target="_top">
         <h1 class="page-title">{{_('Flag this demo?')}}</h1>
@@ -35,7 +35,7 @@
         </fieldset>
     </form>
 
-  </section>
+  </main>
 
 </div>
 </section>


### PR DESCRIPTION
Changed document structure so button inherits correct styles.

To test:
1) go to [a demo](https://developer.mozilla.org/en-US/demos/detail/bananabread)
2) click "demo not working"
3) look for submit button. Is it white on light grey or white on blue?