### PR TITLE
fix bug 1210394 - only diff_table with tidied_content

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -71,7 +71,7 @@
 
         <dt>{{ _('Content:') }}</dt>
         {% if revision_from.get_tidied_content(allow_none=True) == None or revision_to.get_tidied_content(allow_none=True) == None %}
-        <dd id="doc-rendering-scheduled" class="warning">{% trans %}Server is rendering the content comparison. Please refresh this page in a few minutes.{% endtrans %}</dd>
+        <dd id="doc-rendering-scheduled" class="warning">{% trans %}The server is rendering the content comparison. Please refresh this page in a few minutes.{% endtrans %}</dd>
         {% else %}
         <dd>{{ diff_table(revision_from.get_tidied_content(), revision_to.get_tidied_content(), revision_from.id, revision_to.id) }}</dd>
         {% endif %}

--- a/kuma/wiki/templates/wiki/includes/revision_diff_table.html
+++ b/kuma/wiki/templates/wiki/includes/revision_diff_table.html
@@ -3,4 +3,9 @@
 {% else %}
 	{% set from_content = '' %}
 {% endif %}
-{{ diff_table(from_content, revision_to.get_tidied_content(allow_none=True), revision_from.id, revision_to.id) }}
+{% set to_content = revision_to.get_tidied_content(allow_none=True) %}
+{% if from_content == None or to_content == None %}
+    {% trans %}The server is rendering the content comparison. Please refresh this page in a few minutes.{% endtrans %}
+{% else %}
+    {{ diff_table(from_content, revision_to.get_tidied_content(allow_none=True), revision_from.id, revision_to.id) }}
+{% endif %}


### PR DESCRIPTION
@robhudson or @jwhitlock - can you help me figure out why this new test fails? For some reason, the `tidied_content = ''` I'm saving in the test isn't persisted in the code-under-test. I.e., when I debug `revision_from.tidied_content` and `revision_to.tidied_content` inside `compare` view, it shows the actual tidied content and not the `''` I expect. :confused: 