### PR TITLE
Bug 1125850 - Reduce the chunk size for rendering stale documents by 50%.

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -120,7 +120,7 @@ def render_stale_documents(log=None):
 
     pre_task = acquire_render_lock.si()
     render_tasks = [render_document_chunk.si(pks)
-                    for pks in chunked(stale_pks, 10)]
+                    for pks in chunked(stale_pks, 5)]
     post_task = release_render_lock.si()
 
     chord_flow(pre_task, render_tasks, post_task).apply_async()


### PR DESCRIPTION
This is a test to see if that reduces the memory/swap usage of the celery workers.