### PR TITLE
Bug 1148743 - Open jsfiddle and CodePen for Samples

### DIFF
--- a/media/js/wiki-samples.js
+++ b/media/js/wiki-samples.js
@@ -1,0 +1,98 @@
+(function(win, doc, $) {
+    if(!win.waffle || !win.waffle.flag_is_active('wiki_samples')) return;
+
+    var sites = ['codepen'];
+    var frameLength = 'frame_'.length;
+
+    var sourceURL = $('link[rel=canonical]').attr('href') || win.location;
+    var plug = '<!-- Learn about this code on MDN: ' + sourceURL + ' -->\n\n';
+
+    // using id to get sample code section since macros discard other attributes
+    $('.sample-code-frame').after(function() {
+        var section = $(this).attr('id').substring(frameLength);
+        return createSampleButtons(section, sites);
+    });
+    $('.sample-code-table').after(function(){
+        var section = $(this).find('iframe').attr('id').substring(frameLength);
+        return createSampleButtons(section, sites);
+    });
+
+    $('#wikiArticle').on('click', 'button.open-in-host', function(){
+        var $button = $(this);
+        var section = $button.attr('data-section');
+        var sampleCodeHost = $button.attr('data-host');
+        var sampleUrl = win.location.href.split('#')[0] + '?section=' + section + '&raw=1';
+
+        // track the click and sample code host
+        mdn.analytics.trackEvent({
+            category: 'Samples',
+            action: 'open-' + sampleCodeHost,
+            label: section
+        });
+
+        // disable the button, till we open the fiddle
+        $button.attr('disabled', 'disabled');
+        $.get(sampleUrl).then(function(sample) {
+            var $sample = $('<div />').append(sample);
+            var htmlCode = $sample.find('.brush\\:.html, .brush\\:.html\\;').text();
+            var cssCode = $sample.find('.brush\\:.css, .brush\\:.css\\;').text();
+            var jsCode = $sample.find('.brush\\:.js, .brush\\:.js\\;').text();
+            var title = $sample.find('h2[name=' + section + ']').text();
+            openSample(sampleCodeHost, title, htmlCode, cssCode, jsCode);
+
+            $button.removeAttr('disabled');
+        });
+    });
+
+    function openJSFiddle(title, htmlCode, cssCode, jsCode) {
+       var $form = $('<form method="post" target="_blank" action="https://jsfiddle.net/api/mdn/" class="hidden">' +
+            '<input type="hidden" name="html" />' +
+            '<input type="hidden" name="css" />' +
+            '<input type="hidden" name="js" />' +
+            '<input type="hidden" name="title" />' +
+            '<input type="hidden" name="wrap" value="b" />' +
+            '<input type="hidden" name="source" value="mdn" />' +
+            '<input type="hidden" name="medium" value="code-sample" />' +
+            '<input type="submit" />' +
+        '</form>').appendTo(doc.body);
+
+       $form.find('input[name=html]').val(htmlCode);
+       $form.find('input[name=css]').val(cssCode);
+       $form.find('input[name=js]').val(jsCode);
+       $form.find('input[name=title]').val(title);
+       $form.get(0).submit();
+    }
+
+    function openCodepen(title, htmlCode, cssCode, jsCode) {
+       var $form = $('<form method="post" target="_blank" action="https://codepen.io/pen/define" class="hidden">' +
+            '<input type="hidden" name="data">' +
+            '<input type="submit" />' +
+        '</form>').appendTo(doc.body);
+
+       var data = {'title': title, 'html': plug + htmlCode, 'css': cssCode, 'js': jsCode};
+       $form.find('input[name=data]').val(JSON.stringify(data));
+       $form.get(0).submit();
+    }
+
+    function openSample(sampleCodeHost, title, htmlCode, cssCode, jsCode) {
+       if(sampleCodeHost === 'jsfiddle') {
+            openJSFiddle(title, htmlCode, cssCode, jsCode);
+        } else if(sampleCodeHost === 'codepen') {
+            openCodepen(title, htmlCode, cssCode, jsCode);
+        }
+    }
+
+    function createSampleButtons(section, sites) {
+        var buttons = '<div>';
+        $.each(sites, function(){
+            // convert sitename to lowercase for icon name and host identifier
+            var host = this.toLowerCase();
+            buttons += '<button class="open-in-host" data-host="'+ host +'" data-section="' +
+                section + '"><i aria-hidden="true" class="icon-'+ host +'"></i> Open in ' +
+                this +'</button>';
+        });
+        buttons += '</div>';
+        return buttons;
+    }
+
+})(window, document, jQuery);

--- a/media/stylus/base/elements/forms.styl
+++ b/media/stylus/base/elements/forms.styl
@@ -114,3 +114,7 @@ label {
         text-decoration: none;
     }
 }
+
+.open-in-host + .open-in-host {
+    bidi-style(margin-left, ($grid-spacing / 2), margin-right, 0);
+}

--- a/settings.py
+++ b/settings.py
@@ -719,6 +719,7 @@ MINIFY_BUNDLES = {
         'wiki': (
             'js/search-navigator.js',
             'js/wiki.js',
+            'js/wiki-samples.js',
         ),
         'wiki-edit': (
             'js/wiki-edit.js',


### PR DESCRIPTION
Supercedes https://github.com/mozilla/kuma/pull/3240

I needed to redo this due to the VM change -- things go weird.

How to test:

1.  Create a macro called `EmbedLiveSample`:  https://gist.github.com/darkwing/cbd69a8756081d482474  (this was changed)
2.  Create a macro called `LiveSampleURL`:  https://gist.github.com/darkwing/4b09b0b1d1e6e41a66d2  (this is unchanged)
3.  Create a document with the following content:  https://gist.github.com/darkwing/0dd8cdaba22497efb76c

You should see the "Open" buttons above the rendered sample