### PR TITLE
Fix Bug 1156233 - zebra stripe tables

### DIFF
--- a/media/stylus/components/content.styl
+++ b/media/stylus/components/content.styl
@@ -24,7 +24,14 @@ $table-blue = #d4dde4;
                 box-shadow: inset 0 -1px 0 0 rgba-fallback(rgba($table-blue, 0.5));
             }
 
-            td.header, th {
+            /* zebra strip if 5 or more rows */
+            tr:first-child:nth-last-child(n+5) ~ tr:nth-child(2n-2) td {
+                background-color: rgba-fallback(rgba($table-blue, 0.25));
+            }
+
+
+            td.header,
+            th {
                 border: @border;
                 border-bottom: 2px solid rgba-fallback(rgba($table-blue, 1));
                 background: rgba-fallback(rgba($table-blue, 0.5));


### PR DESCRIPTION
Slightly darker bg in tables with 5 or more rows.

Examples:
![screen shot 2015-06-01 at 15 56 36](https://cloud.githubusercontent.com/assets/854701/7925248/698f53ac-0877-11e5-8848-a7213115b283.png)
![screen shot 2015-06-01 at 15 57 45](https://cloud.githubusercontent.com/assets/854701/7925249/6cac7baa-0877-11e5-8129-b10fc3642a06.png)
