### PR TITLE
Bug 1054265 - Updated django-allauth to 0.21.0.

### DIFF
--- a/requirements/source.txt
+++ b/requirements/source.txt
@@ -69,7 +69,7 @@ Django==1.7.8
 
 commonware==0.4.3
 
-django-allauth==0.20.0
+django-allauth==0.21.0
 
 django-appconf==1.0.1
 


### PR DESCRIPTION
This fixes a regression in e6940b8141ff1ce312ad7057d08d0b40af59465b.