### PR TITLE
Bug 1139490: Improve local Pipeline performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ kuma/static/js/libs/ckeditor/source/ckbuilder
 htmlcov/
 locale/**/*.mo
 /bower_components
+build/assets/css/*
+!build/assets/css/README.md

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ web: make clean && python2.7 manage.py runserver 0.0.0.0:8000
 worker: python2.7 manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
 camera: python2.7 manage.py celerycam --freq=2.0
 kumascript: node kumascript/run.js
+stylus: scripts/compile-stylesheets --watch

--- a/build/assets/css/README.md
+++ b/build/assets/css/README.md
@@ -1,0 +1,2 @@
+This directory contains generated files. To update a style, edit the
+corresponding Stylus file in *kuma/static/styles* instead.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -53,6 +53,18 @@ Kumascript tests
 If you're changing Kumascript, be sure to run its tests too.
 See https://github.com/mozilla/kumascript
 
+Compiling Stylus Files
+======================
+
+Stylus files need to be compiled for changes to take effect. Vagrant will
+automatically compile Stylus files when they change, but compilation can also be
+run manually::
+
+    compile-stylesheets
+
+The relevant CSS files will be generated and placed within the
+`build/assets/css` directory. You can add a ``-w`` flag to that call to compile
+stylesheets upon save.
 
 Database Migrations
 ===================
@@ -237,6 +249,7 @@ assets locally, follow these steps:
 #. In settings_local.py, set ``DEBUG = False``
 #. In settings_local.py, set ``DEV = False``
 #. Run ``vagrant ssh`` to enter the virtual machine
+#. Run ``compile-stylesheets``
 #. Run ``./manage.py collectstatic``
 #. Edit the file /etc/apache2/sites-enabled/kuma.conf and uncomment any lines
    pertaining to hosting static files

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -86,6 +86,11 @@ running it. (See `Running individual processes`_.)
 -  If you see ``Kumascript service failed unexpectedly: HTTPConnectionPool``,
    make sure you enabled :ref:`KumaScript <enable KumaScript>`.
 
+-  If changes to stylesheets do not have any effect, try compiling the Stylus
+   manually by running this command in the VM::
+
+       compile-stylesheets
+
 .. _more-help:
 
 Getting more help

--- a/kuma/static/styles/includes/vars.styl
+++ b/kuma/static/styles/includes/vars.styl
@@ -172,7 +172,7 @@ $selector-heading-font-fallback = 'html[data-ffo-opensanslight="false"]:not(.no-
 /*
 paths
 ====================================================================== */
-$path-to-assets = '../../static/';
+$path-to-assets = '../';
 $path-to-images = $path-to-assets + 'img/';
 $path-to-embedded-images = $path-to-images + 'embed/';
 $path-to-fonts = $path-to-assets + 'fonts/';

--- a/provisioning/roles/kuma/files/apache2/vhosts.conf
+++ b/provisioning/roles/kuma/files/apache2/vhosts.conf
@@ -73,7 +73,7 @@ Listen 8080
     RewriteRule ^/media/(redesign/)?css/(.*)-min.css$ /static/build/styles/$2.css [L,R=301]
     RewriteRule ^/media/(redesign/)?js/(.*)-min.js$ /static/build/js/$2.js [L,R=301]
     RewriteRule ^/media/(redesign/)?img(.*) /static/img$2 [L,R=301]
-    RewriteRule ^/media/(redesign/)?css(.*) /static/styles$2 [L,R=301]
+    RewriteRule ^/media/(redesign/)?css(.*) /static/css$2 [L,R=301]
     RewriteRule ^/media/(redesign/)?js(.*) /static/js$2 [L,R=301]
     RewriteRule ^/media/(redesign/)?fonts(.*) /static/fonts$2 [L,R=301]
 

--- a/provisioning/roles/kuma/files/vagrant/settings_local.py
+++ b/provisioning/roles/kuma/files/vagrant/settings_local.py
@@ -108,6 +108,3 @@ if SENTRY_DSN:
     )
 
 SOCIALACCOUNT_PROVIDERS['persona']['AUDIENCE'] = 'https://developer-local.allizom.org'
-
-if DEBUG:
-    PIPELINE_STYLUS_ARGUMENTS = '--sourcemap'

--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -39,6 +39,7 @@ def update_locales(ctx):
 @task
 def update_assets(ctx):
     with ctx.lcd(settings.SRC_DIR):
+        ctx.local("./scripts/compile-stylesheets")
         ctx.local("python2.7 manage.py collectstatic --noinput")
         ctx.local("python2.7 manage.py compilejsi18n")
 

