### PR TITLE
bug 1177264 - make dumb_doc_urls change permanent

### DIFF
--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -2,7 +2,6 @@
 from nose.tools import eq_
 
 from kuma.core.cache import memcache
-from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 from kuma.wiki.models import DocumentZone
 from kuma.wiki.tests import revision
@@ -113,36 +112,3 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s?raw=1' % self.other_doc.slug
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
-
-    def test_reverse_rewrite(self):
-        """Ensure reverse() URLs are remapped"""
-        # HACK: This actually exercises code in kuma/core/urlresolvers.py, but
-        # lives here to share fixtures and such with other wiki URL remap code.
-        url = reverse('wiki.document',
-                      args=[self.other_doc.slug],
-                      locale='en-US')
-        eq_('/en-US/docs/otherPage', url)
-        url = reverse('wiki.edit_document',
-                      args=[self.other_doc.slug],
-                      locale='en-US')
-        eq_('/en-US/docs/otherPage$edit', url)
-
-        url = reverse('wiki.document',
-                      args=[self.middle_doc.slug],
-                      locale='en-US')
-        eq_('/en-US/ExtraWiki/Middle', url)
-        url = reverse('wiki.edit_document',
-                      args=[self.middle_doc.slug],
-                      locale='en-US')
-        eq_('/en-US/ExtraWiki/Middle$edit', url)
-
-        url = reverse('wiki.edit_document',
-                      args=[self.middle_doc.slug])
-        eq_('/ExtraWiki/Middle$edit', url)
-
-        self.root_zone.url_root = 'NewRoot'
-        self.root_zone.save()
-
-        url = reverse('wiki.edit_document',
-                      args=[self.middle_doc.slug])
-        eq_('/NewRoot/Middle$edit', url)


### PR DESCRIPTION
I [asked if the new behavior is an improvement in the bug about language-specific header links](https://bugzilla.mozilla.org/show_bug.cgi?id=1089537#c16) and [the original reporter verified the new behavior is better](https://bugzilla.mozilla.org/show_bug.cgi?id=1089537#c17).

So, this makes the change permanent to improve the UX **and** the response time.