### PR TITLE
Bug 1032455: Tweaks to helpfulness

### DIFF
--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -3,8 +3,13 @@
     // this feature requires localStorage
     if (('localStorage' in win)) {
         var ignore = localStorage.getItem('helpful-ignore') === 'true'; // true if ever clicked ignore
-        var askedRecently = parseInt(localStorage.getItem(doc.location + '#answered-helpful'), 10) > Date.now();
-        if (!ignore && !askedRecently) {
+        var articleAskedRecently = parseInt(localStorage.getItem(doc.location + '#answered-helpful'), 10) > Date.now();
+        var lastAsked = localStorage.getItem('helpful-asked-last');
+        var today = new Date();
+        today.setHours(0,0,0,0);
+        var askedToday = String(lastAsked) === String(today);
+
+        if (!ignore && !articleAskedRecently && !askedToday) {
             // ask about helpfulness after 1 min
             setTimeout(inquire, 60000);
         }
@@ -14,6 +19,9 @@
     function inquire() {
         // dimension7 is "helpfulness"
         if(win.ga) ga('set', 'dimension7', 'Yes');
+
+        // note that we asked today
+        localStorage.setItem('helpful-asked-last', today);
 
         // ask a simple question
         var ask = gettext('Did this page help you?') +
@@ -47,6 +55,8 @@
             {val: 'Make-Simpler', text: gettext('Make explanations clearer')},
             {val: 'Needs-More-Info', text: gettext('Add more details')},
             {val: 'Needs-Correction', text: gettext('Fix incorrect information')},
+            {val: 'Needs-Examples', text: gettext('Add or improve examples')},
+            {val: 'SEO', text: gettext('My search should have lead to a different article.')},
             {val: 'Other', text: gettext('Something else')}
         ]
         var $select = $('<select />').attr({


### PR DESCRIPTION
2 new options for "What would make it better?".
Do not ask more than once per day.

To test:
1) drop helpfulness.js line 15 to 600 for a shorter wait
2) turn `helpfulness` waffle flag on
2) clear local storage for your local MDN
3) visit page on local MDN, should be prompted (don't answer survey)
4) visit another page, should not be prompted
5) clear local storage
6) visit another page, should be prompted
7) fill out helpfulness survey
8) visit another page, should not be prompted

Not sure about testing the 'never ask again' functionality or testing if it will ask again the next day. I didn't touch the 'never ask again' mechanics so it should still be working. Maybe this is just a PR that takes 25 hours to test?