### PR TITLE
Fixes bug 1217208 - Remove tower dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -85,9 +85,6 @@
 [submodule "vendor/src/requests-oauthlib"]
 	path = vendor/src/requests-oauthlib
 	url = git://github.com/requests/requests-oauthlib.git
-[submodule "vendor/src/tower"]
-	path = vendor/src/tower
-	url = git://github.com/clouserw/tower.git
 [submodule "vendor/src/urllib3"]
 	path = vendor/src/urllib3
 	url = git://github.com/shazow/urllib3.git
@@ -174,3 +171,6 @@
 [submodule "vendor/src/django-celery-transactions"]
 	path = vendor/src/django-celery-transactions
 	url = git://github.com/fellowshipofone/django-celery-transactions.git
+[submodule "vendor/src/puente"]
+	path = vendor/src/puente
+	url = git://github.com/mozilla/puente.git

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -175,7 +175,7 @@ Strings in Python are more complex for two reasons:
 
 Here's how you might localize a string in a view::
 
-    from tower import ugettext
+    from django.utils.translation import ugettext
 
     def my_view(request):
         if request.user.is_superuser:
@@ -198,7 +198,7 @@ L10n comments are normal one-line Python comments::
 
 If you need to use plurals, import the function ``ungettext`` from Tower::
 
-    from tower import ungettext
+    from django.utils.translation import ungettext
 
     n = len(results)
     msg = ungettext('Found {0} result', 'Found {0} results', n).format(n)
@@ -218,7 +218,7 @@ methods, ``ugettext_lazy`` and ``ungettext_lazy``. The result doesn't get
 translated until it is evaluated as a string, for example by being output or
 passed to ``unicode()``::
 
-    from tower import ugettext_lazy as _
+    from django.utils.translation import ugettext_lazy as _
 
     PAGE_TITLE = _(u'Page Title')
 

--- a/docs/vendor.rst
+++ b/docs/vendor.rst
@@ -62,7 +62,8 @@ Using PyPI
 ----------
 
 Update the ``requirements/packages.txt`` file with the package you'd like to
-add. To add the package to the vendored packages do::
+add. To add the package to the vendored packages run the following from
+within the vagrant machine::
 
     $ cd vendor
     $ make packages

--- a/kuma/attachments/forms.py
+++ b/kuma/attachments/forms.py
@@ -1,14 +1,12 @@
 import magic
-from tower import ugettext_lazy as _lazy
-
-from django import forms
-
 from constance import config
+from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from .models import AttachmentRevision
 
 
-MIME_TYPE_INVALID = _lazy(u'Files of this type are not permitted.')
+MIME_TYPE_INVALID = _(u'Files of this type are not permitted.')
 
 
 class AttachmentRevisionForm(forms.ModelForm):

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -2,19 +2,15 @@ import json
 import mimetypes
 
 import jinja2
