### PR TITLE
Bug 1144134 - indicator refinements

### DIFF
--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -297,11 +297,11 @@
                 {% endif %}
                 {% if document.current_revision.localization_in_progress %}
                   {% if document.current_revision.translation_age >= 10 %}
-                      <div class="warning warning-review"><p>{% trans translate_url=url('wiki.edit_document', document.slug, locale=document.locale) %}
+                      <div class="overheadIndicator translationInProgress"><p>{% trans translate_url=url('wiki.edit_document', document.slug, locale=document.locale) %}
                         This translation is incomplete. Please help <a href="{{ translate_url }}">translate this article</a> from English.
                       {% endtrans %}</p></div>
                   {% else %}
-                      <div class="warning warning-review"><p>
+                      <div class="overheadIndicator translationInProgress"><p>
                         {{ _('This translation is in progress.') }}
                       </p></div>
                   {% endif %}

--- a/media/stylus/components/wiki/indicators.styl
+++ b/media/stylus/components/wiki/indicators.styl
@@ -31,11 +31,6 @@ block indicators aka banners
     p > strong {
         @extends $indicator-block-heading;
     }
-
-    /* heading */
-    &:first-line {
-        @extends $indicator-block-heading;
-    }
 }
 
 /* heading */


### PR DESCRIPTION
Adding language icon to in translation warning.

Removing first-line styling (beginning with a strong tag is a convention I would like the writers to follow but not one I should be enforcing with CSS)