### PR TITLE
Fix bug 1212844 - Properties lists

### DIFF
--- a/kuma/static/stylus/components/wiki/properties.styl
+++ b/kuma/static/stylus/components/wiki/properties.styl
@@ -60,5 +60,29 @@ $properties-indent = ($grid-spacing * 2) - $properties-item-spacing;
     td {
         border-width: 0;
         vertical-align: top;
+
+        li {
+            display: list-item;
+            list-style-type: disc;
+            line-height: 1;
+        }
+    }
+}
+
+/* small screen improvments to table display, only need to apply to .properties
+because we can be sure that is implemented with a table element */
+@media $media-query-small-mobile {
+    .properties {
+        th,
+        td {
+            display:block;
+        }
+        th {
+            padding-bottom: 0;
+        }
+        td {
+            padding-top: 0;
+            padding-left: $grid-spacing * 2;
+        }
     }
 }


### PR DESCRIPTION
Lists inside of the new table world order need to be properly styled, for now we just override the rules from the old list world order but eventually we can decrease the specificity of this.

Also added display improvements for small mobile screens.

Test page:
https://developer.mozilla.org/en-US/docs/Web/CSS/background-clip
(easier to view source and copy the table markup to local dev than to try to migrate the macros)