### PR TITLE
Bug 775569 and other small fixes

### DIFF
--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -115,17 +115,17 @@
         { name: 'None', element: 'p' },
         { name: 'Note box', element: 'div', attributes: { 'class': 'note' }, type: 'wrap' },
         { name: 'Warning box', element: 'div', attributes: { 'class': 'warning' }, type: 'wrap' },
-        { name: 'Callout box', element: 'div', attributes: { 'class': 'geckoVersionNote' }, type: 'wrap' },
         { name: 'Two columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
         { name: 'Three columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },
         { name: 'Syntax Box', element: 'div', attributes: { 'class': 'syntaxbox' } },
-        { name: 'Right Sidebar', element: 'div', attributes: { 'class': 'standardSidebar' } },
         { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } }
       ]);
     }
 
     config.keystrokes = [
+      // CTRL+0
+      [ CKEDITOR.CTRL + 48, 'removeFormat' ],
       // CTRL+2
       [ CKEDITOR.CTRL + 50, 'mdn-format-h2' ],
       // CTRL+3
@@ -140,6 +140,8 @@
       [ CKEDITOR.CTRL + 80, 'mdn-format-pre' ],
       // CTRL+K
       [ CKEDITOR.CTRL + 75, 'link' ],
+      // CTRL+SHIFT+K
+      [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 75, 'unlink' ],
       // CTRL+SHIFT+L
       [ CKEDITOR.CTRL + CKEDITOR.SHIFT + 76, 'mdn-toggle-block' ],
       // CTRL+S


### PR DESCRIPTION
Implements Ctrl+0 (Cmd-0) as a key shortcut for the "Remove formatting" option in
CKEditor (bug 775569).

There are also some fixes which are parts of other general editing clean-up
bugs:

* Removed the "Right sidebar" and "Callout box" styles from
the Style drop-down menu.

* Added the key shortcut Ctrl+Shift+K (Cmd-Shift-K) for "Remove link".