### PR TITLE
fix bug 1174498 - error message for revert dupes

### DIFF
--- a/kuma/wiki/templates/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/templates/wiki/confirm_revision_revert.html
@@ -9,6 +9,12 @@
 
         <h1>{{ _('Are you sure you want to revert to this revision?') }}</h1>
 
+        {% if error %}
+        <ul class="errorlist">
+          <li>{{ error }}</li>
+        </ul>
+        {% endif %}
+
         <label><strong>{{ _('Document') }}</strong></label>
         <div>{{ document.title }}</div>
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2469,6 +2469,21 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(mock_kumascript_get.called,
             "kumascript should have been used")
 
+    def test_revert_moved(self):
+        doc = document(slug='move-me', save=True)
+        rev = revision(document=doc, save=True)
+        prev_rev_id = rev.id
+        doc._move_tree('moved-doc')
+        self.client.login(username='admin', password='testpass')
+
+        resp = self.client.post(reverse('wiki.revert_document',
+                                        args=[doc.slug, prev_rev_id],
+                                        locale=doc.locale),
+                                follow=True)
+
+        eq_(200, resp.status_code)
+        ok_("cannot revert a document that has been moved" in resp.content)
+
     def test_store_revision_ip(self):
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()


### PR DESCRIPTION
When a user reverts a document to an old revision, we want to catch the
IntegrityError if it collides with the document's redirect, so the user knows
they can fix it by deleting the redirect.