### PR TITLE
Fix bug 1184513 - Move selected wiki columns to use MySQL's utf8mb4 encoding.

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -222,16 +222,20 @@ configuration is::
             'PASSWORD': 'kuma',
             'OPTIONS': {
                 'sql_mode': 'TRADITIONAL',
-                'charset': 'utf8',
+                'charset': 'utf8mb4',
                 'init_command': 'SET '
                     'storage_engine=INNODB,'
-                    'character_set_connection=utf8,'
-                    'collation_connection=utf8_general_ci',
+                    'character_set_client=utf8mb4,'
+                    'character_set_server=utf8mb4,'
+                    'character_set_database=utf8mb4,'
+                    'collation_connection=utf8mb4_unicode_ci,'
+                    'collation_server=utf8mb4_unicode_ci,'
+                    'collation_database=utf8mb4_unicode_ci'
             },
             'ATOMIC_REQUESTS': True,
             'TEST': {
-                'CHARSET': 'utf8',
-                'COLLATION': 'utf8_general_ci',
+                'CHARSET': 'utf8mb4',
+                'COLLATION': 'utf8mb4_unicode_ci',
             },
         },
     }

--- a/kuma/wiki/migrations/0007_utf8mb4.py
+++ b/kuma/wiki/migrations/0007_utf8mb4.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+from django.db import migrations
+
+logger = logging.getLogger(__name__)
+
+
+document_columns = [
+    ('html', 'NOT NULL'),
+    ('rendered_html', ''),
+    ('rendered_errors', ''),
+    ('json', ''),
+    ('body_html', ''),
+    ('quick_links_html', ''),
+    ('zone_subnav_local_html', ''),
+    ('toc_html', ''),
+    ('summary_html', ''),
+    ('summary_text', ''),
+]
+
+revision_columns = [
+    ('summary', 'NOT NULL'),
+    ('content', 'NOT NULL'),
+    ('tidied_content', 'NOT NULL'),
+]
+
+
+def alter_columns(cursor, table, columns, charset, collation):
+    for column, extra in columns:
+        logger.debug('Altering column %s of table %s', column, table)
+        query = ('ALTER TABLE %s '
+                 'CHANGE %s %s LONGTEXT '
+                 'CHARACTER SET %s '
+                 'COLLATE %s '
+                 '%s;' %
+                 (table, column, column, charset, collation, extra))
+        logger.debug('Running query %s', query)
+        cursor.execute(query)
+
+
+def forwards(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        alter_columns(cursor, 'wiki_document', document_columns,
+                      'utf8mb4', 'utf8mb4_unicode_ci')
+        alter_columns(cursor, 'wiki_revision', revision_columns,
+                      'utf8mb4', 'utf8mb4_unicode_ci')
+
+
+def backwards(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        alter_columns(cursor, 'wiki_document', document_columns,
+                      'utf8', 'utf8_unicode_ci')
+        alter_columns(cursor, 'wiki_revision', revision_columns,
+                      'utf8', 'utf8_unicode_ci')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0006_revision_tidied_content'),
+    ]
+
+    operations = [migrations.RunPython(forwards, backwards)]

--- a/settings.py
+++ b/settings.py
@@ -43,16 +43,20 @@ DATABASES = {
         'PORT': '3306',  # Set to empty string for default. Not used with sqlite3.
         'OPTIONS': {
             'sql_mode': 'TRADITIONAL',
-            'charset': 'utf8',
+            'charset': 'utf8mb4',
             'init_command': 'SET '
                 'storage_engine=INNODB,'
-                'character_set_connection=utf8,'
-                'collation_connection=utf8_general_ci',
+                'character_set_client=utf8mb4,'
+                'character_set_server=utf8mb4,'
+                'character_set_database=utf8mb4,'
+                'collation_connection=utf8mb4_unicode_ci,'
+                'collation_server=utf8mb4_unicode_ci,'
+                'collation_database=utf8mb4_unicode_ci'
         },
         'ATOMIC_REQUESTS': True,
         'TEST': {
-            'CHARSET': 'utf8',
-            'COLLATION': 'utf8_general_ci',
+            'CHARSET': 'utf8mb4',
+            'COLLATION': 'utf8mb4_unicode_ci',
         },
     },
 }


### PR DESCRIPTION
This enables those columns to store 4 byte unicode characters such as mathamatical symbols, emojis etc.