### PR TITLE
Fix bug 1179897 - Reduce number of db queries on profile page.

### DIFF
--- a/kuma/attachments/feeds.py
+++ b/kuma/attachments/feeds.py
@@ -16,8 +16,7 @@ class AttachmentsFeed(DocumentsFeed):
         return item.title
 
     def item_description(self, item):
-        previous = item.get_previous()
-        if previous is None:
+        if item.previous is None:
             return '<p>Created by: %s</p>' % item.creator.username
         return "<p>Edited by %s: %s" % (item.creator.username, item.comment)
 

--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -16,8 +16,7 @@
         </thead>
         <tbody>
             {% for revision in revisions %}
-
-                {% set previous_id = revision.get_previous().id %}
+                {% set previous_id = revision.previous.id %}
                 {% set revision_url = revision.document.get_absolute_url() %}
                 <tr
                     tabindex="0"

--- a/kuma/demos/feeds.py
+++ b/kuma/demos/feeds.py
@@ -13,6 +13,7 @@ import jingo
 
 from kuma.core.validators import valid_jsonp_callback_value
 from kuma.core.urlresolvers import reverse
+from kuma.users.helpers import gravatar_url
 
 from . import TAG_DESCRIPTIONS
 from .models import Submission
@@ -47,7 +48,8 @@ class SubmissionJSONFeedGenerator(SyndicationFeed):
                 'link', 'title', 'pubdate', 'author_name', 'author_link',
             ))
 
