### PR TITLE
Fix bug 1197444: Remove media/fonts symlink

### DIFF
--- a/media/fonts
+++ b/media/fonts
@@ -1,1 +1,0 @@
-../kuma/static/fonts


### PR DESCRIPTION
A permanent redirect from /media/fonts to /static/fonts is now active on
stage and prod, so we don't need the symlink any more.