### PR TITLE
Fix bugs 1195351 and 1198301: (Live Sample "open in" buttons)

### DIFF
--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -22,38 +22,8 @@
         var source = $this.attr('src').replace(/^https?:\/\//,'');
         source = source.slice(source.indexOf('/'), source.indexOf('$'));
 
-        $(parentTable || $this).after(function() {
-            return createSampleButtons(section, source);
-        });
-    });
-
-    // Listen for clicks on open buttons
-    $('#wikiArticle').on('click', 'button.open-in-host', function(){
-        var $button = $(this);
-        var section = $button.attr('data-section');
-        var source  = $button.attr('data-source');
-        var sampleCodeHost = $button.attr('data-host');
-
-        // track the click and sample code host
-        mdn.analytics.trackEvent({
-            category: 'Samples',
-            action: 'open-' + sampleCodeHost,
-            label: section
-        });
-
-        // disable the button, till we open the fiddle
-        $button.attr('disabled', 'disabled');
-        $.get(source + '?section=' + section + '&raw=1').then(function(sample) {
-            var $sample = $('<div />').append(sample);
-            var htmlCode = $sample.find('pre[class*=html]').text();
-            var cssCode = $sample.find('pre[class*=css]').text();
-            var jsCode = $sample.find('pre[class*=js]').text();
-            var title = $sample.find('h2[name=' + section + ']').text();
-
-            openSample(sampleCodeHost, title, htmlCode, cssCode, jsCode);
-
-            $button.removeAttr('disabled');
-        });
+        var $sampleFrame = parentTable ? parentTable : $this;
+        createSampleButtons($sampleFrame, section, source);
     });
 
     function openJSFiddle(title, htmlCode, cssCode, jsCode) {
@@ -84,32 +54,65 @@
        $form.get(0).submit();
     }
 
-    function openSample(sampleCodeHost, title, htmlCode, cssCode, jsCode) {
-       if(sampleCodeHost === 'jsfiddle') {
+    function openSample(sampleCodeHost, section, title, htmlCode, cssCode, jsCode) {
+        //track the click and sample code host as event
+        mdn.analytics.trackEvent({
+            category: 'Samples',
+            action: 'open-' + sampleCodeHost,
+            label: section
+        });
+        // add user to segement that has used samples
+        if(win.ga) ga('set', 'dimension8', 'Yes');
+
+        if(sampleCodeHost === 'jsfiddle') {
             openJSFiddle(title, htmlCode, cssCode, jsCode);
         } else if(sampleCodeHost === 'codepen') {
             openCodepen(title, htmlCode, cssCode, jsCode);
         }
     }
 
-    function createSampleButtons(section, source) {
-        var $parent = $('<div class="open-in-host-container" />');
+    function createSampleButtons($sampleFrame, section, source) {
+        // get this sample's html/css/js
+        $.get(source + '?section=' + section + '&raw=1').then(function(sample) {
+            var $sample = $('<div />').append(sample);
+            var htmlCode = $sample.find('pre[class*=html]').text();
+            var cssCode = $sample.find('pre[class*=css]').text();
+            var jsCode = $sample.find('pre[class*=js]').text();
+            var title = $sample.find('h2[name=' + section + ']').text();
 
-        $.each(sites, function(){
-            // convert sitename to lowercase for icon name and host identifier
-            var host = this.toLowerCase();
-            $parent.append([
-                '<button class="open-in-host" ',
-                        'data-host="', host, '" ',
-                        'data-section="', section, '"',
-                        'data-source="', source, '">',
-                    '<i aria-hidden="true" class="icon-', host,'"></i> ',
-                    'Open in ', this,
-                '</button>'
-            ].join(''));
+            // check that there is enough data to add buttons
+            if(htmlCode.length || cssCode.length || jsCode.length){
+                // add buttons if we have good data
+                var $buttonContainer = $('<div class="open-in-host-container" />');
+                $.each(sites, function() {
+                    // convert sitename to lowercase for icon name and host identifier
+                    var sampleCodeHost = this.toLowerCase();
+                    // create button
+                    var $button = $('<button />', { 'class': 'open-in-host' });
+                    // create icon
+                    var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
+                    // create text
+                    var $text = 'Open in ' + this + ' ';
+
+                    // add button icon and text to DOM
+                    $button.append($text).append($icon).appendTo($buttonContainer);
+                    $buttonContainer.insertAfter($sampleFrame);
+
+                    // add listener for button interactions
+                    $button.on('click', function(){
+                        openSample(sampleCodeHost, section, title, htmlCode, cssCode, jsCode);
+                    });
+                });
+            } else if($sample.children().length == 0) {
+                // no content, log error
+                mdn.analytics.trackError('embedLiveSample Error', '$sample was empty', section);
+            } else {
+                // no content, log error
+                mdn.analytics.trackError('embedLiveSample Error', '$sample did not cointain any code', section);
+            }
+        }).fail( function() {
+            mdn.analytics.trackError('embedLiveSample Error', 'ajax error retreiving source', section);
         });
-
-        return $parent;
     }
 
 })(window, document, jQuery);


### PR DESCRIPTION
Fix bug 1195351:

Re-jigged when the sample sections are downloaded so they are parsed by the script to make sure there's matching sample code found before we add the buttons to the page, log errors with GA if something goes wrong there.

Fix bug 1198301:

Added user to a ga segment if they click on button.

Some pages with embedLiveSample for testing purposes:
https://developer.mozilla.org/en-US/docs/User%3Astephaniehobson%3Acode
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/progress
https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Drawing_DOM_objects_into_a_canvas
