### PR TITLE
fix bug 1189222 - $subscribe: skip zone middleware

### DIFF
--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -23,6 +23,11 @@ class DocumentZoneMiddleware(object):
     incoming path_info to point at the internal wiki path
     """
     def process_request(self, request):
+        # https://bugzil.la/1189222
+        # Don't redirect POST $subscribe requests to GET zone url
+        if request.method == 'POST' and '$subscribe' in request.path:
+            return None
+
         remaps = DocumentZoneURLRemapsJob().get(request.locale)
         for original_path, new_path in remaps:
 


### PR DESCRIPTION
Redirecting POST $subscribe requests to zone urls causes a GET to $subscribe,
which has @require_POST decorator.

I'm not sold on this approach, though. :confused: 

Checks:
* [x] Edit a document still works
* [x] Subscribe to a zone document now works