### PR TITLE
fix bug 1197779 - restore username to UserEditForm

### DIFF
--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -245,7 +245,7 @@ class UserEditForm(forms.ModelForm):
                   'locale', 'timezone', 'bio', 'irc_nickname', 'interests',
                   'website_url', 'twitter_url', 'github_url',
                   'stackoverflow_url', 'linkedin_url', 'mozillians_url',
-                  'facebook_url')
+                  'facebook_url', 'username')
 
     def __init__(self, *args, **kwargs):
         super(UserEditForm, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This fixes the bug in the site UI, but it seems to cause errors for the tests that test the edit view and I can't figure out why. :cry: Need @jwhitlock, @jezdez, or maybe even @robhudson to see if/why I'm crazy here?