### PR TITLE
bug 1205667 - get_tidied_content can return blank

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -70,7 +70,11 @@
         {% endif %}
 
         <dt>{{ _('Content:') }}</dt>
+        {% if revision_from.get_tidied_content(allow_none=True) == None or revision_to.get_tidied_content(allow_none=True) == None %}
+        <dd id="doc-rendering-scheduled" class="warning">{% trans %}Server is rendering the content comparison. Please refresh this page in a few minutes.{% endtrans %}</dd>
+        {% else %}
         <dd>{{ diff_table(revision_from.get_tidied_content(), revision_to.get_tidied_content(), revision_from.id, revision_to.id) }}</dd>
+        {% endif %}
       </dl>
     </section>
   {% endif %}

--- a/kuma/wiki/templates/wiki/includes/revision_diff_table.html
+++ b/kuma/wiki/templates/wiki/includes/revision_diff_table.html
@@ -1,6 +1,6 @@
 {% if revision_from.id != revision_to.id %}
-	{% set from_content = revision_from.get_tidied_content() %}
+	{% set from_content = revision_from.get_tidied_content(allow_none=True) %}
 {% else %}
 	{% set from_content = '' %}
 {% endif %}
-{{ diff_table(from_content, revision_to.get_tidied_content(), revision_from.id, revision_to.id) }}
+{{ diff_table(from_content, revision_to.get_tidied_content(allow_none=True), revision_from.id, revision_to.id) }}


### PR DESCRIPTION
When a $compare request is made for a large revision,
we want to skip tidy_content and return a warning to the user,
so we don't block requests on the expensive tidy operation.