### PR TITLE
bug 842340 - only show <ul> if there are items

### DIFF
--- a/kuma/wiki/templates/wiki/includes/document_macros.html
+++ b/kuma/wiki/templates/wiki/includes/document_macros.html
@@ -161,10 +161,13 @@
 
                   </ul>
 
-                <ul>
-                  {% for watched_parent_tree in document.parent_trees_watched_by(user) %}
-                    {{ watch_tree_item(watched_parent_tree, user) }}
-                  {% endfor %}
+                  {% set watched_parent_trees = document.parent_trees_watched_by(user) %}
+                  {% if watched_parent_trees %}
+                    <ul>
+                      {% for watched_parent_tree in watched_parent_trees %}
+                        {{ watch_tree_item(watched_parent_tree, user) }}
+                      {% endfor %}
+                    </ul>
+                  {% endif %}
 
-                </ul>
 {%- endmacro %}


### PR DESCRIPTION
Fixes this display bug on pages where there are no watched parents ...

![watch-ul-error](https://cloud.githubusercontent.com/assets/71928/11192513/3d549ec2-8c67-11e5-8dce-ce9887e790b7.png)
