### PR TITLE
fix bug 1151523 - Ensure allowedContent receives an object that allows classes and attribtues

### DIFF
--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -78,7 +78,15 @@
 
     // Disable the Advanced Content Filter because too many pages
     // use unlimited HTML.
-    config.allowedContent = '{{ allowed_tags }}';
+    config.allowedContent = {
+        $1: {
+            // Use the ability to specify elements as an object.
+            elements: '{{ allowed_tags }}',
+            attributes: true,
+            styles: true,
+            classes: true
+        }
+    };
     config.disallowedContent = 'iframe; *[on*]';
 
     // Don't use HTML entities in the output except basic ones (config.basicEntities).


### PR DESCRIPTION
This alternate configuration should explicitly allow classes and attributes for code samples.  To test:

- Add an iframe, ensure it doesn't display in content mode
-  Add an image, allow SRC