### PR TITLE
fix bug 1221110 - private, no-cache ban responses

### DIFF
--- a/kuma/users/middleware.py
+++ b/kuma/users/middleware.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import logout
 from django.shortcuts import render
+from django.utils.cache import add_never_cache_headers
 
 from .models import UserBan
 
@@ -17,8 +18,10 @@ class BanMiddleware(object):
             if not bans:
                 return None
             logout(request)
-            return render(request,
-                          'users/user_banned.html',
-                          {'bans': bans,
-                           'path': request.path})
+            banned_response = render(request, 'users/user_banned.html', {
+                'bans': bans,
+                'path': request.path
+            })
+            add_never_cache_headers(banned_response)
+            return banned_response
         return None

--- a/kuma/users/tests/test_middleware.py
+++ b/kuma/users/tests/test_middleware.py
@@ -1,4 +1,4 @@
-from nose.plugins.attrib import attr
+import mock
 
 from . import UserTestCase
 from ..models import UserBan
@@ -7,8 +7,8 @@ from ..models import UserBan
 class BanTestCase(UserTestCase):
     localizing_client = True
 
-    @attr('bans')
-    def test_ban_middleware(self):
+    @mock.patch('django.utils.cache.add_never_cache_headers')
+    def test_ban_middleware(self, mock_add_nch):
         """Ban middleware functions correctly."""
         self.client.login(username='testuser', password='testpass')
 
@@ -24,3 +24,4 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get('/')
         self.assertTemplateUsed(resp, 'users/user_banned.html')
+        self.assertTrue(mock_add_nch.called)

--- a/kuma/users/tests/test_middleware.py
+++ b/kuma/users/tests/test_middleware.py
@@ -1,4 +1,5 @@
-import mock
+from email.utils import parsedate
+from time import gmtime
 
 from . import UserTestCase
 from ..models import UserBan
@@ -7,8 +8,7 @@ from ..models import UserBan
 class BanTestCase(UserTestCase):
     localizing_client = True
 
-    @mock.patch('django.utils.cache.add_never_cache_headers')
-    def test_ban_middleware(self, mock_add_nch):
+    def test_ban_middleware(self):
         """Ban middleware functions correctly."""
         self.client.login(username='testuser', password='testpass')
 
@@ -24,4 +24,4 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get('/')
         self.assertTemplateUsed(resp, 'users/user_banned.html')
-        self.assertTrue(mock_add_nch.called)
+        assert parsedate(resp['Expires']) <= gmtime()


### PR DESCRIPTION
This adds `private, no-cache` to the response when a banned user's request is caught by the `BanMiddleware`.

Assuming our load-balancer follows standard `Cache-Control` implementation, this should stop it from caching these responses.

In theory, `no-cache` alone can do this; `private` is an extra indicator to the cache that the response is meant for a single user.

We can deploy and test this ourselves to see if it fixes the problem before getting WebOps involved debugging the load balancer.