### PR TITLE
fix bug 1188297 - add sv-SE locale

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -138,6 +138,7 @@ MDN_LANGUAGES = (
     'ru',
     'son',
     'sq',
+    'sv-SE',
     'sw',
     'ta',
     'th',


### PR DESCRIPTION
Spot-check on this branch:
1. [Get the localizations](http://kuma.readthedocs.org/en/latest/localization.html#get-localizations) if you don't already have them.
2.
```
cd locale
svn up
./compile-mo.sh .
```
3. Go to https://developer-local.allizom.org/sv-SE/ and make sure it pulls up.
4. Translate a test document into Svenska.