### PR TITLE
bug 1206309 - waffled api driven compat tables

### DIFF
--- a/media/js/wiki-compat-tables.js
+++ b/media/js/wiki-compat-tables.js
@@ -1,5 +1,7 @@
 (function(win, doc, $) {
 
+    $('#compat-api').removeClass('hidden');
+
     // Private var to assign IDs to history for accessibility purposes
     var historyCount = 0;
 

--- a/media/js/wiki.js
+++ b/media/js/wiki.js
@@ -304,8 +304,12 @@
         Load and build compat tables if present in page
     */
     (function() {
-        var $compatTables = $('.bc-table');
+        // don't run if no compat table on page
+        var $compatTables = $('#compat-api table');
         if(!$compatTables.length) return;
+
+        // don't run if waffle not active
+        if(!win.waffle || !win.waffle.flag_is_active('compat_api')) return;
 
         $('<link />').attr({
                 href: mdn.mediaPath + 'css/wiki-compat-tables-min.css',


### PR DESCRIPTION
Display api-driven compat tables to users with a waffle enabled on pages that have been identified as ready.

Testing:
1) download PR
2) `./manage.py compress_assets`
3) create waffle flag named `compat-api` and enable it for yourself
4) make/update a local copy of: https://developer.allizom.org/en-US/docs/Template%3AEmbedCompatTable
5) embed the macro and call it `{{EmbedCompatTable('web-css-background')}}`
6) verify that new table appears
7) disable waffle flag
8) verify that new table does not appear

This PR does not hide the old table yet. For debugging/testing purposes it is useful to see both side by side. 

Skateboard for @lonnen:
![200](https://cloud.githubusercontent.com/assets/854701/9973614/c74890d4-5e3b-11e5-878c-61ba11c2d0cb.gif)
