### PR TITLE
bug-1199840-style-move-error-message

### DIFF
--- a/media/stylus/components/wiki/edit/move-page.styl
+++ b/media/stylus/components/wiki/edit/move-page.styl
@@ -10,8 +10,4 @@
     input[type=text] {
         width: 400px;
     }
-
-    .warning {
-        color: #fff;
-    }
 }


### PR DESCRIPTION
Fix Bug 1199840: white text on red background in move page error message.