### PR TITLE
Fix Bug: 1143084 - moztt use

### DIFF
--- a/media/stylus/base/fonts/moztt.styl
+++ b/media/stylus/base/fonts/moztt.styl
@@ -2,16 +2,16 @@
 @font-face {
   font-family: 'MozTT';
   font-weight: 200;
-  src: url('//developer.cdn.mozilla.net/fonts/MozTT-light-webfont.eot');
-  src: url('//developer.cdn.mozilla.net/fonts/MozTT-light-webfont.eot?#iefix') format('embedded-opentype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-light-webfont.woff') format('woff'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-light-webfont.ttf') format('truetype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-light-webfont.svg#mozttlight') format('svg');
+  src: url('/media/fonts/MozTT-light-webfont.eot');
+  src: url('/media/fonts/MozTT-light-webfont.eot?#iefix') format('embedded-opentype'), url('/media/fonts/MozTT-light-webfont.woff') format('woff'), url('/media/fonts/MozTT-light-webfont.ttf') format('truetype'), url('/media/fonts/MozTT-light-webfont.svg#mozttlight') format('svg');
 }
 @font-face {
   font-family: 'MozTT';
-  src: url('//developer.cdn.mozilla.net/fonts/MozTT-regular-webfont.eot');
-  src: url('//developer.cdn.mozilla.net/fonts/MozTT-regular-webfont.eot?#iefix') format('embedded-opentype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-regular-webfont.woff') format('woff'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-regular-webfont.ttf') format('truetype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-regular-webfont.svg#mozttregular') format('svg');
+  src: url('/media/fonts/MozTT-regular-webfont.eot');
+  src: url('/media/fonts/MozTT-regular-webfont.eot?#iefix') format('embedded-opentype'), url('/media/fonts/MozTT-regular-webfont.woff') format('woff'), url('/media/fonts/MozTT-regular-webfont.ttf') format('truetype'), url('/media/fonts/MozTT-regular-webfont.svg#mozttregular') format('svg');
 }
 @font-face {
   font-family: 'MozTT';
   font-weight: 600;
-  src: url('//developer.cdn.mozilla.net/fonts/MozTT-medium-webfont.eot'); src: url('//developer.cdn.mozilla.net/media/fonts/MozTT-medium-webfont.eot?#iefix') format('embedded-opentype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-medium-webfont.woff') format('woff'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-medium-webfont.ttf') format('truetype'), url('//developer.cdn.mozilla.net/media/fonts/MozTT-medium-webfont.svg#mozttmedium') format('svg');
+  src: url('/media/fonts/MozTT-medium-webfont.eot'); src: url('/media/fonts/MozTT-medium-webfont.eot?#iefix') format('embedded-opentype'), url('/media/fonts/MozTT-medium-webfont.woff') format('woff'), url('/media/fonts/MozTT-medium-webfont.ttf') format('truetype'), url('/media/fonts/MozTT-medium-webfont.svg#mozttmedium') format('svg');
 }

--- a/media/stylus/gaia.styl
+++ b/media/stylus/gaia.styl
@@ -1,0 +1,6 @@
+/*
+Fonts for Gaia demos
+====================================================================== */
+
+@require 'base/fonts/moztt';
+@require 'base/fonts/opensans';

--- a/settings.py
+++ b/settings.py
@@ -622,6 +622,9 @@ MINIFY_BUNDLES = {
         'devderby': (
             'css/devderby.css',
         ),
+        'gaia': (
+            'css/gaia.css',
+        ),
         'home': (
             'css/home.css',
             'js/libs/owl.carousel/owl-carousel/owl.carousel.css',


### PR DESCRIPTION
Getting moztt to be included in Gaia 1.0 demos.
- changed declaration to pull font without CDN (I could not locate the fonts in the CDN, but this is how we include the font-face milk as well so I am copying an existent convention)
- created separate gaia.styl file to include global fonts for demos (just font faces at the moment)

Testing:
1) Edit line 12 of https://developer-local.allizom.org/en-US/docs/Template:FXOSUXLiveSampleSetup to be `@import url('/media/css/gaia.css');`
2) Start ALL THE PROCESSES. You're going to need kumascript for this one
3) Testing page: https://developer-local.allizom.org/en-US/Apps/Design/Firefox_OS_building_blocks/1.x/Confirmation/Coding You're looking to see that the font loads in the Gaia demos, identified by orange boxes. Compare to same page on prod, if the font is different, success!

I have already edited the FXOSUXLiveSampleSetup on prod, it was 404ing before and it'll 404 until these changes are pushed so I figured no harm done.