### PR TITLE
Bug 1190284 - Whitespace at the bottom of languages drop down menu

### DIFF
--- a/media/stylus/includes/mixin_submenu.styl
+++ b/media/stylus/includes/mixin_submenu.styl
@@ -109,7 +109,6 @@ $submenu {
         .submenu-column {
             vertical-align: text-top;
             width: 100%;
-            min-height: 90px;
             display: inline-block;
 
             &:nth-child(even) {


### PR DESCRIPTION
Removed min-height from submenus.