### PR TITLE
Bug 1190171 - Revision content denormalization and other cleanups of the compare revision view.

### DIFF
--- a/kuma/wiki/__init__.py
+++ b/kuma/wiki/__init__.py
@@ -1,0 +1,2 @@
+# work around for bug in Jingo: https://github.com/jbalogh/jingo/issues/68
+default_app_config = 'kuma.wiki.apps.WikiConfig'

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -1,0 +1,123 @@
+from __future__ import absolute_import, unicode_literals
+
+from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
+from django.db.models import signals
+from django.apps import AppConfig
+from django.utils.translation import ugettext_lazy as _
+
+from elasticsearch_dsl.connections import connections as es_connections
+
+from .jobs import (DocumentContributorsJob, DocumentZoneStackJob,
+                   DocumentZoneURLRemapsJob)
+from .signals import render_done
+
+
+def invalidate_zone_stack_cache(document, async=False):
+    """
+    Reset the cache for the zone stack for all of the documents
+    in the document tree branch.
+    """
+    pks = [document.pk] + [parent.pk for parent in
+                           document.get_topic_parents()]
+    job = DocumentZoneStackJob()
+    if async:
+        invalidator = job.invalidate
+    else:
+        invalidator = job.refresh
+    for pk in pks:
+        invalidator(pk)
+
+
+def invalidate_zone_urls_cache(document, async=False):
+    """
+    Reset the URL remap list cache for the given document, assuming it
+    even has a zone.
+    """
+    job = DocumentZoneURLRemapsJob()
+    if async:
+        invalidator = job.invalidate
+    else:
+        invalidator = job.refresh
+    try:
+        if document.zone:
+            # reset the cached list of zones of the document's locale
+            invalidator(document.locale)
+    except ObjectDoesNotExist:
+        pass
+
+
+def invalidate_zone_caches_for_document(sender, instance, **kwargs):
+    """
+    A signal handler to trigger the cache invalidation of both the zone URLs
+    and stack cache for a given document.
+    """
+    async = kwargs.get('async', True)
+    invalidate_zone_urls_cache(instance, async=async)
+    invalidate_zone_stack_cache(instance, async=async)
+
+
+def invalidate_zone_caches_for_zone(sender, instance, **kwargs):
+    """
+    A signal handler to trigger the cache invalidation of both the zone URLs
+    and stack cache for a given zone's document.
+    """
+    invalidate_zone_caches_for_document(sender=instance.document.__class__,
+                                        instance=instance.document,
+                                        async=False)
+
+
+def invalidate_contributors(sender, instance, **kwargs):
+    """
+    A signal handler to trigger the contributor bar for a given document.
+    """
+    DocumentContributorsJob().invalidate(instance.pk)
+
+
+def build_json_data(sender, instance, **kwargs):
+    """
+    A signal handler to update the given document's json field.
+    """
+    from .tasks import build_json_data_for_document
+    if not instance.deleted:
+        build_json_data_for_document.delay(instance.pk, stale=False)
+
+
+class WikiConfig(AppConfig):
+    """
+    The Django App Config class to store information about the wiki app
+    and do startup time things.
+    """
+    name = 'kuma.wiki'
+    verbose_name = _("Wiki")
+
+    def ready(self):
+        super(WikiConfig, self).ready()
+
+        # Configure Elasticsearch connections for connection pooling.
+        es_connections.configure(
+            default={
+                'hosts': settings.ES_URLS,
+            },
+            indexing={
+                'hosts': settings.ES_URLS,
+                'timeout': settings.ES_INDEXING_TIMEOUT,
+            },
+        )
+
+        # the list of wiki document signal handlers to connect to
+        Document = self.get_model('Document')
+        signals.post_save.connect(invalidate_zone_caches_for_document,
+                                  sender=Document,
+                                  dispatch_uid='wiki.zones.invalidate.document')
+        signals.post_save.connect(invalidate_contributors,
+                                  sender=Document,
+                                  dispatch_uid='wiki.contributors.invalidate')
+        render_done.connect(build_json_data,
+                            dispatch_uid='wiki.document.build_json')
+
+        # the list of wiki document zone signal handlers to connect to
+        DocumentZone = self.get_model('DocumentZone')
+        signals.post_save.connect(invalidate_zone_caches_for_zone,
+                                  sender=DocumentZone,
+                                  dispatch_uid='wiki.zones.invalidate.zone')

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -7,7 +7,7 @@ from kuma.core.helpers import add_utm
 from kuma.core.urlresolvers import reverse
 from tidings.events import InstanceEvent
 
