### PR TITLE
Bug 815693: Header nav menu item refresh

### DIFF
--- a/kuma/landing/templates/landing/homepage.html
+++ b/kuma/landing/templates/landing/homepage.html
@@ -82,7 +82,7 @@
         </ul>
       </div>
       <div class="column-home-features">
-        <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Zones') }}</span></h3>
+        <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Mozilla<br> Docs') }}</span></h3>
         <ul>
           <li><a href="{{ wiki_url('Firefox') }}">{{ _('Firefox') }}</a></li>
           <li><a href="{{ wiki_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
@@ -94,10 +94,10 @@
       <div class="column-home-features">
         <h3><i aria-hidden="true" class="icon-wrench"></i><span>{{ _('Developer<br />Tools') }}</span></h3>
         <ul>
-        <li><a href="{{ wiki_url('Mozilla/Firefox_OS/Using_the_App_Manager') }}">{{ _('Firefox OS App Manager') }}</a></li>
         <li><a href="{{ wiki_url('Tools/Page_Inspector') }}">{{ _('Page Inspector') }}</a></li>
-        <li><a href="{{ wiki_url('Tools/Debugger') }}">{{ _('JavaScript Debugger') }}</a></li>
         <li><a href="{{ wiki_url('Tools/Web_Console') }}">{{ _('Web Console') }}</a></li>
+        <li><a href="{{ wiki_url('Tools/Debugger') }}">{{ _('JavaScript Debugger') }}</a></li>
+        <li><a href="{{ wiki_url('Tools/Performance') }}">{{ _('Performance Tools') }}</a></li>
         <li><a href="{{ wiki_url('Tools') }}">{{ _('more...') }}</a></li>
         </ul>
       </div>

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -229,7 +229,7 @@ class AllauthPersonaTestCase(UserTestCase):
                              locale=settings.WIKI_DEFAULT_LANGUAGE))
             parsed = pq(response.content)
 
-            login_info = parsed.find('.header-login .oauth-logged-in')
+            login_info = parsed.find('.oauth-logged-in')
             ok_(len(login_info.children()))
 
             signed_in_message = login_info.children()[0]
@@ -315,7 +315,7 @@ class AllauthPersonaTestCase(UserTestCase):
                              locale=settings.WIKI_DEFAULT_LANGUAGE))
             parsed = pq(response.content)
 
-            login_info = parsed.find('.header-login .oauth-logged-in')
+            login_info = parsed.find('.oauth-logged-in')
             ok_(len(login_info.children()))
 
             signed_in_message = login_info.children()[0]

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -165,7 +165,7 @@
           <span class="from-search-navigate-wrap">
             <a href="#" class="from-search-navigate"><span class="from-search-navigate-up"><i aria-hidden="true" class="icon-double-angle-up"></i></span><span class="from-search-navigate-down"><i aria-hidden="true" class="icon-double-angle-down"></i></span></a>
           </span>
-          <div class="from-search-toc">
+          <div class="from-search-toc submenu">
             <span class="title">{{ _('Your Search Results') }}</span>
             <ol></ol>
           </div>

--- a/media/js/main.js
+++ b/media/js/main.js
@@ -12,11 +12,12 @@
         - language and admin menus
         - profile menu
     */
+
     (function() {
-         var $submenus = $('.js-submenu');
-         $submenus.prev('a, button').mozMenu();
-         $submenus.mozKeyboardNav();
-     })();
+        var $submenus = $('.js-submenu');
+        $submenus.prev('a, button').mozMenu();
+        $submenus.mozKeyboardNav();
+    })();
 
     /*
         Search animation

--- a/media/stylus/base/elements/sectioning.styl
+++ b/media/stylus/base/elements/sectioning.styl
@@ -94,4 +94,18 @@ hr {
 }
 
 
+@media $media-query-mobile {
+
+   /* add bottom spacing to the footer */
+    footer {
+        padding-bottom: $grid-spacing;
+    }
+}
+
+
+@media print {
+    header, footer {
+        display: none;
+    }
+}
 

--- a/media/stylus/base/icons.styl
+++ b/media/stylus/base/icons.styl
@@ -17,3 +17,9 @@
         bidi-style(margin-right, 0, margin-left, 0);
     }
 }
+
+label {$selector-icon} {
+    $label-icon-margin = ($grid-spacing / 2);
+    bidi-value(margin-left, 0, $label-icon-margin);
+    bidi-value(margin-right, $label-icon-margin, 0);
+}

--- a/media/stylus/base/utilities.styl
+++ b/media/stylus/base/utilities.styl
@@ -19,6 +19,14 @@
     position: relative;
     max-width: $max-width-default;
     add-center-spacing();
+
+    @media $media-query-mobile {
+        add-center-spacing(15px);
+    }
+
+    @media print {
+        remove-center-spacing();
+    }
 }
 
 /* simple hiding of elements */

--- a/media/stylus/components/home/base.styl
+++ b/media/stylus/components/home/base.styl
@@ -84,7 +84,7 @@ Override MDN standard styles
             }
         }
 
-        &.zones, &.connect {
+        &.connect {
             span {
                 padding-top: 10px;
             }

--- a/media/stylus/components/profile/profile-head.styl
+++ b/media/stylus/components/profile/profile-head.styl
@@ -16,10 +16,6 @@
         bidi-value(float, left, right);
         bidi-value(margin, 0 5px 0 0, 0 0 0 5px);
     }
-
-    .submenu {
-        @extend $advanced-menu;
-    }
 }
 
 @media $media-query-tablet {

--- a/media/stylus/components/structure.styl
+++ b/media/stylus/components/structure.styl
@@ -1,742 +1,72 @@
 /*
-    Main CSS file for MDN.  Holds the site structure and key styles.
-*/
+Main CSS file for MDN.  Holds the site structure and key styles.
 
-/*
-    Classes which should be mirror extensions and mixins - mixins.styl
-    These classes are used within wiki content so we must have them available as classes as well
-*/
+Classes which should be mirror extensions and mixins - mixins.styl
+These classes are used within wiki content so
+we must have them available as classes as well.
 
-@require '../includes/mixin_draw-grid';
+====================================================================== */
 
 /* grid setup for direct class uses */
+@require '../includes/mixin_draw-grid';
 draw-grid();
 
+/* columns */
+@require 'structure/cols';
 
-/* global notices (via soapbox) */
-.global-notice {
-    background: $light-background-color;
+/*
+Pre-header
+====================================================================== */
 
-    .wrap {
-        @extend .center;
-        set-smaller-font-size();
-        padding: 10px 24px;
-        max-width: $max-width-default;
+/* soapbox notice */
+@require 'structure/global-notice';
 
-        prevent-last-child-spacing(p, margin-bottom);
-    }
-}
+/* keyboard/screen reader skip link menu */
+@require 'structure/nav-access';
 
-/* header */
-#main-header {
-    clearfix();
-    border-color: transparent;
-    border-bottom-width: 1px;
-    border-bottom-style: solid;
-    border-top: 2px solid #fff;
 
-    /* margin-top will be added to small-mobile media query to ensure oauth widget doesn't overly */
-    .logo {
-        bidi-value(float, left, right);
-        width: 205px;
-        height: 40px;
-        margin-top: 7px;
-        background-image: url($logo-sprite-url);
-        background-position: 0 0;
-        background-repeat: no-repeat;
-        background-size:100% auto;
-        display: block;
-        direction: ltr; // ltr should be set with negative text indent
-        text-indent: -9999px;
-        overflow: hidden;
-    }
+/*
+Header
+====================================================================== */
 
-    a {
-        &:link, &:visited, &:hover, &:active {
-            color: $menu-link-color;
-        }
-    }
-}
+@require 'structure/main-header';
+@require 'structure/tabzilla';
+@require 'structure/submenu';
 
-#tabzilla {
-    /* below copied from https://github.com/mozilla/bedrock/blob/master/media/css/tabzilla/tabzilla.less#L51-L60 */
-    bidi-value(float, right, left);
-    display: block;
-    height: 44px;
-    width: 150px;
-    overflow: hidden;
 
-    /* Prevents the "mozilla" link from displaying before tabzilla is loaded */
-    opacity: 0;
+/*
+Secondary Navigation
+- login widget
+- profile (logged in) links
+-------------------------------------------------------------- */
 
-    &.loaded {
-        opacity: 1;
-    }
-}
+@require 'structure/nav-sec';
+@require 'structure/oauth-logged-in';
+@require 'structure/oauth-login';
 
