### PR TITLE
bug 1186899 - Intern improvements for safari, timeouts, logout

### DIFF
--- a/tests/ui/tests/auth.js
+++ b/tests/ui/tests/auth.js
@@ -19,11 +19,11 @@ define([
         name: 'auth',
 
         before: function() {
-            Page.init(this.remote, config.homepageUrl);
+            return Page.init(this.remote, config.homepageUrl);
         },
 
         beforeEach: function() {
-            return Page.setup().then(function() {
+            return Page.setup(this).then(function() {
                 return libLogin.openLoginWidget(Page.remote);
             });
         },

--- a/tests/ui/tests/dashboards.js
+++ b/tests/ui/tests/dashboards.js
@@ -19,11 +19,11 @@ define([
         name: 'dashboards',
 
         before: function() {
-            Page.init(this.remote, config.url + 'dashboards/revisions');
+            return Page.init(this.remote, config.url + 'dashboards/revisions');
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/demos.js
+++ b/tests/ui/tests/demos.js
@@ -20,7 +20,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/env.js
+++ b/tests/ui/tests/env.js
@@ -19,7 +19,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/footer.js
+++ b/tests/ui/tests/footer.js
@@ -23,7 +23,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/header.js
+++ b/tests/ui/tests/header.js
@@ -24,7 +24,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/homepage.js
+++ b/tests/ui/tests/homepage.js
@@ -24,7 +24,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {

--- a/tests/ui/tests/lib/capabilities.js
+++ b/tests/ui/tests/lib/capabilities.js
@@ -8,10 +8,11 @@ define(['intern/dojo/node!leadfoot/keys'], function(keys) {
             return remote.session.capabilities.browserName.toLowerCase();
         },
 
-        // Safari is whack with popups so we need to shim it with sleeps;
-        // Polling for elements is not fruitful
         getBrowserSleepShim: function(remote) {
-            return this.getBrowserName(remote) === 'safari' ? 3000 : 0;
+            // Safari and Chrome are whack with popups and crossing domains so we need to shim it with sleeps;
+            // Polling for elements is not fruitful, so simply waiting is the best solution
+
+            return 3000;
         },
 
         crossbrowserConfirm: function(remote) {

--- a/tests/ui/tests/lib/config.js
+++ b/tests/ui/tests/lib/config.js
@@ -4,7 +4,7 @@ define(['intern'], function(intern) {
     var httpsAddress = 'https://' + domain + '/';
     var defaultLocale = 'en-US';
 
-    var timeouts = 60000;
+    var testTimeout = 90000;
 
     return {
 
@@ -35,8 +35,7 @@ define(['intern'], function(intern) {
         personaPassword: intern.args.p || '',
 
         // Async testing in milliseconds
-        testTimeout: timeouts,
-        asyncExecutionTimeout: timeouts,
+        testTimeout: testTimeout,
 
         // Wiki-specific
         wikiDocumentSlug: intern.args.wd || ''

--- a/tests/ui/tests/wiki.js
+++ b/tests/ui/tests/wiki.js
@@ -36,7 +36,7 @@ define([
         },
 
         beforeEach: function() {
-            return Page.setup();
+            return Page.setup(this);
         },
 
         after: function() {


### PR DESCRIPTION
- [ ] - Sets the individual test timeout to 90 instead of 30, which should give us more flexibility on Browserstack if their network or MDN is slow

- [ ] - Ensures logout before each test suite runs so that Safari testing locally is less of a nightmare

- [ ] - Presses the "this session" button in the Persona login window if presented (instead of ignoring it and the winding "hanging")