### PR TITLE
bug 1177264 - optimize zone root summary display

### DIFF
--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -6,7 +6,6 @@ import urllib
 import urlparse
 
 import jinja2
-from pyquery import PyQuery as pq
 from tower import ugettext as _
 
 from django.contrib.sites.models import Site
@@ -138,20 +137,6 @@ def colorize_diff(diff):
 def wiki_bleach(val):
     from kuma.wiki.models import Document
     return jinja2.Markup(Document.objects.clean_content(val))
-
-
-@register.filter
-def selector_content_find(document, selector):
-    """
-    Provided a selector, returns the relevant content from the document
-    """
-    summary = ''
-    try:
-        page = pq(document.rendered_html)
-        summary = page.find(selector).text()
-    except:
-        pass
-    return summary
 
 
 def _recursive_escape(value, esc=conditional_escape):

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -110,7 +110,6 @@
 
           <h1>{{ document.title }}</h1>
 
-          {% set summary = document|selector_content_find('.summary') %}
           {% if (zone_subnav_html or quick_links_html) %}
           <div class="column-container zone-landing-header-preview">
             <div class="column-strip">
@@ -127,10 +126,10 @@
               </div>
               <div class="zone-landing-header-spacing"></div>
             </div>
-            <div class="column-5 masthead-text"><p>{{ summary }}</p></div>
+            <div class="column-5 masthead-text"><p>{{ document.get_summary_text() }}</p></div>
           </div>
           {% else %}
-            <div class="column-5 masthead-text"><p>{{ summary }}</p></div>
+            <div class="column-5 masthead-text"><p>{{ document.get_summary_text() }}</p></div>
           {% endif %}
 
           <div class="zone-image"></div>


### PR DESCRIPTION
Assigning to @darkwing in case he can remember a reason to keep the `selector_content_find` helper?