### PR TITLE
bug 1211651 - assign tasks to certain queues

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,5 +1,5 @@
 web: make clean && python2.7 manage.py runserver 0.0.0.0:8000
-worker: python2.7 manage.py celery worker --events --beat --autoreload --concurrency=4
+worker: python2.7 manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
 camera: python2.7 manage.py celerycam --freq=2.0
 kumascript: node kumascript/run.js
 stylus: scripts/compile-stylesheets --watch

--- a/settings.py
+++ b/settings.py
@@ -796,6 +796,93 @@ CELERY_IMPORTS = (
 CELERY_ANNOTATIONS = {
     'cacheback.tasks.refresh_cache': {
         'rate_limit': '120/m',
+    }
+}
+
+CELERY_ROUTES = {
+    'cacheback.tasks.refresh_cache': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.actioncounters.tasks.update_actioncounter_counts': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.core.tasks.clean_sessions': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.core.tasks.delete_old_ip_bans': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.humans.tasks.humans_txt': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.build_index_sitemap': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.build_locale_sitemap': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.build_sitemaps': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.delete_old_revision_ips': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.tidy_revision_content': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.update_community_stats': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.wiki.tasks.update_document_share_url': {
+        'queue': 'mdn_purgeable'
+    },
+    'kuma.search.tasks.prepare_index': {
+        'queue': 'mdn_search'
+    },
+    'kuma.search.tasks.finalize_index': {
+        'queue': 'mdn_search'
+    },
+    'kuma.wiki.tasks.index_documents': {
+        'queue': 'mdn_search'
+    },
+    'kuma.wiki.tasks.unindex_documents': {
+        'queue': 'mdn_search'
+    },
+    'kuma.users.tasks.send_welcome_email': {
+        'queue': 'mdn_emails'
+    },
+    'kuma.users.tasks.email_render_document_progress': {
+        'queue': 'mdn_emails'
+    },
+    'kuma.wiki.tasks.send_first_edit_email': {
+        'queue': 'mdn_emails'
+    },
+    'tidings.events._fire_task': {
+        'queue': 'mdn_emails'
+    },
+    'tidings.events.claim_watches': {
+        'queue': 'mdn_emails'
+    },
+    'kuma.wiki.tasks.move_page': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.acquire_render_lock': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.release_render_lock': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.render_document': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.render_document_chunk': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.render_stale_documents': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.build_json_data_for_document': {
+        'queue': 'mdn_wiki'
     },
 }
 


### PR DESCRIPTION
Work in progress; not sure this is the best (or even a good) way to do this, but ...

Uses `CELERY_ANNOTATIONS` setting to assign 1 of 4 queues to every celery task we have:
* `mdn_purgeable` - queue for low-priority tasks, and/or tasks that will automatically come back after a time period (e.g., cacheback refreshes, sitemap cron jobs, etc.). Any task assigned to this queue should always be safe to purge when we need to. Purging these tasks will not corrupt data and will cause trivial service disruption.
* `mdn_search` - queue for tasks related to search. Purging these tasks will not corrupt data (since we can rebuild the search index), but will cause service disruption (if the search indices are unavailable or fall grossly out-of-date).
* `mdn_emails` - queue for tasks that send emails - e.g., welcomes, document subscriptions, first-edits. Purging these tasks will not currupt data, but will cause a serious service disruption - all the pending emails will be lost.
* `mdn_wiki` - queue for tasks vital to wiki operation - e.g,. rendering, moving, building JSON. Purging these tasks can corrupt data and cause serious service disruption.

To spot-check locally, check out this branch, and use the site as normal for a while. Then run this in your vm: `sudo rabbitmqctl list_queues -p kuma` and you should see the rabbitmq messages spread across the multiple queues:
```
(env)vagrant@developer-local:~/src$ sudo rabbitmqctl list_queues -p kuma
celery  1
celeryev.24626c7e-5967-446e-af5c-725e438462f8   0
mdn_emails      1
mdn_purgeable   8
mdn_search      0
mdn_wiki        1
```
Run the new `foreman start worker` command which includes all the queues to process the tasks.

To spot-check a purge, start a batch of long-running tasks. If you have a full prod db dump, [populating a new search index](https://developer-local.allizom.org/admin/search/index/) is a good way to do this. After you run the populate command, you should see a spike in the number of `mdn_search` queue messages:
```
(env)vagrant@developer-local:~/src$ sudo rabbitmqctl list_queues -p kuma
Listing queues ...
celery  2
celery@developer-local.celery.pidbox    0
celeryev.24626c7e-5967-446e-af5c-725e438462f8   0
celeryev.d578f1bb-df6d-4ced-bdd5-e4478e705297   0
mdn_emails      0
mdn_purgeable   0
mdn_search      69
mdn_wiki        0
```
And your celery worker process should receive all of them. Next, run `sudo rabbitmqctl purge_queue mdn_search -p kuma`, and then check the queues again:
```
(env)vagrant@developer-local:~/src$ sudo rabbitmqctl list_queues -p kuma
Listing queues ...
celery  2
celery@developer-local.celery.pidbox    0
celeryev.24626c7e-5967-446e-af5c-725e438462f8   0
celeryev.d578f1bb-df6d-4ced-bdd5-e4478e705297   0
mdn_emails      0
mdn_purgeable   0
mdn_search      12
mdn_wiki        0
```
It should drop all of the tasks that were `PENDING`.

I need some help deciding how best to proceed ... @jwhitlock @robhudson @jezdez ?