### PR TITLE
bug 1177264 - remove extra tags.exists() check (1.1% of app server time)

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_tag.html
+++ b/kuma/wiki/templates/wiki/includes/document_tag.html
@@ -1,4 +1,4 @@
-{% if tags.exists() %}
+{% if tags %}
   <div class="tag-attach-list contributors-sub">
     <i aria-hidden="true" class="icon-tags"></i>
     <strong>{{_('Tags:')}}</strong>&nbsp;


### PR DESCRIPTION
Per [the latest New Relic profile](https://rpm.newrelic.com/accounts/263620/applications/3172075/profiles/1716288), 1.1% of app server time is spent in `django/db/models/query.py.exists` [called by `kuma/wiki/templates/wiki/includes/document_tag.html`](https://github.com/mozilla/kuma/blob/374c12e203f80ade3d77aa401e3b6a99b1fa1a36/kuma/wiki/templates/wiki/includes/document_tag.html#L1).

This check is superfluous, because:
1. Both calling templates: [`document.html`](https://github.com/mozilla/kuma/blob/374c12e203f80ade3d77aa401e3b6a99b1fa1a36/kuma/wiki/templates/wiki/document.html#L356-L357) and [`revision.html`](https://github.com/mozilla/kuma/blob/374c12e203f80ade3d77aa401e3b6a99b1fa1a36/kuma/wiki/templates/wiki/revision.html#L56-L57) call `tags.all()` anyway
2. Most requests are to documents with tags

This PR removes the `exists()` call which removes a superfluous database query from almost every document view.