### PR TITLE
Bug 815693: Rename .user-state

### DIFF
--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -229,7 +229,7 @@ class AllauthPersonaTestCase(UserTestCase):
                              locale=settings.WIKI_DEFAULT_LANGUAGE))
             parsed = pq(response.content)
 
-            login_info = parsed.find('.header-login .user-state')
+            login_info = parsed.find('.header-login .oauth-logged-in')
             ok_(len(login_info.children()))
 
             signed_in_message = login_info.children()[0]
@@ -315,7 +315,7 @@ class AllauthPersonaTestCase(UserTestCase):
                              locale=settings.WIKI_DEFAULT_LANGUAGE))
             parsed = pq(response.content)
 
-            login_info = parsed.find('.header-login .user-state')
+            login_info = parsed.find('.header-login .oauth-logged-in')
             ok_(len(login_info.children()))
 
             signed_in_message = login_info.children()[0]

--- a/media/stylus/components/home/base.styl
+++ b/media/stylus/components/home/base.styl
@@ -105,7 +105,7 @@ Override MDN standard styles
         font-style: italic;
     }
 
-    .user-state {
+    .oauth-logged-in {
         > {$selector-icon} {
             color: $blue-background-text-color;
         }

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -309,7 +309,7 @@ a.github-button {
     }
 }
 
-.user-state {
+.oauth-logged-in {
     bidi-value(float, none, left);
 
     ul, > {$selector-icon} {
@@ -619,7 +619,7 @@ a.github-button {
         bidi-style(right, $gutter-width, left, auto);
     }
 
-    .user-state {
+    .oauth-logged-in {
         li {
             display: block;
 

--- a/media/stylus/includes/mixins.styl
+++ b/media/stylus/includes/mixins.styl
@@ -248,8 +248,8 @@ remove-center-spacing() {
 /* overrides the navigation menu color - zones and homepage */
 override-main-nav-color(hex) {
     #main-nav > ul > li > a,
-    .user-state,
-    .user-state a,
+    .oauth-logged-in,
+    .oauth-logged-in a,
     .submenu-close {
         color: hex;
     }

--- a/media/stylus/zones.styl
+++ b/media/stylus/zones.styl
@@ -16,7 +16,7 @@
         border-bottom-color: rgba-fallback(rgba(255, 255, 255, 0.2));
     }
 
-    .user-state {
+    .oauth-logged-in {
         a, a:hover, a:focus, a:visited, > {$selector-icon} {
             color: $blue-background-text-color;
         }

--- a/templates/includes/login.html
+++ b/templates/includes/login.html
@@ -1,9 +1,9 @@
 {% if user.is_authenticated() %}
-    <div class="user-state">
+    <div class="oauth-logged-in">
         {% include 'socialaccount/snippets/login_service_icon.html' %}
         <ul>
-            <li><a href="{{ request.user.get_absolute_url() }}" class="user-state-profile">{{ user_display(request.user) }}</a></li>
-            <li><a href="{{ url('account_logout') }}?next={{ next_url }}" class="user-state-signout">{{ _('Sign out') }}</a></li>
+            <li><a href="{{ request.user.get_absolute_url() }}" class="oauth-logged-in-profile">{{ user_display(request.user) }}</a></li>
+            <li><a href="{{ url('account_logout') }}?next={{ next_url }}" class="oauth-logged-in-signout">{{ _('Sign out') }}</a></li>
         </ul>
     </div>
 {% else %}

--- a/tests/ui/tests/auth.js
+++ b/tests/ui/tests/auth.js
@@ -86,7 +86,7 @@ define([
             libLogin.completePersonaWindow(remote).then(function() {
 
                 return remote
-                    .findByCssSelector('.user-state-profile')
+                    .findByCssSelector('.oauth-logged-in-profile')
                     .then(function(element) {
                         poll.until(element, 'isDisplayed')
                                 .then(function() {
@@ -103,7 +103,7 @@ define([
                                                                 .findByCssSelector('.memberSince')
                                                                 .click() // Just ensuring the element is there
                                                                 .end()
-                                                                .findByCssSelector('.user-state-signout')
+                                                                .findByCssSelector('.oauth-logged-in-signout')
                                                                 .click()
                                                                 .end()
                                                                 .findByCssSelector('.oauth-login-container')

--- a/tests/ui/tests/lib/login.js
+++ b/tests/ui/tests/lib/login.js
@@ -141,9 +141,9 @@ define([
                                 })
 
                                 // ... and to confirm the login worked, we need to poll for either the "#id_username" element (signup page)
-                                // or the "a.user-state-signout" element (sign out link)
+                                // or the "a.oauth-logged-in-signout" element (sign out link)
                                 .then(function() {
-                                    return pollUntil('return document.querySelector("#id_username") || document.querySelector("a.user-state-signout")');
+                                    return pollUntil('return document.querySelector("#id_username") || document.querySelector("a.oauth-logged-in-signout")');
                                 })
 
                                 .end()


### PR DESCRIPTION
Renamed user-state to oauth-logged-in to mirror oauth-login class as the two components swap places depending on user state. (I know this seems picky but it's to support some other more complex changes).

Testing:
- sign in, make sure signout widget displays correctly