### PR TITLE
Fix bug 1177468: Improve <code> font on Linux

### DIFF
--- a/media/stylus/includes/vars.styl
+++ b/media/stylus/includes/vars.styl
@@ -55,7 +55,7 @@ $site-font-family-fallback = Arial, sans-serif;
 $heading-font-family = 'Open Sans Light', 'Helvetica', Arial, sans-serif;
 $heading-font-family-fallback = 'Helvetica', Arial, sans-serif;
 $code-block-font-family = Consolas, Monaco, 'Andale Mono', monospace; /* prism */
-$code-inline-font-family = 'Courier', 'Andale Mono', monospace; /* inline */
+$code-inline-font-family = Consolas, "Liberation Mono", Courier, monospace; /* inline */
 $diff-font-family = $code-inline-font-family;
 
 /*


### PR DESCRIPTION
After this change, the font used for `<code>` elements should be the same on Windows and Mac. On Linux, a better, easier-to-read font should be used instead.