### PR TITLE
bug 957802 - license badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,10 @@ Kuma
 .. image:: https://requires.io/github/mozilla/kuma/requirements.svg?branch=master
    :target: https://requires.io/github/mozilla/kuma/requirements/?branch=master
    :alt: Requirements Status
+   
+.. image:: http://img.shields.io/badge/license-MPL2-blue.svg
+   :target: https://raw.githubusercontent.com/mozilla/kuma/master/LICENSE
+   :alt: License
 
 Kuma is the platform that powers `MDN (developer.mozilla.org)
 <https://developer.mozilla.org>`_


### PR DESCRIPTION
Supersedes https://github.com/mozilla/kuma/pull/3361 with bug in commit message.