### PR TITLE
bug 957802 - Fix issues running tests in new vagrant install

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -28,6 +28,7 @@
 [submodule "vendor/src/django-memcached-hashring"]
 	path = vendor/src/django-memcached-hashring
 	url = git://github.com/jezdez/django-memcached-hashring.git
+	ignore = untracked
 [submodule "vendor/src/django-nose"]
 	path = vendor/src/django-nose
 	url = git://github.com/django-nose/django-nose.git
@@ -46,9 +47,11 @@
 [submodule "vendor/src/django-tidings"]
 	path = vendor/src/django-tidings
 	url = git://github.com/mozilla/django-tidings.git
+	ignore = untracked
 [submodule "vendor/src/django-timezones"]
 	path = vendor/src/django-timezones
 	url = git://github.com/brosner/django-timezones.git
+	ignore = untracked
 [submodule "vendor/src/django-waffle"]
 	path = vendor/src/django-waffle
 	url = git://github.com/jsocol/django-waffle.git
@@ -70,6 +73,7 @@
 [submodule "vendor/src/python-magic"]
 	path = vendor/src/python-magic
 	url = git://github.com/ahupp/python-magic.git
+	ignore = untracked
 [submodule "vendor/src/python-memcached"]
 	path = vendor/src/python-memcached
 	url = git://github.com/linsomniac/python-memcached.git
@@ -118,6 +122,7 @@
 [submodule "vendor/src/django-cacheback"]
 	path = vendor/src/django-cacheback
 	url = https://github.com/codeinthehole/django-cacheback.git
+	ignore = untracked
 [submodule "vendor/src/django-ratelimit"]
 	path = vendor/src/django-ratelimit
 	url = git://github.com/jsocol/django-ratelimit.git

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -35,15 +35,16 @@ class TestWelcomeEmails(UserTestCase):
         eq_(expected_to, welcome_email.to)
         ok_(u'utm_campaign=welcome' in welcome_email.body)
 
-    @mock.patch('kuma.core.utils.strings_are_translated')
+    @mock.patch('kuma.users.tasks.strings_are_translated')
     def test_dont_send_untranslated_language_email(self,
                                                    strings_are_translated):
         strings_are_translated.return_value = False
         testuser = self.user_model.objects.get(username='testuser')
-        send_welcome_email(testuser.pk, 'tlh')  # Qapla'
+        send_welcome_email(testuser.pk, 'tlh')  # mev!
         eq_([], mail.outbox)
 
-        send_welcome_email(testuser.pk, 'de')  # Servus
+        strings_are_translated.return_value = True
+        send_welcome_email(testuser.pk, 'tlh')  # Qapla'!
         eq_(1, len(mail.outbox))
 
     def test_welcome_mail_for_verified_email(self):

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -247,10 +247,11 @@ class ContentSectionTool(object):
         self.parser = html5lib.HTMLParser(tree=self.tree,
                                           namespaceHTMLElements=False)
 
-        self.serializer = html5lib.serializer.htmlserializer.HTMLSerializer(
-            omit_optional_tags=False, quote_attr_values=True,
-            escape_lt_in_attrs=True)
-
+        self._serializer = None
+        self._default_serializer_options = {
+            'omit_optional_tags': False, 'quote_attr_values': True,
+            'escape_lt_in_attrs': True}
+        self._serializer_options = None
         self.walker = html5lib.treewalkers.getTreeWalker("etree")
 
         self.src = ''
@@ -270,10 +271,19 @@ class ContentSectionTool(object):
         self.stream = self.walker(self.doc)
         return self
 
-    def serialize(self, stream=None):
+    def _get_serializer(self, **options):
+        soptions = self._default_serializer_options.copy()
+        soptions.update(options)
+        if not (self._serializer and self._serializer_options == soptions):
+            self._serializer = html5lib.serializer.htmlserializer.HTMLSerializer(
+                **soptions)
+            self._serializer_options = soptions
+        return self._serializer
+
+    def serialize(self, stream=None, **options):
         if stream is None:
             stream = self.stream
-        return u"".join(self.serializer.serialize(stream))
+        return u"".join(self._get_serializer(**options).serialize(stream))
 
     def __unicode__(self):
         return self.serialize()

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -149,7 +149,7 @@ def normalize_html(input):
     return (kuma.wiki.content
             .parse(unicode(input))
             .filter(WhitespaceRemovalFilter)
-            .serialize())
+            .serialize(alphabetical_attributes=True))
 
 
 @nottest


### PR DESCRIPTION
Updates for issues found when running tests (`./manage.py test`) in a new vagrant install, with just a `git submodule update` and a superuser:

* Some content tests failed due to attribute order.  Adjusted the content tool to alpha-sort attributes in tests, but leave them alone in regular content flow.
* Some submodules don't ignore *.pyc files, so I set them to ignore non-tracked files, so that `git status` is clean.
* A test required setting up translated strings.  Fixed the mock so it works w/o translations installed.