### PR TITLE
fix bug 1193455 - Include font observer in main package

### DIFF
--- a/media/js/fonts.js
+++ b/media/js/fonts.js
@@ -31,10 +31,8 @@
     // timout for all observers
     var ffoTimeout = 2000;
 
-    // load the observer plug in
-    $.getScript(mdn.mediaPath + 'js/fontfaceobserver-min.js')
-      .done(ffoLoad)
-      .fail(ffoFinished);
+    // run the observer plug in
+    ffoLoad();
 
     // starts observers for all fonts in fonts array
     function ffoLoad() {

--- a/settings.py
+++ b/settings.py
@@ -661,6 +661,7 @@ MINIFY_BUNDLES = {
             'js/analytics.js',
             'js/main.js',
             'js/auth.js',
+            'js/libs/fontfaceobserver/fontfaceobserver-standalone.js',
             'js/fonts.js',
         ),
         'home': (
@@ -734,9 +735,6 @@ MINIFY_BUNDLES = {
         ),
         'fellowship': (
             'js/fellowship.js',
-        ),
-        'fontfaceobserver': (
-            'js/libs/fontfaceobserver/fontfaceobserver-standalone.js',
         ),
     },
 }


### PR DESCRIPTION
Since this is no longer waffled, we don't need to load the item via AJAX.  Save a request.