### PR TITLE
Add edit username 1197779

### DIFF
--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -245,7 +245,7 @@ class UserEditForm(forms.ModelForm):
                   'locale', 'timezone', 'bio', 'irc_nickname', 'interests',
                   'website_url', 'twitter_url', 'github_url',
                   'stackoverflow_url', 'linkedin_url', 'mozillians_url',
-                  'facebook_url')
+                  'facebook_url', 'username')
 
     def __init__(self, *args, **kwargs):
         super(UserEditForm, self).__init__(*args, **kwargs)

--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -270,6 +270,9 @@ class UserEditForm(forms.ModelForm):
     def clean_username(self):
         new_username = self.cleaned_data['username']
 
+        if not new_username:
+            raise forms.ValidationError(_('This field cannot be blank.'))
+
         if (self.instance is not None and
                 User.objects.exclude(pk=self.instance.pk)
                             .filter(username=new_username)

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -55,6 +55,15 @@ class TestUserEditForm(KumaTestCase):
         eq_(form.is_valid(), False)
         eq_(form.errors, {'username': [USERNAME_CHARACTERS]})
 
+    def test_blank_username_invalid(self):
+        test_user = user(save=True)
+        data = {
+            'username': '',
+        }
+        form = UserEditForm(data, instance=test_user)
+        eq_(form.is_valid(), False)
+        eq_(form.errors, {'username': ['This field cannot be blank.']})
+
     def test_https_user_urls(self):
         """bug 733610: User URLs should allow https"""
         protos = (

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from nose.tools import eq_
+from nose.tools import eq_, ok_
 
 from kuma.core.tests import KumaTestCase
 
@@ -25,6 +25,35 @@ class TestUserEditForm(KumaTestCase):
         test_user2 = user(save=True)
         form = UserEditForm(data, instance=test_user2)
         eq_(False, form.is_valid())
+
+    def test_can_keep_legacy_username(self):
+        test_user = user(username='legacy@example.com', save=True)
+        ok_(test_user.has_legacy_username)
+        data = {
+            'username': 'legacy@example.com'
+        }
+        form = UserEditForm(data, instance=test_user)
+        ok_(form.is_valid(), repr(form.errors))
+
+    def test_cannot_change_legacy_username(self):
+        test_user = user(username='legacy@example.com', save=True)
+        ok_(test_user.has_legacy_username)
+        data = {
+            'username': 'mr.legacy@example.com'
+        }
+        form = UserEditForm(data, instance=test_user)
+        eq_(form.is_valid(), False)
+        eq_(form.errors, {'username': [USERNAME_CHARACTERS]})
+
+    def test_cannot_change_to_legacy_username(self):
+        test_user = user(save=True)
+        eq_(test_user.has_legacy_username, False)
+        data = {
+            'username': 'mr.legacy@example.com'
+        }
+        form = UserEditForm(data, instance=test_user)
+        eq_(form.is_valid(), False)
+        eq_(form.errors, {'username': [USERNAME_CHARACTERS]})
 
     def test_https_user_urls(self):
         """bug 733610: User URLs should allow https"""

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -65,6 +65,7 @@ class TestUserEditForm(KumaTestCase):
             for name, site in sites:
                 url = '%s%s' % (proto, site)
                 data = {
+                    'username': edit_user.username,
                     'email': 'lorchard@mozilla.com',
                     '%s_url' % name: url,
                 }

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -220,6 +220,7 @@ class UserViewsTest(UserTestCase):
             doc.find('#user-edit input[name="user-irc_nickname"]').val())
 
         new_attrs = {
+            'user-username': testuser.username,
             'user-email': 'testuser@test.com',
             'user-fullname': "Another Name",
             'user-title': "Another title",

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -126,13 +126,16 @@ class UserViewsTest(UserTestCase):
 
     def _get_current_form_field_values(self, doc):
         # Scrape out the existing significant form field values.
+        fields = ('username', 'email', 'fullname', 'title', 'organization',
+                  'location', 'irc_nickname', 'bio', 'interests')
         form = dict()
-        for fn in ('username', 'email', 'fullname', 'title', 'organization',
-                   'location', 'irc_nickname', 'bio', 'interests'):
-            form[fn] = doc.find('#user-edit *[name="user-%s"]' %
-                                fn).val()
-        form['country'] = 'us'
-        form['format'] = 'html'
+        lookup_pattern = '#{prefix}edit *[name="{prefix}{field}"]'
+        prefix = 'user-'
+        for field in fields:
+            lookup = lookup_pattern.format(prefix=prefix, field=field)
+            form[prefix + field] = doc.find(lookup).val()
+        form[prefix + 'country'] = 'us'
+        form[prefix + 'format'] = 'html'
         return form
 
     @attr('docs_activity')


### PR DESCRIPTION
Add username back to UserEditForm as a required (non-blankable) field.  Replaces #3474 