### PR TITLE
bug 1193427 - Make 'social' and 'helpfulness' resources async

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -417,10 +417,13 @@
       {# This can be removed once the social network button multivariate test is completed. #}
       mdn.optimizely.push(['activate', 2796520257]);
   </script>
+
   {% if waffle.flag('share_links') %}
-    {{ js('social') }}
+    {{ js('social', async=True) }}
   {% endif %}
+
   {% if waffle.flag('helpfulness') %}
-    {{ js('helpfulness') }}
+    {{ js('helpfulness', async=True) }}
   {% endif %}
+
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -235,8 +235,6 @@
         if(window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
       </script>
 
-    </script>
-
     {% for script in scripts %}
       {{ js(script) }}
     {% endfor %}


### PR DESCRIPTION
Neither of these resources require a fully loaded page so we can make them async