### PR TITLE
bug 1184662 - Allow time for scrolling CSS to apply

### DIFF
--- a/tests/ui/tests/wiki.js
+++ b/tests/ui/tests/wiki.js
@@ -242,7 +242,7 @@ define([
                         })
                         .executeAsync(function(done) {
                             scrollTo(0, 1200);
-                            done();
+                            setTimeout(done, 1000);
                         })
                         .end()
                         .findByCssSelector(tocSelector)
@@ -252,7 +252,7 @@ define([
                         })
                         .getComputedStyle('position')
                         .then(function(position) {
-                            assert.isTrue(position == 'fixed', 'Testing position is fixed: ' + position);
+                            assert.isTrue(position === 'fixed', 'Testing position is fixed: ' + position);
                         });
 
         },


### PR DESCRIPTION
Since we debounce scroll events, we should provide an allowance time before testing a given CSS property.