### PR TITLE
bug 1177264 - measure dashboard pagination usage

### DIFF
--- a/kuma/dashboards/templates/dashboards/revisions.html
+++ b/kuma/dashboards/templates/dashboards/revisions.html
@@ -153,7 +153,14 @@
     // AJAX loads for pagination
     $revisionReplaceBlock.on('click', '.pagination a', function (e) {
         e.preventDefault();
-        $pageInput.val(/page=([^&#]*)/.exec(this.href)[1]);
+        var pageNum = /page=([^&#]*)/.exec(this.href)[1];
+        var linkText = this.text.trim();
+        mdn.analytics.trackEvent({
+            category: 'Dashboard Pagination',
+            action: pageNum,
+            label: linkText
+        });
+        $pageInput.val(pageNum);
         $filterForm.submit();
     });
 


### PR DESCRIPTION
Per New Relic, many of our transaction response time spikes are coming from `kuma.dashboards.views:revisions` (green in the graph):

<img width="777" alt="mdn-nr-transactions" src="https://cloud.githubusercontent.com/assets/71928/11146568/0f17befc-89d5-11e5-93f0-f86ad200a841.png">

I profiled and debugged it down to extremely slow queries against the `wiki_revision` table.

<img width="735" alt="mdn-nr-revision-select" src="https://cloud.githubusercontent.com/assets/71928/11147912/15385832-89df-11e5-80a8-43cca5ef22a1.png">

I [filed a bug with DBA to help fix it](https://bugzilla.mozilla.org/show_bug.cgi?id=1210830). The problem seems to be poor performance of DB/MySQL `OFFSET` pagination on large tables. (Note: the same problem seems to affect `kuma.users.views:user_detail` [orange in the graph] too.)

I have [a branch ready to PR](https://github.com/mozilla/kuma/compare/revision-dashboard-pagination-1177264?expand=1) that removes the default Django `OFFSET`-based pagination with [an optimized pagination approach based on "last seen ID" of the auto-increment primary index field](http://www.xarg.org/2011/10/optimized-pagination-using-mysql/). But, I've only implemented the "Next" link - not the specific page number links, because id-derived page number links requires us to store/cache a new estimated count value. I'd like to avoid it if we can.

So, before I do it, I want to measure how much users are actually clicking the page number links, vs. clicking the "Next" link. That way we can decide if I need to finish out the page number links, or if we can run with just the "Next" links.