### PR TITLE
bug 1189451 - add 'Host' header

### DIFF
--- a/tests/performance/smoke.py
+++ b/tests/performance/smoke.py
@@ -1,3 +1,5 @@
+import os
+
 from locust import HttpLocust, TaskSet, task
 
 
@@ -8,6 +10,10 @@ class SmokeBehavior(TaskSet):
     generated later.
     See https://bugzil.la/1186085
     """
+
+    def on_start(self):
+        locust_host = os.environ.get('LOCUST_HOST', 'developer.allizom.org')
+        self.client.headers['Host'] = locust_host
 
     @task(weight=265)
     def home(self):


### PR DESCRIPTION
To by-pass the internal load balancer from the locust cluster to the stage web-heads, we run locust with: `--host=<IP of stage web server>`.

So, we need to add an explicit 'Host' HTTP header on the requests so Apache will respond to them on the correct vhost.