### PR TITLE
bug 957802 - Remove bootcamp link 

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,7 +59,7 @@ Install and run everything
    in the future. Until then see this blog post for how to
    `Run Vagrant with Ansible Provisioning on Windows <http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/>`_
 
-#. Fork the project. (See `GitHub <https://help.github.com/articles/fork-a-repo#step-1-fork-the-spoon-knife-repository>`_ and `Webdev Bootcamp <http://mozweb.readthedocs.org/en/latest/git.html#working-on-projects>`_)
+#. Fork the project. (See `GitHub <https://help.github.com/articles/fork-a-repo#step-1-fork-the-spoon-knife-repository>`)
 
 #. Clone your fork of Kuma and update submodules::
 


### PR DESCRIPTION
Superseding https://github.com/mozilla/kuma/pull/3279 with bug # in commit message.