### PR TITLE
Fix Bug 1226283: Local Storage feature test

### DIFF
--- a/kuma/static/js/auth.js
+++ b/kuma/static/js/auth.js
@@ -144,7 +144,7 @@
         Show notifications about account association status as part of the
         registration process.
     */
-    if('localStorage' in win) (function() {
+    if(win.mdn.features.localStorage) (function() {
         try {
             var $browserRegister = $('#browser_register');
             var matchKey = 'account-match-for';
@@ -186,7 +186,7 @@
     /*
         Fire off events when the user logs in and logs out.
     */
-    if('localStorage' in win) (function() {
+    if(win.mdn.features.localStorage) (function() {
         var serviceKey = 'login-service';
         var serviceStored = localStorage.getItem(serviceKey);
         var serviceCurrent = $(doc.body).data(serviceKey);

--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -3,7 +3,7 @@
     var waitBeforeAsking = 60000;
     var articleTracker = doc.location.pathname + '#answered-helpful';
     // this feature requires localStorage
-    if (('localStorage' in win)) {
+    if (win.mdn.features.localStorage) {
         var ignore = localStorage.getItem('helpful-ignore') === 'true'; // true if ever clicked ignore
         var articleAskedRecently = parseInt(localStorage.getItem(articleTracker), 10) > Date.now();
         var helpfulnessAskedRecently = parseInt(localStorage.getItem('helpfulnessTracker'), 10) > Date.now();

--- a/kuma/static/js/main.js
+++ b/kuma/static/js/main.js
@@ -7,6 +7,23 @@
     mdn.analytics.trackClientErrors();
 
     /*
+        Feature detection
+    */
+
+    win.mdn.features.localStorage = (function() {
+        var uid = new Date;
+        var result;
+        try {
+            localStorage.setItem(uid, uid);
+            result = localStorage.getItem(uid) == uid;
+            localStorage.removeItem(uid);
+            return result;
+        } catch (exception) {
+            return false;
+        }
+    }());
+
+    /*
         Submenus
         - main and secondary navigation
         - language and admin menus

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -187,7 +187,7 @@
     var DRAFT_NAME;
     var DRAFT_TIMEOUT_ID;
 
-    var supportsLocalStorage = ('localStorage' in win);
+    var supportsLocalStorage = win.mdn.features.localStorage;
     var $form = $('#wiki-page-edit');
     var isTranslation;
     var isTemplate;


### PR DESCRIPTION
Making local storage feature test more robust to solve problem of iOS identifying that is supports localStorage and then preventing usage in private browsing mode. (note that I was not able to duplicate this problem in my testing environment but I'm 90% sure this is the source of the problems identified by New Relic - details in bug)

Testing:
- save and recover draft
- helpfulness
- login with Persona
- check that GA event fires when login completes
- try to create a new account with a email address that matches an existing account, associate the accounts. Check you get confirmation notification. (I disconnected my git hub log in and then re-logged in with it).