### PR TITLE
Bug 1218466: Queue errors before GA loads.

### DIFF
--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -38,8 +38,7 @@
             };
 
             // If Analytics has loaded, go ahead with tracking
-            // Checking for ".create" due to Ghostery mocking of ga
-            if(ga && ga.create) {
+            if(ga) {
                 // Send event to GA
                 ga('send', data);
             }


### PR DESCRIPTION
If we wait for ga to initialize we miss anything that executes before it.