### PR TITLE
Bug 1139490: Remove cache-busting params in styles

### DIFF
--- a/kuma/static/styles/base/fonts/compat-icons.styl
+++ b/kuma/static/styles/base/fonts/compat-icons.styl
@@ -1,10 +1,10 @@
 @font-face {
     font-family: 'compat-icons';
-    src:url($path-to-fonts + 'compat-icons.eot?-ehmwve');
-    src:url($path-to-fonts + 'compat-icons.eot?#iefix-ehmwve') format('embedded-opentype'),
-        url($path-to-fonts + 'compat-icons.woff2?-ehmwve') format('woff2'),
-        url($path-to-fonts + 'compat-icons.woff?-ehmwve') format('woff'),
-        url($path-to-fonts + 'compat-icons.ttf?-ehmwve') format('truetype');
+    src:url($path-to-fonts + 'compat-icons.eot');
+    src:url($path-to-fonts + 'compat-icons.eot?#iefix') format('embedded-opentype'),
+        url($path-to-fonts + 'compat-icons.woff2') format('woff2'),
+        url($path-to-fonts + 'compat-icons.woff') format('woff'),
+        url($path-to-fonts + 'compat-icons.ttf') format('truetype');
     font-weight: normal;
     font-style: normal;
 }

--- a/kuma/static/styles/components/demos/backgrounds.styl
+++ b/kuma/static/styles/components/demos/backgrounds.styl
@@ -2,7 +2,7 @@
 
 /* Background */
 .section-demos {
-  background: #00101b url($path-to-images + "demos/bg-demostudio.jpg?v=2") center top no-repeat;
+  background: #00101b url($path-to-images + "demos/bg-demostudio.jpg") center top no-repeat;
   min-width: 960px;
 }
 
@@ -27,7 +27,7 @@
 
 
 #demostudio.detail {
-  background: #00101b url($path-to-images + "demos/bg-demodetail.jpg?v=2") center top no-repeat;
+  background: #00101b url($path-to-images + "demos/bg-demodetail.jpg") center top no-repeat;
 }
 
 #demostudio.detail #content-main {
@@ -41,10 +41,10 @@
 }
 
 #demostudio.landing {
-  background: #00101b url($path-to-images + "demos/bg-demolanding.jpg?v=2") center top no-repeat;
+  background: #00101b url($path-to-images + "demos/bg-demolanding.jpg") center top no-repeat;
 
   @media $media-query-mobile {
-    background-image: url($path-to-images + "demos/bg-demolanding-low.jpg?v=2");
+    background-image: url($path-to-images + "demos/bg-demolanding-low.jpg");
   }
 }
 

--- a/kuma/static/styles/components/demos/gallery-head.styl
+++ b/kuma/static/styles/components/demos/gallery-head.styl
@@ -68,7 +68,7 @@
   font-weight: normal;
   color: $link-color;
   padding-bottom: 6px;
-  background: url($path-to-images + "demos/sort-arrow.png?v=2") center bottom no-repeat;
+  background: url($path-to-images + "demos/sort-arrow.png") center bottom no-repeat;
 }
 
 @media $media-query-mobile {

--- a/kuma/static/styles/components/demos/paging.styl
+++ b/kuma/static/styles/components/demos/paging.styl
@@ -17,7 +17,7 @@
 #demos-head .paging a {
   display: block;
   color: #fff;
-  background: url($path-to-images + "demos/demobox-icons.png?v=2") no-repeat;
+  background: url($path-to-images + "demos/demobox-icons.png") no-repeat;
 }
 #demos-head .paging .prev {
   width: 45%;

--- a/kuma/static/styles/includes/vars.styl
+++ b/kuma/static/styles/includes/vars.styl
@@ -175,7 +175,7 @@ paths
 $path-to-assets = '../../static/';
 $path-to-images = $path-to-assets + 'img/';
 $path-to-fonts = $path-to-assets + 'fonts/';
-$logo-sprite-url = $path-to-images + 'logo_sprite.svg?2014-01';
+$logo-sprite-url = $path-to-images + 'logo_sprite.svg';
 
 
 /*

--- a/kuma/static/styles/libs/font-awesome/css/font-awesome.css
+++ b/kuma/static/styles/libs/font-awesome/css/font-awesome.css
@@ -7,8 +7,8 @@
  * -------------------------- */
 @font-face {
   font-family: 'FontAwesome';
-  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?v=4.1.0');
-  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.1.0') format('embedded-opentype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.woff?v=4.1.0') format('woff'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.ttf?v=4.1.0') format('truetype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular') format('svg');
+  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot');
+  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.woff') format('woff'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.ttf') format('truetype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.svg#fontawesomeregular') format('svg');
   font-weight: normal;
   font-style: normal;
 }

--- a/kuma/static/styles/libs/font-awesome/stylus/font-awesome.styl
+++ b/kuma/static/styles/libs/font-awesome/stylus/font-awesome.styl
@@ -7,8 +7,8 @@
  * -------------------------- */
 @font-face
   font-family: 'FontAwesome'
-  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?v=4.1.0')
-  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?#iefix&v=4.1.0') format('embedded-opentype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.woff?v=4.1.0') format('woff'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.ttf?v=4.1.0') format('truetype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.svg?v=4.1.0#fontawesomeregular') format('svg')
+  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot')
+  src: url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.eot?#iefix') format('embedded-opentype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.woff') format('woff'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.ttf') format('truetype'), url('/static/styles/libs/font-awesome/fonts/fontawesome-webfont.svg#fontawesomeregular') format('svg')
   font-weight: normal
   font-style: normal
 


### PR DESCRIPTION
collectstatic automatically updates stylesheets to cache-bust images and
other assets when their contents change, so these manual cache-busting
parameters are no longer needed.