### PR TITLE
bug 997788 - fix ga event label to track position clicked

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -518,10 +518,11 @@
         $contributors.on('click', 'a', function(e) {
             var newTab = (e.metaKey || e.ctrlKey);
             var href = this.href;
+            var index = $(this).parent().index() + 1;
             var data = {
                 category: 'Top Contributors',
                 action: 'Click position',
-                label: href
+                label: index
             };
 
             if (newTab) {


### PR DESCRIPTION
As we roll out the contributor bar, we want to record which contribution **position** is clicked so we know if users tend to click the contributors listed first. Not sure why this was changed in https://github.com/mozilla/kuma/commit/42a74bed25f578a05da32a12b32cb92eadf6c430