### PR TITLE
bug 1196342 - use Travis elasticsearch service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
     - "2.7"
 services:
     - memcached
+    - elasticsearch
 env:
     matrix:
         - TOXENV=py27

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -14,11 +14,6 @@ then
     tar -C .. -zxf etc/data/product_details_json.tar.gz
     tar xvfz etc/data/locale.tar.gz
 
-    # elasticsearch
-    curl -O https://download.elasticsearch.org/elasticsearch/elasticsearch/elasticsearch-1.3.7.deb
-    sudo dpkg --force-confdef -i elasticsearch-1.3.7.deb
-    sudo service elasticsearch start
-
     # completely and utterly remove Travis' MySQL and let the Ansible role install it
     sudo apt-get remove --purge 'mysql*'
     sudo apt-get autoremove


### PR DESCRIPTION
Alternative to https://github.com/mozilla/kuma/pull/3426: try using Travis CI's built-in elastic search service. Doesn't version-match to prod, but it's better than the all-out failures we have now.