### PR TITLE
Fix bug 1174804 - Fix rendering of choice fields with Django >=1.7.

### DIFF
--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -462,6 +462,17 @@ class ProfileViewsTest(UserTestCase):
                 response.context['profile_form'].fields[field].label, basestring),
                 'Field %s is a string!' % field)
 
+    def test_bug_1174804(self):
+        """Test that the newsletter form field are safely rendered"""
+        testuser = self.user_model.objects.get(username='testuser')
+        self.client.login(username=testuser.username,
+                          password=TESTUSER_PASSWORD)
+
+        url = reverse('users.profile_edit', args=(testuser.username,))
+        response = self.client.get(url, follow=True)
+        doc = pq(response.content)
+        eq_(len(doc.find('input[name=newsletter-format]')), 2)
+
 
 class Test404Case(UserTestCase):
 


### PR DESCRIPTION
This is a case of a monkeypatch in jingo being out of date and a regression from us updating to a current Django release while jingo hasn't been released yet.

This makes use of https://github.com/jbalogh/jingo/commit/0d293ae8aefa0419961ab6480f38a3d2dfbadc44 and its explicit monkey patching of the `django.forms.widgets.RadioChoiceInput` class that replaces the old `django.forms.widgets.RadioInput`.

Note: There is https://github.com/jbalogh/jingo/issues/67 to ask the maintainers to do a proper release with little results yet.