### PR TITLE
bug 957802 - re-arrange kuma docs and toc

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -2,27 +2,57 @@
 Development
 ===========
 
-We only support developing MDN with the :doc:`Vagrant-managed VM <installation>`.
+First, make sure you are running the :doc:`Vagrant-managed VM <installation>`.
+
+Developing with Vagrant
+=======================
+
+Edit files as usual on your host machine; the current directory is
+mounted via NFS at ``/home/vagrant/src`` within the VM. Updates should be
+reflected without any action on your part. Useful vagrant sub-commands::
+
+    vagrant ssh     # Connect to the VM via ssh
+    vagrant suspend # Sleep the VM, saving state
+    vagrant halt    # Shutdown the VM
+    vagrant up      # Boot up the VM
+    vagrant destroy # Destroy the VM
+
+Run all commands in this doc on the vm after ``vagrant ssh``.
 
 Running Kuma
 ============
 
-You can start all Kuma servers and services with::
+You can start all Kuma servers and services on the vm with::
 
-    vagrant ssh
     foreman start
 
-Log in
-======
+Running the Tests
+=================
 
-You can log into MDN using Persona or GitHub. For GitHub, you must first enable
-:ref:`GitHub Auth` as described in the installation instructions.
+A great way to check that everything really is working is to run the test
+suite.
 
-Set up permissions
-==================
+Django tests
+------------
 
-Some features are only available to privileged users. To manage permissions
-use the Auth -> Users section of the Django admin interface.
+Running the kuma Django test suite is easy::
+
+    python manage.py test kuma
+
+For more information, see the :doc:`test documentation <tests>`.
+
+Front-end tests
+---------------
+
+To run the front-end (selenium) tests, see :doc:`Client-side Testing with
+Intern <tests-ui>`.
+
+Kumascript tests
+----------------
+
+If you're changing Kumascript, be sure to run its tests too.
+See https://github.com/mozilla/kumascript
+
 
 Compiling Stylus Files
 ======================
@@ -37,20 +67,8 @@ The relevant CSS files will be generated and placed within the `media/css`
 directory. You can add a ``-w`` flag to that call to compile stylesheets
 upon save.
 
-Hacking on bleeding edge features
-=================================
-To hack on the features not yet ready for production you have to enable them first.
-
-Enable Kumascript
------------------
-
-Kuma uses a separate nodejs-based service to process templates in wiki pages. Its
-use is disabled by default, to enable: open the django admin interface and in the
-Constance section change the value of ``KUMASCRIPT_TIMEOUT`` parameter to a positive
-value (such as ``2.0`` seconds).
-
-Migrations
-==========
+Database Migrations
+===================
 
 Basically all apps are migrated using Django's migration system.
 
@@ -64,32 +82,6 @@ Run the migrations via the Django management command::
 
     python manage.py migrate
 
-Running the Tests
-=================
-
-A great way to check that everything really is working is to run the test
-suite.
-
-Django tests
-------------
-
-Running the test suite is easy::
-
-    ./manage.py test
-
-Note that this will try (and fail) to run tests that depend on apps disabled
-via ``INSTALLED_APPS``. You should run a subset of tests::
-
-    ./manage.py test kuma
-
-For more information, see the :doc:`test documentation <tests>`.
-
-Kumascript tests
-----------------
-
-If you're changing Kumascript, be sure to run its tests too.
-See https://github.com/mozilla/kumascript
-
 Coding Conventions
 ==================
 
@@ -99,3 +91,162 @@ Tests
 * If you're expecting ``reverse`` to return locales in the URL, use
   ``LocalizingClient`` instead of the default client for the ``TestCase``
   class.
