### PR TITLE
Fix bug 1178252 - Stop updated the json blob when a wiki document is logically deleted like when it's marked as spam.

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -555,17 +555,13 @@ class Document(NotificationsMixin, models.Model):
 
         self.save()
 
-        # If we're a translation, rebuild our source doc's JSON so its
-        # translation list includes our last edit date.
-        if self.parent is not None:
-            parent_json = json.dumps(self.parent.build_json_data())
-            Document.objects.filter(pk=self.parent.pk).update(json=parent_json)
-
         render_done.send(sender=self.__class__, instance=self)
 
     def get_summary(self, strip_markup=True, use_rendered=True):
-        """Attempt to get the document summary from rendered content, with
-        fallback to raw HTML"""
+        """
+        Attempt to get the document summary from rendered content, with
+        fallback to raw HTML
+        """
         if use_rendered and self.rendered_html:
             src = self.rendered_html
         else:


### PR DESCRIPTION
This also fixes and reenables some deferred tests that were skipped.