### PR TITLE
fix bug 1158888 - Added comment "Technical/Editorial review completed…

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -858,6 +858,9 @@ class Document(NotificationsMixin, models.Model):
 
         new_rev.summary = data.get('summary', '')
 
+        # To add comment, when Technical/Editorial review completed
+        new_rev.comment = data.get('comment', '')
+
         # Accept HTML edits, optionally by section
         new_html = data.get('content', data.get('html', False))
         if new_html:

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2155,6 +2155,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             review_tags.sort()
             for expected_str in data_dict['message_contains']:
                 ok_(expected_str in rev.summary)
+                ok_(expected_str in rev.comment)
             eq_(data_dict['expected_tags'], review_tags)
 
     @attr('midair')

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -2173,7 +2173,7 @@ def quick_review(request, document_slug, document_locale):
     if messages:
         # We approved something, make the new revision.
         new_rev = doc.revise(request.user,
-                             data={'summary': ' '.join(messages)})
+                             data={'summary': ' '.join(messages), 'comment': ' '.join(messages)})
         if new_tags:
             new_rev.review_tags.set(*new_tags)
         else:


### PR DESCRIPTION
…" , when somebody completes Technical/Editorial review.

Supersedes https://github.com/mozilla/kuma/pull/3260