+
+(Advanced) Managing Dependencies
+================================
+
+Pure Python Packages
+--------------------
+
+All of the pure Python dependencies are included in the git repository,
+in the ``vendor`` subdirectory. This allows them to be available on the
+Python path without needing to be installed in the system, allowing multiple
+versions for multiple projects simultaneously.
+
+Compiled Python Packages
+------------------------
+
+There are a small number of compiled packages, including the MySQL Python
+client. You can install these using ``pip`` or via a package manager.
+To use ``pip``, you only need to do the following.
+
+First SSH into the Vagrant VM::
+
+    vagrant ssh
+
+Then disable the virtualenv that is auto-enabled and install the compiled
+dependencies::
+
+    deactivate
+    sudo pip install -r requirements/compiled.txt
+
+(Advanced) Configuration
+========================
+
+.. _vagrant-config:
+
+Vagrant
+-------
+
+If you'd like to change the way Vagrant works, we've added a few
+configuration values that may be worthwhile to look at. In case something
+doesn't suffice for your machine, please let us know!
+
+To change the config values, simply create a dotenv_ file (``.env``) in the
+directory (``/home/vagrant/src/.env`` in the Vagrant VM) and write
+``<KEY>=<VALUE>`` for each configuration variable you'd like to set.
+
+Here's the configuration variables that are available for Vagrant:
+
+- ``VAGRANT_NFS``
+
+  Default: true (Windows: false)
+  Whether or not to use NFS for the synced folder.
+
+- ``VAGRANT_MEMORY_SIZE``
+
+  The size of the Virtualbox VM memory in MB. Default: 2048
+
+- ``VAGRANT_CPU_CORES``
+
+  The number of virtual CPU core the Virtualbox VM should have. Default: 2
+
+- ``VAGRANT_IP``
+
+  The static IP the Virtualbox VM should be assigned to. Default: 192.168.10.55
+
+- ``VAGRANT_GUI``
+
+  Whether the Virtualbox VM should boot with a GUI. Default: false
+
+- ``VAGRANT_ANSIBLE_VERBOSE``
+
+  Whether the Ansible provisioner should print verbose output. Default: false
+
+A possible ``/home/vagrant/src/.env`` file could look like this for example::
+
+    VAGRANT_MEMORY_SIZE=4096
+    VAGRANT_CPU_CORES=4
+    VAGRANT_ANSIBLE_VERBOSE=true
+
+.. _dotenv: http://12factor.net/config
+
+Database
+~~~~~~~~
+
+At a minimum, you will need to define a database connection. An example
+configuration is::
+
+    DATABASES = {
+        'default': {
+            'NAME': 'kuma',
+            'ENGINE': 'django.db.backends.mysql',
+            'HOST': 'localhost',
+            'PORT': '3306',
+            'USER': 'kuma',
+            'PASSWORD': 'kuma',
+            'OPTIONS': {
+                'sql_mode': 'TRADITIONAL',
+                'charset': 'utf8',
+                'init_command': 'SET '
+                    'storage_engine=INNODB,'
+                    'character_set_connection=utf8,'
+                    'collation_connection=utf8_general_ci',
+            },
+            'ATOMIC_REQUESTS': True,
+            'TEST': {
+                'CHARSET': 'utf8',
+                'COLLATION': 'utf8_general_ci',
+            },
+        },
+    }
+
+Note the two values ``CHARSET`` and ``COLLATION`` of the ``TEST`` setting.
+Without these, the test suite will use MySQL's (moronic) defaults when
+creating the test database (see below) and lots of tests will fail. Hundreds.
+
+Once you've set up the database, you can generate the schema with Django's
+``migrate`` command::
+
+    ./manage.py migrate
+
+This will generate an empty database, which will get you started!
+
+Assets
+~~~~~~
+
+If you want to see images and have the pages formatted with CSS you need to
+set your ``settings_local.py`` with the following::
+
+    DEBUG = True
+    TEMPLATE_DEBUG = DEBUG
+    SERVE_MEDIA = True
+
+Setting ``DEBUG = False`` will put the installation in production mode
+and ask for minified assets. In that case, you will need to generate
+CSS from stylus and compress resource::
+
+    ./scripts/compile-stylesheets
+    ./manage.py compress_assets
+
+
+Mozilla Product Details
+~~~~~~~~~~~~~~~~~~~~~~~
+
+One of the packages Kuma uses, Django Mozilla Product Details, needs to
+fetch JSON files containing historical Firefox version data and write them
+to disk. To set this up, just run::
+
+    ./manage.py update_product_details
+
+...to do the initial fetch or run it again to update it.
+
+
+Secure Cookies
+~~~~~~~~~~~~~~
+
+To prevent error messages like ``Forbidden (CSRF cookie not set.):``, you need to
+set your ``settings_local.py`` with the following::
+
+    CSRF_COOKIE_SECURE = False
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,17 +6,17 @@ Contents:
    :maxdepth: 2
 
    installation
