### PR TITLE
Fix Bug 1222648: Track Kumascript Errors in GA

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -539,13 +539,29 @@
     });
 
     /*
-        Toggle kumascript error detail pane
+        Kumascript error detected
     */
-    $('.kserrors-details-toggle').toggleMessage({
-        toggleCallback: function() {
-            $('.kserrors-details').toggleClass('hidden');
-        }
-    });
+    // is there an error?
+    var $kserrors = $('#kserrors');
+    if($kserrors.length){
+        // enable the details toggle
+        var $kserrorsToggle = $kserrors.find('.kserrors-details-toggle');
+        var $kserrorsDetails = $kserrors.find('.kserrors-details');
+        $kserrorsToggle.toggleMessage({
+            toggleCallback: function() {
+                $kserrorsDetails.toggleClass('hidden');
+            }
+        });
+        // loop through error list and log errors
+        var $kserrorsList = $('#kserrors-list');
+        $kserrorsList.each(function(){
+            var $thisError = $(this);
+            var errorType = $thisError.find('.kserror-type').text().trim();
+            var errorMacro = $thisError.find('.kserror-macro').text().trim();
+            var errorParse = $thisError.find('.kserror-parse').text().trim().replace(/\s\s+/g, ' ');
+            mdn.analytics.trackError('Kumascript Error', errorType, 'in: ' + errorMacro + '; parsing: ' + errorParse );
+        });
+    }
 
 
     /*

--- a/kuma/static/styles/components/wiki/content/compact.styl
+++ b/kuma/static/styles/components/wiki/content/compact.styl
@@ -1,0 +1,16 @@
+.compact {
+    dt {
+      display: inline;
+    }
+
+    dd {
+      display: inline;
+      margin-bottom: 0;
+      bidi-style(padding-left, $content-horizontal-spacing, padding-right, 0);
+
+        &:after {
+          content: '\A';
+          white-space: pre;
+        }
+    }
+}

--- a/kuma/static/styles/wiki.styl
+++ b/kuma/static/styles/wiki.styl
@@ -62,6 +62,7 @@ Styling for article content
 
 @require 'components/wiki/content/moreinfo';
 @require 'components/wiki/content/summary';
+@require 'components/wiki/content/compact';
 @require 'components/wiki/customcss';
 @require 'components/wiki/open-in-host';
 @require 'components/wiki/section-edit';

--- a/kuma/wiki/templates/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/templates/wiki/includes/kumascript_errors.html
@@ -20,39 +20,51 @@
         Anyone with an MDN profile can edit a document to fix an error. Use the <a href="/docs/MDN/Kuma/Troubleshooting_KumaScript_errors">KumaScript troubleshooting guide</a> as a starting point.
       {% endtrans %}</p>
 
-      <ul>
+      <ul id="kserrors-list">
       {% for error in kumascript_errors %}
         <li>
+          <dl class="compact">
             {% if error.args %}
-                {% set error_type = error.args[0] %}
-                {{ _('Error type:') }} <strong class="type">{{ error_type }}</strong><br>
-
-                {% set error_meta = error.args[2] %}
-                {% if error_meta %}
-                    {% set template_name = error_meta.name %}
-
-                    {% if '$' not in template_name %}
-                        {% set template_slug = 'Template: %s' % template_name %}
-                        {% set edit_url = url('wiki.edit', template_slug) %}
-                        {% set new_url = url('wiki.create') + '?slug=Template:%s' % template_name %}
-                    {% endif %}
-
-                    {{ _('In macro:') }} <code>{{ template_name }}</code>
-
-                    {% if 'status 404' in error.message %}
-                        {% if new_url %}
-                            (<a href="{{ new_url }}">{{ _('Create Template') }}</a>)
-                        {% endif %}
-                    {% elif edit_url  %}
-                        (<a href="{{ edit_url }}">{{ _('Edit Template') }}</a>)
-                    {% endif %}<br>
-
-                    {{ _('Parsing macro:') }} <code>{{ template_name }}({% if error_meta.token %}{{ error_meta.token.args }}{% endif %})</code> {% if document %}(<a href="{{ document.get_edit_url() }}">{{ _('Edit Document') }}</a>){% endif %}
+              {% set error_type = error.args[0] %}
+              <dt>{{ _('Error type:') }}</dt>
+              <dd class="kserror-type">
+                {{ error_type }}
+              </dd>
+              {% set error_meta = error.args[2] %}
+              {% if error_meta %}
+                {% set template_name = error_meta.name %}
+                {% if '$' not in template_name %}
+                  {% set template_slug = 'Template: %s' % template_name %}
+                  {% set edit_url = url('wiki.edit', template_slug) %}
+                  {% set new_url = url('wiki.create') + '?slug=Template:%s' % template_name %}
                 {% endif %}
+                <dt>{{ _('In macro:') }}</dt>
+                <dd>
+                  <code class="kserror-macro">{{ template_name }}</code>
+                  {% if 'status 404' in error.message %}
+                    {% if new_url %}
+                      (<a href="{{ new_url }}">{{ _('Create Template') }}</a>)
+                    {% endif %}
+                  {% elif edit_url  %}
+                    (<a href="{{ edit_url }}">{{ _('Edit Template') }}</a>)
+                  {% endif %}
+                </dd>
+                <dt>{{ _('Parsing macro:') }}</dt>
+                <dd>
+                  <code class="kserror-parse">{{ template_name }}
+                    {% if error_meta.token %}
+                      ({{ error_meta.token.args }})
+                    {% endif %}
+                  </code>
+                  {% if document %}
+                    (<a href="{{ document.get_edit_url() }}">{{ _('Edit Document') }}</a>)
+                  {% endif %}
+                </dd>
+              {% endif %}
             {% endif %}
-
-            {{ _('Full text of error:') }}<br>
-            <pre class="message brush: text">{{ error.message }}</pre>
+            <dt>{{ _('Full text of error:') }}</dt>
+            <dd><pre class="message brush: text">{{ error.message }}</pre></dd>
+          </dl>
         </li>
       {% endfor %}
       </ul>


### PR DESCRIPTION
Add hooks to markup to identify errors and javascript to parse the errors and send to google analytics.

Depends on #3629 and #3608.