### PR TITLE
bug 1197444 - Load just-in-time assets in development environment

### DIFF
--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -3,11 +3,15 @@ import mock
 from nose.tools import eq_
 
 from django.contrib.sites.models import Site
+from django.test import TestCase
+from django.test.utils import override_settings
+from jingo_minify.helpers import BUILD_ID_CSS, BUILD_ID_JS
 
 from kuma.core.cache import memcache
 from kuma.users.tests import UserTestCase
 from . import document, revision, WikiTestCase
-from ..helpers import (absolutify, document_zone_management_links,
+from ..helpers import (absolutify, css_url_array,
+                       document_zone_management_links, js_url_array,
                        revisions_unified_diff, tojson)
 from ..models import DocumentZone
 
@@ -135,3 +139,51 @@ class DocumentZoneTests(UserTestCase, WikiTestCase):
             result_links = document_zone_management_links(user, doc)
             eq_(add, result_links['add'] is not None, (user, doc))
             eq_(change, result_links['change'] is not None)
+
+
+class UrlArrayTests(TestCase):
+    def test_css_prod(self):
+        bundle = 'wiki-compat-tables'
+        result = css_url_array(bundle, False)
+        expected = (
+            '["/static/css/%s-min.css?build=%s"]' % (bundle, BUILD_ID_CSS))
+        eq_(result, expected)
+
+    @mock.patch('jingo_minify.helpers._get_mtime')
+    def test_css_debug(self, mock_mtime):
+        mock_mtime.return_value = 100
+        bundle = 'wiki-compat-tables'
+        result = css_url_array(bundle, True)
+        mock_mtime.assert_called_once_with('css/%s.css' % bundle)
+        eq_(result, '["/static/css/%s.css?build=100"]' % bundle)
+
+    @override_settings(TEMPLATE_DEBUG=True)
+    @mock.patch('jingo_minify.helpers._get_mtime')
+    def test_css_standard(self, mock_mtime):
+        mock_mtime.return_value = 200
+        bundle = 'wiki-compat-tables'
+        result = css_url_array(bundle)
+        mock_mtime.assert_called_once_with('css/%s.css' % bundle)
+        eq_(result, '["/static/css/%s.css?build=200"]' % bundle)
+
+    def test_js_prod(self):
+        bundle = 'syntax-prism'
+        result = js_url_array(bundle, False)
+        expected = (
+            '["/static/js/%s-min.js?build=%s"]' % (bundle, BUILD_ID_JS))
+        eq_(result, expected)
+
+    @mock.patch('jingo_minify.helpers._get_mtime')
+    def test_js_debug(self, mock_mtime):
+        mock_mtime.return_value = 300
+        result = js_url_array('syntax-prism', True)
+        eq_(mock_mtime.call_count, 5)
+        expected = (
+            '["/static/js/libs/prism/prism.js?build=300",'
+            ' "/static/js/prism-mdn/components/prism-json.js?build=300",'
+            ' "/static/js/prism-mdn/plugins/line-numbering/'
+            'prism-line-numbering.js?build=300",'
+            ' "/static/js/libs/prism/plugins/line-highlight/'
+            'prism-line-highlight.js?build=300",'
+            ' "/static/js/syntax-prism.js?build=300"]')
+        eq_(result, expected)

--- a/templates/includes/config.html
+++ b/templates/includes/config.html
@@ -30,6 +30,16 @@
             // Wiki-specific settings will be placed here
             wiki: {
                 autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
+            },
+            // Just-in-time asset paths
+            assets: {
+                css: {
+                    'wiki-compat-tables': {{ css_url_array('wiki-compat-tables') }}
+                },
+                js: {
+                    'syntax-prism': {{ js_url_array('syntax-prism') }},
+                    'wiki-compat-tables': {{ js_url_array('wiki-compat-tables') }}
+                }
             }
         };
     })(this);


### PR DESCRIPTION
Add jingo helpers to get paths to bundled CSS and JS assets, and add to the in-page global mdn.assets. Use these paths rather than hard-coded values when dynamically loading JS and CSS.

In a development environment, style-prism.js is split into 5 files, and the first one has to be fully loaded before the rest will load correctly.