### PR TITLE
Bug 1100690: Let django-waffle bucket users

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -420,6 +420,8 @@ MIDDLEWARE_CLASSES = (
 
     'badger.middleware.RecentBadgeAwardsMiddleware',
     'kuma.wiki.badges.BadgeAwardingMiddleware',
+
+    'waffle.middleware.WaffleMiddleware',
 )
 
 # Auth


### PR DESCRIPTION
When using percent-activated flags, django-waffle is supposed to
permanently group a user into one variation or another. Before this
change, this was not happening. The probability of a flag being active
was re-determined on every page load.

This change adds the django-waffle middleware to our stack. This gives
django-waffle the opportunity to set a cookie and, in turn, use
percent-activated flags as intended.