### PR TITLE
Bug 1144134 - editorial reviews should be yellow

### DIFF
--- a/media/stylus/components/wiki/indicators.styl
+++ b/media/stylus/components/wiki/indicators.styl
@@ -209,7 +209,7 @@ Colours for both types
 }
 
 /* if you don't know this it won't work */
-.warning-review,
+.warning.warning-review,
 .draft,
 .todo,
 .note,


### PR DESCRIPTION
Upping the specificity on this to override the cascade.

I want to fix the mess that is the 40 classes we're using quite badly.