### PR TITLE
Fix typo in an en-US compatibility string

### DIFF
--- a/kuma/static/js/wiki-compat-tables.js
+++ b/kuma/static/js/wiki-compat-tables.js
@@ -22,7 +22,7 @@
     // The open button template
     var $historyLink = $('<button title="' + gettext('Open') + '" class="bc-history-link only-icon" tabindex="-1"><span>' + gettext('Open') + '</span><i class="ic-history" aria-hidden="true"></i></button>');
     // The close button template
-    var $historyCloseButton = $('<button class="bc-history-button"><abbr class="only-icon" title="' + gettext('Return to compatability table.') + '"><span>' + gettext('Close') + '</span><i class="icon-times" aria-hidden="true"></i></abbr></button>');
+    var $historyCloseButton = $('<button class="bc-history-button"><abbr class="only-icon" title="' + gettext('Return to compatibility table.') + '"><span>' + gettext('Close') + '</span><i class="icon-times" aria-hidden="true"></i></abbr></button>');
 
     var animationProps = {
         duration: 250,


### PR DESCRIPTION
The classical compatability -> compatibility error.

Notified by Tonnes, our nl translator.