### PR TITLE
fix bug 1212518 - Don't forward users when control-clicking a link

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -375,16 +375,24 @@
     /*
         Track clicks on Crumb links
     */
-    $('.crumbs').on('click', 'a', function() {
+    $('.crumbs').on('click', 'a', function(e) {
         var url = this.href;
-
-        mdn.analytics.trackEvent({
+        var newTab = (e.metaKey || e.ctrlKey);
+        var data = {
             category: 'Wiki',
             action: 'Crumbs',
             label: url
-        }, function() {
-            window.location = url;
-        });
+        };
+
+        if(newTab) {
+            mdn.analytics.trackEvent(data);
+        }
+        else {
+            e.preventDefault();
+            mdn.analytics.trackEvent(data, function() {
+                window.location = url;
+            });
+        }
     });
 
 
@@ -617,7 +625,9 @@
               mdn.analytics.trackEvent(data);
             } else {
               e.preventDefault();
-              mdn.analytics.trackEvent(data, function() { win.location = href; });
+              mdn.analytics.trackEvent(data, function() {
+                win.location = href;
+              });
             }
         });
 


### PR DESCRIPTION
To test:

1.  Click any breadcrumb link, should go to the page
2.  Command-click any breadcrumb link, original tab should go nowhere, new tab should open