### PR TITLE
Bug 957802 - Switch to Codecov from coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ install:
 script: tox -v
 after_failure:
     - dmesg | tail
-after_success: coveralls
+after_success:
+    - codecov
 notifications:
     irc:
         channels:

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ Kuma
    :target: https://travis-ci.org/mozilla/kuma
    :alt: Build Status
 
-.. image:: https://img.shields.io/coveralls/mozilla/kuma/master.svg
-   :target: https://coveralls.io/r/mozilla/kuma?branch=master
+.. image:: https://codecov.io/github/mozilla/kuma/coverage.svg?branch=master
+   :target: https://codecov.io/github/mozilla/kuma?branch=master
    :alt: Code Coverage Status
 
 .. image:: https://requires.io/github/mozilla/kuma/requirements.svg?branch=master

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,4 +1,4 @@
 ansible==1.9.2
-coveralls
+codecov
 tox==2.1.1
 lxml==3.4.4


### PR DESCRIPTION
The rational here is simple, [Codecov](https://codecov.io/#features) is a better UI for coverage.