-            item_out['author_avatar'] = item['obj'].creator.profile.gravatar
+            if item['obj'].creator.email:
+                item_out['author_avatar'] = gravatar_url(item['obj'].creator)
 
             # Linkify the tags used in the feed item
             item_out['categories'] = dict(

--- a/kuma/demos/templates/demos/elements/profile_link.html
+++ b/kuma/demos/templates/demos/elements/profile_link.html
@@ -1,2 +1,2 @@
 {% set display_name = user_display(user) %}
-<a href="{{ user.get_absolute_url() }}" class="url fn" title="{% trans %}See {{ display_name }}'s profile{% endtrans %}">{% if show_gravatar %}<img src="{{ user.profile.gravatar() }}" class="photo avatar" width="{{ gravatar_size }}" height="{{ gravatar_size }}" border="0" /> {% endif %}<span>{{ display_name }}</span></a>
+<a href="{{ user.get_absolute_url() }}" class="url fn" title="{% trans %}See {{ display_name }}'s profile{% endtrans %}">{% if show_gravatar %}<img src="{{ gravatar_url(user, size=gravatar_size) }}" class="photo avatar" width="{{ gravatar_size }}" height="{{ gravatar_size }}" border="0" /> {% endif %}<span>{{ display_name }}</span></a>

--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -54,7 +54,6 @@
             {{ admin_link(profile.user) }}
           {% endif %}
 
-
           <!-- Only shown for the user and admins -->
           {% if profile.allows_editing_by(request.user) %}
               <a id="edit-profile" href="{{ url('users.profile_edit', username=profile.user.username) }}" class="button neutral">{{ _("Edit") }}<i aria-hidden="true" class="icon-pencil"></i></a>
@@ -116,7 +115,7 @@
       </div>
       <div class="column-2 ">
         <figure>
-          <img src="{{ profile.gravatar() }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
+          <img src="{{ gravatar_url(profile.user, size=200) }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
         </figure>
 
         <ul class="profile-links">
@@ -137,7 +136,7 @@
       </div>
     </section>
 
-    {% if demos_page.object_list|length %}
+    {% if demos_paginator.count %}
         <section id="profile-demos" class="profile-section">
             {{ submission_listing(
                 request, demos_page.object_list, demos_page.has_other_pages(),
@@ -161,7 +160,6 @@
               <h2>{{ _("Recent Docs Activity") }}</h2> <a href="{{ url('dashboards.revisions') }}?user={{ profile.user.username }}" class="button">{{ _('View all activity') }}</a>
             </header>
 
-            {% if wiki_activity and wiki_activity|length %}
             <table class="activity">
               <thead>
                 <th scope="col" class="activity-page">{{ _("Page") }}</th>
@@ -169,46 +167,38 @@
                 <th scope="col" class="activity-summary">{{ _("Comment") }}</th>
               </thead>
               <tbody>
-                {% for rev in wiki_activity %}
-                {% set previous_rev = rev.get_previous() %}
+                {% for revision in profile.user.wiki_revisions() %}
                 <tr>
                   <th scope="row">
-                      <h3><a href="{{ rev.document.get_absolute_url() }}">{{ rev.document.title }}</a></h3>
+                      <h3><a href="{{ revision.document.get_absolute_url() }}">{{ revision.document.title }}</a></h3>
                       <ul class="activity-actions">
-                          <li><a href="{{ rev.document.get_absolute_url() }}$edit" class="edit">{{ _("Edit page") }}</a></li>
-                          <li>{% if previous_rev %}<a href="{{ rev.document.get_absolute_url() }}$compare?from={{ previous_rev.id }}&amp;to={{ rev.id }}" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
-                          <li><a href="{{ rev.document.get_absolute_url() }}$history" class="history">{{ _("View page history") }}</a></li>
+                          <li><a href="{{ url('wiki.edit_document', revision.document.slug, locale=revision.document.locale) }}" class="edit">{{ _("Edit page") }}</a></li>
+                          <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
+                          <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history">{{ _("View page history") }}</a></li>
                       </ul>
                   </th>
-                  <td>{{ datetimeformat(rev.created, format='date') }}<br />
-                      {{ datetimeformat(rev.created, format='time') }}</td>
+                  <td>{{ datetimeformat(revision.created, format='date') }}<br />
+                      {{ datetimeformat(revision.created, format='time') }}</td>
                   {# TODO: auto-generate smart comment like "N words changed." #}
-                  <td>{{ format_comment(rev) }}</td>
+                  <td>{{ format_comment(revision, previous_revision=revision.previous) }}</td>
+                </tr>
+                {% else %}
+                <tr>
+                    <th scope="row">
+                    {% if profile.user == request.user %}
+                        {% trans docs_url=wiki_url('Project:MDN/Contributing/Creating_and_editing_pages') %}
+                        <p class="none">You haven't contributed to any MDN docs. <a href="{{ docs_url }}">Pitch in!</a></p>
+                        {% endtrans %}
+                    {% else %}
+                        <p class="none">{{ _('This user has no activity.') }}</p>
+                    {% endif %}
+                    </th>
                 </tr>
                 {% endfor %}
               </tbody>
               <tfoot>
-                      {# TODO: create user revision activity feed
-                <tr>
-                  <td colspan="3">
-                      <a href="/index.php?title=Special:Contributions&feed=rss&target={{ profile.user.username | urlencode }}" rel="alternate" class="feed">{{ _("Feed") }}</a>
-                  </td>
-                </tr>
-                      #}
               </tfoot>
             </table>
-
-            {% else %}
-
-            {% if profile.user == request.user %}
-                {% trans docs_url=wiki_url('Project:MDN/Contributing/Creating_and_editing_pages') %}
-                <p class="none">You haven't contributed to any MDN docs. <a href="{{ docs_url }}">Pitch in!</a></p>
-                {% endtrans %}
-            {% else %}
-                <p class="none">{{ _('This user has no activity.') }}</p>
-            {% endif %}
-
-          {% endif %}
           </section>
 
   </section><!-- /#content-main -->

--- a/kuma/users/templates/users/profile_edit.html
+++ b/kuma/users/templates/users/profile_edit.html
@@ -35,7 +35,7 @@
 
       <div class="column-2 smaller">
         <figure class="acc-avatar">
-          <img src="{{ profile.gravatar() }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
+          <img src="{{ gravatar_url(profile.user, size=200) }}" alt="{{ profile.user.username }}" width="200" height="200" class="profile-photo avatar" />
           <figcaption>
               {{ _('Change your avatar at') }} <a href="http://gravatar.com" rel="external">gravatar.com</a>
           </figcaption>

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -2,6 +2,8 @@ from nose.tools import eq_, ok_
 from nose.plugins.attrib import attr
 
 from kuma.wiki.tests import revision
+
+from ..helpers import gravatar_url
 from ..models import UserBan, UserProfile
 from . import profile, UserTestCase
 
@@ -88,8 +90,7 @@ class TestUserProfile(UserTestCase):
         user = self.user_model.objects.get(username='testuser')
         user.email = u"Someguy Dude\xc3\xaas Lastname"
         try:
-            profile = UserProfile.objects.get(user=user)
-            profile.gravatar
+            gravatar_url(user)
         except UnicodeEncodeError:
             self.fail("There should be no UnicodeEncodeError")
 
@@ -102,11 +103,10 @@ class TestUserProfile(UserTestCase):
         ok_(hasattr(profile_from_db, 'timezone'))
         ok_(str(profile_from_db.timezone) == 'US/Pacific')
 
-    def test_wiki_activity(self):
+    def test_wiki_revisions(self):
         user = self.user_model.objects.get(username='testuser')
-        profile = UserProfile.objects.get(user=user)
         rev = revision(save=True, is_approved=True)
-        ok_(rev.pk in profile.wiki_activity().values_list('pk', flat=True))
+        ok_(rev.pk in user.wiki_revisions().values_list('pk', flat=True))
 
 
 class BanTestCase(UserTestCase):

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -17,7 +17,7 @@ log = logging.getLogger('kuma.wiki.events')
 def context_dict(revision):
     """Return a dict that fills in the blanks in notification templates."""
     document = revision.document
-    from_revision = revision.get_previous()
+    from_revision = revision.previous
     to_revision = revision
     diff = revisions_unified_diff(from_revision, to_revision)
 

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -308,7 +308,7 @@ class RevisionsFeed(DocumentsFeed):
 
     def item_description(self, item):
         # TODO: put this in a jinja template if django syndication will let us
-        previous = item.get_previous()
+        previous = item.previous
         if previous is None:
             action = u'Created'
         else:

--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -113,12 +113,12 @@ def bugize_text(content):
 
 
 @register.function
-def format_comment(rev):
+def format_comment(rev, previous_revision=None):
     """ Massages revision comment content after the fact """
 
-    prev_rev = getattr(rev, 'previous_revision', None)
+    prev_rev = getattr(rev, 'previous_revision', previous_revision)
     if prev_rev is None:
-        prev_rev = rev.get_previous()
+        prev_rev = rev.previous
     comment = bugize_text(rev.comment if rev.comment else "")
 
     # If a page move, say so

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1811,7 +1811,8 @@ class Revision(models.Model):
         else:
             return Document.objects.clean_content(self.content)
 
-    def get_previous(self):
+    @cached_property
+    def previous(self):
         """
         Returns the previous approved revision or None.
         """

--- a/kuma/wiki/templates/wiki/edit_document.html
+++ b/kuma/wiki/templates/wiki/edit_document.html
@@ -143,7 +143,7 @@
 
         </header>
 
-        {% if request.user.profile.wiki_activity().count() == 0 %}
+        {% if request.user.wiki_revisions().count() == 0 %}
           <section class="first-contrib-welcome">
             <h2>{{_('Thank you for taking the time to improve MDN!')}}</h2>
             <p>

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -640,22 +640,22 @@ class RevisionTests(UserTestCase):
         de_rev.clean()
         eq_(en_rev.document.current_revision, de_rev.based_on)
 
-    def test_get_previous(self):
-        """Revision.get_previous() should return this revision's document's
+    def test_previous(self):
+        """Revision.previous should return this revision's document's
         most recent approved revision."""
         rev = revision(is_approved=True, save=True)
-        eq_(None, rev.get_previous())
+        eq_(None, rev.previous)
         # wait a second so next revision is a different datetime
         time.sleep(1)
         next_rev = revision(document=rev.document, content="Updated",
                             is_approved=True)
         next_rev.save()
-        eq_(rev, next_rev.get_previous())
+        eq_(rev, next_rev.previous)
         time.sleep(1)
         last_rev = revision(document=rev.document, content="Finally",
                             is_approved=True)
         last_rev.save()
-        eq_(next_rev, last_rev.get_previous())
+        eq_(next_rev, last_rev.previous)
 
     @attr('toc')
     def test_show_toc(self):

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -2185,7 +2185,7 @@ def _save_rev_and_notify(rev_form, request, document):
     """Save the given RevisionForm and send notifications."""
     creator = request.user
     # have to check for first edit before we rev_form.save
-    first_edit = creator.profile.wiki_activity().count() == 0
+    first_edit = creator.wiki_revisions().count() == 0
 
     new_rev = rev_form.save(creator, document)
 

--- a/settings.py
+++ b/settings.py
@@ -401,7 +401,12 @@ PASSWORD_HASHERS = (
 
 USER_AVATAR_PATH = 'uploads/avatars/'
 DEFAULT_AVATAR = MEDIA_URL + 'img/avatar.png'
-AVATAR_SIZE = 48  # in pixels
+AVATAR_SIZES = [  # in pixels
+    34,   # wiki document page
+    48,   # profile_link helper
+    200,  # profile pages
+    220,  # default, e.g. used in feeds
+]
 ACCOUNT_ACTIVATION_DAYS = 30
 MAX_AVATAR_FILE_SIZE = 131072  # 100k, in bytes
 


### PR DESCRIPTION
This does a bunch of things:

- Move revision helper to custom user model (ref bug 1180208).
- Use else clause for for loop for getting rid of slow count query.
- Prefetch revision documents to reduce related queries.
- Use a cached property for the previous revision for in-page load caching.
- Refactor the gravatar method with better caching.