### PR TITLE
Bug 1221061 - Use lower case for adding and querying tag names.

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -8,6 +8,7 @@ from tower import ugettext_lazy as _lazy
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db.models.functions import Lower
 from django.forms.widgets import CheckboxSelectMultiple
 from django.template.loader import render_to_string
 from django.utils import translation
@@ -347,27 +348,28 @@ class RevisionForm(AkismetFormMixin, forms.ModelForm):
 
         if tags:
             for tag in parse_tags(tags):
-                # Note: The exact match query doesn't work correctly with
-                # MySQL with regards to case-sensitivity. If we move to
-                # Postgresql in the future this code may need to change.
-                doc_tag = (DocumentTag.objects.filter(name__exact=tag)
-                                              .values_list('name', flat=True))
+                doc_tags = DocumentTag.objects.annotate(
+                    lowered_name=Lower('name'),
+                ).filter(
+                    lowered_name=tag.lower(),
+                ).values_list('name', flat=True)
 
                 # Write a log we can grep to help find pre-existing duplicate
                 # document tags for cleanup.
-                if len(doc_tag) > 1:
-                    log.warn('Found duplicate document tags: %s' % doc_tag)
+                if len(doc_tags) > 1:
+                    log.warn('Found duplicate document tags: %s' % doc_tags)
 
-                if doc_tag:
-                    if doc_tag[0] != tag and doc_tag[0].lower() == tag.lower():
+                if doc_tags:
+                    if (doc_tags[0] != tag and
+                            doc_tags[0].lower() == tag.lower()):
                         # The tag differs only by case. Do not add a new one,
                         # add the existing one.
-                        cleaned_tags.append(doc_tag[0])
+                        cleaned_tags.append(doc_tags[0])
                         continue
 
                 cleaned_tags.append(tag)
 
-        return ' '.join([u'"%s"' % t for t in cleaned_tags])
+        return ' '.join([u'"%s"' % tag for tag in cleaned_tags])
 
     def clean_content(self):
         """

--- a/kuma/wiki/migrations/0012_convert_to_utf8bin.py
+++ b/kuma/wiki/migrations/0012_convert_to_utf8bin.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+from django.db import migrations
+
+
+logger = logging.getLogger(__name__)
+
+
+tables = [
+    'taggit_tag',
+    'wiki_documenttag',
+    'wiki_localizationtag',
+    'wiki_reviewtag',
+]
+
+
+def alter_collation(cursor, collation):
+    for table in tables:
+        logger.info('Altering table %s to collation %s...', table, collation)
+        cursor.execute("ALTER TABLE %s "
+                       "MODIFY name VARCHAR(100) "
+                       "CHARACTER SET utf8 COLLATE %s;" %
+                       (table, collation))
+
+
+def forwards(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        alter_collation(cursor, 'utf8_bin')
+
+
+def backwards(apps, schema_editor):
+    with schema_editor.connection.cursor() as cursor:
+        alter_collation(cursor, 'utf8_distinct_ci')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0011_create_spam_data'),
+    ]
+
+    operations = [migrations.RunPython(forwards, backwards)]

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -688,11 +688,9 @@ class DocumentListTests(UserTestCase, WikiTestCase):
     @attr('tags')
     def test_tag_list(self):
         """Verify the tagged documents list view."""
-        tag = DocumentTag(name='Test Tag', slug='test-tag')
-        tag.save()
+        tag = DocumentTag.objects.create(name='Test Tag', slug='test-tag')
         self.doc.tags.add(tag)
-        response = self.client.get(reverse('wiki.tag',
-                                   args=[tag.name]))
+        response = self.client.get(reverse('wiki.tag', args=[tag.name]))
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.document-list li')))
@@ -709,8 +707,7 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         fr_tag.save()
         self.doc.tags.add(en_tag)
         self.doc.tags.add(fr_tag)
-        response = self.client.get(reverse('wiki.tag',
-                                   args=[en_tag.name]))
+        response = self.client.get(reverse('wiki.tag', args=[en_tag.name]))
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.document-list li')))

--- a/settings.py
+++ b/settings.py
@@ -1519,3 +1519,5 @@ BLOCKABLE_USER_AGENTS = [
 REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'kuma.search.utils.search_exception_handler'
 }
+
+TAGGIT_CASE_INSENSITIVE = True


### PR DESCRIPTION
This makes use of Django's new first class support of database functions to query the tags. In our case by using `LOWER` to annotate the tag querysets with a lowercase name and then querying that.

https://bugzilla.mozilla.org/show_bug.cgi?id=1221061
