### PR TITLE
fix bug 1175873 - Fix broken link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ The [GitHub Flow](https://guides.github.com/introduction/flow/) site is a great 
 GitHub workflow
 ---------------
 
-1. [Install our development environment](http://kuma.readthedocs.org/en/latest/installation-vagrant.html)
+1. [Install our development environment](http://kuma.readthedocs.org/en/latest/installation.html)
 2. Create a branch for your bug:
 
     ```


### PR DESCRIPTION
Fix the broken link to the documentation page on installing the
development environment in CONTRIBUTING.md.