### PR TITLE
Fix bug 1173170 - Fix code section extraction to work with updated pyquery.

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -172,15 +172,18 @@ def extract_code_sample(id, src):
         sample = pq('<section>%s</section>' % section)
     else:
         # If no section, fall back to plain old ID lookup
-        sample = pq(src).find('#%s' % id)
+        sample = pq(src).find('[id="%s"]' % id)
+
+    selector_templates = (
+        '.%s',
+        # HACK: syntaxhighlighter (ab)uses the className as a
+        # semicolon-separated options list...
+        'pre[class*="brush:%s"]',
+        'pre[class*="%s;"]'
+    )
     for part in parts:
-        selector = ','.join(x % (part,) for x in (
-            '.%s',
-            # HACK: syntaxhighlighter (ab)uses the className as a
-            # semicolon-separated options list...
-            'pre[class*="brush:%s"]',
-            'pre[class*="%s;"]'
-        ))
+        selector = ','.join(selector_template % part
+                            for selector_template in selector_templates)
         src = sample.find(selector).text()
         if src is not None:
             # Bug 819999: &nbsp; gets decoded to \xa0, which trips up CSS


### PR DESCRIPTION
Pyquery now uses cssselect which raises a syntax exception when using the `#<id>` shorthand instead of the more proper selector `[id="<id>"]`.

This is a regression of us updating pyquery.

Fix bug 1179525.