-from .helpers import revisions_unified_diff
+from .helpers import revisions_unified_diff, get_compare_url
 from .models import Document
 
 
@@ -30,11 +30,9 @@ def context_dict(revision):
     }
 
     if from_revision:
-        compare_url = (
-            reverse('wiki.compare_revisions',
-                    args=[document.slug], locale=document.locale) +
-            '?from=%s&to=%s' % (from_revision.id, to_revision.id)
-        )
+        compare_url = get_compare_url(document,
+                                      from_revision.id,
+                                      to_revision.id)
     else:
         compare_url = ''
 

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -346,11 +346,13 @@ class RevisionsFeed(DocumentsFeed):
         previous_id = u'N/A'
         content_diff = u'<h3>Content changes:</h3>'
         if previous:
-            previous_content = previous.content
+            previous_content = previous.get_tidied_content()
+            current_content = item.get_tidied_content()
             previous_id = previous.id
-            if previous_content != item.content:
+            if previous_content != current_content:
                 content_diff = content_diff + diff_table(
-                    previous_content, item.content, previous_id, item.id)
+                    previous_content, current_content,
+                    previous_id, item.id)
                 content_diff = colorize_diff(content_diff)
         else:
             content_diff = content_diff + escape(item.content)

--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -33,8 +33,9 @@ def compare_url(doc, from_id, to_id):
 
 # http://stackoverflow.com/q/774316/571420
 def show_diff(seqm):
-    """Unify operations between two compared strings
-seqm is a difflib.SequenceMatcher instance whose a & b are strings"""
+    """
+    Unify operations between two compared strings
+    seqm is a difflib.SequenceMatcher instance whose a & b are strings"""
     lines = config.FEED_DIFF_CONTEXT_LINES
     full_output = []
     for opcode, a0, a1, b0, b1 in seqm.get_opcodes():

--- a/kuma/wiki/migrations/0006_revision_tidied_content.py
+++ b/kuma/wiki/migrations/0006_revision_tidied_content.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0005_delete_teamwork_contenttypes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='revision',
+            name='tidied_content',
+            field=models.TextField(blank=True),
+            preserve_default=True,
+        ),
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -47,8 +47,7 @@ from .content import (extract_code_sample, extract_css_classnames,
                       extract_html_attributes, extract_kumascript_macro_names,
                       get_content_sections, get_seo_description, H2TOCFilter,
                       H3TOCFilter, SectionTOCFilter)
-from .jobs import (DocumentZoneStackJob, DocumentZoneURLRemapsJob,
-                   DocumentContributorsJob)
+from .jobs import DocumentZoneStackJob, DocumentContributorsJob
 from .exceptions import (DocumentRenderedContentNotAvailable,
                          DocumentRenderingInProgress, PageMoveError,
                          SlugCollision, UniqueCollision)
@@ -57,6 +56,7 @@ from .managers import (DeletedDocumentManager, DocumentAdminManager,
                        TaggedDocumentManager, TransformManager)
 from .search import WikiDocumentType
 from .signals import render_done
+from .utils import tidy_content
 
 
 def cache_with_field(field_name):
@@ -1613,6 +1613,7 @@ class Revision(models.Model):
 
     summary = models.TextField()  # wiki markup
     content = models.TextField()  # wiki markup
+    tidied_content = models.TextField(blank=True)  # wiki markup tidied up
 
     # Keywords are used mostly to affect search rankings. Moderators may not
     # have the language expertise to translate keywords, so we put them in the
@@ -1754,6 +1755,30 @@ class Revision(models.Model):
     def get_section_content(self, section_id):
         """Convenience method to extract the content for a single section"""
         return self.document.extract_section(self.content, section_id)
