### PR TITLE
fix bug 1190582 - add Malagasy locale

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -125,6 +125,7 @@ MDN_LANGUAGES = (
     'ka',
     'ko',
     'ln',
+    'mg',
     'ml',
     'ms',
     'my',


### PR DESCRIPTION
Spot-check on this branch:
1. [Get the localizations](http://kuma.readthedocs.org/en/latest/localization.html#get-localizations) if you don't already have them.
2.
```
cd locale
svn up
./compile-mo.sh .
```
3. Go to https://developer-local.allizom.org/mg/ and make sure it pulls up.
4. Translate a test document into Malagasy.