### PR TITLE
Allow removal of all *.pyc files from root.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -66,7 +66,7 @@
 [submodule "vendor/src/python-magic"]
 	path = vendor/src/python-magic
 	url = git://github.com/ahupp/python-magic.git
-	ignore = untracked
+	ignore = dirty
 [submodule "vendor/src/python-memcached"]
 	path = vendor/src/python-memcached
 	url = git://github.com/linsomniac/python-memcached.git


### PR DESCRIPTION
The only vendor module that seems to have a problem with this (because
they have .pyc files checked into their repo) is python-magic.

According to the git submodule docs:
"dirty" will ignore all changes to the submodules work tree and takes
only differences between the HEAD of the submodule and the commit
recorded in the superproject into account.