### PR TITLE
bug 1184662 - Add support for Safari

### DIFF
--- a/docs/tests-ui.rst
+++ b/docs/tests-ui.rst
@@ -47,6 +47,12 @@ The above tries to run the entire suite of tests. You can change the behavior wi
 
 The user credentials must be Persona-only (not GMail or Mozilla LDAP lookups).  User credentials are the only required custom command line arguments.
 
+Safari requires some special configuration to ensure tests run correctly:
+
+1.  Open your Safari browser's preferences dialog and disable the popup blocker
+
+2.  You must download and manually install the `Safari Selenium Extension <https://github.com/SeleniumHQ/selenium/blob/master/javascript/safari-driver/prebuilt/SafariDriver.safariextz>`_.  Once downloaded, drag the extension into the Safari extensions list within the Preferences dialog.
+
 On a Cloud Provider
 ~~~~~~~~~~~~~~~~~~~
 

--- a/tests/ui/_base.js
+++ b/tests/ui/_base.js
@@ -34,8 +34,6 @@ define({
     },
 
     // A regular expression matching URLs to files that should not be included in code coverage analysis
-    excludeInstrumentation: /^(_cli\.js|node_modules|tests\/lib)/,
-
-    reporters: ['Pretty']
+    excludeInstrumentation: /^(_cli\.js|node_modules|tests\/lib)/
 
 });

--- a/tests/ui/intern-browserstack.js
+++ b/tests/ui/intern-browserstack.js
@@ -12,5 +12,8 @@ define(['./_base', './_cli', 'intern'], function(config, cli, intern) {
     // Name of the tunnel class to use for WebDriver tests
     config.tunnel = 'BrowserStackTunnel';
 
+    // Format for outputting test results
+    config.reporters = ['Pretty'];
+
     return cli.mixinArgs(intern.args, config);
 });

--- a/tests/ui/intern-sauce-labs.js
+++ b/tests/ui/intern-sauce-labs.js
@@ -16,5 +16,8 @@ define(['./_base', './_cli', 'intern'], function(config, cli, intern) {
     // Name of the tunnel class to use for WebDriver tests
     config.tunnel = 'SauceLabsTunnel';
 
+    // Format for outputting test results
+    config.reporters = ['Pretty'];
+
     return cli.mixinArgs(intern.args, config);
 });

