### PR TITLE
Bug 957802: Allow all hosts in settings_local.py

### DIFF
--- a/provisioning/roles/kuma/files/vagrant/settings_local.py
+++ b/provisioning/roles/kuma/files/vagrant/settings_local.py
@@ -3,6 +3,9 @@ import logging
 
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1',)
 
+# ALLOWED_HOSTS must be set whenever DEBUG = False
+ALLOWED_HOSTS = '*'
+
 DEBUG = True
 DEV = True
 TEMPLATE_DEBUG = DEBUG


### PR DESCRIPTION
The ALLOWED_HOSTS setting needs to be set to disable debug mode and
emulate production locally.