### PR TITLE
Fix Bug 1148752 - CSS break long article titles.

### DIFF
--- a/media/stylus/base/elements/typography.styl
+++ b/media/stylus/base/elements/typography.styl
@@ -12,14 +12,16 @@ Headings
 
 h1, h2, h3, h4 {
     margin-bottom: ($content-block-margin / 2);
+    word-wrap: break-word; /* keep for browsers & locales that don't support hyphens */
+    vendorize(hyphens, auto);
 
     font-family: $heading-font-family;
     font-weight: $light-font-weight;
-    line-height: 1.5;
+    line-height: 1;
     {$selector-heading-font-fallback} {
         font-family: $heading-font-family-fallback;
         letter-spacing: -0.04em;
-        line-height: 1.515;
+        line-height: 1;
         word-spacing: 0.01em;
     }
 }
@@ -28,21 +30,17 @@ h2, h3 {
     font-family: $site-font-family;
     {$selector-site-font-fallback} {
         font-family: $site-font-family-fallback;
-        line-height: 1.515;
-    }
-}
-
-h2, h3, h4 {
-    line-height: 100%;
-
-    {$selector-site-font-fallback} {
-        line-height: 1;
     }
 }
 
 h1 {
     heading-1();
     margin-bottom: $grid-spacing;
+
+    line-height: 1.5;
+    {$selector-heading-font-fallback} {
+        line-height: 1.515;
+    }
 }
 
 h2 {

--- a/media/stylus/components/wiki/document-head.styl
+++ b/media/stylus/components/wiki/document-head.styl
@@ -3,6 +3,12 @@
     clear: both;
 
     h1 {
-        margin-bottom: 20px;
+        margin-top: $grid-spacing;
+        margin-bottom: ($grid-spacing * 1.5);
+
+        line-height: 1;
+        {$selector-site-font-fallback} {
+            line-height: 1.005;
+        }
     }
 }


### PR DESCRIPTION
Added word-wrap: break-word to auto-break when necessary. Added hyphens: auto to add hyphen at break for supporting browser/locale combos.

Moved line height 1 declaration to apply to all headings by default and over ride for h1 (instead of applying to all and being over ridden by all but h1).

Decreased line height on document head. Increased margins on document head to account for decreased line height.

Before:
![screen shot 2015-06-01 at 15 21 22](https://cloud.githubusercontent.com/assets/854701/7924659/101d5080-0872-11e5-87bc-56d66ab89d55.png)

After:
![screen shot 2015-06-01 at 15 26 10](https://cloud.githubusercontent.com/assets/854701/7924739/b655b69a-0872-11e5-9726-c55fc20df259.png)