--- a/scripts/compile-stylesheets
+++ b/scripts/compile-stylesheets
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# The Stylus executable resides in /usr/local/bin on our public servers. For
+# this script to work correctly on those servers, we need to include the
+# directory in our PATH.
+#
+# See: https://bugzilla.mozilla.org/show_bug.cgi?id=1092364
+PATH=/usr/local/bin:$PATH
+
+BASEDIR=$(dirname $0)
+CSSDIR=$BASEDIR/../build/assets/css
+STYLUSDIR=$BASEDIR/../kuma/static/styles
+
+for opt in "$@"; do
+  case $opt in
+    --watch|-w) WATCH=true;;
+    --quiet|-q) QUIET=true;;
+  esac
+done
+
+if [ ! -d "$CSSDIR" ]; then
+  mkdir $CSSDIR
+fi
+
+STYLESHEETS=($STYLUSDIR/*.styl)
+if [ $WATCH ]; then
+  echo Watching and automatically compiling stylesheets
+
+  # Using $STYLESHEETS directly so that stylus only watches each stylesheet
+  # once, even if it is @included multiple times.
+  if [ $QUIET ]; then
+    (stylus ${STYLESHEETS[@]} --out $CSSDIR --sourcemap --watch &) &> /dev/null
+  else
+    stylus ${STYLESHEETS[@]} --out $CSSDIR --sourcemap --watch
+  fi
+else
+  # Iterating through stylesheets so that shell output is immediate.
+  for ss in ${STYLESHEETS[@]}; do
+    stylus $ss --out $CSSDIR --sourcemap
+  done
+fi

--- a/settings.py
+++ b/settings.py
@@ -424,6 +424,7 @@ STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
 
 STATICFILES_DIRS = (
     path('kuma', 'static'),
+    path('build', 'assets'),
 )
 
 # TODO: Figure out why changing the order of apps (for example, moving taggit
@@ -554,20 +555,14 @@ PUENTE = {
 STANDALONE_DOMAINS = ['django', 'javascript']
 STATICI18N_DOMAIN = 'javascript'
 
-PIPELINE_COMPILERS = (
-    'pipeline.compilers.stylus.StylusCompiler',
-)
-
-PIPELINE_STYLUS_ARGUMENTS = ''
-
 PIPELINE_CSS_COMPRESSOR = 'kuma.core.pipeline.cleancss.CleanCSSCompressor'
 PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
 
 PIPELINE_CSS = {
     'mdn': {
         'source_filenames': (
-            'styles/font-awesome.styl',
-            'styles/main.styl',
+            'css/font-awesome.css',
+            'css/main.css',
         ),
         'output_filename': 'build/styles/mdn.css',
         'variant': 'datauri',
@@ -576,88 +571,88 @@ PIPELINE_CSS = {
         'source_filenames': (
             'js/libs/jquery-ui-1.10.3.custom/css/ui-lightness/jquery-ui-1.10.3.custom.min.css',
             'styles/libs/jqueryui/moz-jquery-plugins.css',
-            'styles/jquery-ui-customizations.styl',
+            'css/jquery-ui-customizations.css',
         ),
         'output_filename': 'build/styles/jquery-ui.css',
     },
     'demostudio': {
         'source_filenames': (
-            'styles/demos.styl',
+            'css/demos.css',
         ),
         'output_filename': 'build/styles/demostudio.css',
     },
     'devderby': {
         'source_filenames': (
-            'styles/devderby.styl',
+            'css/devderby.css',
         ),
         'output_filename': 'build/styles/devderby.css',
     },
     'gaia': {
         'source_filenames': (
-            'styles/gaia.styl',
+            'css/gaia.css',
         ),
         'output_filename': 'build/styles/gaia.css',
     },
     'home': {
         'source_filenames': (
-            'styles/home.styl',
+            'css/home.css',
         ),
         'output_filename': 'build/styles/home.css',
         'variant': 'datauri',
     },
     'search': {
         'source_filenames': (
-            'styles/search.styl',
+            'css/search.css',
         ),
         'output_filename': 'build/styles/search.css',
     },
     'search-suggestions': {
         'source_filenames': (
-            'styles/search-suggestions.styl',
+            'css/search-suggestions.css',
         ),
         'output_filename': 'build/styles/search-suggestions.css',
     },
     'wiki': {
         'source_filenames': (
-            'styles/wiki.styl',
-            'styles/zones.styl',
-            'styles/diff.styl',
+            'css/wiki.css',
+            'css/zones.css',
+            'css/diff.css',
 
             'js/libs/prism/prism.css',
             'js/prism-mdn/components/prism-json.css',
-            'styles/wiki-syntax.styl',
+            'css/wiki-syntax.css',
         ),
         'output_filename': 'build/styles/wiki.css',
     },
     'wiki-revisions': {
         'source_filenames': (
-            'styles/wiki-revisions.styl',
+            'css/wiki-revisions.css',
         ),
         'output_filename': 'build/styles/wiki-revisions.css',
     },
     'wiki-edit': {
         'source_filenames': (
-            'styles/wiki-edit.styl',
+            'css/wiki-edit.css',
         ),
         'output_filename': 'build/styles/wiki-edit.css',
     },
     'wiki-compat-tables': {
         'source_filenames': (
-            'styles/wiki-compat-tables.styl',
+            'css/wiki-compat-tables.css',
         ),
         'output_filename': 'build/styles/wiki-compat-tables.css',
         'template_name': 'pipeline/javascript-array.jinja',
     },
     'sphinx': {
         'source_filenames': (
-            'styles/wiki.styl',
-            'styles/sphinx.styl',
+            'css/wiki.css',
+            'css/sphinx.css',
         ),
         'output_filename': 'build/styles/sphinx.css',
     },
     'users': {
         'source_filenames': (
-            'styles/users.styl',
+            'css/users.css',
         ),
         'output_filename': 'build/styles/users.css',
     },
@@ -669,72 +664,72 @@ PIPELINE_CSS = {
     },
     'promote': {
         'source_filenames': (
-            'styles/promote.styl',
+            'css/promote.css',
         ),
         'output_filename': 'build/styles/promote.css',
     },
     'error': {
         'source_filenames': (
-            'styles/error.styl',
+            'css/error.css',
         ),
         'output_filename': 'build/styles/error.css',
     },
     'error-404': {
         'source_filenames': (
-            'styles/error.styl',
-            'styles/error-404.styl',
+            'css/error.css',
+            'css/error-404.css',
         ),
         'output_filename': 'build/styles/error-404.css',
     },
     'dashboards': {
         'source_filenames': (
-            'styles/dashboards.styl',
-            'styles/diff.styl',
+            'css/dashboards.css',
+            'css/diff.css',
         ),
         'output_filename': 'build/styles/dashboards.css',
     },
     'newsletter': {
         'source_filenames': (
-            'styles/newsletter.styl',
+            'css/newsletter.css',
         ),
         'output_filename': 'build/styles/newsletter.css',
     },
     'submission': {
         'source_filenames': (
-            'styles/submission.styl',
+            'css/submission.css',
         ),
         'output_filename': 'build/styles/submission.css',
     },
     'user-banned': {
         'source_filenames': (
-            'styles/user-banned.styl',
+            'css/user-banned.css',
         ),
         'output_filename': 'build/styles/user-banned.css',
     },
     'error-403-alternate': {
         'source_filenames': (
-            'styles/error-403-alternate.styl',
+            'css/error-403-alternate.css',
         ),
         'output_filename': 'build/styles/error-403-alternate.css',
     },
     'fellowship': {
         'source_filenames': (
-            'styles/fellowship.styl',
+            'css/fellowship.css',
         ),
         'output_filename': 'build/styles/fellowship.css',
     },
     'mdn10': {
         'source_filenames': (
-            'styles/mdn10.styl',
+            'css/mdn10.css',
         ),
         'output_filename': 'build/styles/mdn10.css',
     },
     'editor-content': {
         'source_filenames': (
-            'styles/main.styl',
-            'styles/wiki.styl',
-            'styles/wiki-wysiwyg.styl',
-            'styles/wiki-syntax.styl',
+            'css/main.css',
+            'css/wiki.css',
+            'css/wiki-wysiwyg.css',
+            'css/wiki-syntax.css',
             'styles/libs/font-awesome/css/font-awesome.min.css',
         ),
         'output_filename': 'build/styles/editor-content.css',
@@ -742,8 +737,8 @@ PIPELINE_CSS = {
     },
     'demowrap': {
         'source_filenames': (
-            'styles/demowrap.styl',
-            'styles/demos_wrap.styl',
+            'css/demowrap.css',
+            'css/demos_wrap.css',
         ),
         'output_filename': 'build/styles/demowrap.css',
     },


### PR DESCRIPTION
Kuma pages load very slowly locally when Pipeline kicks off compilation.
This change restores the old workflow, where the `stylus` executable
compiles individual stylesheets as needed.

More info:
https://github.com/mozilla/kuma/pull/3597#issuecomment-151984236