### PR TITLE
Fix bug 1193815 - Fixed rendering of JavaScript translation catalogs.

### DIFF
--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -263,6 +263,10 @@ you need them for something, they're pretty easy to get::
 
 if you're a git fan.)
 
+Then run the Django management command to update the static JavaScript
+translation catalogs::
+
+    python manage.py compilejsi18n
 
 Updating the Localizations
 ==========================

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -1,7 +1,13 @@
+import os
 import hashlib
 import six
 
+from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
+from django.utils.safestring import mark_safe
+
 from cacheback.base import Job, to_bytestring
+from statici18n.utils import get_filename
 
 
 class KumaJob(Job):
@@ -43,3 +49,15 @@ class IPBanJob(KumaJob):
 
     def empty(self):
         return "60/m"
+
+
+class StaticI18nJob(KumaJob):
+    lifetime = 60 * 60 * 24
+
+    def fetch(self, locale):
+        if not locale:
+            locale = settings.LANGUAGE_CODE
+        filename = get_filename(locale, settings.STATICI18N_DOMAIN)
+        path = os.path.join(settings.STATICI18N_OUTPUT_DIR, filename)
+        with staticfiles_storage.open(path) as i18n_file:
+            return mark_safe(i18n_file.read())

--- a/settings.py
+++ b/settings.py
@@ -18,8 +18,6 @@ TEMPLATE_DEBUG = DEBUG
 ROOT = os.path.dirname(os.path.abspath(__file__))
 path = lambda *a: os.path.join(ROOT, *a)
 
-ROOT_PACKAGE = os.path.basename(ROOT)
-
 ADMINS = (
     ('MDN devs', 'mdn-dev@mozilla.com'),
 )
@@ -546,6 +544,7 @@ DOMAIN_METHODS = {
 STANDALONE_DOMAINS = [
     'javascript',
 ]
+STATICI18N_DOMAIN = 'javascript'
 
 # If you have trouble extracting strings with Tower, try setting this
 # to True

--- a/templates/base.html
+++ b/templates/base.html
@@ -221,10 +221,6 @@
   </div></footer>
 
   <!-- site js -->
-  {% if not waffle.flag('static-i18njs') %}
-  <script src="{{ url('jsi18n') }}build:{{ BUILD_ID_JS }}"></script>
-  {% endif %}
-
   {% block site_js %}
     <!--[if lte IE 8]><script src="/media/js/libs/selectivizr-1.0.2/selectivizr-build.js"></script><![endif]-->
 

--- a/templates/includes/config.html
+++ b/templates/includes/config.html
@@ -1,12 +1,11 @@
 <script type="text/javascript">
+    {{ inlinei18n(request.locale) }}
+
     (function(win) {
         'use strict';
 
         {% if not is_sphinx %}
             {{ waffle.wafflejs() }}
-        {% endif %}
-        {% if waffle.flag('static-i18njs') %}
-            {{ inlinei18n(request.locale) }}
         {% endif %}
 
         // This represents the site configuration
@@ -33,10 +32,5 @@
                 autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
             }
         };
-
-        // Ensures gettext always returns something, is always set
-        win.gettext = function(x) {
-            return x;
-        }
-    })(window);
+    })(this);
 </script>

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skipsdist = True
 deps=
     -rrequirements/compiled.txt
 commands =
+    python manage.py compilejsi18n
     coverage run manage.py test --noinput -v2 {posargs:kuma}
     coverage report
 setenv =

--- a/urls.py
+++ b/urls.py
@@ -3,8 +3,6 @@ from django.conf import settings
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
-from django.views.i18n import javascript_catalog
-from django.views.decorators.cache import cache_page
 from django.views.static import serve
 import jingo.monkey
 
@@ -44,13 +42,6 @@ urlpatterns = [
         attachment_views.list_files,
         name='attachments.list_files'),
     url(r'^docs', include('kuma.wiki.urls')),
-
-    # Javascript translations.
-    url(r'^jsi18n/.*$',
-        cache_page(60 * 60 * 24 * 365)(javascript_catalog),
-        {'domain': 'javascript',
-         'packages': [settings.ROOT_PACKAGE]},
-        name='jsi18n'),
 
     url(r'^files/', include('kuma.attachments.urls')),
     url(r'^', include('kuma.dashboards.urls')),


### PR DESCRIPTION
This makes use of the "javascript" domain name used by the non-standard i18n setup Mozilla uses.
Also move to using a cacheback job to profit from thundering herd protection etc.