### PR TITLE
Bug 1116335 - Don't run syncdb during deployment but only the new migrate command.

### DIFF
--- a/scripts/anonymize.py
+++ b/scripts/anonymize.py
@@ -60,7 +60,6 @@ TABLES_TO_DUMP=[x.strip() for x in """
     gallery_video
     schema_version
     soapbox_message
-    south_migrationhistory
     tagging_tag
     tagging_taggeditem
     taggit_tag

--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -46,8 +46,7 @@ def update_assets(ctx):
 @task
 def database(ctx):
     with ctx.lcd(settings.SRC_DIR):
-        ctx.local("python2.7 manage.py syncdb --noinput")                   # Django
-        ctx.local("python2.7 manage.py migrate --noinput")                  # South (new)
+        ctx.local("python2.7 manage.py migrate --noinput")
 
 
 @task


### PR DESCRIPTION
The syncdb command is deprecated in Django 1.7 (https://docs.djangoproject.com/en/1.7/ref/django-admin/#syncdb).