### PR TITLE
Fix Bug 1213548: Min-width on .properties headings.

### DIFF
--- a/kuma/static/stylus/components/wiki/properties.styl
+++ b/kuma/static/stylus/components/wiki/properties.styl
@@ -12,13 +12,16 @@ $properties-indent = ($grid-spacing * 2) - $properties-item-spacing;
 .htmlelt,
 .summary-box-js,
 .summary-box-events {
-    display: table;
-    margin: 0 0 $grid-spacing 0;
-    border-style: solid;
-    bidi-value(clear, left, right);
-    background: $code-block-background-alt-color;
 
-    .text-content & { /* need to override default text-content styles */
+    .text-content & {
+        /* could be defined one level up but that creates duplicate classes in output */
+        display: table;
+        margin: 0 0 $grid-spacing 0;
+        border-style: solid;
+        bidi-value(clear, left, right);
+        background: $code-block-background-alt-color;
+
+        /* need extra level of specificity to override default text-content styles */
         border-collapse: separate;
         bidi-value(padding, $properties-spacing $properties-indent $properties-spacing $properties-spacing, $properties-spacing $properties-spacing $properties-spacing $properties-indent);
         bidi-value(border-width, 0 0 0 $border-width, 0 $border-width 0 0);
@@ -52,6 +55,7 @@ $properties-indent = ($grid-spacing * 2) - $properties-item-spacing;
     }
 
     th {
+        min-width: 150px;
         font-weight: bold;
     }
 


### PR DESCRIPTION
Also moved some definitions around to decrease the number of lines in the complied Stylus files.

Test:
- using dev tools DOM inspector copy the HTML from this page into an article on your local instance: https://developer.mozilla.org/ja/docs/Web/CSS/flex-basis (There are several kumascript macros that need updating if you want to try to duplicate the output by actually editing the article.)
- check https://developer.mozilla.org/en-US/docs/User:teoli/In_content to make sure the other summery boxes are still displaying properly.