### PR TITLE
Bug 1189515 - Details and summary

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -17,8 +17,8 @@ ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'section', 'header', 'footer', 'nav', 'article', 'aside', 'figure',
     'figcaption',
     'dialog', 'hgroup', 'mark', 'time', 'meter', 'command', 'output',
-    'progress', 'audio', 'video', 'details', 'datagrid', 'datalist', 'table',
-    'address', 'font',
+    'progress', 'audio', 'video', 'details', 'summary', 'datagrid', 'datalist',
+    'table', 'address', 'font',
     'bdi', 'bdo', 'del', 'ins', 'kbd', 'samp', 'var',
     'ruby', 'rp', 'rt', 'q',
     # MathML
@@ -51,6 +51,7 @@ ALLOWED_ATTRIBUTES['th'] = ['style', 'id', 'class', 'colspan', 'rowspan',
 ALLOWED_ATTRIBUTES['video'] = ['style', 'id', 'class', 'lang', 'src',
                                'controls', 'dir']
 ALLOWED_ATTRIBUTES['font'] = ['color', 'face', 'size', 'dir']
+ALLOWED_ATTRIBUTES['details'] = ['open']
 ALLOWED_ATTRIBUTES['select'] = ['name', 'dir']
 ALLOWED_ATTRIBUTES['option'] = ['value', 'selected', 'dir']
 ALLOWED_ATTRIBUTES['ol'] = ['style', 'class', 'id', 'lang', 'start', 'dir']

--- a/media/stylus/base/elements/sectioning.styl
+++ b/media/stylus/base/elements/sectioning.styl
@@ -81,6 +81,7 @@ details {
 
 summary  {
     display: block;
+    color: $link-color;
 
     h1, h2, h3, h4, h5, h6 {
         display: inline-block;

--- a/media/stylus/wiki-wysiwyg.styl
+++ b/media/stylus/wiki-wysiwyg.styl
@@ -100,3 +100,23 @@ li[data-default-state='open'] > a:after {
     display: inline-block;
     padding-left: 6px;
 }
+
+details {
+    position: relative;
+    display: block;
+    border: 2px dotted #000;
+    padding: 3px;
+
+    &:before {
+        set-font-size(10px);
+        content: 'details';
+        position: absolute;
+        top: -17px;
+        left: -2px;
+        z-index: 10;
+        display: block;
+        padding: 0 2px;
+        background: #000;
+        color: #fff;
+    }
+}


### PR DESCRIPTION
Added `<summary>` to allowed tags and `open` to allowed attributes on `<details>`. 
Added CSS to make `<summary>` look clickable and outline `<details>` in editor view.

@darkwing do I need to re-build CKEditor and commit those files to make these changes take effect?