### PR TITLE
Fix Bug 1177571: Standardize and variablize item spacing 

### DIFF
--- a/media/stylus/base/elements/forms.styl
+++ b/media/stylus/base/elements/forms.styl
@@ -15,7 +15,7 @@ input, button, textarea, select, optgroup, option {
 input[type=text], input[type=password], input[type=search], input[type=email], input[type=url], textarea {
     background: #fff;
     border: 1px solid #cbc8b9;
-    padding: 6px 8px;
+    padding: $content-vertical-spacing $content-horizontal-spacing;
 }
 
 input[type='search'] {

--- a/media/stylus/components/components.styl
+++ b/media/stylus/components/components.styl
@@ -55,7 +55,7 @@
         a {
             set-smaller-font-size();
             display: block;
-            padding: $list-item-spacing $grid-spacing;
+            padding: $content-vertical-spacing $grid-spacing;
         }
 
         .toggleable {

--- a/media/stylus/components/content.styl
+++ b/media/stylus/components/content.styl
@@ -47,16 +47,15 @@ $table-blue = #d4dde4;
 
             td {
                 border: 1px solid #ccc;
-                padding: 5px 15px;
-                text-align: left;
+                padding: 5px;
+                bidi-value(text-align, left, right);
                 vertical-align: top;
             }
 
             td.header, th {
                 background: rgba-fallback(rgba($table-blue, 0.5));
                 border: 1px solid rgba-fallback(rgba($table-blue, 1));
-                font-weight: bold;
-                padding: 0 5px;
+                padding: 5px;
             }
         }
     }
@@ -64,7 +63,7 @@ $table-blue = #d4dde4;
     td, th {
         border: solid #e0e0dc;
         border-width: 0 1px 1px 0;
-        padding: 6px;
+        padding: $content-vertical-spacing $content-horizontal-spacing;
         bidi-value('text-align', left, right);
     }
 
@@ -83,7 +82,7 @@ $table-blue = #d4dde4;
 
     ul ul, ol ol, ul ol, ol ul {
         margin-bottom: 0;
-        padding-top: 6px;
+        padding-top: $content-vertical-spacing;
     }
 
     ul, ol {
@@ -101,7 +100,7 @@ $table-blue = #d4dde4;
     }
 
     li {
-        padding-bottom: 6px;
+        margin-bottom: $content-vertical-spacing;
     }
     prevent-last-child-spacing(li, padding-bottom);
 

--- a/media/stylus/components/home/home-contribute.styl
+++ b/media/stylus/components/home/home-contribute.styl
@@ -17,7 +17,7 @@ Contribute row at bottom
 
     li {
         border-bottom: 1px solid #ececec;
-        padding: $list-item-spacing 0;
+        padding: $content-vertical-spacing 0;
 
         &:last-child {
             border-bottom: 0;

--- a/media/stylus/components/home/home-demos.styl
+++ b/media/stylus/components/home/home-demos.styl
@@ -60,7 +60,7 @@ demos section and carousel
         border: 6px solid #fff;
         display: block;
         box-shadow: 2px 2px 1px rgba(0 , 0, 0, .1);
-        margin-bottom: 6px;
+        margin-bottom: $content-vertical-spacing;
         width: 180px;
         height: 133px;
     }

--- a/media/stylus/components/share-link.styl
+++ b/media/stylus/components/share-link.styl
@@ -6,7 +6,7 @@ share-link
     border-radius: 2px;
     box-shadow: none;
     color: #fff;
-    bidi-value(margin, 0 6px 6px 0, 0 0 6px 6px);
+    bidi-value(margin, 0 $content-horizontal-spacing $content-vertical-spacing 0, 0 0 $content-vertical-spacing $content-horizontal-spacing);
     padding: 3px;
 
     &.facebook {

--- a/media/stylus/components/share.styl
+++ b/media/stylus/components/share.styl
@@ -6,7 +6,7 @@
     top: $grid-spacing;
 
     strong {
-        bidi-style(margin-right, 6px, margin-left, 0);
+        bidi-style(margin-right, $content-horizontal-spacing, margin-left, 0);
     }
 
     ul,

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -417,7 +417,7 @@ a.github-button {
 
     a {
         display: block;
-        padding: 6px 8px;
+        padding: $content-vertical-spacing $content-horizontal-spacing;
         position: relative;
 
         &:hover, &:active, &:focus {
@@ -585,7 +585,7 @@ a.github-button {
             bidi-value(text-align, left, right);
 
             > li {
-                bidi-value(margin, 6px 6px 6px 0, 6px 0 6px 6px);
+                bidi-value(margin, $content-vertical-spacing $content-horizontal-spacing $content-vertical-spacing 0, $content-vertical-spacing 0 $content-vertical-spacing $content-horizontal-spacing);
             }
         }
     }

--- a/media/stylus/components/tags.styl
+++ b/media/stylus/components/tags.styl
@@ -35,9 +35,11 @@ ul.tags li {
     small
 */
 
+$small-tag-spacing = 3px;
+
 ul.tags-small li {
-    margin: 0 6px 6px 0;
-    padding: 1px 3px;
+    margin: 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2) 0;
+    padding: 1px $small-tag-spacing;
 }
 
 .tag-attach-list .tags-small {

--- a/media/stylus/components/wiki/contributor-avatars.styl
+++ b/media/stylus/components/wiki/contributor-avatars.styl
@@ -2,7 +2,7 @@
 .contributor-avatars {
     set-smaller-font-size();
     color: #777;
-    padding: 10px 10px 6px;
+    padding: 10px 10px $content-vertical-spacing;
     border-bottom: 1px solid rgb(241, 241, 241);
     border-top: 1px solid rgb(241, 241, 241);
     background: none repeat scroll 0 0 rgba-fallback(rgba(234, 239, 243, 0.4));

--- a/media/stylus/components/wiki/quick-links.styl
+++ b/media/stylus/components/wiki/quick-links.styl
@@ -34,7 +34,7 @@ $see-also-outdent = 6px;
     }
 
     li {
-        padding-top: $list-item-spacing;
+        padding-top: $content-vertical-spacing;
         position: relative;
     }
 

--- a/media/stylus/components/wiki/reviews.styl
+++ b/media/stylus/components/wiki/reviews.styl
@@ -8,7 +8,11 @@
         margin: 0;
     }
 
+    ul {
+        padding-bottom: $content-vertical-spacing;
+    }
+
     li {
-        padding-top: $list-item-spacing;
+        padding-top: $content-vertical-spacing;
     }
 }

--- a/media/stylus/components/wiki/summary-box.styl
+++ b/media/stylus/components/wiki/summary-box.styl
@@ -3,10 +3,7 @@
 Summary boxes
 ====================================================================== */
 
-/* item-spacing matches border and text-content li and td padding
-but no global varible becuase we should really pick 6 or 8 and
-just use $list-item-spacing everywhere */
-$summary-box-item-spacing = 6px;
+$summary-box-item-spacing = $content-horizontal-spacing;
 $summary-box-spacing = ($grid-spacing) - $summary-box-item-spacing;
 $summary-box-indent = ($grid-spacing * 2) - $summary-box-item-spacing;
 

--- a/media/stylus/dashboards.styl
+++ b/media/stylus/dashboards.styl
@@ -74,7 +74,7 @@
     #page-buttons {
         li {
             display: inline-block;
-            margin-right: $list-item-spacing;
+            margin-right: $content-horizontal-spacing;
         }
     }
 }
@@ -86,7 +86,7 @@
     }
     label {
         display: inline-block;
-        margin-right: $list-item-spacing;
+        margin-right: $content-horizontal-spacing;
     }
     .revision-field {
         display: inline-block;

--- a/media/stylus/includes/vars.styl
+++ b/media/stylus/includes/vars.styl
@@ -107,16 +107,21 @@ $slide-timing-function = cubic-bezier(0, 1, 0.5, 1);
 dimensions
 ====================================================================== */
 $gutter-width = 24px;
-$first-content-top-padding = ($grid-spacing * 1.5);
-$list-item-spacing = 8px;
 $content-block-margin = $gutter-width;
+
+$first-content-top-padding = ($grid-spacing * 1.5);
+
+$content-horizontal-spacing = 8px;
+$content-vertical-spacing = 6px;
+$list-item-spacing = $content-horizontal-spacing;
+
 $icon-margin = 10px;
 
 
 /*
 forms
 ====================================================================== */
-$input-padding = 6px 8px;
+$input-padding = $content-vertical-spacing $content-horizontal-spacing;
 
 
 /*

--- a/media/stylus/zones.styl
+++ b/media/stylus/zones.styl
@@ -125,7 +125,7 @@
 }
 
 .zone-landing-lists li {
-    padding: $list-item-spacing 0;
+    padding: $content-vertical-spacing 0;
     prevent-last-child-spacing(padding-bottom);
 }
 


### PR DESCRIPTION
Also fix bug 1177223: change list item spacing to margin instead of padding.

Created variables $content-horizontal-spacing and $content-vertical-spacing and attempted to replace references to 6px and 8px with them. Please note: I have attempted to replicate the most common current usage of these values, discussing if there is value in these design decisions is out of the scope of this PR.

Minor display changes in some places, no more than 2px difference, all of which I think are acceptable.

Test pages:
https://developer-local.mozilla.org/en-US/docs/User:teoli/In_content
- quick links
- specification tables (small change)
- summary boxes (small change, partially due to li change)
- there's also a few lists where you can see the effect of the switch from padding to margin
Your profile page
- form items should not change appearance
https://developer-local.allizom.org/en-US/docs/User%3Astephaniehobson%3Atest
- has a tripple nested list so you can observe switch from padding to margin on lis
https://developer-local.allizom.org/en-US/docs/MDN/Contribute/Localize/RSS_feeds
- scroll down to the bottom to look at the "fullwidth-table"s
https://developer-local.allizom.org/en-US/docs/Web/CSS/display
- left sidebar (slightly less space)
- small tags in the footer (should not be any change)
https://developer-local.allizom.org/en-US/docs/Web/API/AnimationEvent/initAnimationEvent
- left sidebar (links should be closer, but icons should not be mis-aligned)
A page that needs an editorial review
- box in left hand column should have a bit more spacing between the form and button 
https://developer-local.allizom.org/en-US/dashboards/revisions
- shouldn't look substantially different
A zone with a left nav
- shouldn't look any different.