### PR TITLE
bug 1197971 - dont render previews of deferred docs

### DIFF
--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -42,15 +42,22 @@ def preview(request):
     """
     Create an HTML fragment preview of the posted wiki syntax.
     """
-    wiki_content = request.POST.get('content', '')
     kumascript_errors = []
+    doc = None
+    render_preview = True
+
+    wiki_content = request.POST.get('content', '')
     doc_id = request.POST.get('doc_id')
     if doc_id:
         doc = Document.objects.get(id=doc_id)
-    else:
-        doc = None
 
-    if kumascript.should_use_rendered(doc, request.GET, html=wiki_content):
+    if doc and doc.defer_rendering:
+        render_preview = False
+    else:
+        render_preview = kumascript.should_use_rendered(doc,
+                                                        request.GET,
+                                                        html=wiki_content)
+    if render_preview:
         wiki_content, kumascript_errors = kumascript.post(request,
                                                           wiki_content,
                                                           request.locale)


### PR DESCRIPTION
To help mitigate risk of [disruptions of service caused by previewing documents with a large number of macro calls](https://bugzilla.mozilla.org/show_bug.cgi?id=1197971#c1), skip KumaScript rendering when previewing a document with deferred rendering. ([We automatically set documents to defer rendering when they take too long to render.](https://github.com/mozilla/kuma/blob/1de4dd081432647c8eb3f8c519a6d141cbf24be5/kuma/wiki/models.py#L547-L553)