### PR TITLE
fix bug 1184601 - Remove YouTube video load tracking

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -696,13 +696,6 @@
             $youtubeIframes.each(function(i){
                 players[i] = new YT.Player($(this).get(0));
 
-                players[i].addEventListener('onReady', function(){
-                   mdn.analytics.trackEvent({
-                        category: 'YouTube',
-                        action: 'Load',
-                        label: players[i].getVideoUrl()
-                    });
-                });
                 players[i].addEventListener('onStateChange', function(event) {
                     var action;
                     switch(event.data) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1184601