### PR TITLE
bug 1177264 - remove search_filters context processor (12.8% of app server time)

### DIFF
--- a/kuma/landing/templates/landing/homepage.html
+++ b/kuma/landing/templates/landing/homepage.html
@@ -209,6 +209,9 @@
       {{ js('home', async=True) }}
   {% endif %}
   {% if waffle.flag('search_suggestions') %}
+    <script>
+        window.mdn.searchFilters = {{ command_search_filters|jsonencode }};
+    </script>
     {{ js('search-suggestions') }}
     <script>
         jQuery('#home-search-form').searchSuggestions();

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -2,12 +2,12 @@ from django.conf import settings
 from django.shortcuts import render
 from django.views import static
 
-from constance import config
-
 from kuma.core.sections import SECTION_USAGE
 from kuma.core.cache import memcache
 from kuma.demos.models import Submission
 from kuma.feeder.models import Bundle
+from kuma.search.models import FilterGroup
+from kuma.search.serializers import GroupWithFiltersSerializer
 
 
 def home(request):
@@ -23,13 +23,14 @@ def home(request):
     if not community_stats:
         community_stats = {'contributors': 5453, 'locales': 36}
 
-    devderby_tag = str(config.DEMOS_DEVDERBY_CURRENT_CHALLENGE_TAG).strip()
+    groups = FilterGroup.objects.all()
+    serializer = GroupWithFiltersSerializer(groups, many=True)
 
     context = {
         'demos': demos,
         'updates': updates,
         'stats': community_stats,
-        'current_challenge_tag_name': devderby_tag,
+        'command_search_filters': serializer.data
     }
     return render(request, 'landing/homepage.html', context)
 

--- a/settings.py
+++ b/settings.py
@@ -360,8 +360,6 @@ TEMPLATE_CONTEXT_PROCESSORS = (
 
     'jingo_minify.helpers.build_ids',
     'constance.context_processors.config',
-
-    'kuma.search.context_processors.search_filters',
 )
 
 MIDDLEWARE_CLASSES = (

--- a/templates/includes/config.html
+++ b/templates/includes/config.html
@@ -31,8 +31,7 @@
             // Wiki-specific settings will be placed here
             wiki: {
                 autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
-            },
-            searchFilters: {{ command_search_filters|jsonencode }}
+            }
         };
 
         // Ensures gettext always returns something, is always set


### PR DESCRIPTION
Per [the latest New Relic profile](https://rpm.newrelic.com/accounts/263620/applications/3172075/profiles/1716288), at least 12.8% of app server time was spent in `kuma/search/context_processors.py.search_filters`.

On top of the fact that [the search filter feature is currently waffled off](https://developer.mozilla.org/admin/waffle/flag/65/), the `searchFilters` json is only needed on the home page, where search filter suggestions are displayed (when the feature is waffled on.)

So, I moved its logic into the `homepage` view to cut out the time spent processing this context during other views.

Spot-check:
* [x] Enable the `search_suggestions` waffle flag
* Go to home page
  * [x] Verify search filter suggestions still work
* Go to a document page
  * [x] Verify document page still works
* [x] Disable the `search_suggestions` waffle flag
  * [x] Verify search filter suggestions disappear from home page
  * [x] Verify document page still works