### PR TITLE
Bug 1201967: Make all doc titles match

### DIFF
--- a/kuma/wiki/templates/wiki/create.html
+++ b/kuma/wiki/templates/wiki/create.html
@@ -26,9 +26,9 @@
 
         {{ document_form.category|safe }}
 
-        <div class="title">
-            <h1><span class="title-prefix">{{ ('Create a ') }}</span><em>{{ _('New Document') }}</em></h1>
-	    <p class="save-state" id="draft-status">
+        <div class="doc-title">
+            <h1><span class="title-prefix">{{ _('Create a ') }}</span><em>{{ _('New Document') }}</em></h1>
+            <p class="save-state" id="draft-status">
               {% trans %}Draft <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>{% endtrans %}
             </p>
         </div>

--- a/kuma/wiki/templates/wiki/edit.html
+++ b/kuma/wiki/templates/wiki/edit.html
@@ -87,7 +87,7 @@
 
         <header id="article-head">
 
-          <div class="title">
+          <div class="doc-title">
             <h1>{{ _('<span class="title-prefix">Editing</span> <em>{title}</em>')|fe(title=revision.title) }}</h1>
             <p class="save-state" id="draft-status">
               {% if not section_id %}

--- a/kuma/wiki/templates/wiki/move.html
+++ b/kuma/wiki/templates/wiki/move.html
@@ -12,7 +12,7 @@
 
 {% block content %}
 
-      <div class="title">
+      <div class="doc-title">
         <h1>{{ _('<span class="title-prefix">Moving</span> <em>{title}</em>')|fe(title=document.title) }}</h1>
       </div>
 

--- a/kuma/wiki/templates/wiki/translate.html
+++ b/kuma/wiki/templates/wiki/translate.html
@@ -25,7 +25,7 @@
 
       <div id="localize-document" class="editing">
         <header id="article-head">
-          <div class="title">
+          <div class="doc-title">
            <h1>{{ _('<span class="title-prefix">Translating</span> <em>{title}</em>')|fe(title=parent.title) }}</h1>
           </div>
 

--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -319,7 +319,7 @@
                 // metadata, since that can change the URL of the page and
                 // tangle up where the iframe posts.
                 ev.preventDefault();
-                $('#article-head .title').hide();
+                $('#article-head .doc-title').hide();
                 $('#article-head .metadata').show();
                 $('#article-head .metadata #id_title').focus();
             }

--- a/media/stylus/components/doc-title.styl
+++ b/media/stylus/components/doc-title.styl
@@ -1,0 +1,33 @@
+/* page titles on doc/move/edit/translate/new pages
+   except we can't call them page titles because demos already has
+   a class with that name */
+.doc-title {
+    clearfix();
+    title-header();
+    position: relative;
+    margin-bottom: 10px;
+
+    h1 {
+        letter-spacing: normal;
+        line-height: 40px;
+        margin-bottom: 20px;
+    }
+
+    em {
+        color: #333;
+        font-style: normal;
+        bidi-style(margin-left, -3px, margin-right, 0);
+        text-transform: none;
+    }
+}
+
+/* small writing above the page title that says what action the user is
+   performing on it Editing/Moving/Translating. In a perfect world this
+   class wouild be doc-title-prefix but it's part of the translation
+   string and I didn't want to lose the translations by changing it */
+.title-prefix {
+    set-larger-font-size();
+    display: block;
+    line-height: 20px;
+    color: #888;
+}

--- a/media/stylus/components/wiki/edit/editing.styl
+++ b/media/stylus/components/wiki/edit/editing.styl
@@ -4,19 +4,6 @@
 .editing {
     position: relative;
 
-    h1 {
-        letter-spacing: normal;
-        line-height: 40px;
-        margin-bottom: $grid-spacing;
-
-        em {
-            color: #333;
-            font-style: normal;
-            margin-left: -3px;
-            text-transform: none;
-        }
-    }
-
     h2 {
         margin-bottom: $grid-spacing;
         text-transform: none;

--- a/media/stylus/components/wiki/edit/title.styl
+++ b/media/stylus/components/wiki/edit/title.styl
@@ -1,9 +1,0 @@
-/* small writing above the page title that says what action the user is
-   performing on it Editing/Moving/Translating */
-
-.title-prefix {
-    set-larger-font-size();
-    display: block;
-    line-height: 20px;
-    color: #888;
-}

--- a/media/stylus/components/wiki/title.styl
+++ b/media/stylus/components/wiki/title.styl
@@ -1,6 +1,0 @@
-/* alternative styling for headings, used throughout site often paired with other classes */
-.title {
-    clearfix();
-    margin-bottom: 10px;
-    position: relative;
-}

--- a/media/stylus/main.styl
+++ b/media/stylus/main.styl
@@ -14,3 +14,4 @@
 @require 'components/content';
 @require 'components/structure';
 @require 'components/tags';
+@require 'components/doc-title';

--- a/media/stylus/wiki-edit.styl
+++ b/media/stylus/wiki-edit.styl
@@ -10,7 +10,6 @@
 @require 'components/wiki/edit/cke';
 @require 'components/wiki/edit/page-attachments';
 @require 'components/wiki/edit/save-and-edit-target';
-@require 'components/wiki/edit/title';
 @require 'components/wiki/edit/guide-links';
 @require 'components/wiki/edit/ace-content';
 @require 'components/wiki/edit/save-state';

--- a/media/stylus/wiki.styl
+++ b/media/stylus/wiki.styl
@@ -11,7 +11,6 @@ General element over-rides
 /*
 Utitlity classes (reused in a variety of contexts)
 ====================================================================== */
-@require 'components/wiki/title';
 @require 'components/wiki/document-list';
 @require 'components/wiki/external-icon';
 


### PR DESCRIPTION
Fix bug 1201967 - Makes titles on new, edit, translate, and move pages match.

Created class to apply to all, added it to main.css, removed disparate jumble of classes that previously accomplished this.