### PR TITLE
Fix Bug 1203301: Standardize language in dropdown

### DIFF
--- a/kuma/wiki/templates/wiki/includes/buttons.html
+++ b/kuma/wiki/templates/wiki/includes/buttons.html
@@ -60,11 +60,11 @@
 
                 </li>{% endif %}
                 {% if user.is_authenticated() and not document.is_template %}
-                  <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow, noindex">{{ _('New sub-page') }}</a></li>
-                  <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow, noindex">{{ _('Clone this page') }}</a></li>
+                  <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow, noindex">{{ _('New sub-article') }}</a></li>
+                  <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow, noindex">{{ _('Clone this article') }}</a></li>
                 {% endif %}
                 {% if user.is_authenticated() and user.has_perm('wiki.move_tree') %}
-                  <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}" rel="nofollow, noindex">{{ _('Move this page') }}</a></li>
+                  <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}" rel="nofollow, noindex">{{ _('Move this article') }}</a></li>
                 {% endif %}
                 {% if user.is_superuser %}
                   <li><a href="{{ url('admin:wiki_document_change', document.id) }}" rel="nofollow, noindex">{{ _('View in admin') }}</a></li>
@@ -75,7 +75,7 @@
     # TODO: https://bugzil.la/972541 -  Deleting a page that has subpages
 #}
                 {% if user.has_perm('wiki.delete_document') and not document.children.exists() %}
-                  <li><a href="{{ url('wiki.delete_document', document.slug) }}" rel="nofollow, noindex">{{ _('Delete this page') }}</a></li>
+                  <li><a href="{{ url('wiki.delete_document', document.slug) }}" rel="nofollow, noindex">{{ _('Delete this article') }}</a></li>
                 {% endif %}
 
                 {% set zone_links = document_zone_management_links(request.user, document) %}
@@ -85,7 +85,7 @@
                 {% if zone_links['add'] and not document.is_template %}
                   <li><a target="_blank" href="{{ zone_links['add'] }}" rel="nofollow, noindex">{{ _('Convert to content zone') }}</a></li>
                 {% endif %}
-                <li class="page-print"><a href="#" onclick="return window.print();">{{ _('Print this page') }}</a></li>
+                <li class="page-print"><a href="#" onclick="return window.print();">{{ _('Print this article') }}</a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
We currently have both pages and articles in this dropdown, needed to be standardized. Writers would like us to refer to articles instead of pages.