### PR TITLE
Bug 1177264 - Stop LANGUAGES_DICT being populated on every request.

### DIFF
--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 from django.utils import translation
 
+from .i18n import LANGUAGES_DICT
+
 
 def global_settings(request):
     """Adds settings to the context."""
@@ -9,7 +11,7 @@ def global_settings(request):
 
 def i18n(request):
     return {
-        'LANGUAGES': settings.LANGUAGES_DICT,
+        'LANGUAGES': LANGUAGES_DICT,
         'LANG': (settings.LANGUAGE_URL_MAP.get(translation.get_language()) or
                  translation.get_language()),
         'DIR': 'rtl' if translation.get_language_bidi() else 'ltr',

--- a/kuma/core/i18n.py
+++ b/kuma/core/i18n.py
@@ -1,0 +1,6 @@
+from django.conf import settings
+from product_details import product_details
+
+# a static mapping of lower case language names and their native names
+LANGUAGES_DICT = dict([(lang.lower(), product_details.languages[lang]['native'])
+                       for lang in settings.MDN_LANGUAGES])

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -36,6 +36,7 @@ from kuma.attachments.models import Attachment
 from kuma.core.exceptions import ProgrammingError
 from kuma.core.cache import memcache
 from kuma.core.fields import LocaleField
+from kuma.core.i18n import LANGUAGES_DICT
 from kuma.core.urlresolvers import reverse, split_path
 from kuma.search.decorators import register_live_index
 
@@ -1288,9 +1289,9 @@ Full traceback:
     def show_toc(self):
         return self.current_revision and self.current_revision.toc_depth
 
-    @property
+    @cached_property
     def language(self):
-        return settings.LANGUAGES_DICT[self.locale.lower()]
+        return LANGUAGES_DICT[self.locale.lower()]
 
     def get_absolute_url(self, ui_locale=None):
         """Build the absolute URL to this document from its full path"""

--- a/kuma/wiki/templates/wiki/translate.html
+++ b/kuma/wiki/templates/wiki/translate.html
@@ -19,8 +19,6 @@
 {% endblock %}
 
 {% block content %}
-  {% set language = settings.LANGUAGES_DICT[locale.lower()] %}
-
     <form action="" method="post" data-json-url="{{ url('wiki.json') }}" id="translate-document">
       {{ csrf() }}
       <input type="hidden" name="form" value="both" />
@@ -79,7 +77,6 @@
               {% endif %}
             {% endif %}
 
-            {% set default_locale = settings.LANGUAGES_DICT[settings.WIKI_DEFAULT_LANGUAGE.lower()] %}
             <div id="content-fields">
               <article class="approved text-content">
                 <header>

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -45,6 +45,7 @@ from kuma.contentflagging.models import ContentFlag, FLAG_NOTIFICATIONS
 from kuma.attachments.forms import AttachmentRevisionForm
 from kuma.attachments.models import Attachment
 from kuma.attachments.utils import attachments_json, full_attachment_url
+from kuma.core.i18n import LANGUAGES_DICT
 from kuma.core.cache import memcache
 from kuma.core.decorators import (never_cache, login_required,
                                   permission_required, superuser_required)
@@ -1758,12 +1759,17 @@ def translate(request, document_slug, document_locale, revision_id=None):
     if doc and doc.attachments:
         attachments = attachments_json(doc.attachments)
 
+    language = LANGUAGES_DICT[document_locale.lower()]
+    default_locale = LANGUAGES_DICT[settings.WIKI_DEFAULT_LANGUAGE.lower()]
+
     context = {
         'parent': parent_doc,
         'document': doc,
         'document_form': doc_form,
         'revision_form': rev_form,
         'locale': document_locale,
+        'default_locale': default_locale,
+        'language': language,
         'based_on': based_on_rev,
         'disclose_description': disclose_description,
         'discard_href': discard_href,

--- a/settings.py
+++ b/settings.py
@@ -196,24 +196,9 @@ LOCALE_ALIASES = {
     'zh-Hant': 'zh-TW',
 }
 
-try:
-    DEV_LANGUAGES = [
-        loc.replace('_', '-') for loc in os.listdir(path('locale'))
-        if (os.path.isdir(path('locale', loc)) and
-            loc not in ['.svn', '.git', 'templates'])
-    ]
-    for pootle_dir in DEV_LANGUAGES:
-        if pootle_dir in DEV_POOTLE_PRODUCT_DETAILS_MAP:
-            DEV_LANGUAGES.remove(pootle_dir)
-            DEV_LANGUAGES.append(DEV_POOTLE_PRODUCT_DETAILS_MAP[pootle_dir])
-except OSError:
-    DEV_LANGUAGES = ('en-US',)
-
-PROD_LANGUAGES = MDN_LANGUAGES
-
-LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in PROD_LANGUAGES])
+LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in MDN_LANGUAGES])
 for requested_lang, delivered_lang in LOCALE_ALIASES.items():
-    if delivered_lang in PROD_LANGUAGES:
+    if delivered_lang in MDN_LANGUAGES:
         LANGUAGE_URL_MAP[requested_lang.lower()] = delivered_lang
 
 
@@ -229,35 +214,8 @@ def get_locales():
 
 LOCALES = get_locales()
 
-
-def lazy_langs():
-    """Override Django's built-in with our native names"""
-    from product_details import product_details
-    # for bug 664330
-    # from django.conf import settings
-    # langs = DEV_LANGUAGES if (getattr(settings, 'DEV', False) or getattr(settings, 'STAGE', False)) else PROD_LANGUAGES
-    langs = PROD_LANGUAGES
-    return dict([(lang.lower(), product_details.languages[lang]['native'])
-                for lang in langs])
-
-LANGUAGES_DICT = lazy(lazy_langs, dict)()
 LANGUAGES = sorted(tuple([(i, LOCALES[i].native) for i in MDN_LANGUAGES]),
                    key=lambda lang: lang[0])
-
-
-# DEKI uses different locale keys
-def lazy_language_deki_map():
-    # for bug 664330
-    # from django.conf import settings
-    # langs = DEV_LANGUAGES if (getattr(settings, 'DEV', False) or getattr(settings, 'STAGE', False)) else PROD_LANGUAGES
-    langs = PROD_LANGUAGES
-    lang_deki_map = dict([(i, i) for i in langs])
-    lang_deki_map['en-US'] = 'en'
-    lang_deki_map['zh-CN'] = 'cn'
-    lang_deki_map['zh-TW'] = 'zh_tw'
-    return lang_deki_map
-
-LANGUAGE_DEKI_MAP = lazy(lazy_language_deki_map, dict)()
 
 # List of MindTouch locales mapped to Kuma locales.
 #


### PR DESCRIPTION
This should stop the intense memory/memcache usage.

This was basically code laziness gone wrong. Instead we'll populate the mapping now once per process as a global module variable and leave it there until we redeploy at which we run the product_details update management command anyway.

Also get rid of a few old and unused settings.