### PR TITLE
bug 1182627 - add nofollow to profile compare link

### DIFF
--- a/kuma/users/templates/users/profile.html
+++ b/kuma/users/templates/users/profile.html
@@ -173,7 +173,7 @@
                       <h3><a href="{{ revision.document.get_absolute_url() }}">{{ revision.document.title }}</a></h3>
                       <ul class="activity-actions">
                           <li><a href="{{ url('wiki.edit_document', revision.document.slug, locale=revision.document.locale) }}" class="edit">{{ _("Edit page") }}</a></li>
-                          <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
+                          <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" rel="nofollow, noindex" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
                           <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history">{{ _("View page history") }}</a></li>
                       </ul>
                   </th>


### PR DESCRIPTION
Per https://bugzilla.mozilla.org/show_bug.cgi?id=1182627#c0, the Yahoo crawler is getting into `compare_revisions` and triggering slow transactions that are affecting python response times.

This adds `rel="nofollow"` to the last `compare_revisions` link on the site that was missing it. It should discourage more slow transactions from crawlers like Yahoo. 