### PR TITLE
fix bug 1190212 - no 404s from parent seo title

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -39,6 +39,7 @@ from ..events import EditDocumentEvent
 from ..forms import MIDAIR_COLLISION
 from ..models import (Document, Revision, RevisionIP, DocumentZone,
                       DocumentTag, DocumentDeletionLog)
+from ..views import _get_seo_parent_title
 from . import (doc_rev, document, new_document_data, revision,
                normalize_html, create_template_test_users,
                make_translation, WikiTestCase, FakeResponse)
@@ -945,6 +946,15 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 class DocumentSEOTests(UserTestCase, WikiTestCase):
     """Tests for the document seo logic"""
     localizing_client = True
+
+    @attr('bug1190212')
+    def test_get_seo_parent_doesnt_throw_404(self):
+        slug_dict = {'seo_root': 'Root/Does/Not/Exist'}
+        try:
+            _get_seo_parent_title(slug_dict, 'bn-BD')
+        except Http404:
+            self.fail('Missing parent should not cause 404 from '
+                      '_get_seo_parent_title')
 
     def test_seo_title(self):
         self.client.login(username='admin', password='testpass')

--- a/kuma/wiki/views.py
+++ b/kuma/wiki/views.py
@@ -363,15 +363,15 @@ def _filter_doc_html(request, doc, doc_html, rendering_params):
 def _get_seo_parent_title(slug_dict, document_locale):
     """
     Get parent-title information for SEO purposes.
-
     """
     if slug_dict['seo_root']:
-        seo_root_doc = get_object_or_404(Document,
-                                         locale=document_locale,
-                                         slug=slug_dict['seo_root'])
-        return u' - %s' % seo_root_doc.title
-    else:
-        return ''
+        try:
+            seo_root_doc = Document.objects.get(locale=document_locale,
+                                                slug=slug_dict['seo_root'])
+            return u' - %s' % seo_root_doc.title
+        except Document.DoesNotExist:
+            pass
+    return ''
 
 
 #####################################################################


### PR DESCRIPTION
We shouldn't throw 404s on the entire request just because we can't find a page's root document while generating the title for SEO purposes.