-#tabzilla-panel {
-    /* in case the javascript loads before the CSS */
-    height: 0;
-    overflow: hidden;
-}
 
-#nav-access {
-    width: 100%;
-    position: absolute;
-    top: -20em;
-    z-index: 1001;
+/*
+Main Navigation
+- menus & submenus
+- search bar
+-------------------------------------------------------------- */
 
-    a {
-        background: rgba-fallback(rgba(255, 255, 255, 0.9));
-        padding: 12px 10px;
-        position: absolute;
-        left: 0;
-        right: 0;
-        font-weight: bold;
-        text-align: center;
+@require 'structure/main-nav';
+@require 'structure/main-nav-search';
+@require 'structure/search-wrap';
 
-        &:hover, &:focus {
-            box-shadow: 3px 3px 5px #aaa;
-            top: 20em;
-            text-decoration: none;
-        }
-    }
-}
 
-#main-nav {
-    > ul {
-        bidi-value(float, right, left);
-        margin-top: 20px;
-        margin-bottom: $grid-spacing;
+/*
+Misc - needs sorting
+====================================================================== */
 
-        > li {
-            bidi-style(margin-left, 31px, margin-right, 0);
-            position: relative;
-            opacity: 1;
-            max-width: 1000px;
-            display: inline-block;
-            vendorize(transition-property, width);
-            vendorize(transition-duration, $default-animation-duration);
-            vendorize(transition-delay, $default-animation-duration);
-            bidi-value(text-align, left, right);
+@require 'structure/socialaccount-providers';
+@require 'structure/feature-test-element';
+@require 'structure/pagination';
 
-            &:first-child {
-                margin-left: 0;
-            }
-
-            > a i {
-                opacity: 0.85;
-            }
-
-            > a, .search-trigger {
-                text-transform: uppercase;
-                font-weight: bold;
-                {$selector-site-font-fallback} & {
-                    font-weight: 600;
-                }
-            }
-
-            > a {
-                &:link, &:visited, &:hover, &:active {
-                    text-decoration: none;
-                }
-            }
-
-            > a, .search-wrap {
-                padding: 4px 8px;
-            }
-        }
-    }
-
-    &.expand {
-        > ul > li:not(:last-child) {
-            opacity: 0;
-            width: 0;
-            max-width: 0;
-            overflow: hidden;
-            padding: 0;
-            vendorize(transition-delay, 0);
-        }
-    }
-
-    .nav-search-link {
-        display: none;
-
-        {$selector-icon} {
-            margin: 0;
-        }
-    }
-
-    .submenu {
-        $menu-border-color = $text-color;
-        $menu-border-width = 5px;
-        $menu-arrow-top = -19px;
-        component-submenu(380px, 2, #fff, $menu-border-color);
-
-        top: 40px;
-        left: -136px;
-        border-top: $menu-border-width solid $menu-border-color;
-
-        .submenu-column {
-            min-height: 90px;
-        }
-
-        &:before, &:after {
-            top: $menu-arrow-top;
-            bidi-style(left, 190px, right, auto);
-        }
-
-        &:after {
-            top: ($menu-arrow-top - $menu-border-width);
-        }
-    }
-
-    .submenu-single {
-        width: 180px;
-        left: -74px;
-
-        &:before, &:after {
-            bidi-style(left, 98px, right, auto);
-        }
-    }
-}
-
-.main-nav-search {
-    position: relative;
-    width: 73px;
-    height: 21px;
-}
-
-a.persona-button, a.github-button {
-    border-radius: 3px;
-    z-index: 2;
-    display: inline-block;
-    font-weight: bold;
-
-    &:focus{
-        span{
-            text-decoration: underline;
-        }
-    }
-
-    span {
-        text-decoration: none;
-        display: block;
-        float: left;
-        set-font-size($base-font-size);
-        line-height: 24px;
-        color: white;
-        padding: 0 10px 0 20px;
-        position: relative;
-
-        &:after {
-            content: '';
-            position: absolute;
-            top: 0;
-            right: -12px;
-            width: 24px;
-            height: 24px;
-            z-index: 1;
-            vendorize(transform, scale(0.707) rotate(45deg));
-            border-radius: 0 3px 0 50px;
-        }
-
-        &.persona-icon, &.github-icon {
-            padding-left: 3px;
-            border-radius: 3px 0 0 3px;
-            create-gradient(#43a6e2, #287cc2);
-            height: 24px;
-
-            &:after {
-                create-gradient(#43a6e2, #287cc2, left top);
-            }
-
-            i {
-                position: relative;
-                top: 2px;
-                left: 5px;
-                width: 15px;
-                height: 15px;
-                display: inline-block;
-            }
-        }
-
-        &.signin {
-            text-shadow: 0px 1.5px 1px rgba(0, 0, 0, 0.35);
-            line-height: 23px;
-            padding-bottom 1px;
-
-            &:after {
-                z-index: 2;
-                create-gradient(#56565a, #3a3a3a, top left);
-            }
-
-            & {
-                create-gradient(#56565a, #3a3a3a);
-            }
-        }
-    }
-}
-
-a.persona-button {
-    i {
-        background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAQAAAD9CzEMAAABjElEQVR4Ae3WQYQbURjA8ccwhBCGYU+5LiGUEkoJPZUQQk5LWJawLMuSUyhLCTnlVIZSQk6llKGUEIZSQsg1hBCWZZnTEMK/KqqyMcn7Zubd9vddh7+5fN9TenC54wchOws86iid0fmoQJ+IQ3NqWQRKLIg3wEoXKBNy3Hes5AGXFaf1kgdG6KkkC7xii54gWeAL+l7LAxZP6OvJA1UkZvLADRJbbGmgh0xRFrBZIfNBFqgjtZQFOsjZksAlUqHsD1wiZD7LAooWEksK8lUxRF8l2bLTNUm6rsfoqUsC8oUdpDmZA06JKKcJ2PziuFbaV8UZc+J1s3gXObGJDkoSkB//tyheApwziD3/U67IJw04NBmy5rSAe95IAmW6jJF6ZEQT53ggT5816Ux4Hxdo8kA2fNzDwDs2ZOc3uf1AiZBsfdsP+GSv9j9QxYQZ1r/AT8xo7AJFTPF3gQ6mbHH+BgLMuVDkiDDHU1Qwaa64xqSN4hNGKXzTgQZtPuLhETB9Nmv0TA/mKx4et7T/AHu690RA5bMsAAAAAElFTkSuQmCC') 0 0 no-repeat;
-        background-size: cover;
-    }
-}
-
-a.github-button {
-    span.github-icon {
-        create-gradient(#5d649a, #63397b);
-
-        &:after {
-            create-gradient(#5d649a, #63397b, left top);
-        }
-
-        {$selector-icon} {
-            margin-left: 0;
-            top: 0;
-            left: 8px;
-        }
-    }
-}
-
-/* Login widget and profile (logged in) links */
-.header-login {
-    bidi-style(right, 200px, left, auto);
-    position: absolute;
-    top: 12px;
-    z-index: 3;
-
-    set-font-size($small-bump-font-size);
-    {$selector-site-font-fallback} & {
-        letter-spacing: -.005em;
-    }
-}
-
-.oauth-logged-in {
-    bidi-value(float, none, left);
-
-    ul, > {$selector-icon} {
-        bidi-value(float, left, right);
-
-        /* Keep the line height equal to make the icon appear as though it is on
-           the same line. */
-        line-height: 20px;
-    }
-
-    > {$selector-icon} {
-        bidi-style(margin-right, 10px, margin-left, 10px);
-        set-font-size($small-bump-font-size + 20%);
-    }
-
-    li {
-        display: inline;
-        bidi-value(text-align, right, left);
-
-        & + li {
-            bidi-style(border-left, 1px solid #bbb, border-right, 0);
-            bidi-style(padding-left, 10px, padding-right, 0);
-            bidi-style(margin-left, 8px, margin-right, 0);
-        }
-    }
-
-    a, a:hover, a:focus, a:visited {
-        color: $link-color;
-    }
-}
-
-.oauth-login-container {
-    border-radius: 8px;
-    border: 1px solid transparent;
-    display: inline-block;
-    min-width: 90px;
-
-    {$selector-icon} {
-        margin-left: 0;
-
-        &:before {
-            cursor: pointer;
-        }
-    }
-
-    .submenu-close {
-        display: none;
-        color: inherit;
-        margin: 0;
-        padding: 0;
-        position: absolute;
-        top: 7px;
-        bidi-style(right, 10px, left, auto);
-
-        ${icon-selector} {
-            margin: 0;
-        }
-    }
-}
-
-.oauth-login-options {
-    padding: 4px 8px;
-    background: rgba-fallback(rgba(0, 0, 0, 0.1));
-    border-radius: 8px;
-    cursor: default;
-    position: relative;
-
-    &.active {
-        border-color: rgba-fallback(rgba(255, 255, 255, 0.3));
-        border-bottom-left-radius: 0;
-        border-bottom-right-radius: 0;
-
-        .oauth-login-picker {
-            display: block;
-        }
-    }
-}
-
-.oauth-login-options-text-no-icons {
-    display: none;
-}
-
-.oauth-icon {
-    border-radius: 4px;
-    text-align: center;
-    padding: 0px 7px;
-    font-size: $base-bump-font-size;
-    bidi-style(margin-left, 4px, margin-right, 0);
-    color: #fff;
-    display: inline-block;
-    create-gradient(#43a6e2, #287cc2);
-    cursor: pointer;
-
-    {$selector-icon} {
-        bidi-style(margin-left, 0, margin-right, 0);
-    }
-}
-
-.oauth-github {
-    create-gradient(#5d649a, #63397b);
-}
-
-.oauth-login-picker {
-    display: none;
-    background: #fff;
-    position: relative;
-    border-bottom-left-radius: 8px;
-    border-bottom-right-radius: 8px;
-    overflow: hidden;
-
-    a {
-        display: block;
-        padding: $content-vertical-spacing $content-horizontal-spacing;
-        position: relative;
-        color: $link-color !important;
-
-        &:hover, &:active, &:focus {
-            background: rgba-fallback(rgba($link-color, 0.1));
-        }
-    }
-
-    {$selector-icon} {
-        background: none;
-        bidi-style(margin-right, $icon-margin, margin-left, 0);
-    }
-}
-
-.search-wrap {
-    background-color: rgba-fallback(rgba(255, 255, 255, 0.9));
-    border-radius: 3px;
-    height: 21px;
-    position: absolute;
-    padding: 4px 8px;
-    top: 0;
-    bidi-style(right, 0, left, auto);
-    vendorize(transition-property, width);
-    vendorize(transition-duration, $default-animation-duration);
-
-    &.expanded {
-        background: #fff;
-    }
-
-    input {
-        background: transparent;
-        border: solid transparent;
-        bidi-value(border-width, 0 22px 0 0, 0 0 0 22px);
-        box-sizing: border-box;
-        color: $menu-link-color;
-        font-weight: bold;
-        overflow: hidden;
-        padding: 0;
-        position: relative;
-        vendorize(transition-property, 'width, opacity');
-        vendorize(transition-duration, $default-animation-duration);
-        width: 48px;
-        max-width: 100%;
-        z-index: 2;
-        cursor: text;
-        opacity: 0.01;
-
-        set-placeholder-style(color, $text-color);
-        set-placeholder-style(text-transform, uppercase);
-
-        &:focus {
-            width: 500px;
-            opacity: 1;
-        }
-    }
-}
-
-.search-trigger {
-    cursor: text;
-    position: absolute;
-    top: 3px;
-    bidi-style(right, 12px, left, auto);
-    z-index: 1;
-
-}
-
-/* feature testing */
-#feature-test-element {
-    position: absolute;
-    left: 0;
-    top: -999999px;
-    width: 0;
-    height: 0;
-    overflow: hidden;
-    z-index: 1;
-
-    @media $media-query-small-desktop { z-index: 2; }
-    @media $media-query-tablet { z-index: 3; }
-    @media $media-query-mobile { z-index: 4; }
-}
-
-
-/* tablet updates */
-@media $media-query-tablet {
-
-    /* make submenus full width */
-    #main-nav {
-        .submenu {
-            left: 0;
-            right: 0;
-
-            &:before, &:after {
-                bidi-style(left, 10px, right, auto);
-            }
-        }
-    }
-
-    #main-nav {
-        > ul {
-            > li {
-                bidi-style(margin-left, 21px, margin-right, 0);
-
-                > a {
-                    i {
-                        set-larger-font-size();
-                    }
-                }
-            }
-        }
-    }
-
-    .oauth-login-options-text {
-        bidi-style(padding-right, 20px, padding-left, 0);
-    }
-
-    /* remove options to click icons to sign in on smaller screens where a corse pointer is more likely to be present */
-    .oauth-login-options-text-icons {
-        display: none;
-    }
-
-    .oauth-login-options-text-no-icons {
-        display: inline;
-    }
-
-    .oauth-icon {
-        display: none;
-    }
-
-    .oauth-login-options.active{
-        .submenu-close {
-            display: block;
-        }
-    }
-}
-
-/* custom nav menu movement */
-@media $media-query-navigation-break {
-
-    #main-header {
-        .logo {
-            margin-top: -33px;
-        }
-    }
-
-    #main-nav {
-        > ul {
-            bidi-value(text-align, right, left);
-            width: 100%;
-            clear: both;
-
-            > li {
-                vendorize(transition-property, none);
-
-                &:first-child {
-                    margin-left: 0;
-                }
-            }
-        }
-    }
-}
-
-/* break nav into blocks (own line) */
-@media $media-query-navigation-block {
-
-    #main-nav {
-        > ul {
-            float: none;
-            bidi-value(text-align, left, right);
-
-            > li {
-                bidi-value(margin, $content-vertical-spacing $content-horizontal-spacing $content-vertical-spacing 0, $content-vertical-spacing 0 $content-vertical-spacing $content-horizontal-spacing);
-            }
-        }
-    }
-}
-
-
-@media $media-query-mobile {
-
-    .center {
-        add-center-spacing(15px);
-    }
-
-    #tabzilla {
-        display: none;
-    }
-
-    .header-clear {
-        display: none;
-    }
-
-    #main-header {
-        .logo {
-            margin: ($grid-spacing / 2) 0;
-            width: 140px;
-            height: 40px;
-            background-size: auto;
-        }
-    }
-
-    .header-login {
-        bidi-style(right, $gutter-width, left, auto);
-    }
-
-    .oauth-logged-in {
-        li {
-            display: block;
-
-            & + li {
-                padding-left: 0;
-                bidi-style(border-left, none, border-right, none);
-                bidi-style(padding-right, 0, padding-left, 0);
-                bidi-style(margin-right, 0, margin-left, 0);
-            }
-        }
-    }
-
-    /* move the search box under the nav */
-    #main-header {
-        .main-nav-search {
-            display: none;
-            padding: 0px;
-            bidi-value(margin, 10px 0 0 0, 10px 0 0 0);
-            width: auto;
-
-            .search-wrap {
-                width: 90%;
-                width: calc(100% - 16px); /* 16px = left + right padding */
-                bidi-value(left, auto, 0);
-                bidi-value(right, 0, auto);
-
-                input {
-                    width: 100%;
-                }
-            }
-        }
-
-        &.expand {
-            ul {
-                > li:not(:last-child) {
-                    width: auto;
-                    max-width: none;
-                    vendorize(transition-property, none);
-                    overflow: visible;
-                }
-            }
-        }
-    }
-
-    #main-nav > ul > li {
-        margin-bottom: 4px;
-
-        &.nav-search-link {
-            display: inline-block;
-        }
-    }
-
-    /* add bottom spacing to the footer */
-    footer {
-        padding-bottom: $grid-spacing;
-    }
-}
-
-@media $media-query-small-mobile {
-
-    #main-header {
-        .logo {
-            width: 44px;
-        }
-    }
-
-    #main-nav.expand {
-        ul {
-            > li:not(:last-child) {
-                width: auto;
-                max-width: none;
-                vendorize(transition-property, none);
-                overflow: visible;
-            }
-        }
-    }
-}
-
-
-@media print {
-    header, footer {
-        display: none;
-    }
-
-    .center {
-        remove-center-spacing();
-    }
-}
 
 p.field-explanation {
     margin-bottom: 0;
-}
-
-label {$selector-icon} {
-    $label-icon-margin = 10px;
-    bidi-value(margin-left, 0, $label-icon-margin);
-    bidi-value(margin-right, $label-icon-margin, 0);
-}
-
-for i in (2 3 4) {
-    .cols-{i} {
-        vendorize(column-count, i);
-        vendorize(column-gap, ($grid-spacing / 2));
-    }
 }
 
 #content-main.full {
