### PR TITLE
Fix Bug 1226034: Console Error from Live Samples

### DIFF
--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -78,8 +78,10 @@
             var htmlCode = $sample.find('pre[class*=html]').text();
             var cssCode = $sample.find('pre[class*=css]').text();
             var jsCode = $sample.find('pre[class*=js]').text();
-            var title = $sample.find('h2[name=' + section + ']').text();
-
+            // jquery can't handled all our IDs, need to use vanailla js for this
+            // http://stackoverflow.com/questions/7695898/uncaught-exception-syntax-error-unrecognized-expression-jquery
+            var title = doc.getElementById(section);
+            title = title ? title.textContent : '';
             // check that there is enough data to add buttons
             if(htmlCode.length || cssCode.length || jsCode.length){
                 // add buttons if we have good data


### PR DESCRIPTION
samples.js was raising console errors that looked like this: "Uncaught Error: Syntax error, unrecognized expression: h2[name=Usage example]" when used on pages where the code sample title was in an h3.

I tried to switch to just using $("#"+section) but it turns out we have characters in our IDs that, while legal in HTML5, throw jQuery for a loop. Plain JS FTW.