### PR TITLE
fix bug 1191497 - roll back python-memcached update

### DIFF
--- a/requirements/source.txt
+++ b/requirements/source.txt
@@ -44,7 +44,7 @@ oauthlib==1.0.1
 
 python-magic==0.4.6
 
-python-memcached==1.56
+python-memcached==1.54
 
 python-openid==2.2.5
 


### PR DESCRIPTION
As we [discussed in IRC and noted in the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1191497#c1), the python-memcached update introduced errors with the way cached inclusion tag output is stored into and/or retrieved out of memcache.

Rolling back to stop the 1000+ errors this is causing on the live site.

Spot-check:
* `git submodule update --init && find . -name "*.pyc" | xargs rm -f`
* Go to https://developer-local.allizom.org/en-US/demos/
* Refresh a few times
  * [x] Every page load should render fine
* Go to https://developer-local.allizom.org/es/demos/
* Refresh a few times
  * [x] Every page load should render fine