### PR TITLE
Bug 1139490: Don't use Pipeline to wrap JavaScript

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -554,6 +554,8 @@ PUENTE = {
 STANDALONE_DOMAINS = ['django', 'javascript']
 STATICI18N_DOMAIN = 'javascript'
 
+PIPELINE_DISABLE_WRAPPER = True
+
 PIPELINE_CSS_COMPRESSOR = 'kuma.core.pipeline.cleancss.CleanCSSCompressor'
 PIPELINE_JS_COMPRESSOR = 'pipeline.compressors.uglifyjs.UglifyJSCompressor'
 


### PR DESCRIPTION
When PIPELINE_DISABLE_WRAPPER is False (the default), Pipeline wraps all
JavaScript in an anonymous function:

    (function(){
      //JS output...
    })();

We already wrap JavaScript manually, so this extra wrap is not needed.