-   vendor
    development
-   celery
-   email
-   elasticsearch
-
    feature-toggles
-   localization
-   ckeditor
    tests
    tests-ui
    tests-performance
-
    troubleshooting
+
+   vendor
+   celery
+   email
+   elasticsearch
+   localization
+   ckeditor
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -59,7 +59,7 @@ Install and run everything
    in the future. Until then see this blog post for how to
    `Run Vagrant with Ansible Provisioning on Windows <http://www.azavea.com/blogs/labs/2014/10/running-vagrant-with-ansible-provisioning-on-windows/>`_
 
-#. Fork the project. (See `GitHub <https://help.github.com/articles/fork-a-repo#step-1-fork-the-spoon-knife-repository>`)
+#. Fork the project. (See `GitHub <https://help.github.com/articles/fork-a-repo#step-1-fork-the-spoon-knife-repository>`_)
 
 #. Clone your fork of Kuma and update submodules::
 
@@ -103,264 +103,16 @@ Install and run everything
 
 #. Visit the homepage at `https://developer-local.allizom.org <https://developer-local.allizom.org/>`_
 
-#. You've installed Kuma!
-
-   If you want `the badge`_ please `email a screenshot of your browser <mailto:mdn-dev@mozilla.com?subject=Local%20MDN%20Screenshot>`_ to receive the badge.
+#. You've installed Kuma! If you want `the badge`_ please `email a screenshot of your browser <mailto:mdn-dev@mozilla.com?subject=Local%20MDN%20Screenshot>`_ to receive the badge.
 
    .. image:: https://badges.mozilla.org/media/uploads/badge/2/3/23fef80968a03f3ba32321a7f31ae1e2_image_1372816280_0238.png
 
+   Continue reading to create an admin user and enable the wiki.
+
 .. _the badge: https://badges.mozilla.org/badges/badge/Installed-and-ran-Kuma
 
