### PR TITLE
fix bug 1203198 - Add crumb link clicks to Analytics tracking

### DIFF
--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -328,7 +328,7 @@
 
 
     /*
-        Track Clicks on TOC links
+        Track clicks on TOC links
     */
     $('#toc').on('click', 'a', function() {
         var $thisLink = $(this);
@@ -337,6 +337,21 @@
             category: 'TOC Links',
             action: $thisLink.text(),
             label: $thisLink.attr('href')
+        });
+    });
+
+    /*
+        Track clicks on Crumb links
+    */
+    $('.crumbs').on('click', 'a', function() {
+        var url = this.href;
+
+        mdn.analytics.trackEvent({
+            category: 'Wiki',
+            action: 'Crumbs',
+            label: url
+        }, function() {
+            window.location = url;
         });
     });
 


### PR DESCRIPTION
Will help me figure out how important this is for the sake of mobile.
https://bugzilla.mozilla.org/show_bug.cgi?id=1203198