--- a/tests/ui/tests/dashboards.js
+++ b/tests/ui/tests/dashboards.js
@@ -4,8 +4,9 @@ define([
     'base/lib/config',
     'base/lib/login',
     'base/lib/POM',
-    'base/lib/poll'
-], function(registerSuite, assert, config, libLogin, POM, poll) {
+    'base/lib/poll',
+    'base/lib/capabilities'
+], function(registerSuite, assert, config, libLogin, POM, poll, capabilities) {
 
     // Create this page's specific POM
     var Page = new POM({
@@ -56,6 +57,7 @@ define([
                         .getAllWindowHandles().then(function(handles) {
                             return remote
                                     .switchToWindow(handles[1])
+                                    .sleep(capabilities.getBrowserSleepShim(remote))
                                     .getCurrentUrl()
                                     .then(function(url) {
                                         assert.isTrue(url.indexOf('ipban/add') != -1);

--- a/tests/ui/tests/footer.js
+++ b/tests/ui/tests/footer.js
@@ -5,8 +5,9 @@ define([
     'base/lib/config',
     'base/lib/assert',
     'base/lib/POM',
-    'base/lib/poll'
-], function(registerSuite, assert, keys, config, libAssert, POM, poll) {
+    'base/lib/poll',
+    'base/lib/capabilities'
+], function(registerSuite, assert, keys, config, libAssert, POM, poll, capabilities) {
 
     // Create this page's specific POM
     var Page = new POM({
@@ -32,6 +33,11 @@ define([
         'Changing the footer\'s language selector changes locale via URL': function() {
 
             var remote = this.remote;
+
+            // Safari doesn't bubble the onchange so this test wont work
+            if(capabilities.getBrowserName(remote) === 'safari') {
+                return remote;
+            }
 
             return remote
                     .findByCssSelector('#language')

--- a/tests/ui/tests/lib/capabilities.js
+++ b/tests/ui/tests/lib/capabilities.js
@@ -1,0 +1,35 @@
+define(['intern/dojo/node!leadfoot/keys'], function(keys) {
+
+    return {
+
+        getBrowserName: function(remote) {
+            // Returns the browser of the current session
+
+            return remote.session.capabilities.browserName.toLowerCase();
+        },
+
+        // Safari is whack with popups so we need to shim it with sleeps;
+        // Polling for elements is not fruitful
+        getBrowserSleepShim: function(remote) {
+            return this.getBrowserName(remote) === 'safari' ? 3000 : 0;
+        },
+
+        crossbrowserConfirm: function(remote) {
+            // Firefox and Chrome react more reliably to elements with the ENTER key pressed
+            // Safari, on the other hand, only responds to click
+
+            var gbn = this.getBrowserName(remote);
+
+            return function(element) {
+                if(gbn === 'safari') {
+                    return element.click();
+                }
+                else {
+                    return element.type([keys.RETURN]);
+                }
+            };
+        }
+
+    };
+
+});

--- a/tests/ui/tests/lib/login.js
+++ b/tests/ui/tests/lib/login.js
@@ -3,10 +3,10 @@ define([
     'intern/dojo/Promise',
     'base/lib/config',
     'base/lib/poll',
+    'base/lib/capabilities',
     'intern/dojo/node!leadfoot/helpers/pollUntil',
     'intern/chai!assert',
-    'intern/dojo/node!leadfoot/keys'
-], function(http, Promise, config, poll, pollUntil, assert, keys) {
+], function(http, Promise, config, poll, capabilities, pollUntil, assert) {
 
     return {
 
@@ -72,6 +72,12 @@ define([
                     .then(function(handles) {
 
                         return remote.switchToWindow(handles[1])
+
+                            // FOR SAFARI Added this for Safari -- it isn't finding the #authentication_email without it
+                            // Safari has a history with popup issues
+                            // https://code.google.com/p/selenium/issues/detail?id=5195
+                            .sleep(capabilities.getBrowserSleepShim(remote))
+
                             .findByCssSelector('#authentication_email')
                             .then(function() {
 
@@ -119,8 +125,7 @@ define([
                             })
                             .end()
                             .findByCssSelector('button.isStart')
-                            // Using the [ENTER] key is more reliable than selenium's click()
-                            .type([keys.RETURN])
+                            .then(capabilities.crossbrowserConfirm(remote))
                             .end()
                             .findByCssSelector('#authentication_password')
                             .then(function() {
@@ -149,9 +154,7 @@ define([
                             })
                             .end()
                             .findByCssSelector('button.isTransitionToSecondary')
-
-                            // Using the [ENTER] key is more reliable than selenium's click()
-                            .type([keys.RETURN])
+                            .then(capabilities.crossbrowserConfirm(remote))
                             .switchToWindow(handles[0])
 
                             // A bit crazy, but since we need to wait for Persona to (1) close the login window and
@@ -167,6 +170,8 @@ define([
                                     var listener = window.addEventListener(eventType, asyncCallback);
                                 });
                             })
+
+                            .sleep(capabilities.getBrowserSleepShim(remote))
 
                             // ... and to confirm the login worked, we need to poll for either the "#id_username" element (signup page)
                             // or the "a.oauth-logged-in-signout" element (sign out link)

--- a/tests/ui/tests/lib/poll.js
+++ b/tests/ui/tests/lib/poll.js
@@ -1,18 +1,17 @@
 define(['intern/dojo/Promise', 'base/lib/config'], function(Promise, config) {
 
     return {
-        until: function(item, fn, callbackFn, timeout) {
+        until: function(item, fn, callbackFn) {
             // Allows us to poll for a remote.{whatever}() method async result
             // Useful when waiting for an element to fade in, a URL to change, etc.
 
             // Defaults for arguments not passed
-            timeout = timeout || config.testTimeout;
             callbackFn = callbackFn || function(result) {
                 return result === true;
             };
 
             var dfd = new Promise.Deferred();
-            var endTime = Number(new Date()) + timeout;
+            var endTime = Number(new Date()) + config.testTimeout;
 
             (function poll() {
                 item[fn]().then(function() {

--- a/tests/ui/tests/wiki.js
+++ b/tests/ui/tests/wiki.js
@@ -5,9 +5,9 @@ define([
     'base/lib/assert',
     'base/lib/POM',
     'base/lib/poll',
-    'intern/dojo/node!leadfoot/keys',
+    'base/lib/capabilities',
     'intern/dojo/text!tests/fixtures/in-content.html'
-], function(registerSuite, assert, config, libAssert, POM, poll, keys, inContentTemplate) {
+], function(registerSuite, assert, config, libAssert, POM, poll, capabilities, inContentTemplate) {
 
     // Create this page's specific POM
     var Page = new POM({
@@ -219,7 +219,7 @@ define([
 
                                                 return remote
                                                         .findByCssSelector('.page-buttons .btn-save')
-                                                        .type([keys.RETURN])
+                                                        .then(capabilities.crossbrowserConfirm(remote))
                                                         .then(function() {
                                                             return poll.untilUrlChanges(remote, Page.documentCreatedSlug).then(function() {
                                                                 assert.ok('New page is created successfully');


### PR DESCRIPTION
To Do:

- [x] Add instructions for testing with Safari
- [x] Remove the `sleep` calls required to make Safari auth tests work