### PR TITLE
Bug 1139490: Don't load tech icon on Derby pages

### DIFF
--- a/kuma/demos/templates/demos/listing_tag.html
+++ b/kuma/demos/templates/demos/listing_tag.html
@@ -19,7 +19,13 @@
       <header id="page-head" class="column-container">
         <div class="column-8">
             <div class="main">
-                <h1 class="page-title"><img src="{{ static('img/icons/' + tag.name.replace('tech:','') + '.png') }}" alt="" width="160" height="160"> {{ tag_title(tag) }}</h1>
+                <h1 class="page-title">
+                    {# Don't attempt to load a technology icon on Dev Derby contest pages #}
+                    {% if 'challenge:' not in tag.name %}
+                        <img src="{{ static('img/icons/' + tag.name.replace('tech:','') + '.png') }}" alt="" width="160" height="160">
+                    {% endif %}
+                    {{ tag_title(tag) }}
+                </h1>
               <p>{{ tag_description(tag) }}</p>
             </div>
         </div>


### PR DESCRIPTION
This addresses the following error:
https://errormill.mozilla.org/mdn/mdn/group/401204/

---

#### Steps to reproduce

1. [Use production assets](https://kuma.readthedocs.org/en/latest/development.html#production-assets)
2. Visit [this page](https://developer-local.allizom.org/en-US/demos/devderby/2013/june)

#### Result on master

500

#### Result on this branch

Page loads