### PR TITLE
bug 1197858 - Set larger test timeouts for remote runners

### DIFF
--- a/tests/ui/tests/lib/POM.js
+++ b/tests/ui/tests/lib/POM.js
@@ -25,7 +25,9 @@ define(['base/lib/config', 'base/lib/login'], function(config, libLogin) {
     POM.prototype.setup = function() {
         var remote = this.remote;
 
-        remote.setExecuteAsyncTimeout(config.asyncExecutionTimeout);
+        // Set timeouts for the test
+        remote.setExecuteAsyncTimeout(config.testTimeout);
+        this.timeout = config.testTimeout;
 
         // Go to the homepage, set the default size of the window
         return this.goTo()

--- a/tests/ui/tests/lib/config.js
+++ b/tests/ui/tests/lib/config.js
@@ -4,8 +4,6 @@ define(['intern'], function(intern) {
     var httpsAddress = 'https://' + domain + '/';
     var defaultLocale = 'en-US';
 
-    var timeouts = 60000;
-
     return {
 
         // URLs
@@ -34,9 +32,9 @@ define(['intern'], function(intern) {
         personaUsername: intern.args.u || '',
         personaPassword: intern.args.p || '',
 
-        // Async testing in milliseconds
-        testTimeout: timeouts,
-        asyncExecutionTimeout: timeouts,
+        // Testing timeouts in milliseconds
+        // Set high so that remote runners like BrowserStack can complete in case of slow site
+        testTimeout: 60000,
 
         // Wiki-specific
         wikiDocumentSlug: intern.args.wd || ''


### PR DESCRIPTION
Pulling this from my Safari PR.  Important we set a large timeout in case the site and/or BrowserStack are slow.