### PR TITLE
Fix Bug 1126320 - Inline code tag visibility

### DIFF
--- a/media/stylus/base/elements/typography.styl
+++ b/media/stylus/base/elements/typography.styl
@@ -157,7 +157,6 @@ pre/code/kbd
 
 code {
     font-family: $code-inline-font-family;
-    font-weight: bold;
 }
 
 /* pre is a block element so it gets a bit more fancy styling */

--- a/media/stylus/includes/vars.styl
+++ b/media/stylus/includes/vars.styl
@@ -54,9 +54,9 @@ $site-font-family = 'Open Sans', Arial, sans-serif;
 $site-font-family-fallback = Arial, sans-serif;
 $heading-font-family = 'Open Sans Light', 'Helvetica', Arial, sans-serif;
 $heading-font-family-fallback = 'Helvetica', Arial, sans-serif;
-$code-inline-font-family = 'Courier New', 'Andale Mono', monospace; /* inline */
 $code-block-font-family = Consolas, Monaco, 'Andale Mono', monospace; /* prism */
-$diff-font-family = 'Courier New', 'Andale Mono', monospace;
+$code-inline-font-family = 'Courier', 'Andale Mono', monospace; /* inline */
+$diff-font-family = $code-inline-font-family;
 
 /*
 sizes


### PR DESCRIPTION
Dialing back the visibility a bit.

Changed font to Courier since Courier New is too fine at the regular weight. 
Removed default bold.