### PR TITLE
bug 1177264 - waffle switch for dumb doc urls

### DIFF
--- a/kuma/core/urlresolvers.py
+++ b/kuma/core/urlresolvers.py
@@ -5,6 +5,7 @@ from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse as django_reverse
 from django.utils.translation.trans_real import parse_accept_lang_header
 
+from waffle import switch_is_active
 
 # Thread-local storage for URL prefixes. Access with (get|set)_url_prefix.
 _locals = threading.local()
@@ -72,7 +73,7 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
     # trick.
     #
     # See apps/wiki/tests/test_middleware.py for a test exercising this hack.
-    if url.startswith('/docs/'):
+    if (not switch_is_active('dumb_doc_urls') and url.startswith('/docs/')):
         # HACK: Import here, because otherwise it's a circular reference
         from kuma.wiki.jobs import DocumentZoneURLRemapsJob
         # Work out a current locale, from some source.


### PR DESCRIPTION
Per [the latest New Relic thread profile](https://rpm.newrelic.com/accounts/263620/applications/3172075/profiles/1711678), `kuma.core.urlresolvers.py.reverse` takes up as much as:
* 11% (in calls from `wiki_url` in `base.html`)
* 6.7% (during calls from `helpers.py.url` in `document_macros.html`)
* 4.7% (during calls from `Document.get_absolute_url` from `document.html` `extra_head` block)
* 4% (during calls from `Document.get_absolute_url` from `document.html` `lang_switcher` block)
* 1.3% (during calls from `wiki_url` in `base.html` `footer_copyright_redesign` block)
* A couple other areas of 0-1%

![kuma-reverse-profile](https://cloud.githubusercontent.com/assets/71928/8587376/1e45b948-25c0-11e5-8333-0bf0155980fd.png)

For a total of 27.7%+ of all back end execution time. The majority of the time spent in `reverse` is spent waiting on the `memcache.py._get` in the `DocumentZoneURLRemapsJob`. This job remaps any `/docs/{slug}` urls into `/{zone-url-root}` urls, if there's a zone mapping for the document. But, spot-checking some requests to `/docs/{slug}` show they re-direct to `/{zone-url-root}` anyway.

Effectively, our `document.html` templates spend 27.7% looking up **possible** url remaps for every doc link in the template, even though a plain `/docs/{slug}` link will work when the user visits them. I.e., we're incurring needless url remapping logic for every document view although there are only ~100 total zones, and most users will never even click any of the remapped links!

This change introduces a waffle switch that will allow us to short-circuit that logic in production to test:

* The effect on back end execution time
* The effect of the new redirects on user experience

If the effect on back end execution time is worth more than the effect on user experience, we can make this change permanent.