### PR TITLE
Fix bug 1173395 - Don't pass in non-ASCII pseudo filenames to difflib.

### DIFF
--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -52,24 +52,28 @@ def revision(save=False, **kwargs):
     Requires a users fixture if no creator is provided.
 
     """
-    d = None
+    doc = None
     if 'document' not in kwargs:
-        d = document()
-        d.save()
+        doc = document(save=True)
     else:
-        d = kwargs['document']
+        doc = kwargs['document']
 
-    defaults = {'summary': 'Some summary', 'content': 'Some content',
-                'comment': 'Some comment',
-                'creator': kwargs.get('creator', get_user()), 'document': d,
-                'tags': '"some", "tags"', 'toc_depth': 1}
+    defaults = {
+        'summary': 'Some summary',
+        'content': 'Some content',
+        'comment': 'Some comment',
+        'creator': kwargs.get('creator', get_user()),
+        'document': doc,
+        'tags': '"some", "tags"',
+        'toc_depth': 1,
+    }
 
     defaults.update(kwargs)
 
-    r = Revision(**defaults)
+    rev = Revision(**defaults)
     if save:
-        r.save()
-    return r
+        rev.save()
+    return rev
 
 
 def translated_revision(locale='de', **kwargs):

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import mock
 from nose.tools import eq_
 
@@ -5,7 +6,7 @@ from django.contrib.sites.models import Site
 
 from kuma.core.cache import memcache
 from kuma.users.tests import UserTestCase
-from . import revision, WikiTestCase
+from . import document, revision, WikiTestCase
 from ..helpers import (absolutify, document_zone_management_links,
                        revisions_unified_diff, tojson)
 from ..models import DocumentZone
@@ -44,6 +45,16 @@ class RevisionsUnifiedDiffTests(UserTestCase, WikiTestCase):
         except AttributeError:
             self.fail("Should not throw AttributeError")
         eq_("Diff is unavailable.", diff)
+
+    def test_from_revision_non_ascii(self):
+        doc1 = document(title=u'Gänsefüßchen', save=True)
+        rev1 = revision(document=doc1, content=u'spam', save=True)
+        doc2 = document(title=u'Außendienstüberwachlösung', save=True)
+        rev2 = revision(document=doc2, content=u'eggs', save=True)
+        try:
+            revisions_unified_diff(rev1, rev2)
+        except UnicodeEncodeError:
+            self.fail("Should not throw UnicodeEncodeError")
 
 
 class DocumentZoneTests(UserTestCase, WikiTestCase):


### PR DESCRIPTION
This basically works around the upstream issue in difflib, which is documented in the many 3rd party bug reports:
- https://bugzilla.redhat.com/show_bug.cgi?id=1221169
- https://github.com/wbsoft/frescobaldi/issues/674
- https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=784940
- https://bugzilla.mozilla.org/show_bug.cgi?id=1149667