### PR TITLE
Bug 1150118: Dropping time out to 2 seconds

### DIFF
--- a/media/js/fonts.js
+++ b/media/js/fonts.js
@@ -31,7 +31,7 @@
         var fontsLoaded = {};
 
         // timout for all observers
-        var ffoTimeout = 3000;
+        var ffoTimeout = 2000;
 
         // starts observers for all fonts in fonts array
         function ffoLoad() {


### PR DESCRIPTION
Let's experiment with this for a week. It's not quite the "Can we just not swap out the fonts on first load" some people are asking for but it decreases how far someone can get before the swap happens, if it happens at all.