### PR TITLE
Bug 957802: Ignore sanitized database dump

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ celeryev.pid
 media/js/libs/ckeditor/source/ckbuilder
 .tox
 .env
+*_devmo.sql


### PR DESCRIPTION
I always worry when copying the sanitized database dump to the project
root before importing it. Let's be sure it can never be committed.