### PR TITLE
bug 1177264 - remove un-used TeamworkBackend

### DIFF
--- a/kuma/wiki/migrations/0003_auto_20150701_1539.py
+++ b/kuma/wiki/migrations/0003_auto_20150701_1539.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+import kuma.core.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0002_auto_20150430_0805'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='document',
+            name='team',
+        ),
+        migrations.AlterField(
+            model_name='document',
+            name='locale',
+            field=kuma.core.fields.LocaleField(default=b'en-US', max_length=7, db_index=True, choices=[(b'af', 'Afrikaans'), (b'ar', '\u0639\u0631\u0628\u064a'), (b'az', 'Az\u0259rbaycanca'), (b'bm', 'Bamanankan'), (b'bn-BD', '\u09ac\u09be\u0982\u09b2\u09be (\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6)'), (b'bn-IN', '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)'), (b'ca', 'Catal\xe0'), (b'cs', '\u010ce\u0161tina'), (b'de', 'Deutsch'), (b'ee', 'E\u028be'), (b'el', '\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac'), (b'en-US', 'English (US)'), (b'es', 'Espa\xf1ol'), (b'fa', '\u0641\u0627\u0631\u0633\u06cc'), (b'ff', 'Pulaar-Fulfulde'), (b'fi', 'suomi'), (b'fr', 'Fran\xe7ais'), (b'fy-NL', 'Frysk'), (b'ga-IE', 'Gaeilge'), (b'ha', 'Hausa'), (b'he', '\u05e2\u05d1\u05e8\u05d9\u05ea'), (b'hi-IN', '\u0939\u093f\u0928\u094d\u0926\u0940 (\u092d\u093e\u0930\u0924)'), (b'hr', 'Hrvatski'), (b'hu', 'magyar'), (b'id', 'Bahasa Indonesia'), (b'ig', 'Igbo'), (b'it', 'Italiano'), (b'ja', '\u65e5\u672c\u8a9e'), (b'ka', '\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8'), (b'ko', '\ud55c\uad6d\uc5b4'), (b'ln', 'Ling\xe1la'), (b'ml', '\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02'), (b'ms', 'Melayu'), (b'my', '\u1019\u103c\u1014\u103a\u1019\u102c\u1018\u102c\u101e\u102c'), (b'nl', 'Nederlands'), (b'pl', 'Polski'), (b'pt-BR', 'Portugu\xeas (do\xa0Brasil)'), (b'pt-PT', 'Portugu\xeas (Europeu)'), (b'ro', 'rom\xe2n\u0103'), (b'ru', '\u0420\u0443\u0441\u0441\u043a\u0438\u0439'), (b'son', 'So\u014bay'), (b'sq', 'Shqip'), (b'sw', 'Kiswahili'), (b'ta', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd'), (b'th', '\u0e44\u0e17\u0e22'), (b'tl', 'Tagalog'), (b'tr', 'T\xfcrk\xe7e'), (b'vi', 'Ti\u1ebfng Vi\u1ec7t'), (b'wo', 'Wolof'), (b'xh', 'isiXhosa'), (b'yo', 'Yor\xf9b\xe1'), (b'zh-CN', '\u4e2d\u6587 (\u7b80\u4f53)'), (b'zh-TW', '\u6b63\u9ad4\u4e2d\u6587 (\u7e41\u9ad4)'), (b'zu', 'isiZulu')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='documentdeletionlog',
+            name='locale',
+            field=kuma.core.fields.LocaleField(default=b'en-US', max_length=7, db_index=True, choices=[(b'af', 'Afrikaans'), (b'ar', '\u0639\u0631\u0628\u064a'), (b'az', 'Az\u0259rbaycanca'), (b'bm', 'Bamanankan'), (b'bn-BD', '\u09ac\u09be\u0982\u09b2\u09be (\u09ac\u09be\u0982\u09b2\u09be\u09a6\u09c7\u09b6)'), (b'bn-IN', '\u09ac\u09be\u0982\u09b2\u09be (\u09ad\u09be\u09b0\u09a4)'), (b'ca', 'Catal\xe0'), (b'cs', '\u010ce\u0161tina'), (b'de', 'Deutsch'), (b'ee', 'E\u028be'), (b'el', '\u0395\u03bb\u03bb\u03b7\u03bd\u03b9\u03ba\u03ac'), (b'en-US', 'English (US)'), (b'es', 'Espa\xf1ol'), (b'fa', '\u0641\u0627\u0631\u0633\u06cc'), (b'ff', 'Pulaar-Fulfulde'), (b'fi', 'suomi'), (b'fr', 'Fran\xe7ais'), (b'fy-NL', 'Frysk'), (b'ga-IE', 'Gaeilge'), (b'ha', 'Hausa'), (b'he', '\u05e2\u05d1\u05e8\u05d9\u05ea'), (b'hi-IN', '\u0939\u093f\u0928\u094d\u0926\u0940 (\u092d\u093e\u0930\u0924)'), (b'hr', 'Hrvatski'), (b'hu', 'magyar'), (b'id', 'Bahasa Indonesia'), (b'ig', 'Igbo'), (b'it', 'Italiano'), (b'ja', '\u65e5\u672c\u8a9e'), (b'ka', '\u10e5\u10d0\u10e0\u10d7\u10e3\u10da\u10d8'), (b'ko', '\ud55c\uad6d\uc5b4'), (b'ln', 'Ling\xe1la'), (b'ml', '\u0d2e\u0d32\u0d2f\u0d3e\u0d33\u0d02'), (b'ms', 'Melayu'), (b'my', '\u1019\u103c\u1014\u103a\u1019\u102c\u1018\u102c\u101e\u102c'), (b'nl', 'Nederlands'), (b'pl', 'Polski'), (b'pt-BR', 'Portugu\xeas (do\xa0Brasil)'), (b'pt-PT', 'Portugu\xeas (Europeu)'), (b'ro', 'rom\xe2n\u0103'), (b'ru', '\u0420\u0443\u0441\u0441\u043a\u0438\u0439'), (b'son', 'So\u014bay'), (b'sq', 'Shqip'), (b'sw', 'Kiswahili'), (b'ta', '\u0ba4\u0bae\u0bbf\u0bb4\u0bcd'), (b'th', '\u0e44\u0e17\u0e22'), (b'tl', 'Tagalog'), (b'tr', 'T\xfcrk\xe7e'), (b'vi', 'Ti\u1ebfng Vi\u1ec7t'), (b'wo', 'Wolof'), (b'xh', 'isiXhosa'), (b'yo', 'Yor\xf9b\xe1'), (b'zh-CN', '\u4e2d\u6587 (\u7b80\u4f53)'), (b'zh-TW', '\u6b63\u9ad4\u4e2d\u6587 (\u7e41\u9ad4)'), (b'zu', 'isiZulu')]),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='localizationtaggedrevision',
+            name='tag',
+            field=models.ForeignKey(related_name='wiki_localizationtaggedrevision_items', to='wiki.LocalizationTag'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='reviewtaggedrevision',
+            name='tag',
+            field=models.ForeignKey(related_name='wiki_reviewtaggedrevision_items', to='wiki.ReviewTag'),
+            preserve_default=True,
+        ),
+        migrations.AlterField(
+            model_name='taggeddocument',
+            name='tag',
+            field=models.ForeignKey(related_name='wiki_taggeddocument_items', to='wiki.DocumentTag'),
+            preserve_default=True,
+        ),
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -30,7 +30,6 @@ import waffle
 from taggit.managers import TaggableManager
 from taggit.models import ItemBase, TagBase
 from taggit.utils import edit_string_for_tags, parse_tags
-from teamwork.models import Team
 from tidings.models import NotificationsMixin
 
 from kuma.attachments.models import Attachment
@@ -266,9 +265,6 @@ class Document(NotificationsMixin, models.Model):
     # A document's category much always be that of its parent. If it has no
     # parent, it can do what it wants. This invariant is enforced in save().
     category = models.IntegerField(choices=CATEGORIES, db_index=True)
-
-    # Team to which this document belongs, if any
-    team = models.ForeignKey(Team, blank=True, null=True)
 
     # Whether this page is deleted.
     deleted = models.BooleanField(default=False, db_index=True)

--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -88,15 +88,6 @@
                   <li><a href="{{ url('wiki.delete_document', document.slug) }}" rel="nofollow, noindex">{{ _('Delete this page') }}</a></li>
                 {% endif %}
 
-                {% set policy_links = build_policy_admin_links(request.user, document) %}
-                {% if policy_links['change_one'] %}
-                  <li><a target="_blank" href="{{ policy_links['change_one'] }}" rel="nofollow, noindex">{{ _('Manage access policy') }}</a></li>
-                {% elif policy_links['change_list'] %}
-                  <li><a target="_blank" href="{{ policy_links['change_list'] }}" rel="nofollow, noindex">{{ _('Manage access policies') }}</a></li>
-                {% elif policy_links['add'] %}
-                  <li><a target="_blank" href="{{ policy_links['add'] }}" rel="nofollow, noindex">{{ _('Add access policy') }}</a></li>
-                {% endif %}
-
                 {% set zone_links = document_zone_management_links(request.user, document) %}
                 {% if zone_links['change'] %}
                   <li><a target="_blank" href="{{ zone_links['change'] }}" rel="nofollow, noindex">{{ _('Manage content zone') }}</a></li>

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -477,8 +477,7 @@ def document(request, document_slug, document_locale):
     # We found a Document. Now we need to figure out how we're going
     # to display it.
 
-    # Step 1: If we're a redirect, and redirecting hasn't been
-    # disabled, redirect.
+    # If we're a redirect, and redirecting hasn't been disabled, redirect.
 
     # Obey explicit redirect pages:
     # Don't redirect on redirect=no (like Wikipedia), so we can link from a
@@ -498,12 +497,7 @@ def document(request, document_slug, document_locale):
             }), extra_tags='wiki_redirect')
         return HttpResponsePermanentRedirect(url)
 
-    # Step 2: Kick 'em out if they're not allowed to view this Document.
-    if not request.user.has_perm('wiki.view_document', doc):
-        raise PermissionDenied
-
-    # Step 3: Read some request params to see what we're supposed to
-    # do.
+    # Read some request params to see what we're supposed to do.
     rendering_params = {}
     for param in ('raw', 'summary', 'include', 'edit_links'):
         rendering_params[param] = request.GET.get(param, False) is not False
@@ -511,18 +505,18 @@ def document(request, document_slug, document_locale):
     rendering_params['render_raw_fallback'] = False
     rendering_params['use_rendered'] = kumascript.should_use_rendered(doc, request.GET)
 
-    # Step 4: Get us some HTML to play with.
+    # Get us some HTML to play with.
     doc_html, ks_errors, render_raw_fallback = _get_html_and_errors(
         request, doc, rendering_params)
     rendering_params['render_raw_fallback'] = render_raw_fallback
     toc_html = None
 
-    # Step 5: Start parsing and applying filters.
+    # Start parsing and applying filters.
     if not doc.is_template:
         toc_html = _generate_toc_html(doc, rendering_params)
         doc_html = _filter_doc_html(request, doc, doc_html, rendering_params)
 
-    # Step 6: If we're doing raw view, bail out to that now.
+    # If we're doing raw view, bail out to that now.
     if rendering_params['raw']:
         return _document_raw(request, doc, doc_html, rendering_params)
 
@@ -552,7 +546,7 @@ def document(request, document_slug, document_locale):
 
     share_text = _('I learned about %(title)s on MDN.') % {"title": doc.title, }
 
-    # Step 8: Bundle it all up and, finally, return.
+    # Bundle it all up and, finally, return.
     context = {
         'document': doc,
         'document_html': doc_html,

--- a/settings.py
+++ b/settings.py
@@ -429,7 +429,6 @@ MIDDLEWARE_CLASSES = (
 # Auth
 AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',
-    'teamwork.backends.TeamworkBackend',
 )
 AUTH_USER_MODEL = 'users.User'
 


### PR DESCRIPTION
`TeamworkBackend` has been making multiple db queries on every document view even though we have no policies or teams for it. So, this removes the backend.

Note: @jezdez I'm not sure the best way to finish removing `teamwork` completely - i.e., from `INSTALLED_APPS` (and removing the submodule & dependency). When I took `teamwork` out of `INSTALLED_APPS` I got a `Migration 0001_initial dependencies reference nonexistent parent node` error.

Should we merge & push this, update all environments, then squash the wiki migrations again?