### PR TITLE
Add basic section editing buttons to MDN

### DIFF
--- a/kuma/static/stylus/components/wiki/section-edit.styl
+++ b/kuma/static/stylus/components/wiki/section-edit.styl
@@ -1,0 +1,15 @@
+.section-edit {
+    float: right;
+    margin-left: 20px;
+    set-smaller-font-size();
+    opacity: 0;
+
+    @media $media-query-mobile {
+        display: none;
+    }
+
+    &:focus,
+    h2:hover & {
+        opacity: 1;
+    }
+}

--- a/kuma/static/stylus/wiki.styl
+++ b/kuma/static/stylus/wiki.styl
@@ -64,6 +64,7 @@ Styling for article content
 @require 'components/wiki/content/summary';
 @require 'components/wiki/customcss';
 @require 'components/wiki/open-in-host';
+@require 'components/wiki/section-edit';
 
 
 /*

--- a/kuma/wiki/templates/wiki/ckeditor_config.js
+++ b/kuma/wiki/templates/wiki/ckeditor_config.js
@@ -92,6 +92,12 @@
     // Don't use HTML entities in the output except basic ones (config.basicEntities).
     config.entities = false;
 
+    // Allows section editing to be used immediately and not lose focus on desired element
+    // http://docs.ckeditor.com/#!/guide/dev_autogrow
+    if(window.waffle && window.waffle.flag_is_active('section_edit')) {
+        config.autoGrow_onStartup = true;
+    }
+
     config.startupFocus = true;
     config.bodyClass = 'text-content redesign';
     config.contentsCss = [
@@ -102,7 +108,7 @@
       mdn.staticPath + 'css/libs/font-awesome/css/font-awesome.min.css?{{ BUILD_ID_JS }}'
     ];
 
-    if (window.waffle && waffle.FLAGS.enable_customcss) {
+    if(window.waffle && window.waffle.flag_is_active('enable_customcss')) {
       config.contentsCss.push('{{ config.KUMA_CUSTOM_CSS_PATH }}?raw=1');
     }
 

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -429,4 +429,36 @@
     {{ js('helpfulness', async=True) }}
   {% endif %}
 
+  {% if waffle.flag('section_edit') %}
+    <script type="text/javascript">
+        (function($) {
+            $('#wikiArticle').children('h2[id]').each(function() {
+                var id = $(this).attr('id');
+                var href = '{{ document.get_edit_url() }}#' + id;
+
+                $('<a>').attr({
+                    href: href,
+                    'class': 'button section-edit only-icon'
+                })
+                .append($('<i aria-hidden="true" class="icon-pencil"></i>'))
+                .append($('<span>'))
+                .find('span')
+                .text(gettext('Edit'))
+                .end()
+                .on('click', function(e) {
+                    e.preventDefault();
+
+                    mdn.analytics.trackEvent({
+                        category: 'Section Edit',
+                        action: id
+                    }, function() {
+                        window.location = href;
+                    });
+                })
+                .appendTo(this);
+            });
+        })(jQuery);
+    </script>
+  {% endif %}
+
 {% endblock %}

--- a/kuma/wiki/templates/wiki/edit.html
+++ b/kuma/wiki/templates/wiki/edit.html
@@ -215,6 +215,28 @@
       {% include 'wiki/includes/ace_scripts.html' %}
     {% else %}
       {% include 'wiki/includes/ckeditor_scripts.html' %}
+      <script type="text/javascript">
+        if(window.waffle.flag_is_active('section_edit')) CKEDITOR.on('instanceReady', function(evt) {
+            var hash = window.location.hash.replace('#', '');
+            if(!hash) return;
+
+            var element = evt.editor.document.getById(hash);
+            var range;
+
+            if(element) {
+                element.scrollIntoView();
+
+                // Thank you S/O
+                // http://stackoverflow.com/questions/16835365/set-cursor-to-specific-position-in-ckeditor
+                range = evt.editor.createRange();
+                range.setStart(element, 0);
+                range.setEnd(element, 0);
+                evt.editor.getSelection().selectRanges([range]);
+            }
+
+            return false;
+        });
+      </script>
     {% endif %}
     {{ js('wiki-edit') }}
 

--- a/templates/includes/google_analytics.html
+++ b/templates/includes/google_analytics.html
@@ -20,6 +20,11 @@
         {% endif %}
     {% endif %}
 
+    // dimension9 == "Section editing"
+    {% if waffle.flag('section_edit') %}
+        ga('set', 'dimension9', 'Enabled');
+    {% endif %}
+
     (function() {
         // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
         var win = window;


### PR DESCRIPTION
Not ready but a rough prototype for "section editing" whereby:

1.  Finds headings, adds "edit" links
2.  Loads edit page, scrolls down to the relevant section.