@@ -750,45 +80,13 @@ for i in (2 3 4) {
     width: 670px;
 }
 
-.global-notice {
-    position: relative;
-    margin: 0 0 -1px;
-}
+@media $media-query-mobile {
 
-ol.pagination {
-    margin: $grid-spacing 0;
-    padding: 0 0 ($grid-spacing * 1.5) 0;
-
-    li {
-        bidi-value(float, left, right);
-        padding: 0 2px;
-
-        &.prev, &.prev a {
-            bidi-style(padding-left, 0, padding-right, inherit);
-        }
-
-        a {
-            bidi-value(float, left, right);
-            padding: 3px 8px 5px;
-
-            &:hover {
-                text-decoration: underline;
-            }
-        }
-
-        &.selected a {
-            background: #447bc4;
-            color: #fff;
-            border-radius: 5px;
-        }
+    .header-clear {
+        display: none;
     }
+
 }
 
-.socialaccount-providers li {
-    margin: 0 $grid-spacing 0 0;
-    display: inline-block;
 
-    span.signin {
-        min-width: 140px;
-    }
-}
+

--- a/media/stylus/components/structure/cols.styl
+++ b/media/stylus/components/structure/cols.styl
@@ -1,0 +1,6 @@
+for i in (2 3 4) {
+    .cols-{i} {
+        vendorize(column-count, i);
+        vendorize(column-gap, ($grid-spacing / 2));
+    }
+}

--- a/media/stylus/components/structure/feature-test-element.styl
+++ b/media/stylus/components/structure/feature-test-element.styl
@@ -1,0 +1,16 @@
+/*
+Media query detection for use with javascript
+====================================================================== */
+#feature-test-element {
+    position: absolute;
+    left: 0;
+    top: -999999px;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+    z-index: 1;
+
+    @media $media-query-small-desktop { z-index: 2; }
+    @media $media-query-tablet { z-index: 3; }
+    @media $media-query-mobile { z-index: 4; }
+}

--- a/media/stylus/components/structure/global-notice.styl
+++ b/media/stylus/components/structure/global-notice.styl
@@ -1,0 +1,15 @@
+/*
+global notices (via soapbox)
+====================================================================== */
+.global-notice {
+    position: relative;
+    margin: 0 0 -1px;
+    background: $light-background-color;
+
+    .wrap {
+        set-smaller-font-size();
+        padding: 10px 24px;
+
+        prevent-last-child-spacing(p, margin-bottom);
+    }
+}

--- a/media/stylus/components/structure/main-header.styl
+++ b/media/stylus/components/structure/main-header.styl
@@ -1,0 +1,61 @@
+/*
+Main header, wraps all components of logo, main, and secondary navigation
+====================================================================== */
+
+#main-header {
+    clearfix();
+    border-color: transparent;
+    border-bottom: 1px solid @border-color;
+    border-top: 2px solid #fff;
+
+    /* margin-top will be added to small-mobile media query to ensure oauth widget doesn't overly */
+    .logo {
+        bidi-value(float, left, right);
+        width: 205px;
+        height: 40px;
+        margin-top: 7px;
+        background: url($logo-sprite-url) 0 0 no-repeat;
+        background-size: 100% auto;
+        display: block;
+        direction: ltr; // ltr should be set with negative text indent
+        text-indent: -9999px;
+        overflow: hidden;
+    }
+
+    a {
+        &:link, &:visited, &:hover, &:active {
+            color: $menu-link-color;
+        }
+    }
+}
+
+/* custom nav menu movement */
+@media $media-query-navigation-break {
+
+    #main-header {
+        .logo {
+            margin-top: -33px;
+        }
+    }
+}
+
+@media $media-query-mobile {
+
+    #main-header {
+        .logo {
+            margin: ($grid-spacing / 2) 0;
+            width: 140px;
+            height: 40px;
+            background-size: auto;
+        }
+    }
+}
+
+@media $media-query-small-mobile {
+
+    #main-header {
+        .logo {
+            width: 44px;
+        }
+    }
+}

