### PR TITLE
bug 1177264 - Revision dashboard optimizations

### DIFF
--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -49,10 +49,9 @@
                     <br/><a class="dashboard-ban-ip-link" href="{{ ban_ip_url }}" target="_blank">{{ _('Ban IP from Editing') }}</a>
                     </span>
                     {% endif %}
-                    {% set active_ban = revision.creator.active_ban %}
-                    {% if request.user.is_superuser and active_ban %}
+                    {% if request.user.is_superuser and revision.creator.active_ban %}
                         <div class="banned">
-                            banned {{ datetimeformat(active_ban.date, format='date') }}
+                            banned {{ datetimeformat(revision.creator.active_ban.date, format='date') }}
                             by {{ active_ban.by }}
                         </div>
                     {% endif %}

--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -4,7 +4,7 @@
 {% if waffle.switch('store_revision_ips') and user.is_superuser %}
     {% set show_ips = True %}
 {% endif %}
-{% if total %}
+{% if revisions.count %}
     <table class="dashboard-table" width="100%">
         <thead>
             <tr>

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -70,18 +70,10 @@ def revisions(request):
 
     if query_kwargs:
         revisions = revisions.filter(**query_kwargs)
-        total = revisions.count()
-    else:
-        # If no filters, just do a straight count(). It's the same
-        # result, but much faster to compute.
-        total = Revision.objects.count()
 
-    # Only bother with this if we're actually going to get
-    # some revisions from it. Otherwise it's a pointless but
-    # potentially complex query.
     revisions = paginate(request, revisions, per_page=PAGE_SIZE)
 
-    context = {'revisions': revisions, 'page': page, 'total': total}
+    context = {'revisions': revisions, 'page': page}
 
     # Serve the response HTML conditionally upon reques type
     if request.is_ajax():

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -21,7 +21,8 @@ def revisions(request):
     filter_form = RevisionDashboardForm(request.GET)
     page = request.GET.get('page', 1)
 
-    revisions = (Revision.objects.select_related('creator')
+    revisions = (Revision.objects.prefetch_related('creator',
+                                                   'document')
                                  .order_by('-created')
                                  .defer('content'))
 


### PR DESCRIPTION
Superseding https://github.com/mozilla/kuma/pull/3467 with a better version, including:

aad6fce: Don't query for userbans unless it's a super-user looking at the dashboard (saves ~50 queries for non-super-users)

9fc6309: eliminate an expensive duplicate count query