### PR TITLE
1202115 .index bottom margin

### DIFF
--- a/kuma/static/stylus/components/syntax/example.styl
+++ b/kuma/static/stylus/components/syntax/example.styl
@@ -5,18 +5,22 @@ $bg-bad = blend(rgba($negative, 0.05), #fff);
 Pseudo element for icons
 -------------------------------------------------------------- */
 
-:not(pre)>code.example-good[class*='language-']:before,
-pre.example-good[class*='language-']:before,
-:not(pre)>code.example-bad[class*='language-']:before,
-pre.example-bad[class*='language-']:before {
-    border-radius: 100%; /* make it into a circle so bgcolor doesn't show */
-    font-family: 'FontAwesome';
-    font-size: $larger-font-size ;
-    position: absolute;
-    top: 14px;
-    left: 6px;
-    z-index: 10;
-    speak: none;
+:not(pre)>code.example-good[class*='language-'],
+pre.example-good[class*='language-'],
+:not(pre)>code.example-bad[class*='language-'],
+pre.example-bad[class*='language-'] {
+    position: relative;
+
+    &:before{
+        border-radius: 100%; /* make it into a circle so bgcolor doesn't show */
+        font-family: 'FontAwesome';
+        font-size: $larger-font-size ;
+        position: absolute;
+        bottom: 2px;
+        right: 2px;
+        z-index: 10;
+        speak: none;
+    }
 }
 
 :not(pre)>code.example-good[class*='language-']:before,

--- a/kuma/static/stylus/components/wiki/customcss.styl
+++ b/kuma/static/stylus/components/wiki/customcss.styl
@@ -312,6 +312,7 @@ table.blockTable .verticalColumn {
 /* The index page for HTML / CSS */
 div.index {
     vendorize(columns, 18em);
+    margin-bottom: $grid-spacing;
 }
 div.index > span {
     font-family: Georgia, Times, 'Times New Roman', serif;


### PR DESCRIPTION
Test page: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Animations (more details in bug).

The bottom margin on the ul/ol was being applied sporadically by Firefox and not at all by Chrome, by adding it to .index it should always be applied now, and collapse with the margins on the lists if/when they come into play.