+
+    def get_tidied_content(self):
+        """
+        Return the revision content parsed and cleaned by tidy.
+
+        This will first check for a denormalized field,
+        """
+        # we may be lucky and have the tidied content already denormalized
+        # in the database, if so return it
+        if self.tidied_content:
+            return self.tidied_content
+        else:
+            from .tasks import tidy_revision_content
+            tidying_scheduled_cache_key = 'kuma:tidying_scheduled:%s' % self.pk
+            # if there isn't already a task scheduled for the revision
+            tidying_already_scheduled = memcache.get(tidying_scheduled_cache_key)
+            if not tidying_already_scheduled:
+                tidy_revision_content.delay(self.pk)
+                # we temporarily set a flag that we've scheduled a task
+                # already and don't need to schedule it the next time
+                # we use 3 days as a limit to try it again
+                memcache.set(tidying_scheduled_cache_key, 1, 60 * 60 * 24 * 3)
+                tidied_content, errors = tidy_content(self.content)
+            return tidied_content
 
     @property
     def content_cleaned(self):

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -24,14 +24,6 @@ from kuma.core.utils import chord_flow, chunked
 log = logging.getLogger('kuma.wiki.search')
 
 
-# Configure Elasticsearch connections for connection pooling.
-connections.configure(
-    default={'hosts': settings.ES_URLS},
-    indexing={'hosts': settings.ES_URLS,
-              'timeout': settings.ES_INDEXING_TIMEOUT},
-)
-
-
 class WikiDocumentType(document.DocType):
     excerpt_fields = ['summary', 'content']
     exclude_slugs = ['Talk:', 'User:', 'User_talk:', 'Template_talk:',

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -10,7 +10,6 @@ from django.contrib.auth import get_user_model
 from django.contrib.sitemaps import GenericSitemap
 from django.core.mail import EmailMessage, mail_admins, send_mail
 from django.db import connection, transaction
-from django.dispatch import receiver
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
 
@@ -27,7 +26,6 @@ from .exceptions import PageMoveError, StaleDocumentsRenderingInProgress
 from .helpers import absolutify
 from .models import Document, Revision, RevisionIP
 from .search import WikiDocumentType
-from .signals import render_done
 
 
 log = logging.getLogger('kuma.wiki.tasks')
@@ -137,12 +135,6 @@ def build_json_data_for_document(pk, stale):
     if document.parent is not None:
         parent_json = json.dumps(document.parent.build_json_data())
         Document.objects.filter(pk=document.parent.pk).update(json=parent_json)
-
-
-@receiver(render_done)
-def build_json_data_handler(sender, instance, **kwargs):
-    if not instance.deleted:
-        build_json_data_for_document.delay(instance.pk, stale=False)
 
 
 @task

--- a/kuma/wiki/templates/wiki/edit_document.html
+++ b/kuma/wiki/templates/wiki/edit_document.html
@@ -1,8 +1,10 @@
 {% extends "wiki/base.html" %}
 {% from "includes/error_list.html" import errorlist %}
 {% from 'wiki/includes/page_buttons.html' import page_buttons %}
+
 {% set title = _(document.title + ' | Edit {title}')|fe(title=('Template' if document.is_template else 'Article')) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+
 {% set classes = 'edit' %}
 {% block bodyclass %}edit{% if document.is_template %} is-template{% endif %}{% endblock %}
 
@@ -76,7 +78,7 @@
 
             {% if content and current_revision.content and content != current_revision.content %}
                 <h4>{{ _('Content:') }}</h4>
-                {{ diff_table(content, current_content, current_revision.id, "Proposed") }}
+                {{ diff_table(content, current_content, current_revision.id, "Proposed", tidy=True) }}
             {% endif %}
 
           </div>

--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -194,7 +194,7 @@
         {% endif %}
 
         <dt>{{ _('Content:') }}</dt>
-        <dd>{{ diff_table(revision_from.content, revision_to.content, revision_from.id, revision_to.id) }}</dd>
+        <dd>{{ diff_table(revision_from.get_tidied_content(), revision_to.get_tidied_content(), revision_from.id, revision_to.id) }}</dd>
       </dl>
     </section>
   {% endif %}

--- a/kuma/wiki/templates/wiki/includes/revision_diff_table.html
+++ b/kuma/wiki/templates/wiki/includes/revision_diff_table.html
@@ -1,6 +1,6 @@
 {% if revision_from.id != revision_to.id %}
-	{% set from_content = revision_from.content %}
+	{% set from_content = revision_from.get_tidied_content() %}
 {% else %}
 	{% set from_content = '' %}
 {% endif %}
-{{ diff_table(from_content, revision_to.content, revision_from.id, revision_to.id) }}
+{{ diff_table(from_content, revision_to.get_tidied_content(), revision_from.id, revision_to.id) }}

--- a/kuma/wiki/utils.py
+++ b/kuma/wiki/utils.py
@@ -1,3 +1,4 @@
+import tidylib
 from django.conf import settings
 
 
@@ -40,3 +41,21 @@ def locale_and_slug_from_path(path, request=None, path_locale=None):
         locale = getattr(settings, 'WIKI_DEFAULT_LANGUAGE', 'en-US')
 
     return (locale, slug, needs_redirect)
+
+
+def tidy_content(content):
+    options = {
+        'output-xhtml': 0,
+        'force-output': 1,
+    }
+    try:
+        content = tidylib.tidy_document(content, options=options)
+    except UnicodeDecodeError:
+        # In case something happens in pytidylib we'll try again with
+        # a proper encoding
+        content = tidylib.tidy_document(content.encode('utf-8'),
+                                        options=options)
+        tidied, errors = content
+        return tidied.decode('utf-8'), errors
+    else:
+        return content

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -1534,8 +1534,9 @@ def compare_revisions(request, document_slug, document_locale):
         # Punt any errors in parameter handling to a 404
         raise Http404
 
-    revision_from = get_object_or_404(Revision, id=from_id, document=doc)
-    revision_to = get_object_or_404(Revision, id=to_id, document=doc)
+    revisions = Revision.prefetch_related('document', 'tags')
+    revision_from = get_object_or_404(revisions, id=from_id, document=doc)
+    revision_to = get_object_or_404(revisions, id=to_id, document=doc)
 
     context = {
         'document': doc,

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -1512,11 +1512,12 @@ def document_revisions(request, document_slug, document_locale):
 @xframe_options_sameorigin
 @process_document_path
 @prevent_indexing
+@ratelimit(key='user_or_ip', rate='60/m', block=True)
 def compare_revisions(request, document_slug, document_locale):
-    """Compare two wiki document revisions.
+    """
+    Compare two wiki document revisions.
 
     The ids are passed as query string parameters (to and from).
-
     """
     locale = request.GET.get('locale', document_locale)
     doc = get_object_or_404(Document,

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -1512,7 +1512,7 @@ def document_revisions(request, document_slug, document_locale):
 @xframe_options_sameorigin
 @process_document_path
 @prevent_indexing
-@ratelimit(key='user_or_ip', rate='60/m', block=True)
+@ratelimit(key='user_or_ip', rate='15/m', block=True)
 def compare_revisions(request, document_slug, document_locale):
     """
     Compare two wiki document revisions.
@@ -1534,7 +1534,7 @@ def compare_revisions(request, document_slug, document_locale):
         # Punt any errors in parameter handling to a 404
         raise Http404
 
-    revisions = Revision.prefetch_related('document', 'tags')
+    revisions = Revision.objects.prefetch_related('document')
     revision_from = get_object_or_404(revisions, id=from_id, document=doc)
     revision_to = get_object_or_404(revisions, id=to_id, document=doc)
 

--- a/settings.py
+++ b/settings.py
@@ -441,7 +441,7 @@ INSTALLED_APPS = (
     'kuma.landing',
     'kuma.search',
     'kuma.users',
-    'kuma.wiki.apps.WikiConf',
+    'kuma.wiki',
     'kuma.attachments',
     'allauth',
     'allauth.account',

--- a/settings.py
+++ b/settings.py
@@ -441,7 +441,7 @@ INSTALLED_APPS = (
     'kuma.landing',
     'kuma.search',
     'kuma.users',
-    'kuma.wiki',
+    'kuma.wiki.apps.WikiConf',
     'kuma.attachments',
     'allauth',
     'allauth.account',


### PR DESCRIPTION
- Adds ratelimiting to the compare revision view.
- Refactors the signal handling to use new patterns and less confusing code.
- Prefetch revision tags and document for fewer queries.
- Denormalize the revision content in a separate field that is filled on save and uses tidy to do the CPU-intense work once instead of on every request.