### PR TITLE
Bug 1217208 - Fix whitespace in l10n strings

### DIFF
--- a/kuma/demos/__init__.py
+++ b/kuma/demos/__init__.py
@@ -71,8 +71,8 @@ TAG_DESCRIPTIONS = dict((x['tag_name'], x) for x in getattr(
          "title": _("November 2011 Dev Derby Challenge - Canvas"),
          "short_title": _("Canvas"),
          "dateline": _("November 2011"),
-         "summary": _("Canvas lets you paint the Web using JavaScript to render 2D shapes, bitmapped images, and advanced graphical effects.  Each <canvas> element provides a graphics context with its own state and methods that make it easy to control and draw in."),
-         "description": _("Canvas lets you paint the Web using JavaScript to render 2D shapes, bitmapped images, and advanced graphical effects.  Each <canvas> element provides a graphics context with its own state and methods that make it easy to control and draw in."),
+         "summary": _("Canvas lets you paint the Web using JavaScript to render 2D shapes, bitmapped images, and advanced graphical effects. Each <canvas> element provides a graphics context with its own state and methods that make it easy to control and draw in."),
+         "description": _("Canvas lets you paint the Web using JavaScript to render 2D shapes, bitmapped images, and advanced graphical effects. Each <canvas> element provides a graphics context with its own state and methods that make it easy to control and draw in."),
          "learn_more": []},
         {"tag_name": "challenge:2011:december",
          "title": _("December 2011 Dev Derby Challenge - IndexedDB"),
@@ -261,7 +261,7 @@ TAG_DESCRIPTIONS = dict((x['tag_name'], x) for x in getattr(
          )},
         {"tag_name": "tech:fonts",
          "title": _("Fonts & Type"),
-         "description": _("The CSS3-Font specification contains enhanced features for fonts and typography like  embedding own fonts via @font-face or controlling OpenType font features directly via CSS."),
+         "description": _("The CSS3-Font specification contains enhanced features for fonts and typography like embedding own fonts via @font-face or controlling OpenType font features directly via CSS."),
          "learn_more": (
              (_('MDN Documentation'), _('https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face')),
              (_('Wikipedia Article'), _('http://en.wikipedia.org/wiki/Web_typography')),
@@ -301,7 +301,7 @@ TAG_DESCRIPTIONS = dict((x['tag_name'], x) for x in getattr(
          )},
         {"tag_name": "tech:indexeddb",
          "title": _("IndexedDB"),
-         "description": _("IndexedDB is an API for client-side storage of significant amounts of structured data and for high performance searches on this data using indexes. "),
+         "description": _("IndexedDB is an API for client-side storage of significant amounts of structured data and for high performance searches on this data using indexes."),
          "learn_more": (
              (_('MDN Documentation'), _('https://developer.mozilla.org/en-US/docs/IndexedDB')),
              (_('Wikipedia Article'), _('http://en.wikipedia.org/wiki/IndexedDB')),
@@ -357,7 +357,7 @@ TAG_DESCRIPTIONS = dict((x['tag_name'], x) for x in getattr(
          )},
         {"tag_name": "tech:websockets",
          "title": _("WebSockets"),
-         "description": _("WebSockets is a technology that makes it possible to open an interactive  communication session between the user's browser and a server."),
+         "description": _("WebSockets is a technology that makes it possible to open an interactive communication session between the user's browser and a server."),
          "learn_more": (
              (_('MDN Documentation'), _('https://developer.mozilla.org/en-US/docs/WebSockets')),
              (_('Wikipedia Article'), _('http://en.wikipedia.org/wiki/Web_Sockets')),

--- a/kuma/demos/templates/demos/detail.html
+++ b/kuma/demos/templates/demos/detail.html
@@ -215,7 +215,7 @@
             {% set license_class = submission.license_name %}
             <p class="license {{ license_class }}">
                 {% trans link=license_link(submission.license_name)|e, title=license_title(submission.license_name)|e %}
-                    This demo is released under the <a href="{{link}}">{{title}}</a> license.
+                    This demo is released under the <a href="{{link}}">{{title}}</a> license.
                 {% endtrans %}
             </p>
           </div>

--- a/kuma/wiki/templates/wiki/confirm_document_delete.html
+++ b/kuma/wiki/templates/wiki/confirm_document_delete.html
@@ -26,7 +26,7 @@
     <strong>{{ _('Last Change Date') }}</strong>
     <p>{{ datetimeformat(document.current_revision.created, format='longdatetime') }}</p>
 
-    <p>{{ _('You are about to delete this document and all of its revisions.  Please let us know why this page should be deleted.') }}</p>
+    <p>{{ _('You are about to delete this document and all of its revisions. Please let us know why this page should be deleted.') }}</p>
 
     <form action="" method="post">
       {{ csrf() }}

--- a/kuma/wiki/templates/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/templates/wiki/confirm_revision_revert.html
@@ -33,7 +33,7 @@
           {{ _('Why are you reverting to this revision?') }}
           <textarea name="comment"></textarea>
           <p>
-            {{ _('You are about to revert the document to this revision.  Click "revert" to revert to the content&nbsp;above.')|safe }}
+            {{ _('You are about to revert the document to this revision. Click "revert" to revert to the content&nbsp;above.')|safe }}
           </p>
           <div class="submit">
             <input type="submit" value="{{ _('Revert') }}" />

--- a/kuma/wiki/templates/wiki/create.html
+++ b/kuma/wiki/templates/wiki/create.html
@@ -27,23 +27,23 @@
         {{ document_form.category|safe }}
 
         <div class="doc-title">
-            <h1><span class="title-prefix">{{ _('Create a ') }}</span><em>{{ _('New Document') }}</em></h1>
+            <h1><span class="title-prefix">{{ _('Create a') }} </span><em>{{ _('New Document') }}</em></h1>
             <p class="save-state" id="draft-status">
-              {% trans %}Draft <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>{% endtrans %}
+              {{ _('Draft') }} <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>
             </p>
         </div>
 
         <ul class="metadata">
             <li class="clear">
-                <label for="id_title">{{_('Title:')}}</label>
+                <label for="id_title">{{ _('Title:') }}</label>
                 {{ document_form.title | safe }}
             </li>
             <li class="clear">
-                <label for="id_slug"><dfn title="{{_('URL segment that identifies the page')}}">{{_('Slug:')}}</dfn></label>
+                <label for="id_slug"><dfn title="{{ _('URL segment that identifies the page') }}">{{ _('Slug:') }}</dfn></label>
                 {{ document_form.slug | safe }}
             </li>
           {% if parent_slug and not is_template %}
-            <li class="clear"><label>{{_('Parent:')}}</label>
+            <li class="clear"><label>{{ _('Parent:') }}</label>
                 <a href="{{ parent_path }}" class="metadataDisplay" target="_blank">{{ parent_slug }}</a></li>
           {% endif %}
           {% if is_template %}

--- a/kuma/wiki/templates/wiki/edit.html
+++ b/kuma/wiki/templates/wiki/edit.html
@@ -93,7 +93,7 @@
               {% if not section_id %}
                 <a href="" id="btn-properties">{{ _('Edit Page Title and Properties') }}</a><br />
               {% endif %}
-              {% trans %}Draft <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>{% endtrans %}
+              {{ _('Draft') }} <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>
             </p>
           </div>
 

--- a/locale/af/LC_MESSAGES/django.po
+++ b/locale/af/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/az/LC_MESSAGES/django.po
+++ b/locale/az/LC_MESSAGES/django.po
@@ -4338,9 +4338,7 @@ msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/bm/LC_MESSAGES/django.po
+++ b/locale/bm/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/bn_BD/LC_MESSAGES/django.po
+++ b/locale/bn_BD/LC_MESSAGES/django.po
@@ -3871,7 +3871,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/bn_IN/LC_MESSAGES/django.po
+++ b/locale/bn_IN/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -4892,12 +4892,8 @@ msgstr "Neues Dokument"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Entwurf <span id=\"draft-action\"></span><time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Entwurf"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/ee/LC_MESSAGES/django.po
+++ b/locale/ee/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/el/LC_MESSAGES/django.po
+++ b/locale/el/LC_MESSAGES/django.po
@@ -3840,7 +3840,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/en_US/LC_MESSAGES/django.po
+++ b/locale/en_US/LC_MESSAGES/django.po
@@ -4009,8 +4009,8 @@ msgid "New Document"
 msgstr "Search MDN Documentation"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
-msgstr "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Draft"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -4921,12 +4921,8 @@ msgstr "Nuevo documento"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Borrador <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Borrador"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -4374,9 +4374,7 @@ msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ff/LC_MESSAGES/django.po
+++ b/locale/ff/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4962,12 +4962,8 @@ msgstr "Nouveau document"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Brouillon <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Brouillon"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/fy/LC_MESSAGES/django.po
+++ b/locale/fy/LC_MESSAGES/django.po
@@ -3796,7 +3796,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ga/LC_MESSAGES/django.po
+++ b/locale/ga/LC_MESSAGES/django.po
@@ -3938,7 +3938,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ha/LC_MESSAGES/django.po
+++ b/locale/ha/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/he/LC_MESSAGES/django.po
+++ b/locale/he/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/hi_IN/LC_MESSAGES/django.po
+++ b/locale/hi_IN/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/hr/LC_MESSAGES/django.po
+++ b/locale/hr/LC_MESSAGES/django.po
@@ -3883,7 +3883,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -4484,12 +4484,8 @@ msgstr "Új dokumentum"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Piszkozat <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Piszkozat"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -3746,7 +3746,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ig/LC_MESSAGES/django.po
+++ b/locale/ig/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4855,12 +4855,8 @@ msgstr "Nuovo documento"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"bozza <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "bozza"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -3963,8 +3963,8 @@ msgid "New Document"
 msgstr "新しいドキュメント"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
-msgstr "下書き <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "下書き"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -4677,12 +4677,8 @@ msgstr "새 문서"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"초안 <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "초안" 
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/ln/LC_MESSAGES/django.po
+++ b/locale/ln/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/mg/LC_MESSAGES/django.po
+++ b/locale/mg/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ml/LC_MESSAGES/django.po
+++ b/locale/ml/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ms/LC_MESSAGES/django.po
+++ b/locale/ms/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/my/LC_MESSAGES/django.po
+++ b/locale/my/LC_MESSAGES/django.po
@@ -3738,7 +3738,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -3928,8 +3928,8 @@ msgid "New Document"
 msgstr "Nieuw document"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
-msgstr "Concept <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Concept"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -3918,8 +3918,8 @@ msgid "New Document"
 msgstr "Nowy dokument"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
-msgstr "Szkic <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Szkic"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -5030,12 +5030,8 @@ msgstr "Novo documento"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Rascunho <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Rascunho"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4928,12 +4928,8 @@ msgstr "Novo documento"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"Rascunho <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Rascunho"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -4496,9 +4496,7 @@ msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -4648,12 +4648,8 @@ msgstr "Новый документ"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\""
-"timeago\" title=\"\"></time>"
-msgstr ""
-"Черновик <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft" 
+msgstr "Черновик"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -3801,7 +3801,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -3955,7 +3955,7 @@ msgid "New Document"
 msgstr "Dokumentacija MDN"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/son/LC_MESSAGES/django.po
+++ b/locale/son/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -3867,8 +3867,8 @@ msgid "New Document"
 msgstr "Dokument i Ri"
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
-msgstr "Skicë <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "Skicë"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/sv_SE/LC_MESSAGES/django.po
+++ b/locale/sv_SE/LC_MESSAGES/django.po
@@ -4395,9 +4395,7 @@ msgstr "Nytt dokument"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/ta/LC_MESSAGES/django.po
+++ b/locale/ta/LC_MESSAGES/django.po
@@ -3760,7 +3760,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/templates/LC_MESSAGES/django.pot
+++ b/locale/templates/LC_MESSAGES/django.pot
@@ -4434,9 +4434,7 @@ msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\""
-"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -3856,7 +3856,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/tl/LC_MESSAGES/django.po
+++ b/locale/tl/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/tn/LC_MESSAGES/django.po
+++ b/locale/tn/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/wo/LC_MESSAGES/django.po
+++ b/locale/wo/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/xh/LC_MESSAGES/django.po
+++ b/locale/xh/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/yo/LC_MESSAGES/django.po
+++ b/locale/yo/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42

--- a/locale/zh_CN/LC_MESSAGES/django.po
+++ b/locale/zh_CN/LC_MESSAGES/django.po
@@ -4432,12 +4432,8 @@ msgstr "新建文档"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"草稿 <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "草稿"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/zh_TW/LC_MESSAGES/django.po
+++ b/locale/zh_TW/LC_MESSAGES/django.po
@@ -4462,12 +4462,8 @@ msgstr "新文件"
 
 #: kuma/wiki/templates/wiki/create.html:32
 #: kuma/wiki/templates/wiki/edit.html:96
-msgid ""
-"Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
-msgstr ""
-"草稿 <span id=\"draft-action\"></span> <time id=\"draft-time\" "
-"class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
+msgstr "草稿"
 
 #: kuma/wiki/templates/wiki/create.html:42
 msgid "URL segment that identifies the page"

--- a/locale/zu/LC_MESSAGES/django.po
+++ b/locale/zu/LC_MESSAGES/django.po
@@ -3759,7 +3759,7 @@ msgid "New Document"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:32 kuma/wiki/templates/wiki/edit.html:96
-msgid "Draft <span id=\"draft-action\"></span> <time id=\"draft-time\" class=\"timeago\" title=\"\"></time>"
+msgid "Draft"
 msgstr ""
 
 #: kuma/wiki/templates/wiki/create.html:42


### PR DESCRIPTION
This normalizes whitespace in l10n source strings since puente only
collapses whitespace for trans tags