### PR TITLE
bug 957802 - serve fonts to local.allizom for devs

### DIFF
--- a/provisioning/roles/kuma/files/apache2/all-servers.conf
+++ b/provisioning/roles/kuma/files/apache2/all-servers.conf
@@ -10,12 +10,12 @@ Header set Access-Control-Allow-Credentials "false"
 <Location /media/fonts>
     # Only enable CORS for fonts when the request is coming from a Mozilla domain
     Header unset Access-Control-Allow-Origin
-    SetEnvIf Origin "https?://(.*\.mozilla\.(com|org|net))" CORS=$0
+    SetEnvIf Origin "https?://(.*\.(mozilla|allizom)\.(com|org|net))" CORS=$0
     SetEnvIf Origin "https?://(mdn\.mozillademos\.org)" CORS=$0
     Header set Access-Control-Allow-Origin %{CORS}e env=CORS
 
     # block hotlinking by referer to .woff, .eof, .ttf files except mozilla domains
-    RewriteCond "%{HTTP_REFERER}" "!https?://.*\.mozilla\.(com|org|net)/.*$"
+    RewriteCond "%{HTTP_REFERER}" "!https?://.*\.(mozilla|allizom)\.(com|org|net)/.*$"
     RewriteRule \.(woff|eot|ttf)$ - [F,NC,L,E=!CORS]
 </Location>
 

--- a/provisioning/roles/kuma/files/vagrant/settings_local.py
+++ b/provisioning/roles/kuma/files/vagrant/settings_local.py
@@ -32,7 +32,7 @@ CELERY_ALWAYS_EAGER = False
 
 INSTALLED_APPS = INSTALLED_APPS + (
     "django_extensions",
-    "debug_toolbar",
+#    "debug_toolbar",
     "devserver",
 )
 


### PR DESCRIPTION
spot-check: `vagrant provision` and then check a page that tries to load `compat-icons.woff`: the request should succeed instead of a 403.