-Dependencies
-============
-
-Pure Python Packages
---------------------
-
-All of the pure Python dependencies are included in the git repository,
-in the ``vendor`` subdirectory. This allows them to be available on the
-Python path without needing to be installed in the system, allowing multiple
-versions for multiple projects simultaneously.
-
-Compiled Python Packages
-------------------------
-
-There are a small number of compiled packages, including the MySQL Python
-client. You can install these using ``pip`` or via a package manager.
-To use ``pip``, you only need to do the following.
-
-First SSH into the Vagrant VM::
-
-    vagrant ssh
-
-Then disable the virtualenv that is auto-enabled and install the compiled
-dependencies::
-
-    deactivate
-    sudo pip install -r requirements/compiled.txt
-
-Configuration
-=============
-
-.. _vagrant-config:
-
-Vagrant
--------
-
-If you'd like to change the way Vagrant works, we've added a few
-configuration values that may be worthwhile to look at. In case something
-doesn't suffice for your machine, please let us know!
-
-To change the config values, simply create a dotenv_ file (``.env``) in the
-directory (``/home/vagrant/src/.env`` in the Vagrant VM) and write
-``<KEY>=<VALUE>`` for each configuration variable you'd like to set.
-
-Here's the configuration variables that are available for Vagrant:
-
-- ``VAGRANT_NFS``
-
-  Default: true (Windows: false)
-  Whether or not to use NFS for the synced folder.
-
-- ``VAGRANT_MEMORY_SIZE``
-
-  The size of the Virtualbox VM memory in MB. Default: 2048
-
-- ``VAGRANT_CPU_CORES``
-
-  The number of virtual CPU core the Virtualbox VM should have. Default: 2
-
-- ``VAGRANT_IP``
-
-  The static IP the Virtualbox VM should be assigned to. Default: 192.168.10.55
-
-- ``VAGRANT_GUI``
-
-  Whether the Virtualbox VM should boot with a GUI. Default: false
-
-- ``VAGRANT_ANSIBLE_VERBOSE``
-
-  Whether the Ansible provisioner should print verbose output. Default: false
-
-A possible ``/home/vagrant/src/.env`` file could look like this for example::
-
-    VAGRANT_MEMORY_SIZE=4096
-    VAGRANT_CPU_CORES=4
-    VAGRANT_ANSIBLE_VERBOSE=true
-
-.. _dotenv: http://12factor.net/config
-
-The kuma project
-----------------
-
-Start by creating a file named ``settings_local.py``, and putting this line in
-it::
-
-    from settings import *
-
-Now you can copy and modify any settings from ``settings.py`` into
-``settings_local.py`` and the value will override the default.
-
-.. note::
-
-   For some basic features you'll need to use
-   :doc:`feature toggles <feature-toggles>` to enable them.
-
-Database
-~~~~~~~~
-
-At a minimum, you will need to define a database connection. An example
-configuration is::
-
-    DATABASES = {
-        'default': {
-            'NAME': 'kuma',
-            'ENGINE': 'django.db.backends.mysql',
-            'HOST': 'localhost',
-            'PORT': '3306',
-            'USER': 'kuma',
-            'PASSWORD': 'kuma',
-            'OPTIONS': {
-                'sql_mode': 'TRADITIONAL',
-                'charset': 'utf8',
-                'init_command': 'SET '
-                    'storage_engine=INNODB,'
-                    'character_set_connection=utf8,'
-                    'collation_connection=utf8_general_ci',
-            },
-            'ATOMIC_REQUESTS': True,
-            'TEST': {
-                'CHARSET': 'utf8',
-                'COLLATION': 'utf8_general_ci',
-            },
-        },
-    }
-
-Note the two values ``CHARSET`` and ``COLLATION`` of the ``TEST`` setting.
-Without these, the test suite will use MySQL's (moronic) defaults when
-creating the test database (see below) and lots of tests will fail. Hundreds.
-
-Once you've set up the database, you can generate the schema with Django's
-``migrate`` command::
-
-    ./manage.py migrate
-
-This will generate an empty database, which will get you started!
-
-Assets
-~~~~~~
-
-If you want to see images and have the pages formatted with CSS you need to
-set your ``settings_local.py`` with the following::
-
-    DEBUG = True
-    TEMPLATE_DEBUG = DEBUG
-    SERVE_MEDIA = True
-
-Setting ``DEBUG = False`` will put the installation in production mode
-and ask for minified assets. In that case, you will need to generate
-CSS from stylus and compress resource::
-
-    ./scripts/compile-stylesheets
-    ./manage.py compress_assets
-
-.. _enable KumaScript:
-
-KumaScript
-~~~~~~~~~~
-
-To enable KumaScript (Kuma's template system):
-
-#. Sign in
-#. Visit the `constance config admin panel`_
-#. Change ``KUMASCRIPT_TIMEOUT`` to 600
-#. Click "Save" at the bottom
-
-KumaScript is now enabled. You will also want to import the `KumaScript auto-loaded modules`_.
-You can simply copy & paste them from the production site to your local site at
-the same slugs. Or you can email the dev-mdn@lists.mozilla.org list to get a .json file to
-load in your local django admin interface as described in `this comment`_.
-
-.. _constance config admin panel: https://developer-local.allizom.org/admin/constance/config/
-.. _KumaScript auto-loaded modules: https://developer.mozilla.org/en-US/docs/MDN/Kuma/Introduction_to_KumaScript#Auto-loaded_modules
-.. _this comment: https://github.com/mozilla/kuma/issues/2518#issuecomment-53665362
-
-Mozilla Product Details
-~~~~~~~~~~~~~~~~~~~~~~~
-
-One of the packages Kuma uses, Django Mozilla Product Details, needs to
-fetch JSON files containing historical Firefox version data and write them
-to disk. To set this up, just run::
-
-    ./manage.py update_product_details
-
-...to do the initial fetch or run it again to update it.
-
-.. _GitHub Auth:
-
-GitHub Auth
-~~~~~~~~~~~
-
-To enable GitHub authentication ...
-
-`Register your own OAuth application on GitHub`_:
-
-* Application name: MDN (<username>)
-* Homepage url: https://developer-local.allizom.org/docs/MDN/Contribute/Howto/Create_an_MDN_account
-* Application description: My own GitHub app for MDN!
-* Authorization callback URL: https://developer-local.allizom.org/users/github/login/callback/
-
-`Add a django-allauth social app`_ for GitHub:
-
-* Provider: GitHub
-* Name: developer-local.allizom.org
-* Client id: <your GitHub App Client ID>
-* Secret key: <your GitHub App Client Secret>
-* Sites: example.com -> Chosen sites
-
-Now you can sign in with GitHub at https://developer-local.allizom.org/
-
-.. _Add a django-allauth social app: https://developer-local.allizom.org/admin/socialaccount/socialapp/add/
-.. _Register your own OAuth application on GitHub: https://github.com/settings/applications/new
-
-Persona Auth
-~~~~~~~~~~~~
-
-Add the following to ``settings_local.py`` so that Persona works with the
-development instance::
-
-    SITE_URL = 'http://localhost:8000'
-    PROTOCOL = 'http://'
-    DOMAIN = 'localhost'
-    PORT = 8000
-    SESSION_COOKIE_SECURE = False # needed if the server is running on http://
-    SESSION_EXPIRE_AT_BROWSER_CLOSE = False
-
-The ``SESSION_EXPIRE_AT_BROWSER_CLOSE`` setting is not strictly necessary, but
-it's convenient for development.
-
-Secure Cookies
-~~~~~~~~~~~~~~
-
-To prevent error messages like ``Forbidden (CSRF cookie not set.):``, you need to
-set your ``settings_local.py`` with the following::
-
-    CSRF_COOKIE_SECURE = False
-
-Testing it Out
-==============
-
-To start the dev server, run ``./manage.py runserver``, then open up
-``http://localhost:8000``. If everything's working, you should see
-the MDN home page!
-
-You might need to first set ``LC_CTYPE`` if you're on Mac OS X until
-`bug 754728 <https://bugzilla.mozilla.org/show_bug.cgi?id=754728>`_ is fixed::
-
-    export LC_CTYPE=en_US
-
 Create an admin user
---------------------
+====================
 
 You will want to make yourself an admin user to enable important site features.
 
@@ -378,32 +130,85 @@ You will want to make yourself an admin user to enable important site features.
       Query OK, 1 row affected (0.01 sec)
       Rows matched: 1  Changed: 1  Warnings: 0
 
-Create pages
-------------
+Enable the wiki
+===============
 
-You can visit `https://developer-local.allizom.org/docs/new
+By default, the wiki is disabled with a :doc:`feature toggle <feature-toggles>`.
+So, you need to create an admin user, sign in, and then use
+`the Django admin site`_ to enable the wiki so you can create pages.
+
+#. As the admin user you just created, visit the `waffle section`_ of the admin
+site.
+
+#. Click "`Add flag`_".
+
+#. Enter "kumaediting" for the Name.
+
+#. Set "Everyone" to "Yes"
+
+#. Click "Save".
+
+.. _the Django admin site: https://developer-local.allizom.org/admin/
+.. _waffle section: https://developer-local.allizom.org/admin/waffle/
+.. _Add flag: https://developer-local.allizom.org/admin/waffle/flag/add/
+
+You can now visit `https://developer-local.allizom.org/docs/new
 <https://developer-local.allizom.org/docs/new>`_ to create new wiki pages as
 needed.
 
 Many core MDN contributors create a personal ``User:<username>`` page as a
 testing sandbox.
 
-Developing with Vagrant
------------------------
+.. _enable KumaScript:
 
-Edit files as usual on your host machine; the current directory is
-mounted via NFS at ``/home/vagrant/src`` within the VM. Updates should be
-reflected without any action on your part.
+(Advanced) Enable KumaScript
+============================
 
--  See :doc:`development <development>` for tips not specific to vagrant.
+By default, `KumaScript`_ is also disabled with a :doc:`feature toggle <feature-toggles>`.
+To enable KumaScript:
 
--  Useful vagrant sub-commands::
+#. Sign in as the admin user
+#. Visit the `constance config admin panel`_
+#. Change ``KUMASCRIPT_TIMEOUT`` to 600
+#. Click "Save" at the bottom
 
-    vagrant ssh     # Connect to the VM via ssh
-    vagrant suspend # Sleep the VM, saving state
-    vagrant halt    # Shutdown the VM
-    vagrant up      # Boot up the VM
-    vagrant destroy # Destroy the VM
+KumaScript is now enabled. You will also need to import the `KumaScript auto-loaded modules`_.
+You can simply copy & paste them from the production site to your local site at
+the same slugs. Or you can get a .json file to load in your local django admin
+interface as described in `this bugzilla comment`_.
+
+.. _KumaScript: https://developer.mozilla.org/en-US/docs/MDN/Contribute/Tools/KumaScript
+.. _constance config admin panel: https://developer-local.allizom.org/admin/constance/config/
+.. _KumaScript auto-loaded modules: https://developer.mozilla.org/en-US/docs/MDN/Kuma/Introduction_to_KumaScript#Auto-loaded_modules
+.. _this comment: https://github.com/mozilla/kuma/issues/2518#issuecomment-53665362
+
+.. _GitHub Auth:
+
+(Advanced) Enable GitHub Auth
+=============================
+
+To enable GitHub authentication ...
+
+`Register your own OAuth application on GitHub`_:
+
+* Application name: MDN (<username>)
+* Homepage url: https://developer-local.allizom.org/docs/MDN/Contribute/Howto/Create_an_MDN_account
+* Application description: My own GitHub app for MDN!
+* Authorization callback URL: https://developer-local.allizom.org/users/github/login/callback/
+
+As the admin user, `add a django-allauth social app`_ for GitHub:
+
+* Provider: GitHub
+* Name: developer-local.allizom.org
+* Client id: <your GitHub App Client ID>
+* Secret key: <your GitHub App Client Secret>
+* Sites: example.com -> Chosen sites
+
+Now you can sign in with GitHub at https://developer-local.allizom.org/
+
+.. _add a django-allauth social app: https://developer-local.allizom.org/admin/socialaccount/socialapp/add/
+.. _Register your own OAuth application on GitHub: https://github.com/settings/applications/new
+
 
 .. _Errors:
 


### PR DESCRIPTION
To replace [the corresponding wiki docs](https://developer.mozilla.org/en-US/docs/MDN/Kuma/Contributing/Getting_started), I've re-arranged and updated some of our Kuma docs so we can link wiki readers to our code docs rather than wiki docs.