### PR TITLE
fix bug 1225159 - add is_localizable to admin site

### DIFF
--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -268,8 +268,23 @@ class DocumentAdmin(admin.ModelAdmin):
                purge_documents,
                restore_documents)
     change_list_template = 'admin/wiki/document/change_list.html'
-    fields = ('locale', 'title', 'defer_rendering', 'render_expires',
-              'render_max_age', 'parent', 'parent_topic', 'category',)
+    fieldsets = (
+        (None, {
+            'fields': ('locale', 'title')
+        }),
+        ('Rendering', {
+            'fields': ('defer_rendering', 'render_expires', 'render_max_age')
+        }),
+        ('Topical Hierarchy', {
+            'fields': ('parent_topic',)
+        }),
+        ('Localization', {
+            'description': "The document should be <strong>either</strong> "
+                           "localizable, <strong>or</strong> have a parent - "
+                           "never both.",
+            'fields': ('is_localizable', 'parent')
+        })
+    )
     list_display = ('id', 'locale', 'slug', 'title',
                     document_link,
                     'modified',


### PR DESCRIPTION
When a site admin sees a page that can't be translated, they need to update the is_localizable field on the page, so translators can translate it.

Also includes UI enhancements for the doc admin page.