### PR TITLE
bug 1118735 - only build master branch on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+    only:
+        - master
 cache:
     apt: true
     directories:


### PR DESCRIPTION
I guess we'll see if Travis still builds PRs even though they're not the master branch.