### PR TITLE
bug 957802 - set db logging to warn during tests

### DIFF
--- a/settings_test.py
+++ b/settings_test.py
@@ -12,3 +12,9 @@ INSTALLED_APPS += (
 BANISH_ENABLED = False
 
 DEMO_UPLOADS_ROOT = '/home/vagrant/uploads/demos'
+
+LOGGING['loggers']['django.db.backends.schema'] = {
+    'handlers': ['console'],
+    'propagate': True,
+    'level': 'WARNING',
+}


### PR DESCRIPTION
This drives me crazy when I'm trying to debug tests and have to scroll all the way up thru a bunch of `DEBUG` level output from `django.db.backends.schema`. I even [asked on Stack Overflow](https://stackoverflow.com/questions/32158773/how-do-i-disable-django-migration-debug-logging) and I wonder if this is an upstream bug in/between django or django-nose? (@jwhitlock - you do django-nose now right?)