### PR TITLE
Fix bug 1173178 - Catch Unicode decode errors in the search API.

### DIFF
--- a/kuma/search/store.py
+++ b/kuma/search/store.py
@@ -40,12 +40,19 @@ def ref_from_request(request):
 
 def ref_from_url(url):
     url = URL(url)
-    query = url.query.dict.get(QUERY_PARAM, '')
-    page = url.query.dict.get(PAGE_PARAM, 1)
-    filters = get_filters(url.query.multi_dict.get)
+    md5 = hashlib.md5()
+
+    try:
+        query = url.query.dict.get(QUERY_PARAM, '')
+        page = url.query.dict.get(PAGE_PARAM, 1)
+        filters = get_filters(url.query.multi_dict.get)
+    except UnicodeDecodeError:
+        query = ''
+        page = 1
+        filters = []
+
     locale = translation.get_language()
 
-    md5 = hashlib.md5()
     for value in [query, page, locale] + filters:
         md5.update(smart_str(value))
 

--- a/kuma/search/templates/search/down.html
+++ b/kuma/search/templates/search/down.html
@@ -4,6 +4,6 @@
 <article id="search-down" class="main">
   <h1>{{ _('Search Unavailable') }}</h1>
 
-  <p>{{ error }}</p>
+  <p>{{ detail }}</p>
 </article>
 {% endblock %}

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import elasticsearch
 from nose.tools import eq_
 from . import ElasticTestCase
@@ -153,6 +154,21 @@ class ViewTests(ElasticTestCase):
             self.assertContains(response,
                                 'Search is temporarily unavailable',
                                 status_code=200)
+
+    def test_unicode_exception(self):
+        class UnicodeDecodeErrorSearchView(SearchView):
+            filter_backends = ()
+
+            def list(self, *args, **kwargs):
+                # willfully causing a UnicodeDecodeError
+                return 'coöperative'.encode('ascii')
+
+        view = UnicodeDecodeErrorSearchView.as_view()
+        request = self.get_request('/en-US/search')
+        response = view(request)
+        self.assertContains(response,
+                            'Something went wrong with the search query',
+                            status_code=404)
 
     def test_unhandled_exceptions(self):
         class RealExceptionSearchView(SearchView):


### PR DESCRIPTION
This shows a 404 for the search if it's not working because of a decoding error of search query parameters.