### PR TITLE
Fix bug 1206429 - Fix pagination query string args in revision dashboard

### DIFF
--- a/kuma/dashboards/templates/dashboards/revisions.html
+++ b/kuma/dashboards/templates/dashboards/revisions.html
@@ -9,7 +9,7 @@
 
     <div class="dashboard">
         <h1><a href="{{ url('dashboards.revisions') }}">{{ title }}</a></h1>
-        <form method="get" id="revision-filter">
+        <form method="get" id="revision-filter" action="{{ url('dashboards.revisions') }}">
             <div class="revision-field">
                 <label for="id_locale">{{ _('Locale:') }}</label>
                 {{ form.locale }}
@@ -153,7 +153,7 @@
     // AJAX loads for pagination
     $revisionReplaceBlock.on('click', '.pagination a', function (e) {
         e.preventDefault();
-        $pageInput.val(this.href.split('page=')[1]);
+        $pageInput.val(/page=([^&#]*)/.exec(this.href)[1]);
         $filterForm.submit();
     });
 


### PR DESCRIPTION
There were 2 issues here:

1. The 'page=' parsing was picking up the page number plus the rest of
   the query string resulting in an invalid page number on the server.

2. The query string args were sent twice to the server because the form
   action was not set. It happened to work because the second set of
   query string args overwrote the first set.