### PR TITLE
fix bug 1158888 - Added comment "Technical/Editorial review completed"

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -845,6 +845,9 @@ class Document(NotificationsMixin, models.Model):
 
         new_rev.summary = data.get('summary', '')
 
+        # To add comment, when Technical/Editorial review completed
+        new_rev.comment = data.get('comment', '')
+
         # Accept HTML edits, optionally by section
         new_html = data.get('content', data.get('html', False))
         if new_html:

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2148,6 +2148,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             review_tags.sort()
             for expected_str in data_dict['message_contains']:
                 ok_(expected_str in rev.summary)
+                ok_(expected_str in rev.comment)
             eq_(data_dict['expected_tags'], review_tags)
 
     @attr('midair')

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -2158,7 +2158,7 @@ def quick_review(request, document_slug, document_locale):
     if messages:
         # We approved something, make the new revision.
         new_rev = doc.revise(request.user,
-                             data={'summary': ' '.join(messages)})
+                             data={'summary': ' '.join(messages), 'comment': ' '.join(messages)})
         if new_tags:
             new_rev.review_tags.set(*new_tags)
         else:


### PR DESCRIPTION
When somebody completes Technical/Editorial review, Comment will be added automatically to database. 
-- What it was is: when ever somebody completes the Editorial/Technical review, it was adding "Editorial/Technical review completed" in "summary" column of  "wiki_revision" table leaving the comment field empty.
-- What i did is: I also added "Editorial/Technical review completed"  in "comment" column of "wiki_revision" table  when somebody review the document.

![after screen_shot](https://cloud.githubusercontent.com/assets/3767459/8143162/489881d4-11bc-11e5-8ed6-f91dcd9528d3.png)
![before screen_shot](https://cloud.githubusercontent.com/assets/3767459/8143163/48a320bc-11bc-11e5-8634-c1fac8d683b5.png)
![both_review_completed](https://cloud.githubusercontent.com/assets/3767459/8143164/48b4385c-11bc-11e5-9331-8f2746f0195a.png)

