### PR TITLE
fix bug 1156233 - zebra stripe tables

### DIFF
--- a/media/stylus/components/content.styl
+++ b/media/stylus/components/content.styl
@@ -24,6 +24,11 @@ $table-blue = #d4dde4;
                 box-shadow: inset 0 -1px 0 0 rgba-fallback(rgba($table-blue, 0.5));
             }
 
+            /* alternating row colours (aka zebra or candy striping) */
+            &:not(.nostripe) tr:nth-child(odd) td {
+                background-color: rgba-fallback(rgba($table-blue, 0.25));
+            }
+
             td.header, th {
                 border: @border;
                 border-bottom: 2px solid rgba-fallback(rgba($table-blue, 1));


### PR DESCRIPTION
Final word on striped tables. Stripes all tables with class .standard-table. Stripes can be removed by adding 'nostripe' class to table.