### PR TITLE
Bug 1177798 - Order contributors by recency of last edit.

### DIFF
--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -1,3 +1,6 @@
+import collections
+
+from django.contrib.auth import get_user_model
 from kuma.core.jobs import KumaJob
 
 
@@ -40,6 +43,48 @@ class DocumentZoneURLRemapsJob(KumaJob):
         remaps = [('/docs/%s' % zone.document.slug, '/%s' % zone.url_root)
                   for zone in zones]
         return remaps
+
+    def empty(self):
+        # the empty result needs to be an empty list instead of None
+        return []
+
+
+class DocumentContributorsJob(KumaJob):
+    """
+    Given a wiki document returns a list of contributors that have recently
+    authored revisions.
+
+    We invalidate this when a document is saved only, not when a user account
+    changes given the potential of lots of documents needing to be updated
+    everytime a profile is saved. Instead we accept that some contributor links
+    may be wrong until the cache item's lifetime runs out for this edge case.
+    """
+    lifetime = 60 * 60 * 6
+    refresh_timeout = 30
+
+    def fetch(self, pk):
+        from .models import Document
+        User = get_user_model()
+
+        # first get a list of user ID recently authoring revisions
+        document = Document.objects.get(pk=pk)
+        recent_creator_ids = (document.revisions.order_by('-created')
+                                                .values_list('creator_id',
+                                                             flat=True))
+
+        if not recent_creator_ids:
+            return self.empty()
+
+        # then return the ordered results given the ID list, MySQL only syntax
+        select = collections.OrderedDict([
+            ('ordered_ids',
+             'FIELD(id,%s)' % ','.join(map(str, recent_creator_ids))),
+        ])
+        return (User.objects.filter(id__in=list(recent_creator_ids),
+                                    is_active=True)
+                            .only('id', 'username')
+                            .extra(select=select,
+                                   order_by=['ordered_ids']))
 
     def empty(self):
         # the empty result needs to be an empty list instead of None

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -15,11 +15,10 @@ from pyquery import PyQuery
 from tower import ugettext_lazy as _lazy, ugettext as _
 
 from django.conf import settings
-from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import resolve
 from django.db import models
-from django.db.models import Count, signals
+from django.db.models import signals
 from django.dispatch import receiver
 from django.http import Http404
 from django.utils.decorators import available_attrs
@@ -49,7 +48,8 @@ from .content import (extract_code_sample, extract_css_classnames,
                       extract_html_attributes, extract_kumascript_macro_names,
                       get_content_sections, get_seo_description, H2TOCFilter,
                       H3TOCFilter, SectionTOCFilter)
-from .jobs import DocumentZoneStackJob, DocumentZoneURLRemapsJob
+from .jobs import (DocumentZoneStackJob, DocumentZoneURLRemapsJob,
+                   DocumentContributorsJob)
 from .exceptions import (DocumentRenderedContentNotAvailable,
                          DocumentRenderingInProgress, PageMoveError,
                          SlugCollision, UniqueCollision)
@@ -1511,13 +1511,9 @@ Full traceback:
     def get_document_type(self):
         return WikiDocumentType
 
-    def get_contributors(self):
-        top_creator_ids = (self.revisions.values_list('creator', flat=True)
-                                         .annotate(Count('creator'))
-                                         .order_by('-creator__count'))
-        return (get_user_model().objects
-                                .filter(pk__in=list(top_creator_ids),
-                                        is_active=True))
+    @cached_property
+    def contributors(self):
+        return DocumentContributorsJob().get(self.pk)
 
     @cached_property
     def zone_stack(self):
@@ -1569,7 +1565,7 @@ class DocumentZone(models.Model):
         super(DocumentZone, self).save(*args, **kwargs)
 
         # Refresh the cache for the locale of this zone's attached document
-        DocumentZoneURLRemapsJob().refresh(self.document.locale)
+        invalidate_zone_urls_cache(self.document)
         invalidate_zone_stack_cache(self.document)
 
 
@@ -1608,6 +1604,11 @@ def invalidate_zone_urls_cache(document, async=False):
 def invalidate_zone_caches(sender, instance, **kwargs):
     invalidate_zone_urls_cache(instance, async=True)
     invalidate_zone_stack_cache(instance, async=True)
+
+
+@receiver(signals.post_save, sender=Document)
+def invalidate_contributors(sender, instance, **kwargs):
+    DocumentContributorsJob().invalidate(instance.pk)
 
 
 class ReviewTag(TagBase):
@@ -1804,9 +1805,9 @@ class Revision(models.Model):
         self.document.save()
 
     def __unicode__(self):
-        return u'[%s] %s #%s: %s' % (self.document.locale,
-                                     self.document.title,
-                                     self.id, self.content[:50])
+        return u'[%s] %s #%s' % (self.document.locale,
+                                 self.document.title,
+                                 self.id)
 
     def get_section_content(self, section_id):
         """Convenience method to extract the content for a single section"""

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -181,7 +181,7 @@
 
         {% if waffle.flag('top_contributors') %}
             {% set contrib_limit = 13 %}
-            {% set contrib_count = contributors.count() %}
+            {% set contrib_count = document.contributors.count() %}
 
         <div class="contributor-avatars" data-all-text="{{ _('Show all') }}&hellip;<span class='hidden'>{{ _('contributors') }}</span>" {% if contrib_count > contrib_limit %}data-has-hidden="1"{% endif %}>
             <span class="quickstat">
@@ -192,7 +192,7 @@
             {% endtrans %}
             </span>
             <ul>
-            {% for contributor in contributors %}
+            {% for contributor in document.contributors %}
                 <li class="{% if loop.index > contrib_limit %}hidden{% else %}shown{% endif %}">
                 <a href="{{ contributor.get_absolute_url() }}" title="{% trans username=contributor.username %}View profile: {{ username }}{% endtrans %}">
                 <noscript data-class="avatar" data-alt="{{ contributor.username }}" data-src="{{ gravatar_url(contributor, size=34) }}">{{ contributor.username }}</noscript></a>

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -560,7 +560,6 @@ def document(request, document_slug, document_locale):
         'quick_links_html': quick_links_html,
         'zone_subnav_html': zone_subnav_html,
         'body_html': body_html,
-        'contributors': doc.get_contributors(),
         'fallback_reason': fallback_reason,
         'kumascript_errors': ks_errors,
         'render_raw_fallback': rendering_params['render_raw_fallback'],


### PR DESCRIPTION
In other words, the active user with the most recent edit shows up first.

This also moves the fetching of the contributors into a cacheback job to be able to invalidate the cache asynchronously.