### PR TITLE
Bug 957802: Make DB ignore more generic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,5 +38,5 @@ celeryev.pid
 media/js/libs/ckeditor/source/ckbuilder
 .tox
 .env
-*_devmo.sql*
+*devmo*.sql*
 htmlcov/


### PR DESCRIPTION
The .gitignore file is updated to also match files named
devmo_sanitized.sql