--- a/media/stylus/components/structure/main-nav-search.styl
+++ b/media/stylus/components/structure/main-nav-search.styl
@@ -1,0 +1,24 @@
+/*
+list item in #main-nav that contains the search form
+====================================================================== */
+
+/* needs #main-nav prefix to over-ride specificity of other declarations */
+#main-nav {
+
+    .main-nav-search {
+        position: relative;
+        width: 73px;
+        height: 21px;
+    }
+
+    @media $media-query-navigation-block {
+    /* move the search box under the nav */
+
+        .main-nav-search {
+            display: none;
+            padding: 0px;
+            bidi-value(margin, 10px 0 0 0, 10px 0 0 0);
+            width: auto;
+        }
+    }
+}

--- a/media/stylus/components/structure/main-nav.styl
+++ b/media/stylus/components/structure/main-nav.styl
@@ -1,0 +1,186 @@
+@require '../../includes/mixin_submenu.styl';
+
+/*
+Main navigation menu
+====================================================================== */
+
+#main-nav {
+    > ul {
+        bidi-value(float, right, left);
+        bidi-value(text-align, right, left);
+        margin-top: 20px;
+        margin-bottom: $grid-spacing;
+
+        > li {
+            bidi-style(margin-left, 31px, margin-right, 0);
+            position: relative;
+            opacity: 1;
+            max-width: 1000px;
+            display: inline-block;
+            vendorize(transition-property, width);
+            vendorize(transition-duration, $default-animation-duration);
+            vendorize(transition-delay, $default-animation-duration);
+            bidi-value(text-align, left, right);
+
+            &:first-child {
+                margin-left: 0;
+            }
+
+            > a i {
+                opacity: 0.85;
+            }
+
+            > a, .search-trigger {
+                text-transform: uppercase;
+                font-weight: bold;
+                {$selector-site-font-fallback} & {
+                    font-weight: 600;
+                }
+            }
+
+            > a {
+                &:link, &:visited, &:hover, &:active {
+                    text-decoration: none;
+                }
+            }
+
+            > a, .search-wrap {
+                padding: 4px 8px;
+            }
+        }
+    }
+
+    &.expand {
+        > ul > li:not(:last-child) {
+            opacity: 0;
+            width: 0;
+            max-width: 0;
+            overflow: hidden;
+            padding: 0;
+            vendorize(transition-delay, 0);
+        }
+    }
+
+    .nav-search-link {
+        display: none;
+
+        {$selector-icon} {
+            margin: 0;
+        }
+    }
+
+    .submenu {
+        $submenu-width = 180px;
+        submenu-set(180px, 5px, #fff, $text-color);
+
+        @media $media-query-tablet-and-up {
+            bidi-value(left, auto, 50%);
+            bidi-value(right, 50%, auto);
+            margin-right: (($submenu-width / 2 ) + $grid-spacing) * -1;
+
+            &:before, &:after {
+                bidi-style(left, 98px, right, auto);
+            }
+
+            &.submenu-cols-2 {
+                margin-right: ($submenu-width + $grid-spacing) * -1;
+
+                &:before, &:after {
+                    bidi-style(left, 200px, right, auto);
+                }
+            }
+        }
+
+        @media $media-query-mobile {
+
+            & {
+                bidi-style(left, auto, right, auto);
+                bidi-style(right, auto, left, auto);
+
+                &:before, &:after {
+                    bidi-style(left, 10px, right, auto);
+                }
+            }
+        }
+
+    }
+
+}
+
+
+/* custom nav menu movement */
+@media $media-query-navigation-break {
+
+    #main-nav {
+        > ul {
+            /* drop under logo, take full width */
+            width: auto;
+            clear: both;
+
+            > li {
+                vendorize(transition-property, none);
+                bidi-style(margin-left, 21px, margin-right, 0);
+
+                &:first-child {
+                    margin-left: 0;
+                }
+            }
+        }
+    }
+}
+
+
+/* break nav into blocks (own line) */
+@media $media-query-navigation-block {
+
+    #main-nav {
+        > ul {
+            float: none;
+            bidi-value(text-align, left, right);
+            /* expand the container by the width of the margins
+               and padding on the items it contains */
+            margin-left: ($content-horizontal-spacing) * -1;
+            margin-right: ($content-horizontal-spacing) * 2 * -1;
+
+            > li {
+                bidi-value(margin, $content-vertical-spacing $content-horizontal-spacing $content-vertical-spacing 0, $content-vertical-spacing 0 $content-vertical-spacing $content-horizontal-spacing);
+
+                &.nav-search-link {
+                    display: inline-block;
+                }
+            }
+        }
+    }
+}
+
+
+/* tablet updates */
+@media $media-query-tablet {
+
+    #main-nav {
+        > ul {
+            > li {
+                > a {
+                    i {
+                        set-larger-font-size();
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+@media $media-query-small-mobile {
+
+    #main-nav.expand {
+        ul {
+            > li:not(:last-child) {
+                width: auto;
+                max-width: none;
+                vendorize(transition-property, none);
+                overflow: visible;
+            }
+        }
+    }
+}

--- a/media/stylus/components/structure/nav-access.styl
+++ b/media/stylus/components/structure/nav-access.styl
@@ -1,0 +1,26 @@
+/*
+Keyboard & screen reader skip link menu
+====================================================================== */
+
+#nav-access {
+    width: 100%;
+    position: absolute;
+    top: -20em;
+    z-index: 1001;
+
+    a {
+        background: rgba-fallback(rgba(255, 255, 255, 0.9));
+        padding: 12px 10px;
+        position: absolute;
+        left: 0;
+        right: 0;
+        font-weight: bold;
+        text-align: center;
+
+        &:hover, &:focus {
+            box-shadow: 3px 3px 5px #aaa;
+            top: 20em;
+            text-decoration: none;
+        }
+    }
+}

--- a/media/stylus/components/structure/nav-sec.styl
+++ b/media/stylus/components/structure/nav-sec.styl
@@ -1,0 +1,33 @@
+/*
+Secondary navigation, site tools and login info
+====================================================================== */
+
+#nav-sec {
+    position: absolute;
+    top: 12px;
+    bidi-style(right, 200px, left, auto);
+    z-index: 36; /* one more than the demos "learn more" button */
+
+    set-font-size($small-bump-font-size);
+    {$selector-site-font-fallback} & {
+        letter-spacing: -.005em;
+    }
+
+    > ul > li {
+        position: relative;
+        display: inline-block;
+        bidi-value(padding, 0 0 0 16px, 0 16px 0 0); /* same as main nav but we double it because only putting on left */
+    }
+}
+
+
+@media $media-query-mobile {
+
+    #nav-sec {
+        bidi-style(right, $gutter-width, left, auto);
+
+        > ul > li.nav-tools {
+            display: none;
+        }
+    }
+}

--- a/media/stylus/components/structure/oauth-logged-in.styl
+++ b/media/stylus/components/structure/oauth-logged-in.styl
@@ -1,0 +1,57 @@
+/*
+Sign in information displayed after user signed in
+====================================================================== */
+
+.oauth-logged-in {
+    padding: 4px 8px;
+    background: rgba-fallback(rgba(0, 0, 0, 0.1));
+    border-radius: 8px;
+    position: relative;
+
+    > ul {
+        display: inline-block;
+
+        > li {
+            display: inline;
+
+            & + li {
+                bidi-style(border-left, 1px solid #bbb, border-right, 0);
+                bidi-style(padding-left, 6px, padding-right, 0);
+                bidi-style(margin-left, 2px, margin-right, 0);
+            }
+        }
+    }
+
+    > ul,
+    > {$selector-icon} {
+
+        /* Keep the line height equal to make the icon appear as though it is on
+           the same line. */
+        line-height: 20px;
+    }
+
+    > {$selector-icon} {
+        vertical-align: top; /* needed on mobile */
+        bidi-style(margin-right, 0, margin-left, 2px);
+        bidi-style(margin-left, 2px, margin-right, 0);
+        set-font-size($small-bump-font-size + 20%);
+    }
+
+    @media $media-query-mobile {
+
+        li {
+            display: block;
+
+            & + li {
+                padding-left: 0;
+                bidi-style(border-left, none, border-right, none);
+                bidi-style(padding-right, 0, padding-left, 0);
+                bidi-style(margin-right, 0, margin-left, 0);
+            }
+        }
+
+    }
+
+}
+
+

--- a/media/stylus/components/structure/oauth-login.styl
+++ b/media/stylus/components/structure/oauth-login.styl
@@ -1,0 +1,128 @@
+/*
+Login links in secondary navigation
+====================================================================== */
+
+.oauth-login-container {
+    border-radius: 8px;
+    border: 1px solid transparent;
+    display: inline-block;
+    min-width: 90px;
+
+    {$selector-icon} {
+        margin-left: 0;
+
+        &:before {
+            cursor: pointer;
+        }
+    }
+
+    .submenu-close {
+        display: none;
+        color: inherit;
+        margin: 0;
+        padding: 0;
+        position: absolute;
+        top: 7px;
+        bidi-style(right, 10px, left, auto);
+
+        ${icon-selector} {
+            margin: 0;
+        }
+    }
+}
+
+.oauth-login-options {
+    padding: 4px 8px;
+    background: rgba-fallback(rgba(0, 0, 0, 0.1));
+    border-radius: 8px;
+    cursor: default;
+    position: relative;
+
+    &.active {
+        border-color: rgba-fallback(rgba(255, 255, 255, 0.3));
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+
+        .oauth-login-picker {
+            display: block;
+        }
+    }
+}
+
+.oauth-login-options-text-no-icons {
+    display: none;
+}
+
+.oauth-icon {
+    border-radius: 4px;
+    text-align: center;
+    padding: 0px 7px;
+    font-size: $base-bump-font-size;
+    bidi-style(margin-left, 4px, margin-right, 0);
+    color: #fff;
+    display: inline-block;
+    create-gradient(#43a6e2, #287cc2);
+    cursor: pointer;
+
+    {$selector-icon} {
+    	bidi-style(margin-left, 0, margin-right, 0);
+    }
+}
+
+.oauth-github {
+    create-gradient(#5d649a, #63397b);
+}
+
+#nav-sec .oauth-login-picker {
+    display: none;
+    background: #fff;
+    position: relative;
+    border-bottom-left-radius: 8px;
+    border-bottom-right-radius: 8px;
+    overflow: hidden;
+    padding: 0;
+
+    a {
+        display: block;
+        padding: $content-vertical-spacing $content-horizontal-spacing;
+        position: relative;
+        color: $link-color !important;
+
+        &:hover, &:active, &:focus {
+            background: rgba-fallback(rgba($link-color, 0.1));
+        }
+    }
+
+    {$selector-icon} {
+        background: none;
+        bidi-style(margin-right, $icon-margin, margin-left, 0);
+    }
+}
+
+
+/* tablet updates */
+@media $media-query-tablet {
+
+    .oauth-login-options-text {
+        bidi-style(padding-right, 20px, padding-left, 0);
+    }
+
+    /* remove options to click icons to sign in on smaller screens where a corse pointer is more likely to be present */
+    .oauth-login-options-text-icons {
+        display: none;
+    }
+
+    .oauth-login-options-text-no-icons {
+        display: inline;
+    }
+
+    .oauth-icon {
+        display: none;
+    }
+
+    .oauth-login-options.active{
+        .submenu-close {
+            display: block;
+        }
+    }
+}

--- a/media/stylus/components/structure/pagination.styl
+++ b/media/stylus/components/structure/pagination.styl
@@ -1,0 +1,32 @@
+/*
+Pagination
+====================================================================== */
+
+ol.pagination {
+    margin: $grid-spacing 0;
+    padding: 0 0 ($grid-spacing * 1.5) 0;
+
+    li {
+        bidi-value(float, left, right);
+        padding: 0 2px;
+
+        &.prev, &.prev a {
+            bidi-style(padding-left, 0, padding-right, inherit);
+        }
+
+        a {
+            bidi-value(float, left, right);
+            padding: 3px 8px 5px;
+
+            &:hover {
+                text-decoration: underline;
+            }
+        }
+
+        &.selected a {
+            background: #447bc4;
+            color: #fff;
+            border-radius: 5px;
+        }
+    }
+}

--- a/media/stylus/components/structure/search-wrap.styl
+++ b/media/stylus/components/structure/search-wrap.styl
@@ -1,0 +1,68 @@
+/*
+Main navigation search box and its wrapper
+====================================================================== */
+
+.search-wrap {
+    background-color: rgba-fallback(rgba(255, 255, 255, 0.9));
+    border-radius: 3px;
+    height: 21px;
+    position: absolute;
+    padding: 4px 8px;
+    top: 0;
+    bidi-style(right, 0, left, auto);
+    vendorize(transition-property, width);
+    vendorize(transition-duration, $default-animation-duration);
+
+    &.expanded {
+        background: #fff;
+    }
+
+    input {
+        background: transparent;
+        border: solid transparent;
+        bidi-value(border-width, 0 22px 0 0, 0 0 0 22px);
+        box-sizing: border-box;
+        color: $menu-link-color;
+        font-weight: bold;
+        overflow: hidden;
+        padding: 0;
+        position: relative;
+        vendorize(transition-property, 'width, opacity');
+        vendorize(transition-duration, $default-animation-duration);
+        width: 48px;
+        max-width: 100%;
+        z-index: 2;
+        cursor: text;
+        opacity: 0.01;
+
+        set-placeholder-style(color, $text-color);
+        set-placeholder-style(text-transform, uppercase);
+
+        &:focus {
+            width: 500px;
+            opacity: 1;
+        }
+    }
+}
+
+@media $media-query-navigation-block {
+    .search-wrap {
+        width: 90%;
+        width: calc(100% - 16px); /* 16px = left + right padding */
+        bidi-value(left, auto, 0);
+        bidi-value(right, 0, auto);
+
+        input {
+            width: 100%;
+        }
+    }
+}
+
+.search-trigger {
+    cursor: text;
+    position: absolute;
+    top: 3px;
+    bidi-style(right, 12px, left, auto);
+    z-index: 1;
+
+}

--- a/media/stylus/components/structure/socialaccount-providers.styl
+++ b/media/stylus/components/structure/socialaccount-providers.styl
@@ -1,0 +1,107 @@
+/*
+List of social account providers MDN has implemented displayed as
+a call to action to "Sign up with..." or "Connect account..."
+====================================================================== */
+
+.socialaccount-providers li {
+    margin: 0 $grid-spacing 0 0;
+    display: inline-block;
+
+    span.signin {
+        min-width: 140px;
+    }
+}
+
+a.persona-button, a.github-button {
+    border-radius: 3px;
+    z-index: 2;
+    display: inline-block;
+    font-weight: bold;
+
+    &:focus{
+        span{
+            text-decoration: underline;
+        }
+    }
+
+    span {
+        text-decoration: none;
+        display: block;
+        float: left;
+        set-font-size($base-font-size);
+        line-height: 24px;
+        color: white;
+        padding: 0 10px 0 20px;
+        position: relative;
+
+        &:after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: -12px;
+            width: 24px;
+            height: 24px;
+            z-index: 1;
+            vendorize(transform, scale(0.707) rotate(45deg));
+            border-radius: 0 3px 0 50px;
+        }
+
+        &.persona-icon, &.github-icon {
+            padding-left: 3px;
+            border-radius: 3px 0 0 3px;
+            create-gradient(#43a6e2, #287cc2);
+            height: 24px;
+
+            &:after {
+                create-gradient(#43a6e2, #287cc2, left top);
+            }
+
+            i {
+                position: relative;
+                top: 2px;
+                left: 5px;
+                width: 15px;
+                height: 15px;
+                display: inline-block;
+            }
+        }
+
+        &.signin {
+            text-shadow: 0px 1.5px 1px rgba(0, 0, 0, 0.35);
+            line-height: 23px;
+            padding-bottom 1px;
+
+            &:after {
+                z-index: 2;
+                create-gradient(#56565a, #3a3a3a, top left);
+            }
+
+            & {
+                create-gradient(#56565a, #3a3a3a);
+            }
+        }
+    }
+}
+
+a.persona-button {
+    i {
+        background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAQAAAD9CzEMAAABjElEQVR4Ae3WQYQbURjA8ccwhBCGYU+5LiGUEkoJPZUQQk5LWJawLMuSUyhLCTnlVIZSQk6llKGUEIZSQsg1hBCWZZnTEMK/KqqyMcn7Zubd9vddh7+5fN9TenC54wchOws86iid0fmoQJ+IQ3NqWQRKLIg3wEoXKBNy3Hes5AGXFaf1kgdG6KkkC7xii54gWeAL+l7LAxZP6OvJA1UkZvLADRJbbGmgh0xRFrBZIfNBFqgjtZQFOsjZksAlUqHsD1wiZD7LAooWEksK8lUxRF8l2bLTNUm6rsfoqUsC8oUdpDmZA06JKKcJ2PziuFbaV8UZc+J1s3gXObGJDkoSkB//tyheApwziD3/U67IJw04NBmy5rSAe95IAmW6jJF6ZEQT53ggT5816Ux4Hxdo8kA2fNzDwDs2ZOc3uf1AiZBsfdsP+GSv9j9QxYQZ1r/AT8xo7AJFTPF3gQ6mbHH+BgLMuVDkiDDHU1Qwaa64xqSN4hNGKXzTgQZtPuLhETB9Nmv0TA/mKx4et7T/AHu690RA5bMsAAAAAElFTkSuQmCC') 0 0 no-repeat;
+        background-size: cover;
+    }
+}
+
+a.github-button {
+    span.github-icon {
+        create-gradient(#5d649a, #63397b);
+
+        &:after {
+            create-gradient(#5d649a, #63397b, left top);
+        }
+
+        {$selector-icon} {
+            margin-left: 0;
+            top: 0;
+            left: 8px;
+        }
+    }
+}

--- a/media/stylus/components/structure/submenu.styl
+++ b/media/stylus/components/structure/submenu.styl
@@ -1,0 +1,21 @@
+@require '../../includes/mixin_submenu';
+
+.submenu {
+    @extends $submenu;
+    submenu-set(160px, 1px, $light-background-color, $button-shadow-color);
+}
+
+@media $media-query-mobile {
+    .submenu-column,
+    .submenu-column:nth-child(even) {
+        bidi-style(border-left, 0, border-right, 0);
+        bidi-style(padding-left, 0, padding-right, 0);
+    }
+}
+
+@media $media-query-small-mobile {
+    .submenu-column {
+        width: auto;
+        display: block;
+    }
+}

--- a/media/stylus/components/structure/tabzilla.styl
+++ b/media/stylus/components/structure/tabzilla.styl
@@ -1,0 +1,34 @@
+/*
+Tabzilla Rar!
+====================================================================== */
+
+#tabzilla {
+    /* below copied from https://github.com/mozilla/bedrock/blob/master/media/css/tabzilla/tabzilla.less#L51-L60 */
+    bidi-value(float, right, left);
+    display: block;
+    height: 44px;
+    width: 150px;
+    overflow: hidden;
+
+    /* Prevents the "mozilla" link from displaying before tabzilla is loaded */
+    opacity: 0;
+
+    &.loaded {
+        opacity: 1;
+    }
+}
+
+#tabzilla-panel {
+    /* in case the javascript loads before the CSS */
+    height: 0;
+    overflow: hidden;
+}
+
+
+@media $media-query-mobile {
+
+    #tabzilla {
+        display: none;
+    }
+
+}

--- a/media/stylus/components/wiki/from-search.styl
+++ b/media/stylus/components/wiki/from-search.styl
@@ -1,3 +1,5 @@
+@require '../../includes/mixin_submenu.styl';
+
 /* search navigator near article heading */
 .from-search {
     padding-left: ($grid-spacing * 2);
@@ -54,7 +56,7 @@
 }
 
 .from-search-toc {
-    component-submenu(200px, 1, $button-background, $button-shadow-color)
+    submenu-set(200px, 1px, $button-background, $button-shadow-color)
     set-smaller-font-size();
     border: 1px solid $button-shadow-color;
     left: 66px;

--- a/media/stylus/components/wiki/page-buttons.styl
+++ b/media/stylus/components/wiki/page-buttons.styl
@@ -31,10 +31,6 @@
             set-font-size($base-bump-font-size);
         }
     }
-
-    .submenu {
-        @extend $advanced-menu;
-    }
 }
 
 /* Use a dark blue background color for all document edit buttons except those

--- a/media/stylus/includes/mixin_submenu.styl
+++ b/media/stylus/includes/mixin_submenu.styl
@@ -1,0 +1,151 @@
+/* configurable declarations for the submenu extends */
+submenu-set($menu-width, $border-width, $background-color, $arrow-border-color) {
+
+    & {
+        width: $menu-width;
+        border-top: $border-width solid $arrow-border-color;
+        background: $background-color;
+    }
+
+    &:before {
+        border-bottom-color: $background-color;
+        top: -18px;
+    }
+    &:after {
+        border-bottom-color: $arrow-border-color;
+        top: (-19px - $border-width);
+    }
+
+    ul + ul {
+        border-top: 1px dotted $arrow-border-color;
+    }
+
+    /* columns */
+    @media $media-query-tablet-and-up {
+        /* modifications for second column */
+        &.submenu-cols-2 {
+            width: ($menu-width * 2) + $grid-spacing;
+
+            .submenu-column {
+                width: ((($menu-width * 2) - (2 * $grid-spacing) - 1) / 2) + ($grid-spacing / 2);
+            }
+        }
+    }
+
+    @media $media-query-mobile {
+        .submenu-column + .submenu-column {
+            margin-top: ($grid-spacing / 2);
+        }
+    }
+
+    /* media queries */
+    @media $media-query-small-mobile {
+        & {
+            padding-top: ($grid-spacing * 1.5);
+            width: auto;
+        }
+    }
+}
+
+/* submenu */
+$submenu {
+
+    position: absolute;
+    top: 40px;
+    bidi-style(left, auto, right, 0);
+    bidi-style(right, 0, left, auto);
+    z-index: 3;
+    display: none;
+    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.4);
+    padding: $grid-spacing;
+
+    /* arrow */
+    generate-arrow();
+    &:before {
+        position: absolute;
+        z-index: 2;
+        bidi-style(left, auto, right, 10px);
+        bidi-style(right, 10px, left, auto);
+    }
+
+    &:after {
+        position: absolute;
+        z-index: 1;
+        bidi-style(left, auto, right, 10px);
+        bidi-style(right, 10px, left, auto);
+    }
+
+    /* close button */
+    component-submenu-close();
+
+    /* lists */
+    ul + ul {
+        margin-top: ($grid-spacing / 2);
+        padding-top: ($grid-spacing / 2);
+    }
+
+    /* links */
+    reverse-link-decoration();
+    a {
+        set-smaller-font-size();
+        padding: 5px 0;
+        display: block;
+
+        &:link, &:visited, &:hover, &:active {
+            /* links should be link coloured, this could be moved
+               into submenu-set if we ever need them to be something
+               that stands out better on the configurable background */
+            color: $link-color !important;
+        }
+    }
+
+    /* for language menu */
+    bdi {
+        bidi-value(text-align, left, right);
+    }
+
+    /* columns */
+    @media $media-query-tablet-and-up {
+        .submenu-column {
+            vertical-align: text-top;
+            width: 100%;
+            min-height: 90px;
+            display: inline-block;
+
+            &:nth-child(even) {
+                bidi-style(margin-left, $grid-spacing, margin-right, 0);
+                bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
+                bidi-style(padding-left, $grid-spacing, padding-right, 0);
+            }
+        }
+    }
+
+    /* close button */
+    .submenu-close {
+        display: none;
+        position: absolute;
+        top: 0;
+        margin: 0;
+        /* Too many global styles working on `button` so !importatn
+           I don't feel too bad about using it here though
+           since this button should have a bit of size and the
+           rabbit hole that lead me here is pleanty deep enough */
+        padding: 10px !important;
+        bidi-style(right, 0, left, auto);
+        color: inherit;
+
+        i {
+            margin: 0;
+        }
+
+        @media $media-query-tablet {
+            & {
+                display: block;
+            }
+        }
+    }
+}
+
+
+
+

--- a/media/stylus/includes/mixins.styl
+++ b/media/stylus/includes/mixins.styl
@@ -268,18 +268,20 @@ override-main-header-color(hex) {
 /* overrides the size of the navigation search box on certain pages */
 minimize-header-search() {
 
-    .main-nav-search {
-        width: 36px;
-        @media $media-query-mobile {
-            width: auto;
+    @media $media-query-break-and-up {
+        .main-nav-search {
+            width: 36px;
+            @media $media-query-mobile {
+                width: auto;
+            }
         }
-    }
 
-    .search-wrap input {
-        width: 22px;
+        .search-wrap input {
+            width: 22px;
 
-        &:focus {
-            width: 500px;
+            &:focus {
+                width: 500px;
+            }
         }
     }
 }
@@ -394,92 +396,6 @@ title-header() {
     display: block;
 }
 
-/* submenu generator: used in the main navigation and wiki */
-component-submenu(menu-width, num-columns, background-color, arrow-border-color) {
-    position: absolute;
-    padding: $grid-spacing;
-    background: background-color;
-    display: none;
-    width: menu-width;
-    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.4);
-
-    component-submenu-close();
-
-    .submenu-column {
-        if num-columns is 1 {
-            col-width = 100%;
-        } else {
-            col-width = ((menu-width - (num-columns * $grid-spacing) - 1) / num-columns) + ($grid-spacing / 2);
-        }
-        vertical-align: text-top;
-        width: col-width;
-        display: inline-block;
-
-        &:nth-child(even) {
-            bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
-            bidi-style(padding-left, $grid-spacing, padding-right, 0);
-        }
-    }
-
-    a {
-        set-smaller-font-size();
-        padding: 5px 0;
-        display: block;
-        color: $link-color !important;
-    }
-    reverse-link-decoration();
-
-    generate-arrow();
-    &:before {
-        border-bottom-color: background-color;
-        position: absolute;
-        z-index: 2;
-    }
-
-    &:after {
-        border-bottom-color: arrow-border-color;
-        position: absolute;
-        z-index: 1;
-    }
-
-    @media $media-query-mobile {
-        .submenu-column, .submenu-column:nth-child(even) {
-            bidi-style(border-left, 0, border-right, 0);
-            bidi-style(padding-left, 0, padding-right, 0);
-        }
-    }
-
-    @media $media-query-small-mobile {
-        & {
-            width: auto;
-
-            .submenu-column {
-                width: auto;
-                display: block;
-            }
-        }
-    }
-}
-
-component-submenu-close() {
-    .submenu-close {
-        display: none;
-        position: absolute;
-        top: 20px;
-        bidi-style(right, 0, left, auto);
-
-        i {
-            margin-left: 0;
-        }
-    }
-
-    @media $media-query-tablet {
-        .submenu-close {
-            display: block;
-        }
-    }
-
-}
 
 
 /* When an element contains a label and a checkbox in order (as on the edit
@@ -499,32 +415,6 @@ $checkbox-label-container {
 
     > p {
         clear: left;
-    }
-}
-
-
-/* Dropdown menus that hide advanced feature, such as the "This Page" menu on
-   article pages, the "Advanced" menu on profiles, etc. */
-$advanced-menu {
-    component-submenu(160px, 1, $button-background, $button-shadow-color);
-    bidi-style(right, 0, left, auto);
-    top: 40px;
-    z-index: 3;
-    border-top: 1px solid $button-shadow-color;
-    width: 160px !important; /* needs this due to overriding media query rule of component */
-
-    bdi {
-        bidi-value(text-align, left, right);
-    }
-
-    &:before {
-        bidi-style(right, 10px, left, auto);
-        top: -18px;
-    }
-
-    &:after {
-        bidi-style(right, 10px, left, auto);
-        top: -20px;
     }
 }
 

--- a/media/stylus/includes/vars.styl
+++ b/media/stylus/includes/vars.styl
@@ -118,9 +118,15 @@ $media-query-tablet-only = 'all and (min-width: $tablet-starts) and (max-width: 
 $media-query-mobile-only = 'all and (min-width: $mobile-starts) and (max-width: $mobile-ends)';
 $media-query-small-mobile-only = $media-query-small-mobile;
 
-$media-query-navigation-break = 'all and (max-width: 970px)'; /* Moves nav items all the way to the left, moves logo above */
-$media-query-navigation-block = 'all and (max-width: 660px)'; /* Moves nav menu items to block, its own line */
+$navigation-break-ends = 1100px;
+$navigation-block-ends = 850px;
 
+$navigation-break-starts = $navigation-block-ends + 1px;
+
+$media-query-navigation-break = 'all and (max-width: $navigation-break-ends)'; /* Moves nav items all the way to the left, moves logo above */
+$media-query-navigation-block = 'all and (max-width: $navigation-block-ends)'; /* Moves nav menu items to block, its own line */
+
+$media-query-break-and-up = 'all and (min-width: $navigation-break-starts)';
 
 /*
 animation

--- a/media/stylus/zones.styl
+++ b/media/stylus/zones.styl
@@ -16,17 +16,6 @@
         border-bottom-color: rgba-fallback(rgba(255, 255, 255, 0.2));
     }
 
-    .oauth-logged-in {
-        a, a:hover, a:focus, a:visited, > {$selector-icon} {
-            color: $blue-background-text-color;
-        }
-    }
-
-    /*  Change open auth text in white */
-    .oauth-login-options {
-        color: $blue-background-text-color;
-    }
-
     /* zone content area needs to be adjusted for zone pages */
     main {
         background: transparent;

--- a/templates/base.html
+++ b/templates/base.html
@@ -87,29 +87,41 @@
 
     <a href="{{ url('home') }}" class="logo">{{ _('Mozilla Developer Network') }}</a>
 
-    <div class="header-login">
+    <div id="nav-sec">
         {% if not is_sphinx %}
-            {% include "includes/login.html" %}
+
+            {% if waffle.flag('header_tools') %}
+                  <ul>
+                  {% if user.is_authenticated() %}
+                      <li class="nav-tools"><a href="{{ wiki_url('MDN/Doc_status') }}">{{ _('Tools') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+
+                      <div class="submenu submenu-cols-2 js-submenu" id="nav-tools-submenu">
+                        <div class="submenu-column">
+                          <div class="title">{{ _('Contribute to MDN') }}</div>
+                          <ul>
+                            <li><a href="{{ wiki_url('MDN/Getting_started') }}">{{ _('Get started') }}</a></li>
+                            <li><a href="{{ wiki_url('MDN/Doc_status') }}">{{ _('Review or localize docs') }}</a></li>
+                            <li><a href="{{ wiki_url('Inbox') }}">{{ _('Add a new page') }}</a></li>
+                          </ul>
+                        </div><div class="submenu-column last">
+                          <div class="title">{{ _('Site Tools') }}</div>
+                          <ul>
+                            <li><a href="{{ url('dashboards.revisions') }}">{{ _('Revision dashboard') }}</a></li>
+                            <li><a href="{{ wiki_url('MDN/Doc_status') }}">{{ _('Documentation status') }}</a></li>
+                          </ul>
+                        </div>
+                      </div>
+                   </li>{% endif %}<li>{% include "includes/login.html" %}</li>
+                </ul>
+            {% else %}
+              {% include "includes/login.html" %}
+            {% endif %}
         {% endif %}
     </div>
 
-    <nav id="main-nav" role="navigation"><ul><li><a href="{{ wiki_url('Zones') }}">{{ _('Zones') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+    <nav id="main-nav" role="navigation"><ul><li><a href="{{ wiki_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
-        <div class="submenu js-submenu submenu-single" id="nav-zones-submenu">
-          <div class="submenu-column">
-            <ul>
-              <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
-              <li><a href="{{ wiki_url('Apps') }}">{{ _('App Center') }}</a></li>
-              <li><a href="{{ wiki_url('Firefox') }}">{{ _('Firefox') }}</a></li>
-              <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
-              <li><a href="{{ wiki_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
-              <li><a href="{{ wiki_url('Persona') }}">{{ _('Persona') }}</a></li>
-            </ul>
-          </div>
-        </div>
-      </li><li><a href="{{ wiki_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
-
-        <div class="submenu js-submenu" id="nav-platform-submenu">
+        <div class="submenu submenu-cols-2 js-submenu" id="nav-platform-submenu">
           <div class="submenu-column">
             <div class="title">{{ _('Technologies') }}</div>
             <ul>
@@ -134,7 +146,37 @@
             </ul>
           </div>
         </div>
-      </li><li><a href="{{ wiki_url('Tools') }}">{{ _('Tools') }}</a></li><li><a href="{{ url('demos') }}">{{ _('Demos') }}</a></li><li><a href="{{ wiki_url('Mozilla/Connect') }}">{{ _('Connect') }}</a></li><li class="nav-search-link"><a href="{{ url('search') }}" title="Search"><i aria-hidden="true" class="icon-search"></i></a></li>{% if not is_sphinx %}<li class="main-nav-search"><form action="{{ url('search') }}" method="get" role="search">
+      </li><li><a href="{{ wiki_url('Zones') }}">{{ _('Mozilla Docs') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+
+        <div class="submenu js-submenu" id="nav-zones-submenu">
+          <div class="submenu-column">
+            <ul>
+              <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
+              <li><a href="{{ wiki_url('Firefox') }}">{{ _('Firefox') }}</a></li>
+              <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
+              <li><a href="{{ wiki_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
+              <li><a href="{{ wiki_url('Persona') }}">{{ _('Persona') }}</a></li>
+            </ul>
+          </div>
+        </div>
+      </li><li><a href="{{ wiki_url('Tools') }}">{{ _('Developer Tools') }}</a></li><li><a href="{{ url('demos') }}">{{ _('Demos') }}</a></li>{% if not waffle.flag('header_feedback') %}<li><a href="{{ wiki_url('Mozilla/Connect') }}">{{ _('Connect') }}</a></li>{% else %}<li><a href="{{ wiki_url('MDN/Feedback') }}">{{ _('Feedback') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+
+        <div class="submenu js-submenu" id="nav-contact-submenu">
+          <div class="submenu-column">
+            <ul>
+                <li><a href="https://support.mozilla.org/">Help with Firefox<i aria-hidden="true" class="icon-external-link"></i></a></li>
+                <!-- TODO: add locale to URL -->
+                <li><a href="http://stackoverflow.com/">Help with web development<i aria-hidden="true" class="icon-external-link"></i></a></li>
+            </ul>
+            <ul>
+              <li><a href="{{ wiki_url('MDN/Community') }}">{{ _('Join the MDN community') }}</a></li>
+              <li><a href="https://bugzilla.mozilla.org/form.doc">{{ _('Report a content problem') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
+              <li><a href="https://bugzilla.mozilla.org/form.mdn">{{ _('Report a bug') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
+            </ul>
+          </div>
+        </div>
+
+      </li>{% endif %}<li class="nav-search-link"><a href="{{ url('search') }}" title="Search"><i aria-hidden="true" class="icon-search"></i></a></li>{% if not is_sphinx %}<li class="main-nav-search"><form action="{{ url('search') }}" method="get" role="search">
         <div class="search-wrap">
           <label for="main-q" class="offscreen">{{ _('Search') }}</label>
           <input type="search" id="main-q" name="q" placeholder="{{ _('Search') }}" data-value="{{ query }}" value="" />


### PR DESCRIPTION
Bug 815693 (Site Tools). Fix Bug 1180044 (Dev Tools homepage links). Bug 1070001 (re-org stylus - structure.styl).

- Added Feedback menu item to replace Connect (waffled as `header_feedback`).
- Added framework for a secondary nav menu where sign-in widget appears.
- Added Tools menu item to secondary nav (waffled under `header_tools`).
- Made wording changes discussed in email thread (Zones -> Mozilla Docs, Tools -> Developer Tools, moved Web Platform to be first). 
- Made spacing changes to navigation to accommodate longer words (this is a very English centric approach, I am a terrible person).
- Made home page tools links changes discussed in Bug 1180044.
- Separated structure.styl into separate files and included them.
- Changed how submenu styles are generated and inherited.
 - Submenu now assume 1 column, modifier class necessary for 2.
 - use submenu-set instead of $advanced-menu, this assumes the .submenu class has been applied in the CSS already and we're just over-riding specific values. A more OOCSS approach.

- [ ]  **strings need to be gathered and updated in verbatum**

Testing:
- [x] feedback appears in main nav with `header_feedback` waffle on
- [x] connect appears in main nav with `header_feedback` waffle off
- [x] site tools appears with `header_tools` waffle on when logged in
- [x] site tools does not appear with `header_tools` waffle on when logged out
- [x] site tools does not appear with `header_tools` waffle off
- [x] with screen at 320px, 481px, 769px, 850px, 1024px, 1100px, and 1200px navigation menu does not look broken and search box expands without breaking (you will have to refresh between resizing your screen, once the js on the search has been triggered it will not work properly at a different screen size)
- [x] spelling and href on all new links (including inside drop-down menus) are correct
- [x] take a spin around the site looking for broken stuff related to my re-organization of structure.styl

Also check all submenus are still functioning:
- [x] profile page submenu 
- [x] language & advanced submenu
- [x] login submenu
- [x] search results submenu