### PR TITLE
Bug 1197444: Add empty img directory

### DIFF
--- a/media/img/README
+++ b/media/img/README
@@ -1,0 +1,4 @@
+The compress_assets script will fail if this directory does not exist. We can
+remove it once the switch to django-pipeline [1] is completed.
+
+[1] https://bugzilla.mozilla.org/show_bug.cgi?id=1139490


### PR DESCRIPTION
The compress_asset script fails when it cannot find the media/img
directory. This change restores the directory temporarily so that
compress_assets will continue to work until the switch to
django-pipeline is completed.