### PR TITLE
bug 1209185 - ro-order related model saves

### DIFF
--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -1270,7 +1270,8 @@ class PageMoveTests(UserTestCase):
         """Make sure we can detect potential circular dependencies in
         parent/child relationships."""
         # Test detection at one level removed.
-        parent = document(title='Parent of circular-dependency document')
+        parent = document(title='Parent of circular-dependency document',
+                         save=True)
         child = document(title='Document with circular dependency')
         child.parent_topic = parent
         child.save()

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -1271,7 +1271,7 @@ class PageMoveTests(UserTestCase):
         parent/child relationships."""
         # Test detection at one level removed.
         parent = document(title='Parent of circular-dependency document',
-                         save=True)
+                          save=True)
         child = document(title='Document with circular dependency')
         child.parent_topic = parent
         child.save()


### PR DESCRIPTION
Re-based these commits on mozilla/django-1.8.

@robhudson if these look good to you too (@jezdez already gave a review in https://github.com/mozilla/kuma/pull/3660) feel free to merge or let me know and I'll push them up to the django-1.8 branch myself.