### PR TITLE
Fix bug 1203625 - Prevent JS error in edit interface

### DIFF
--- a/media/js/wiki-edit.js
+++ b/media/js/wiki-edit.js
@@ -477,7 +477,7 @@
         $('.btn-save-and-edit').show();
 
         $('#save-and-edit-target').on('load', function () {
-            notifications[0].success(null, 2000);
+            if(notifications[0]) notifications[0].success(null, 2000);
             notifications.shift();
 
             if (supportsLocalStorage) {


### PR DESCRIPTION
Currently the most frequent JS error on the site, which doesn't happen very often.  \o/  But hey, let's fix it.

https://bugzilla.mozilla.org/show_bug.cgi?id=1203625