### PR TITLE
bug 1198931 - Add Archive subtree on all locales to robots.txt

### DIFF
--- a/media/robots.txt
+++ b/media/robots.txt
@@ -8,3 +8,4 @@ Disallow: /*type=feed
 Disallow: /skins
 Disallow: /template:
 Disallow: /media
+Disallow: /*/docs/Archive


### PR DESCRIPTION
This patch adds the Archive subtree in all docs locales to the
robots.txt file so they shouldn’t be indexed by the major search
engines.