### PR TITLE
Bug 1197444: Remove the media/img symlink

### DIFF
--- a/media/img
+++ b/media/img
@@ -1,1 +1,0 @@
-../kuma/static/img


### PR DESCRIPTION
In commit 85754412, we moved images from media/img to kuma/static/img.
We also added a symlink from the former to the latter so that the images
would resolve at both paths between the time the code was pushed and the
time a permanent redirect was published.

Jake published the redirect, so we don't need the symlink any more.