### PR TITLE
bug 1177264 - Revisions feed optimization

### DIFF
--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -21,7 +21,7 @@ def revisions(request):
     filter_form = RevisionDashboardForm(request.GET)
     page = request.GET.get('page', 1)
 
-    revisions = (Revision.objects.select_related('creator')
+    revisions = (Revision.objects.prefetch_related('creator')
                                  .order_by('-created')
                                  .defer('content'))
 

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -21,7 +21,8 @@ def revisions(request):
     filter_form = RevisionDashboardForm(request.GET)
     page = request.GET.get('page', 1)
 
-    revisions = (Revision.objects.prefetch_related('creator')
+    revisions = (Revision.objects.prefetch_related('creator__bans',
+                                                   'document')
                                  .order_by('-created')
                                  .defer('content'))
 


### PR DESCRIPTION
[New Relic traces on kuma.dashboards.views:revisions](https://rpm.newrelic.com/accounts/263620/applications/3172075/transactions#id=5b225765625472616e73616374696f6e2f46756e6374696f6e2f6b756d612e64617368626f617264732e76696577733a7265766973696f6e73222c22225d) consistently show this `wiki_revision` SQL query taking a large amount of time. A MySQL `EXPLAIN SELECT` suggests that the combination of joining on the `creator_id` field in the same query as ordering on the `created` field means the `wiki_revision` query does **not** use the `created` index for ordering. The same traces also show average of 34.9 additional queries to both `wiki_document` and `users_userban`. [Google Analytics confirms that 78% of dashboard revision pageviews contain url params](https://www.google.com/analytics/web/?authuser=1#report/content-pages/a36116321w64965862p66726481/%3Fexplorer-table.filter%3Ddashboards%2Frevisions%26explorer-table.plotKeys%3D[]%26explorer-table-tableMode.selected%3Dpie/) that can trigger the additional queries to these tables.

9803282: This change changes `select_related` into `prefetch_related` to make 2 queries: First to `wiki_revision` and then a (single) second query to `auth_user` for all the creator objects. Django debug toolbar and `EXPLAIN` show this will make better use of indices on both queries.

adbc57c: This change adds `wiki_document` and `users_userban` to the `prefetch_related` chain to combine those 70 queries into a single query for each table.