-from tower import ugettext as _
-
+from constance import config
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.http import (Http404,
-                         HttpResponse,
-                         HttpResponsePermanentRedirect,
+from django.http import (Http404, HttpResponse, HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
 from django.shortcuts import get_object_or_404, render
+from django.utils.translation import ugettext
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_GET, require_POST
-
-from constance import config
 
 from kuma.core.decorators import login_required
 from kuma.core.utils import paginate
@@ -23,8 +19,8 @@ from kuma.wiki.models import Document
 
 from .forms import AttachmentRevisionForm
 from .models import Attachment
-from .utils import (attachments_payload, convert_to_http_date,
-                    allow_add_attachment_by)
+from .utils import (allow_add_attachment_by, attachments_payload,
+                    convert_to_http_date)
 
 
 # Mime types used on MDN
@@ -148,8 +144,9 @@ def new_attachment(request):
             allowed_types = ', '.join(map(guess_extension, allowed_list))
             error_obj = {
                 'title': request.POST.get('is_ajax', ''),
-                'error': _(u'The file provided is not valid. '
-                           u'File must be one of these types: %s.') % allowed_types
+                'error': ugettext(
+                    u'The file provided is not valid. '
+                    u'File must be one of these types: %s.') % allowed_types
             }
             response = render(
                 request,

--- a/kuma/core/form_fields.py
+++ b/kuma/core/form_fields.py
@@ -1,12 +1,11 @@
+from babel import Locale, localedata
+from babel.support import Format
 from django import forms
 from django.conf import settings
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils import translation
-
-from babel import Locale, localedata
-from babel.support import Format
-from tower import ugettext_lazy as _lazy
+from django.utils.translation import ugettext_lazy as _
 
 
 # TODO: remove this and use strip kwarg once ticket #6362 is done
@@ -55,13 +54,13 @@ class BaseValidator(validators.BaseValidator):
 
 
 class MinLengthValidator(validators.MinLengthValidator, BaseValidator):
-    message = _lazy(u'Ensure this value has at least %(limit_value)s '
-                    u'characters (it has %(show_value)s).')
+    message = _(u'Ensure this value has at least %(limit_value)s '
+                u'characters (it has %(show_value)s).')
 
 
 class MaxLengthValidator(validators.MaxLengthValidator, BaseValidator):
-    message = _lazy(u'Ensure this value has at most %(limit_value)s '
-                    u'characters (it has %(show_value)s).')
+    message = _(u'Ensure this value has at most %(limit_value)s '
+                u'characters (it has %(show_value)s).')
 
 
 def _format_decimal(num, format=None):

--- a/kuma/core/helpers.py
+++ b/kuma/core/helpers.py
@@ -1,6 +1,6 @@
-import json
 import datetime
 import HTMLParser
+import json
 import urllib
 
 import bleach
@@ -9,13 +9,6 @@ import pytz
 from babel import localedata
 from babel.dates import format_date, format_datetime, format_time
 from babel.numbers import format_decimal
-from jingo import env, register
-from pytz import timezone
-from soapbox.models import Message
-from tower import ugettext_lazy as _lazy
-from tower import ungettext
-from urlobject import URLObject
-
 from django.conf import settings
 from django.contrib.messages.storage.base import LEVEL_TAGS
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -23,9 +16,15 @@ from django.template import defaultfilters
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
 from django.utils.timezone import get_default_timezone
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ungettext
+from jingo import env, register
+from pytz import timezone
+from soapbox.models import Message
+from urlobject import URLObject
 
-from .jobs import StaticI18nJob
 from .exceptions import DateTimeFormatError
+from .jobs import StaticI18nJob
 from .urlresolvers import reverse, split_path
 
 
@@ -141,7 +140,7 @@ def timesince(d, now=None):
 
 @register.filter
 def yesno(boolean_value):
-    return jinja2.Markup(_lazy(u'Yes') if boolean_value else _lazy(u'No'))
+    return jinja2.Markup(_(u'Yes') if boolean_value else _(u'No'))
 
 
 @register.filter
@@ -295,7 +294,7 @@ def datetimeformat(context, value, format='shortdatetime', output='html'):
     if format == 'shortdatetime':
         # Check if the date is today
         if value.toordinal() == datetime.date.today().toordinal():
-            formatted = _lazy(u'Today at %s') % format_time(
+            formatted = _(u'Today at %s') % format_time(
                 tzvalue, format='short', locale=locale)
         else:
             formatted = format_datetime(tzvalue, format='short', locale=locale)

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -2,10 +2,9 @@ import contextlib
 import urllib
 
 from django.core import urlresolvers
-from django.http import HttpResponsePermanentRedirect, HttpResponseForbidden
+from django.http import HttpResponseForbidden, HttpResponsePermanentRedirect
+from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
-
-import tower
 from jingo.helpers import urlparams
 
 from .urlresolvers import Prefixer, set_url_prefixer, split_path
@@ -55,7 +54,7 @@ class LocaleURLMiddleware(object):
 
         request.path_info = '/' + prefixer.shortened_path
         request.locale = prefixer.locale
-        tower.activate(prefixer.locale)
+        translation.activate(prefixer.locale)
 
     def process_response(self, request, response):
         """Unset the thread-local var we set during `process_request`."""

--- a/kuma/core/sections.py
+++ b/kuma/core/sections.py
@@ -1,4 +1,4 @@
-from tower import ugettext_lazy as _
+from django.utils.translation import ugettext_lazy as _
 
 
 class SECTION_ADDONS:

--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
+from django.utils.translation import ugettext_lazy as _
 
-from tower import ugettext_lazy as _
 from kuma.core.form_fields import StrippedCharField
 
 

--- a/kuma/demos/helpers.py
+++ b/kuma/demos/helpers.py
@@ -3,18 +3,16 @@ import functools
 import hashlib
 import random
 
-from django.conf import settings
-from django.utils.encoding import smart_str
-from django.utils.timezone import get_default_timezone
-
 import bitly_api
 import jingo
 import jinja2
 from babel import localedata
+from django.conf import settings
+from django.utils.encoding import smart_str
+from django.utils.timezone import get_default_timezone
+from django.utils.translation import ugettext, ungettext
 from jingo import register
 from taggit.models import TaggedItem
-from tower import ugettext as _
-from tower import ungettext
 
 from kuma.core.cache import memcache
 from kuma.core.urlresolvers import reverse
@@ -106,11 +104,11 @@ def submission_thumb(submission, extra_class=None, thumb_width="200",
     # TODO: Move to a constant or DB table? Too much view stuff here?
     flags_meta = {
         # flag name      thumb class     flag description
-        'firstplace': ('first-place', _('First Place')),
-        'secondplace': ('second-place', _('Second Place')),
-        'thirdplace': ('third-place', _('Third Place')),
-        'finalist': ('finalist', _('Finalist')),
-        'featured': ('featured', _('Featured')),
+        'firstplace': ('first-place', ugettext('First Place')),
+        'secondplace': ('second-place', ugettext('Second Place')),
+        'thirdplace': ('third-place', ugettext('Third Place')),
+        'finalist': ('finalist', ugettext('Finalist')),
+        'featured': ('featured', ugettext('Featured')),
     }
 
     # If there are any flags, pass them onto the template. Special treatment
@@ -276,7 +274,8 @@ def date_diff(timestamp, to=None):
             count = abs(round(delta.days / chunk, 0))
             break
 
-    date_str = (_('%(number)d %(type)s') % {'number': count, 'type': name(count)})
+    date_str = ugettext('%(number)d %(type)s') % {'number': count,
+                                                  'type': name(count)}
 
     if delta.days > 0:
         return "in " + date_str

--- a/kuma/search/serializers.py
+++ b/kuma/search/serializers.py
@@ -1,9 +1,9 @@
 import collections
 from operator import attrgetter
 
+from django.utils.translation import ugettext
 from elasticsearch_dsl import document
-from rest_framework import serializers, pagination
-from tower import ugettext as _
+from rest_framework import pagination, serializers
 
 from . import models
 from .fields import LocaleField, SearchQueryField, SiteURLField
@@ -91,8 +91,8 @@ class SearchSerializer(pagination.PaginationSerializer):
                 group_slug = None
             else:
                 # Let's check if we can get the name from the gettext catalog
-                filter_name = _(filter_['name'])
-                group_name = _(filter_['group']['name'])
+                filter_name = ugettext(filter_['name'])
+                group_name = ugettext(filter_['group']['name'])
                 group_slug = filter_['group']['slug']
 
             filter_groups.setdefault((
@@ -168,7 +168,7 @@ class FilterSerializer(serializers.ModelSerializer):
         read_only_fields = ('slug', 'shortcut')
 
     def get_localized_name(self, obj):
-        return _(obj.name)
+        return ugettext(obj.name)
 
 
 class GroupWithFiltersSerializer(serializers.ModelSerializer):
@@ -183,7 +183,7 @@ class GroupWithFiltersSerializer(serializers.ModelSerializer):
         fields = ('name', 'slug', 'order', 'filters')
 
     def get_localized_name(self, obj):
-        return _(obj.name)
+        return ugettext(obj.name)
 
 
 class GroupSerializer(serializers.Serializer):

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -30,7 +30,7 @@ class SerializerTests(ElasticTestCase):
             'group': {'name': 'Group', 'slug': 'group', 'order': 1},
             'shortcut': None})
 
-    @mock.patch('kuma.search.serializers._')
+    @mock.patch('kuma.search.serializers.ugettext')
     def test_filter_serializer_with_translations(self, _mock):
         _mock.return_value = u'Juegos'
         translation.activate('es')

--- a/kuma/search/utils.py
+++ b/kuma/search/utils.py
@@ -1,10 +1,10 @@
 import logging
 
 import elasticsearch
+from django.utils.translation import ugettext_lazy as _
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import exception_handler
-from tower import ugettext_lazy as _
 from urlobject import URLObject
 
 

--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -1,6 +1,6 @@
-from django import forms
-from tower import ugettext_lazy as _
 import waffle
+from django import forms
+from django.utils.translation import ugettext_lazy as _
 
 from . import akismet
 from . import constants

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -1,13 +1,12 @@
-from django import forms
-from django.contrib import messages
-from django.contrib.auth import get_user_model
-from django.shortcuts import redirect
-
 from allauth.account.adapter import DefaultAccountAdapter, get_adapter
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from allauth.socialaccount.models import SocialLogin
-from tower import ugettext_lazy as _
+from django import forms
+from django.contrib import messages
+from django.contrib.auth import get_user_model
+from django.shortcuts import redirect
+from django.utils.translation import ugettext_lazy as _
 from waffle import flag_is_active
 
 from kuma.core.urlresolvers import reverse

--- a/kuma/users/backends.py
+++ b/kuma/users/backends.py
@@ -3,8 +3,7 @@ import hashlib
 
 from django.contrib.auth.hashers import BasePasswordHasher, mask_hash
 from django.utils.crypto import constant_time_compare
-
-from tower import ugettext as _
+from django.utils.translation import ugettext
 
 
 class Sha256Hasher(BasePasswordHasher):
@@ -30,7 +29,7 @@ class Sha256Hasher(BasePasswordHasher):
         algorithm, salt, hash = encoded.split('$', 2)
         assert algorithm == self.algorithm
         return collections.OrderedDict([
-            (_('algorithm'), algorithm),
-            (_('salt'), mask_hash(salt, show=2)),
-            (_('hash'), mask_hash(hash)),
+            (ugettext('algorithm'), algorithm),
+            (ugettext('salt'), mask_hash(salt, show=2)),
+            (ugettext('hash'), mask_hash(hash)),
         ])

--- a/kuma/users/constants.py
+++ b/kuma/users/constants.py
@@ -1,5 +1,7 @@
 import re
-from tower import ugettext_lazy as _
+
+from django.utils.translation import ugettext_lazy as _
+
 
 USERNAME_CHARACTERS = _(u'Username may contain only letters, numbers, and '
                         u'these characters: . - _ +')

--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -1,23 +1,24 @@
 import operator
 import time
 
-from django import forms
-from django.conf import settings
-from django.http import HttpResponseServerError
-
 import basket
 from basket.base import BasketException
 from basket.errors import BASKET_UNKNOWN_EMAIL
 from constance import config
+from django import forms
+from django.conf import settings
+from django.http import HttpResponseServerError
+from django.utils.translation import ugettext_lazy as _
 from product_details import product_details
 from sundial.forms import TimezoneChoiceField
 from sundial.zones import COMMON_GROUPED_CHOICES
 from taggit.utils import parse_tags
-from tower import ugettext_lazy as _
 
-from .constants import (USERNAME_CHARACTERS, USERNAME_REGEX,
-                        USERNAME_LEGACY_REGEX)
+
+from .constants import (USERNAME_CHARACTERS, USERNAME_LEGACY_REGEX,
+                        USERNAME_REGEX)
 from .models import User
+
 
 PRIVACY_REQUIRED = _(u'You must agree to the privacy policy.')
 

--- a/kuma/users/helpers.py
+++ b/kuma/users/helpers.py
@@ -1,18 +1,16 @@
-from django.conf import settings
-from django.contrib import admin
-
-from jinja2 import escape, Markup, contextfunction
-from jingo import register
-
-from allauth.utils import get_request_param
 from allauth.account.utils import user_display
 from allauth.socialaccount import providers
 from allauth.socialaccount.templatetags.socialaccount import get_providers
+from allauth.utils import get_request_param
+from django.conf import settings
+from django.contrib import admin
+from django.utils.translation import ugettext
 from honeypot.templatetags.honeypot import render_honeypot_field
-from tower import ugettext as _
+from jingo import register
+from jinja2 import Markup, contextfunction, escape
 
-from kuma.core.urlresolvers import reverse
 from kuma.core.helpers import datetimeformat
+from kuma.core.urlresolvers import reverse
 
 from .jobs import UserGravatarURLJob
 
@@ -34,11 +32,20 @@ def ban_link(context, ban_user, banner_user):
         active_ban = ban_user.active_ban
         if active_ban:
             url = reverse('admin:users_userban_change', args=(active_ban.id,))
-            title = _('Banned on {ban_date} by {ban_admin}.').format(ban_date=datetimeformat(context, active_ban.date, format='date', output='json'), ban_admin=active_ban.by)
-            link = '<a href="%s" class="button ban-link" title="%s">%s<i aria-hidden="true" class="icon-ban"></i></a>' % (url, title, _('Banned'))
+            title = ugettext('Banned on {ban_date} by {ban_admin}.').format(
+                ban_date=datetimeformat(context, active_ban.date,
+                                        format='date', output='json'),
+                ban_admin=active_ban.by)
+            link = ('<a href="%s" class="button ban-link" title="%s">%s'
+                    '<i aria-hidden="true" class="icon-ban"></i></a>'
+                    % (url, title, ugettext('Banned')))
         else:
-            url = '%s?user=%s&by=%s' % (reverse('admin:users_userban_add'), ban_user.id, banner_user.id)
-            link = '<a href="%s" class="button negative ban-link">%s<i aria-hidden="true" class="icon-ban"></i></a>' % (url, _('Ban User'))
+            url = '%s?user=%s&by=%s' % (
+                reverse('admin:users_userban_add'), ban_user.id,
+                banner_user.id)
+            link = ('<a href="%s" class="button negative ban-link">%s'
+                    '<i aria-hidden="true" class="icon-ban"></i></a>'
+                    % (url, ugettext('Ban User')))
     return Markup(link)
 
 
@@ -49,7 +56,7 @@ def admin_link(user):
                   current_app=admin.site.name)
     link = ('<a href="%s" class="button neutral">%s'
             '<i aria-hidden="true" class="icon-wrench"></i></a>' %
-            (url, _('Admin')))
+            (url, ugettext('Admin')))
     return Markup(link)
 
 

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -1,14 +1,13 @@
 import datetime
 
+from constance import config
 from django.conf import settings
 from django.contrib.auth.models import AbstractUser
 from django.core import validators
 from django.db import models
 from django.utils.functional import cached_property
-
-from constance import config
+from django.utils.translation import ugettext_lazy as _
 from sundial.zones import COMMON_GROUPED_CHOICES
-from tower import ugettext_lazy as _
 
 from kuma.core.managers import NamespacedTaggableManager
 

--- a/kuma/users/signup.py
+++ b/kuma/users/signup.py
@@ -1,8 +1,8 @@
+from allauth.socialaccount.forms import SignupForm as BaseSignupForm
 from django import forms
 from django.core import validators
+from django.utils.translation import ugettext_lazy as _
 
-from allauth.socialaccount.forms import SignupForm as BaseSignupForm
-from tower import ugettext_lazy as _
 
 USERNAME_REQUIRED = _(u'Username is required.')
 USERNAME_SHORT = _(u'Username is too short (%(show_value)s characters). '

--- a/kuma/users/tasks.py
+++ b/kuma/users/tasks.py
@@ -1,16 +1,16 @@
 import logging
-from constance import config
-from tower import ugettext_lazy as _
 
+from constance import config
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
-
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
 from djcelery_transactions import task as transaction_task
 
 from kuma.core.utils import strings_are_translated
-from kuma.core.email_utils import uselocale
+
 
 log = logging.getLogger('kuma.users.tasks')
 
@@ -28,7 +28,7 @@ def send_welcome_email(user_pk, locale):
             strings_are_translated(WELCOME_EMAIL_STRINGS, locale)):
         context = {'username': user.username}
         log.debug('Using the locale %s to send the welcome email', locale)
-        with uselocale(locale):
+        with translation.override(locale):
             content_plain = render_to_string('users/email/welcome/plain.ltxt',
                                              context)
             content_html = render_to_string('users/email/welcome/html.ltxt',

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,6 +1,12 @@
 import collections
 import operator
 
+from allauth.account.adapter import get_adapter
+from allauth.account.models import EmailAddress
+from allauth.socialaccount import helpers
+from allauth.socialaccount.models import SocialAccount
+from allauth.socialaccount.views import SignupView as BaseSignupView
+from constance import config
 from django import forms
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
@@ -8,25 +14,18 @@ from django.contrib.auth.models import Group
 from django.core.paginator import Paginator
 from django.db import transaction
 from django.db.models import Q
-from django.http import Http404, HttpResponseForbidden, HttpResponseBadRequest
-from django.shortcuts import get_object_or_404, render, redirect
-
-from allauth.account.adapter import get_adapter
-from allauth.account.models import EmailAddress
-from allauth.socialaccount import helpers
-from allauth.socialaccount.models import SocialAccount
-from allauth.socialaccount.views import SignupView as BaseSignupView
-from constance import config
+from django.http import Http404, HttpResponseBadRequest, HttpResponseForbidden
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.translation import ugettext_lazy as _
 from honeypot.decorators import verify_honeypot_value
 from taggit.utils import parse_tags
-from tower import ugettext_lazy as _
 
 from kuma.core.decorators import login_required
 from kuma.demos.models import Submission
 from kuma.demos.views import DEMOS_PAGE_SIZE
 
-from .forms import UserBanForm, UserEditForm, NewsletterForm
-from .models import UserBan, User
+from .forms import NewsletterForm, UserBanForm, UserEditForm
+from .models import User, UserBan
 # we have to import the signup form here due to allauth's odd form subclassing
 # that requires providing a base form class (see ACCOUNT_SIGNUP_FORM_CLASS)
 from .signup import SignupForm

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -1,7 +1,8 @@
 import re
 
 import bleach
-from tower import ugettext_lazy as _lazy
+from django.utils.translation import ugettext_lazy as _
+
 
 ALLOWED_TAGS = bleach.ALLOWED_TAGS + [
     'div', 'span', 'p', 'br', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
@@ -202,13 +203,13 @@ KUMASCRIPT_TIMEOUT_ERROR = [
 # TODO: Put this under the control of Constance / Waffle?
 # Flags used to signify revisions in need of review
 REVIEW_FLAG_TAGS = (
-    ('technical', _lazy('Technical - code samples, APIs, or technologies')),
-    ('editorial', _lazy('Editorial - prose, grammar, or content')),
+    ('technical', _('Technical - code samples, APIs, or technologies')),
+    ('editorial', _('Editorial - prose, grammar, or content')),
 )
 REVIEW_FLAG_TAGS_DEFAULT = ['technical', 'editorial']
 
 LOCALIZATION_FLAG_TAGS = (
-    ('inprogress', _lazy('Localization in progress - not completely translated yet.')),
+    ('inprogress', _('Localization in progress - not completely translated yet.')),
 )
 
 # TODO: This is info derived from urls.py, but unsure how to DRY it

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -1,20 +1,21 @@
 # -*- coding: utf-8 -*-
-from collections import defaultdict
 import re
 import urllib
+from collections import defaultdict
 from urllib import urlencode
 from urlparse import urlparse
 
 import html5lib
-from html5lib.filters._base import Filter as html5lib_Filter
 import newrelic.agent
+from django.utils.translation import ugettext
+from html5lib.filters._base import Filter as html5lib_Filter
 from lxml import etree
 from pyquery import PyQuery as pq
 
-from tower import ugettext as _
-
 from kuma.core.urlresolvers import reverse
+
 from .utils import locale_and_slug_from_path
+
 
 # A few regex patterns for various parsing efforts in this file
 MACRO_RE = re.compile(r'\{\{\s*([^\(\} ]+)', re.MULTILINE)
@@ -690,7 +691,7 @@ class SectionEditLinkFilter(html5lib_Filter):
                         ts = ({'type': 'StartTag',
                                'name': 'a',
                                'data': {
-                                   (None, u'title'): _('Edit section'),
+                                   (None, u'title'): ugettext('Edit section'),
                                    (None, u'class'): 'edit-section',
                                    (None, u'data-section-id'): value,
                                    (None, u'data-section-src-url'): u'%s?%s' % (
@@ -709,7 +710,7 @@ class SectionEditLinkFilter(html5lib_Filter):
                                    )
                                }},
                               {'type': 'Characters',
-                               'data': _(u'Edit')},
+                               'data': ugettext(u'Edit')},
                               {'type': 'EndTag', 'name': 'a'})
                         for t in ts:
                             yield t

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -1,13 +1,13 @@
 import logging
 
-from tower import ugettext as _
+from django.utils.translation import ugettext
+from tidings.events import InstanceEvent
 
 from kuma.core.email_utils import emails_with_users_and_watches
 from kuma.core.helpers import add_utm
 from kuma.core.urlresolvers import reverse
-from tidings.events import InstanceEvent
 
-from .helpers import revisions_unified_diff, get_compare_url
+from .helpers import get_compare_url, revisions_unified_diff
 from .models import Document
 
 
@@ -68,7 +68,8 @@ class EditDocumentEvent(InstanceEvent):
         document = revision.document
         log.debug('Sending edited notification email for document (id=%s)' %
                   document.id)
-        subject = _(u'[MDN] Page "{document_title}" changed by {creator}')
+        subject = ugettext(
+            u'[MDN] Page "{document_title}" changed by {creator}')
         context = context_dict(revision)
 
         return emails_with_users_and_watches(

--- a/kuma/wiki/helpers.py
+++ b/kuma/wiki/helpers.py
@@ -6,18 +6,17 @@ import urllib
 import urlparse
 
 import jinja2
+from constance import config
 from cssselect.parser import SelectorSyntaxError
-from pyquery import PyQuery as pq
-from tower import ugettext as _
-
 from django.contrib.sites.models import Site
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.html import conditional_escape
-
-from constance import config
+from django.utils.translation import ugettext
 from jingo import register
+from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
+
 from .constants import DIFF_WRAP_COLUMN
 from .jobs import DocumentZoneStackJob
 from .utils import tidy_content
@@ -98,13 +97,13 @@ def diff_table(content_from, content_to, prev_id, curr_id, tidy=False):
     try:
         diff = html_diff.make_table(content_from.splitlines(),
                                     content_to.splitlines(),
-                                    _('Revision %s') % prev_id,
-                                    _('Revision %s') % curr_id,
+                                    ugettext('Revision %s') % prev_id,
+                                    ugettext('Revision %s') % curr_id,
                                     context=True,
                                     numlines=config.DIFF_CONTEXT_LINES)
     except RuntimeError:
         # some diffs hit a max recursion error
-        message = _(u'There was an error generating the content.')
+        message = ugettext(u'There was an error generating the content.')
         diff = '<div class="warning"><p>%s</p></div>' % message
     return jinja2.Markup(diff)
 
@@ -114,8 +113,8 @@ def tag_diff_table(prev_tags, curr_tags, prev_id, curr_id):
     html_diff = difflib.HtmlDiff(wrapcolumn=DIFF_WRAP_COLUMN)
 
     diff = html_diff.make_table([prev_tags], [curr_tags],
-                                _('Revision %s') % prev_id,
-                                _('Revision %s') % curr_id)
+                                ugettext('Revision %s') % prev_id,
+                                ugettext('Revision %s') % curr_id)
 
     # Simple formatting update: 784877
     diff = diff.replace('",', '"<br />').replace('<td', '<td valign="top"')

--- a/kuma/wiki/management/commands/generate_sphinx_template.py
+++ b/kuma/wiki/management/commands/generate_sphinx_template.py
@@ -1,11 +1,9 @@
-from html5lib import constants as html5lib_constants
-
 from django.conf import settings
 from django.core.management.base import NoArgsCommand
 from django.shortcuts import render
 from django.test import RequestFactory
-
-from tower import ugettext as _
+from django.utils.translation import ugettext
+from html5lib import constants as html5lib_constants
 
 from kuma.wiki.content import parse
 
@@ -30,8 +28,8 @@ class Command(NoArgsCommand):
         request.META['SERVER_NAME'] = 'developer.mozilla.org'
 
         # Load the page with sphinx template
-        content = render(request, 'wiki/sphinx.html', {'is_sphinx': True,
-                                                       'gettext': _}).content
+        content = render(request, 'wiki/sphinx.html',
+                         {'is_sphinx': True, 'gettext': ugettext}).content
 
         # Use a filter to make links absolute
         tool = parse(content, is_full_document=True)

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -111,8 +111,8 @@ def valid_slug_parent(slug, locale):
             parent = Document.objects.get(locale=locale, slug=parent_slug)
         except Document.DoesNotExist:
             raise Exception(
-                ugettext("Parent %s/%s does not exist." % (locale,
-                                                           parent_slug)))
+                ugettext('Parent %s does not exist.' % (
+                    '%s/%s' % (locale, parent_slug))))
 
     return parent
 
@@ -120,8 +120,8 @@ def valid_slug_parent(slug, locale):
 class DocumentTag(TagBase):
     """A tag indexing a document"""
     class Meta:
-        verbose_name = ugettext("Document Tag")
-        verbose_name_plural = ugettext("Document Tags")
+        verbose_name = _('Document Tag')
+        verbose_name_plural = _('Document Tags')
 
 
 def tags_for(cls, model, instance=None, **extra_filters):
@@ -1506,15 +1506,15 @@ class DocumentZone(models.Model):
 class ReviewTag(TagBase):
     """A tag indicating review status, mainly for revisions"""
     class Meta:
-        verbose_name = ugettext("Review Tag")
-        verbose_name_plural = ugettext("Review Tags")
+        verbose_name = _('Review Tag')
+        verbose_name_plural = _('Review Tags')
 
 
 class LocalizationTag(TagBase):
     """A tag indicating localization status, mainly for revisions"""
     class Meta:
-        verbose_name = ugettext("Localization Tag")
-        verbose_name_plural = ugettext("Localization Tags")
+        verbose_name = _('Localization Tag')
+        verbose_name_plural = _('Localization Tags')
 
 
 class ReviewTaggedRevision(ItemBase):
@@ -1655,7 +1655,6 @@ class Revision(models.Model):
                     old = self.based_on
                     self.based_on = based_on  # Guess a correct value.
                     locale = settings.LOCALES[settings.WIKI_DEFAULT_LANGUAGE].native
-                    # TODO(erik): This error message ignores non-translations.
                     error = ugettext(
                         'A revision must be based on a revision of the '
                         '%(locale)s document. Revision ID %(id)s does '

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -3,25 +3,20 @@ import json
 import sys
 import traceback
 from datetime import datetime, timedelta
-
-try:
-    from functools import wraps
-except ImportError:
-    from django.utils.functional import wraps
+from functools import wraps
 
 import newrelic.agent
-from pyquery import PyQuery
-from tower import ugettext_lazy as _lazy, ugettext as _
-
+import waffle
+from constance import config
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.db.models import signals
 from django.utils.decorators import available_attrs
 from django.utils.functional import cached_property
-
-import waffle
-from constance import config
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
+from pyquery import PyQuery
 from taggit.managers import TaggableManager
 from taggit.models import ItemBase, TagBase
 from taggit.utils import edit_string_for_tags, parse_tags
@@ -116,8 +111,8 @@ def valid_slug_parent(slug, locale):
             parent = Document.objects.get(locale=locale, slug=parent_slug)
         except Document.DoesNotExist:
             raise Exception(
-                _("Parent %s/%s does not exist." % (locale,
-                                                    parent_slug)))
+                ugettext("Parent %s/%s does not exist." % (locale,
+                                                           parent_slug)))
 
     return parent
 
@@ -125,8 +120,8 @@ def valid_slug_parent(slug, locale):
 class DocumentTag(TagBase):
     """A tag indexing a document"""
     class Meta:
-        verbose_name = _("Document Tag")
-        verbose_name_plural = _("Document Tags")
+        verbose_name = ugettext("Document Tag")
+        verbose_name_plural = ugettext("Document Tags")
 
 
 def tags_for(cls, model, instance=None, **extra_filters):
@@ -179,8 +174,8 @@ class DocumentAttachment(models.Model):
 class Document(NotificationsMixin, models.Model):
     """A localized knowledgebase document, not revision-specific."""
     CATEGORIES = (
-        (00, _lazy(u'Uncategorized')),
-        (10, _lazy(u'Reference')),
+        (00, _(u'Uncategorized')),
+        (10, _(u'Reference')),
     )
     TOC_FILTERS = {
         1: SectionTOCFilter,
@@ -768,7 +763,7 @@ class Document(NotificationsMixin, models.Model):
             # All we really need to do here is make sure category != '' (which
             # is what it is when it's missing from the DocumentForm). The extra
             # validation is just a nicety.
-            raise ValidationError(_('Please choose a category.'))
+            raise ValidationError(ugettext('Please choose a category.'))
         else:  # An article cannot have both a parent and children.
             # Make my children the same as me:
             if self.id:
@@ -1511,15 +1506,15 @@ class DocumentZone(models.Model):
 class ReviewTag(TagBase):
     """A tag indicating review status, mainly for revisions"""
     class Meta:
-        verbose_name = _("Review Tag")
-        verbose_name_plural = _("Review Tags")
+        verbose_name = ugettext("Review Tag")
+        verbose_name_plural = ugettext("Review Tags")
 
 
 class LocalizationTag(TagBase):
     """A tag indicating localization status, mainly for revisions"""
     class Meta:
-        verbose_name = _("Localization Tag")
-        verbose_name_plural = _("Localization Tags")
+        verbose_name = ugettext("Localization Tag")
+        verbose_name_plural = ugettext("Localization Tags")
 
 
 class ReviewTaggedRevision(ItemBase):
@@ -1552,11 +1547,11 @@ class Revision(models.Model):
     TOC_DEPTH_H4 = 4
 
     TOC_DEPTH_CHOICES = (
-        (TOC_DEPTH_NONE, _lazy(u'No table of contents')),
-        (TOC_DEPTH_ALL, _lazy(u'All levels')),
-        (TOC_DEPTH_H2, _lazy(u'H2 and higher')),
-        (TOC_DEPTH_H3, _lazy(u'H3 and higher')),
-        (TOC_DEPTH_H4, _lazy('H4 and higher')),
+        (TOC_DEPTH_NONE, _(u'No table of contents')),
+        (TOC_DEPTH_ALL, _(u'All levels')),
+        (TOC_DEPTH_H2, _(u'H2 and higher')),
+        (TOC_DEPTH_H3, _(u'H3 and higher')),
+        (TOC_DEPTH_H4, _('H4 and higher')),
     )
 
     document = models.ForeignKey(Document, related_name='revisions')
@@ -1661,9 +1656,10 @@ class Revision(models.Model):
                     self.based_on = based_on  # Guess a correct value.
                     locale = settings.LOCALES[settings.WIKI_DEFAULT_LANGUAGE].native
                     # TODO(erik): This error message ignores non-translations.
-                    error = _('A revision must be based on a revision of the '
-                              '%(locale)s document. Revision ID %(id)s does '
-                              'not fit those criteria.')
+                    error = ugettext(
+                        'A revision must be based on a revision of the '
+                        '%(locale)s document. Revision ID %(id)s does '
+                        'not fit those criteria.')
                     raise ValidationError(error %
                                           {'locale': locale, 'id': old.id})
 
@@ -1818,11 +1814,11 @@ class DocumentSpamAttempt(SpamAttempt):
     to see where it happens.
     """
     title = models.CharField(
-        verbose_name=_('Title'),
+        verbose_name=ugettext('Title'),
         max_length=255,
     )
     slug = models.CharField(
-        verbose_name=_('Slug'),
+        verbose_name=ugettext('Slug'),
         max_length=255,
     )
     document = models.ForeignKey(
@@ -1830,7 +1826,7 @@ class DocumentSpamAttempt(SpamAttempt):
         related_name='spam_attempts',
         null=True,
         blank=True,
-        verbose_name=_('Document (optional)')
+        verbose_name=ugettext('Document (optional)')
     )
 
     def __unicode__(self):

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-from tower import ugettext as _
-
 from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError, transaction
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.translation import ugettext
 
-from kuma.core.decorators import login_required, permission_required, block_user_agents
+from kuma.core.decorators import (block_user_agents, login_required,
+                                  permission_required)
 from kuma.core.urlresolvers import reverse
 
 from ..decorators import check_readonly, process_document_path
 from ..forms import DocumentDeletionForm
-from ..models import Document, Revision, DocumentDeletionLog
+from ..models import Document, DocumentDeletionLog, Revision
 from ..utils import locale_and_slug_from_path
 
 
@@ -47,9 +47,10 @@ def revert_document(request, document_path, revision_id):
                 {
                     'revision': revision,
                     'document': revision.document,
-                    'error': _("Document already exists. Note: You cannot "
-                               "revert a document that has been moved until you "
-                               "delete its redirect.")
+                    'error': ugettext(
+                        "Document already exists. Note: You cannot "
+                        "revert a document that has been moved until you "
+                        "delete its redirect.")
                 }
             )
         return redirect('wiki.document_revisions', revision.document.slug)

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -3,29 +3,26 @@ import textwrap
 from urllib import urlencode
 
 import newrelic.agent
-from tower import ugettext as _
-
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse
-from django.shortcuts import get_object_or_404, render, redirect
+from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.translation import ugettext
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
-
 from jingo.helpers import urlparams
 from ratelimit.decorators import ratelimit
 
+import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
-from kuma.core.decorators import never_cache, login_required, block_user_agents
+from kuma.core.decorators import block_user_agents, login_required, never_cache
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import limit_banned_ip_to_0
 
-import kuma.wiki.content
-from ..decorators import (check_readonly, process_document_path,
-                          prevent_indexing)
+from ..decorators import (check_readonly, prevent_indexing,
+                          process_document_path)
 from ..forms import DocumentForm, RevisionForm
 from ..models import Document, Revision
-
 from .translate import translate
 from .utils import document_form_initial, split_slug
 
@@ -115,7 +112,7 @@ def edit(request, document_slug, document_locale, revision_id=None):
 
     section_id = request.GET.get('section', None)
     if section_id and not request.is_ajax():
-        return HttpResponse(_("Sections may only be edited inline."))
+        return HttpResponse(ugettext("Sections may only be edited inline."))
     disclose_description = bool(request.GET.get('opendescription'))
 
     doc_form = rev_form = None

--- a/kuma/wiki/views/misc.py
+++ b/kuma/wiki/views/misc.py
@@ -1,25 +1,23 @@
 # -*- coding: utf-8 -*-
 import newrelic.agent
-from tower import ugettext_lazy as _lazy, ugettext as _
-
 from django.contrib import messages
 from django.db.models import Q
 from django.http import HttpResponseBadRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.decorators.http import require_GET, require_POST
+from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import ugettext
 from django.views.decorators.clickjacking import xframe_options_sameorigin
-
+from django.views.decorators.http import require_GET, require_POST
 from smuggler.forms import ImportForm
 
-from kuma.contentflagging.models import ContentFlag, FLAG_NOTIFICATIONS
-
-from kuma.core.decorators import superuser_required, block_user_agents
+from kuma.contentflagging.models import FLAG_NOTIFICATIONS, ContentFlag
+from kuma.core.decorators import block_user_agents, superuser_required
 from kuma.users.models import User
 
-from ..constants import REDIRECT_CONTENT, ALLOWED_TAGS
-from ..decorators import process_document_path, allow_CORS_GET
+from ..constants import ALLOWED_TAGS, REDIRECT_CONTENT
+from ..decorators import allow_CORS_GET, process_document_path
 from ..forms import DocumentContentFlagForm
-from ..models import Document, HelpfulVote, EditorToolbar
+from ..models import Document, EditorToolbar, HelpfulVote
 from ..utils import locale_and_slug_from_path
 
 
@@ -58,9 +56,9 @@ def autosuggest_documents(request):
     if not partial_title:
         # Only handle actual autosuggest requests, not requests for a
         # memory-busting list of all documents.
-        return HttpResponseBadRequest(_lazy('Autosuggest requires a partial '
-                                            'title. For a full document '
-                                            'index, see the main page.'))
+        return HttpResponseBadRequest(_('Autosuggest requires a partial '
+                                        'title. For a full document '
+                                        'index, see the main page.'))
 
     # Retrieve all documents that aren't redirects or templates
     docs = (Document.objects.extra(select={'length': 'Length(slug)'})
@@ -140,10 +138,12 @@ def helpful_vote(request, document_path):
 
         if 'helpful' in request.POST:
             vote.helpful = True
-            message = _('Glad to hear it &mdash; thanks for the feedback!')
+            message = ugettext(
+                'Glad to hear it &mdash; thanks for the feedback!')
         else:
-            message = _('Sorry to hear that. Perhaps one of the solutions '
-                        'below can help.')
+            message = ugettext(
+                'Sorry to hear that. Perhaps one of the solutions '
+                'below can help.')
 
         if request.user.is_authenticated():
             vote.creator = request.user
@@ -152,7 +152,7 @@ def helpful_vote(request, document_path):
 
         vote.save()
     else:
-        message = _('You already voted on this Article.')
+        message = ugettext('You already voted on this Article.')
 
     if request.is_ajax():
         return JsonResponse({'message': message})
@@ -183,11 +183,11 @@ def load_documents(request):
             # Try to import the data, but report any error that occurs.
             try:
                 counter = Document.objects.load_json(request.user, file_data)
-                user_msg = (_('%(obj_count)d object(s) loaded.') %
+                user_msg = (ugettext('%(obj_count)d object(s) loaded.') %
                             {'obj_count': counter, })
                 messages.add_message(request, messages.INFO, user_msg)
             except Exception as e:
-                err_msg = (_('Failed to import data: %(error)s') %
+                err_msg = (ugettext('Failed to import data: %(error)s') %
                            {'error': '%s' % e, })
                 messages.add_message(request, messages.ERROR, err_msg)
 

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
 import newrelic.agent
-from tower import ugettext_lazy as _lazy
-
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
-from django.views.decorators.http import require_GET, require_POST
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_sameorigin
-
+from django.views.decorators.http import require_GET, require_POST
 from ratelimit.decorators import ratelimit
-from kuma.core.decorators import login_required, block_user_agents
+
+from kuma.core.decorators import block_user_agents, login_required
 from kuma.core.utils import smart_int
 
 from .. import kumascript
-from ..decorators import process_document_path, prevent_indexing
+from ..decorators import prevent_indexing, process_document_path
 from ..helpers import format_comment
 from ..models import Document, Revision
 
@@ -138,7 +137,7 @@ def quick_review(request, document_slug, document_locale):
         # Ideal is to kick them to the diff view, but that expects
         # fully-filled-out editing forms, and we don't have those
         # here.
-        raise PermissionDenied(_lazy("Document has been edited; please re-review."))
+        raise PermissionDenied(_("Document has been edited; please re-review."))
 
     needs_technical = rev.needs_technical_review
     needs_editorial = rev.needs_editorial_review

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -1,24 +1,22 @@
 # -*- coding: utf-8 -*-
-from tower import ugettext_lazy as _lazy
-
 from django.conf import settings
-from django.core.exceptions import PermissionDenied, ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
-
+from django.utils.translation import ugettext_lazy as _
 from jingo.helpers import urlparams
 
+import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
+from kuma.core.decorators import block_user_agents, login_required, never_cache
 from kuma.core.i18n import get_language_mapping
-from kuma.core.decorators import never_cache, login_required, block_user_agents
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import get_object_or_none, smart_int
 
-import kuma.wiki.content
-from ..decorators import (check_readonly, process_document_path,
-                          prevent_indexing)
+from ..decorators import (check_readonly, prevent_indexing,
+                          process_document_path)
 from ..forms import DocumentForm, RevisionForm
 from ..models import Document, Revision
-from .utils import split_slug, document_form_initial
+from .utils import document_form_initial, split_slug
 
 
 @block_user_agents
@@ -72,7 +70,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
             args=[parent_doc.slug]))
 
     if not parent_doc.is_localizable:
-        message = _lazy(u'You cannot translate this document.')
+        message = _(u'You cannot translate this document.')
         context = {'message': message}
         return render(request, 'handlers/400.html', context, status=400)
 

--- a/requirements/packages.txt
+++ b/requirements/packages.txt
@@ -9,6 +9,8 @@ Babel==2.0
 
 BeautifulSoup==3.2.1
 
+django-babel==0.4.0
+
 django-picklefield==0.3.1
 
 feedparser==5.2.1

--- a/requirements/source.txt
+++ b/requirements/source.txt
@@ -54,7 +54,7 @@ requests==2.7.0
 
 requests-oauthlib==0.5.0
 
-tower==0.4.1
+puente==0.3
 
 urllib3==1.11
 

--- a/settings.py
+++ b/settings.py
@@ -463,7 +463,7 @@ INSTALLED_APPS = (
     # util
     'pipeline',
     'product_details',
-    'tower',
+    'puente',
     'smuggler',
     'constance.backends.database',
     'constance',
@@ -504,11 +504,17 @@ def JINJA_CONFIG():
     from django.core.cache.backends.memcached import MemcachedCache
     from django.core.cache import caches
     cache = caches['memcache']
-    config = {'extensions': ['jinja2.ext.i18n', 'tower.template.i18n',
-                             'jinja2.ext.with_', 'jinja2.ext.loopcontrols',
-                             'jinja2.ext.autoescape',
-                             'pipeline.templatetags.ext.PipelineExtension'],
-              'finalize': lambda x: x if x is not None else ''}
+    config = {
+        'extensions': [
+            'jinja2.ext.i18n',
+            'puente.ext.i18n',
+            'jinja2.ext.with_',
+            'jinja2.ext.loopcontrols',
+            'jinja2.ext.autoescape',
+            'pipeline.templatetags.ext.PipelineExtension'
+        ],
+        'finalize': lambda x: x if x is not None else ''
+    }
     if isinstance(cache, MemcachedCache) and not settings.DEBUG:
         # We're passing the _cache object directly to jinja because
         # Django can't store binary directly; it enforces unicode on it.
@@ -520,34 +526,26 @@ def JINJA_CONFIG():
         config['bytecode_cache'] = bc
     return config
 
-# Let Tower know about our additional keywords.
-# DO NOT import an ngettext variant as _lazy.
-TOWER_KEYWORDS = {
-    '_lazy': None,
+PUENTE = {
+    'BASE_DIR': ROOT,
+    # Tells the extract script what files to look for l10n in and what function
+    # handles the extraction.
+    'DOMAIN_METHODS': {
+        'django': [
+            ('vendor/**', 'ignore'),
+            ('kuma/**.py', 'python'),
+            ('kuma/demos/templates/admin/**.html',
+             'django_babel.extract.extract_django'),
+            ('**/templates/**.html', 'jinja2'),
+            ('**/templates/**.ltxt', 'jinja2'),
+        ],
+        'javascript': [
+            # We can't say **.js because that would dive into any libraries.
+            ('kuma/static/js/libs/ckeditor/plugins/mdn-link/**.js',
+             'javascript')
+        ],
+    },
 }
-
-# Tells the extract script what files to look for l10n in and what function
-# handles the extraction.  The Tower library expects this.
-DOMAIN_METHODS = {
-    'django': [
-        ('vendor/**', 'ignore'),
-        ('kuma/dashboards/**', 'ignore'),
-        ('kuma/core/**', 'ignore'),
-        ('kuma/**.py',
-            'tower.management.commands.extract.extract_tower_python'),
-        ('**/templates/**.html',
-            'tower.management.commands.extract.extract_tower_template'),
-        ('**/templates/**.ltxt',
-            'tower.management.commands.extract.extract_tower_template'),
-    ],
-    'javascript': [
-        # We can't say **.js because that would dive into any libraries.
-        ('kuma/static/js/libs/ckeditor/plugins/mdn-link/**.js', 'javascript')
-    ],
-}
-
-# Override tower's default to match Django's default.
-TEXT_DOMAIN = 'django'
 
 # These domains will not be merged into messages.pot and will use separate PO
 # files. See the following URL for an example of how to set these domains
@@ -555,10 +553,6 @@ TEXT_DOMAIN = 'django'
 # http://github.com/jbalogh/zamboni/blob/d4c64239c24aa2f1e91276909823d1d1b290f0ee/settings.py#L254
 STANDALONE_DOMAINS = ['django', 'javascript']
 STATICI18N_DOMAIN = 'javascript'
-
-# If you have trouble extracting strings with Tower, try setting this
-# to True
-TOWER_ADD_HEADERS = True
 
 PIPELINE_COMPILERS = (
     'pipeline.compilers.stylus.StylusCompiler',

--- a/urls.py
+++ b/urls.py
@@ -1,10 +1,12 @@
-from django.conf.urls import include, url
+import jingo
+import jingo.monkey
 from django.conf import settings
+from django.conf.urls import include, url
 from django.contrib import admin
 from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.shortcuts import redirect
+from django.utils import translation
 from django.views.static import serve
-import jingo.monkey
 
 from kuma.attachments import views as attachment_views
 from kuma.contentflagging.views import flagged
@@ -12,7 +14,10 @@ from kuma.core import views as core_views
 from kuma.wiki.admin import purge_view
 from kuma.wiki.views.legacy import mindtouch_to_kuma_redirect
 
+
 jingo.monkey.patch()
+jingo.env.install_gettext_translations(translation, newstyle=True)
+
 admin.autodiscover()
 
 handler403 = core_views.handler403

--- a/vendor/kuma.pth
+++ b/vendor/kuma.pth
@@ -39,6 +39,8 @@ src/jingo
 src/jingo-minify
 src/kombu
 src/oauthlib
+src/pipeline
+src/puente
 src/py-amqp
 src/pyquery
 src/python-dateutil
@@ -51,8 +53,6 @@ src/requests
 src/requests-oauthlib
 src/responses
 src/sqlparse
-src/tower
 src/urllib3
 src/urlobject
 src/werkzeug
-src/pipeline

--- a/vendor/packages/django_babel/__init__.py
+++ b/vendor/packages/django_babel/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+__version__ = '1.0-dev'

--- a/vendor/packages/django_babel/extract.py
+++ b/vendor/packages/django_babel/extract.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+try:
+    from django.template import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+except ImportError:
+    # Django 1.8 moved most stuff to .base
+    from django.template.base import Lexer, TOKEN_TEXT, TOKEN_VAR, TOKEN_BLOCK
+
+from django.utils.translation.trans_real import (
+    inline_re, block_re, endblock_re, plural_re, constant_re)
+from django.utils.encoding import smart_text
+
+
+def extract_django(fileobj, keywords, comment_tags, options):
+    """Extract messages from Django template files.
+
+    :param fileobj: the file-like object the messages should be extracted from
+    :param keywords: a list of keywords (i.e. function names) that should
+                     be recognized as translation functions
+    :param comment_tags: a list of translator tags to search for and
+                         include in the results
+    :param options: a dictionary of additional options (optional)
+    :return: an iterator over ``(lineno, funcname, message, comments)``
+             tuples
+    :rtype: ``iterator``
+    """
+    intrans = False
+    inplural = False
+    singular = []
+    plural = []
+    lineno = 1
+
+    encoding = options.get('encoding', 'utf8')
+    text = fileobj.read().decode(encoding)
+
+    for t in Lexer(text, None).tokenize():
+        lineno += t.contents.count('\n')
+        if intrans:
+            if t.token_type == TOKEN_BLOCK:
+                endbmatch = endblock_re.match(t.contents)
+                pluralmatch = plural_re.match(t.contents)
+                if endbmatch:
+                    if inplural:
+                        yield (
+                            lineno,
+                            'ngettext',
+                            (smart_text(u''.join(singular)),
+                             smart_text(u''.join(plural))),
+                            [])
+                    else:
+                        yield (
+                            lineno,
+                            None,
+                            smart_text(u''.join(singular)),
+                            [])
+
+                    intrans = False
+                    inplural = False
+                    singular = []
+                    plural = []
+                elif pluralmatch:
+                    inplural = True
+                else:
+                    raise SyntaxError('Translation blocks must not include '
+                                      'other block tags: %s' % t.contents)
+            elif t.token_type == TOKEN_VAR:
+                if inplural:
+                    plural.append('%%(%s)s' % t.contents)
+                else:
+                    singular.append('%%(%s)s' % t.contents)
+            elif t.token_type == TOKEN_TEXT:
+                if inplural:
+                    plural.append(t.contents)
+                else:
+                    singular.append(t.contents)
+        else:
+            if t.token_type == TOKEN_BLOCK:
+                imatch = inline_re.match(t.contents)
+                bmatch = block_re.match(t.contents)
+                cmatches = constant_re.findall(t.contents)
+                if imatch:
+                    g = imatch.group(1)
+                    if g[0] == '"':
+                        g = g.strip('"')
+                    elif g[0] == "'":
+                        g = g.strip("'")
+                    yield lineno, None, smart_text(g), []
+                elif bmatch:
+                    for fmatch in constant_re.findall(t.contents):
+                        yield lineno, None, smart_text(fmatch), []
+                    intrans = True
+                    inplural = False
+                    singular = []
+                    plural = []
+                elif cmatches:
+                    for cmatch in cmatches:
+                        yield lineno, None, smart_text(cmatch), []
+            elif t.token_type == TOKEN_VAR:
+                parts = t.contents.split('|')
+                cmatch = constant_re.match(parts[0])
+                if cmatch:
+                    yield lineno, None, smart_text(cmatch.group(1)), []
+                for p in parts[1:]:
+                    if p.find(':_(') >= 0:
+                        p1 = p.split(':', 1)[1]
+                        if p1[0] == '_':
+                            p1 = p1[1:]
+                        if p1[0] == '(':
+                            p1 = p1.strip('()')
+                        if p1[0] == "'":
+                            p1 = p1.strip("'")
+                        elif p1[0] == '"':
+                            p1 = p1.strip('"')
+                        yield lineno, None, smart_text(p1), []

--- a/vendor/packages/django_babel/management/commands/babel.py
+++ b/vendor/packages/django_babel/management/commands/babel.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+import os
+from distutils.dist import Distribution
+from optparse import make_option
+from subprocess import call
+
+from django.core.management.base import LabelCommand, CommandError
+from django.conf import settings
+
+
+class Command(LabelCommand):
+
+    args = '[makemessages] [compilemessages]'
+
+    option_list = LabelCommand.option_list + (
+        make_option(
+            '--locale', '-l',
+            default=None, dest='locale', action='append',
+            help='Creates or updates the message files for the given locale(s)'
+                 ' (e.g pt_BR). Can be used multiple times.'),
+        make_option('--domain', '-d',
+            default='django', dest='domain',
+            help='The domain of the message files (default: "django").'),
+        make_option('--mapping-file', '-F',
+            default=None, dest='mapping_file',
+            help='Mapping file')
+    )
+
+    def handle_label(self, command, **options):
+        if command not in ('makemessages', 'compilemessages'):
+            raise CommandError(
+                "You must either apply 'makemessages' or 'compilemessages'"
+            )
+
+        if command == 'makemessages':
+            self.handle_makemessages(**options)
+        if command == 'compilemessages':
+            self.handle_compilemessages(**options)
+
+    def handle_makemessages(self, **options):
+        locale_paths = list(settings.LOCALE_PATHS)
+        domain = options.pop('domain')
+        locales = options.pop('locale')
+
+        # support for mapping file specification via setup.cfg
+        # TODO: Try to support all possible options.
+        distribution = Distribution()
+        distribution.parse_config_files(distribution.find_config_files())
+
+        mapping_file = options.pop('mapping_file', None)
+        has_extract = 'extract_messages' in distribution.command_options
+        if mapping_file is None and has_extract:
+            opts = distribution.command_options['extract_messages']
+            try:
+                mapping_file = opts['mapping_file'][1]
+            except (IndexError, KeyError):
+                mapping_file = None
+
+        for path in locale_paths:
+            potfile = os.path.join(path, '%s.pot' % domain)
+
+            if not os.path.exists(path):
+                os.makedirs(path)
+
+            if not os.path.exists(potfile):
+                with open(potfile, 'wb') as fobj:
+                    fobj.write(b'')
+
+            cmd = ['pybabel', 'extract', '-o', potfile]
+
+            if mapping_file is not None:
+                cmd.extend(['-F', mapping_file])
+
+            cmd.append(os.path.dirname(os.path.relpath(path)))
+
+            call(cmd)
+
+            for locale in locales:
+                pofile = os.path.join(
+                    os.path.dirname(potfile),
+                    locale,
+                    'LC_MESSAGES',
+                    '%s.po' % domain)
+
+                if not os.path.isdir(os.path.dirname(pofile)):
+                    os.makedirs(os.path.dirname(pofile))
+
+                if not os.path.exists(pofile):
+                    with open(pofile, 'wb') as fobj:
+                        fobj.write(b'')
+
+                cmd = ['pybabel', 'update', '-D', domain,
+                       '-i', potfile,
+                       '-d', os.path.relpath(path),
+                       '-l', locale]
+                call(cmd)
+
+    def handle_compilemessages(self, **options):
+        locale_paths = list(settings.LOCALE_PATHS)
+        domain = options.pop('domain')
+        locales = options.pop('locale')
+
+        for path in locale_paths:
+            for locale in locales:
+                po_file = os.path.join(
+                    path, locale, 'LC_MESSAGES', domain + '.po'
+                )
+                if os.path.exists(po_file):
+                    cmd = ['pybabel', 'compile', '-D', domain,
+                           '-d', path, '-l', locale]
+                    call(cmd)

--- a/vendor/packages/django_babel/middleware.py
+++ b/vendor/packages/django_babel/middleware.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+from babel import Locale, UnknownLocaleError
+from django.utils.translation import get_language
+try:
+    from threading import local
+except ImportError:
+    from django.utils._threading_local import local
+
+
+__all__ = ['get_current_locale', 'LocaleMiddleware']
+
+_thread_locals = local()
+
+
+def get_current_locale():
+    """Get current locale data outside views.
+
+    See http://babel.pocoo.org/docs/api/core/#babel.core.Locale for Locale
+    objects documentation
+    """
+    return getattr(_thread_locals, 'locale', None)
+
+
+class LocaleMiddleware(object):
+
+    """Simple Django middleware that makes available a Babel `Locale` object
+    via the `request.locale` attribute.
+    """
+
+    def process_request(self, request):
+        try:
+            code = getattr(request, 'LANGUAGE_CODE', get_language())
+            locale = Locale.parse(code, sep='-')
+        except (ValueError, UnknownLocaleError):
+            pass
+        else:
+            _thread_locals.locale = request.locale = locale

--- a/vendor/packages/django_babel/templatetags/__init__.py
+++ b/vendor/packages/django_babel/templatetags/__init__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2007 Edgewall Software
+# All rights reserved.
+#
+# This software is licensed as described in the file COPYING, which
+# you should have received as part of this distribution. The terms
+# are also available at http://babel.edgewall.org/wiki/License.
+#
+# This software consists of voluntary contributions made by many
+# individuals. For the exact contribution history, see the revision
+# history and logs, available at http://babel.edgewall.org/log/.

--- a/vendor/packages/django_babel/templatetags/babel.py
+++ b/vendor/packages/django_babel/templatetags/babel.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+from django.conf import settings
+from django.template import Library
+from django.utils.translation import to_locale, get_language
+try:
+    from pytz import timezone
+except ImportError:
+    timezone = None
+
+from django_babel.middleware import get_current_locale
+
+babel = __import__('babel', {}, {}, ['core', 'support'])
+Format = babel.support.Format
+Locale = babel.core.Locale
+
+register = Library()
+
+
+def _get_format():
+    locale = get_current_locale()
+    if not locale:
+        locale = Locale.parse(to_locale(get_language()))
+    if timezone:
+        tzinfo = timezone(settings.TIME_ZONE)
+    else:
+        tzinfo = None
+    return Format(locale, tzinfo)
+
+
+def datefmt(date=None, format='medium'):
+    return _get_format().date(date, format=format)
+datefmt = register.filter(datefmt)
+
+
+def datetimefmt(datetime=None, format='medium'):
+    return _get_format().datetime(datetime, format=format)
+datetimefmt = register.filter(datetimefmt)
+
+
+def timefmt(time=None, format='medium'):
+    return _get_format().time(time, format=format)
+timefmt = register.filter(timefmt)
+
+
+def numberfmt(number):
+    return _get_format().number(number)
+numberfmt = register.filter(numberfmt)
+
+
+def decimalfmt(number, format=None):
+    return _get_format().decimal(number, format=format)
+decimalfmt = register.filter(decimalfmt)
+
+
+def currencyfmt(number, currency):
+    return _get_format().currency(number, currency)
+currencyfmt = register.filter(currencyfmt)
+
+
+def percentfmt(number, format=None):
+    return _get_format().percent(number, format=format)
+percentfmt = register.filter(percentfmt)
+
+
+def scientificfmt(number):
+    return _get_format().scientific(number)
+scientificfmt = register.filter(scientificfmt)


### PR DESCRIPTION
The puente project is a new project that should act as a bridge ("puente" is Spanish for "bridge") from tower to a completely vanilla Django/Jinja2 project. The goal of puente is to not exist but for now it provides some of the same utilities that tower provided in a nicer package.

We can spot-check the .pot files changes if you check out this branch and run `./manage.py extract`. The changes should be minimal but there may be some text wrapping differences (since babel wraps slightly differently than translate-toolkit) and some new strings (since this fixes some wrongly ignored paths and broken templates).

Todo:
- [ ] Re-run extract/merge before merging. This causes a lot of rebasing as new l10n commits come in so I'm not including it here for now.