### PR TITLE
Add "make coverage" target

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,4 +3,4 @@ source = kuma
 branch = 1
 
 [report]
-omit = *tests*,*migrations*,*vendor*
+omit = *tests*,*migrations*,*vendor*,*/management/commands/*

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ media/js/libs/ckeditor/source/ckbuilder
 .tox
 .env
 *_devmo.sql*
+htmlcov/

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,30 @@
+# Use username as signal that we're in the vagrant box
+ifeq (vagrant, ${USER})
+IN_VAGRANT := 1
+else
+IN_VAGRANT := 0
+endif
+
 # Note: these targets should be run from the kuma vm
-django-tests:
+django-tests: in_vagrant
 	python manage.py test
 
-performance-tests:
+performance-tests: in_vagrant
 	locust -f tests/performance/smoke.py --host=https://developer.allizom.org
 
 # Note: this target should be run from the host machine with selenium running
-browser-tests:
+browser-tests: on_host
 	pushd tests/ui ; ./node_modules/.bin/intern-runner config=intern-local d=developer.allizom.org b=firefox; popd
 
 clean:
 	find kuma -name '*.pyc' -exec rm {} \;
 
+
+in_vagrant:
+	@if [ ${IN_VAGRANT} -eq 0 ]; then echo "*** Run in vagrant ***"; exit 1; fi
+
+on_host:
+	@if [ ${IN_VAGRANT} -eq 1 ]; then echo "*** Run on host ***"; exit 1; fi
+
 # Those tasks don't have file targets
-.PHONY: django-tests performance-tests browser-tests clean
+.PHONY: django-tests performance-tests browser-tests clean in_vagrant on_host

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,23 @@ browser-tests: on_host
 clean:
 	find kuma -name '*.pyc' -exec rm {} \;
 
+# On host: run coverage and display HTML
+# On VM: run coverage
+coverage:
+	echo ${USER}
+	if [ ${IN_VAGRANT} -eq 0 ]; then \
+		vagrant ssh --command "\
+		coverage erase; \
+		coverage run ./manage.py test; \
+		coverage report; \
+		coverage html"; \
+		python -c "import webbrowser, os.path; name='file://' + os.path.abspath('htmlcov/index.html'); webbrowser.open(name)"; \
+	else \
+		coverage erase; \
+		coverage run ./manage.py test; \
+		coverage report; \
+		coverage html; \
+	fi
 
 in_vagrant:
 	@if [ ${IN_VAGRANT} -eq 0 ]; then echo "*** Run in vagrant ***"; exit 1; fi
@@ -27,4 +44,4 @@ on_host:
 	@if [ ${IN_VAGRANT} -eq 1 ]; then echo "*** Run on host ***"; exit 1; fi
 
 # Those tasks don't have file targets
-.PHONY: django-tests performance-tests browser-tests clean in_vagrant on_host
+.PHONY: django-tests performance-tests browser-tests clean in_vagrant on_host coverage


### PR DESCRIPTION
Add a 'make coverage' target.  If run from the host, it enters VM, runs tests with coverage, builds HTML coverage docs, and opens them in the browser.  If run from the VM, it runs coverage and prints coverage to console.

Opening browser works on OS X, needs confirmation on desktop Linux.