### PR TITLE
bug 1195335 - Fix path to wiki/list/tags.html

### DIFF
--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -69,7 +69,7 @@ def tags(request):
     """
     tags = DocumentTag.objects.order_by('name')
     tags = paginate(request, tags, per_page=DOCUMENTS_PER_PAGE)
-    return render(request, 'wiki/list_tags.html', {'tags': tags})
+    return render(request, 'wiki/list/tags.html', {'tags': tags})
 
 
 @require_GET


### PR DESCRIPTION
The template was moved from ``wiki/list_tags.html`` to ``wiki/list/tags.html``