### PR TITLE
Fix Bug 1216296: RTL tweaks

### DIFF
--- a/kuma/static/styles/components/structure/tabzilla.styl
+++ b/kuma/static/styles/components/structure/tabzilla.styl
@@ -4,38 +4,41 @@ V 0.3.0
 ====================================================================== */
 
 #tabzilla {
-  position: relative;
-  float: right;
+    position: relative;
+    bidi-value(float, right, left);
 }
+
 #tabzilla a {
-  position: relative;
-  display: block;
-  width: 147px;
-  height: 37px;
-  text-indent: 120%;
-  white-space: nowrap;
-  overflow: hidden;
-  background-image: url($path-to-embedded-images + 'tabzilla-static.png');
-  background-repeat: no-repeat;
-  z-index: 2;
+    position: relative;
+    display: block;
+    width: 147px;
+    height: 37px;
+    text-indent: 120%;
+    white-space: nowrap;
+    overflow: hidden;
+    background-image: url($path-to-embedded-images + 'tabzilla-static.png');
+    background-repeat: no-repeat;
+    z-index: 2;
 }
+
 @media (-webkit-min-device-pixel-ratio: 1.5), (min--moz-device-pixel-ratio: 1.5), (-o-min-device-pixel-ratio: 3/2), (min-resolution: 1.5dppx) {
-  #tabzilla a {
-    background-image: url($path-to-embedded-images + 'tabzilla-static-high-res.png');
-    -webkit-background-size: 147px 37px;
-    background-size: 147px 37px;
-  }
+    #tabzilla a {
+        background-image: url($path-to-embedded-images + 'tabzilla-static-high-res.png');
+        -webkit-background-size: 147px 37px;
+        background-size: 147px 37px;
+    }
 }
+
 #tabzilla:before {
-  position: absolute;
-  display: block;
-  left: 28px;
-  top: 0;
-  width: 88px;
-  height: 26px;
-  content: '';
-  background-color: transparent;
-  z-index: 1;
+    position: absolute;
+    display: block;
+    bidi-style(left, 28px, right, auto);
+    top: 0;
+    width: 88px;
+    height: 26px;
+    content: '';
+    background-color: transparent;
+    z-index: 1;
 }
 
 

--- a/kuma/static/styles/components/wiki/quick-links.styl
+++ b/kuma/static/styles/components/wiki/quick-links.styl
@@ -39,7 +39,11 @@ $see-also-outdent = 6px;
     }
 
     li li {
-        bidi-style(padding-left, $grid-spacing * 2, padding-right, 0);
+        bidi-style(padding-left, $grid-spacing * 1.5, padding-right, 0);
+    }
+
+    li li li {
+        bidi-style(padding-left, $grid-spacing, padding-right, 0);
     }
 
     /* don't allow empty paragraphs by CKEditor */

--- a/kuma/static/styles/components/wiki/section-edit.styl
+++ b/kuma/static/styles/components/wiki/section-edit.styl
@@ -1,6 +1,6 @@
 .section-edit {
-    float: right;
-    margin-left: 20px;
+    bidi-value(float, right, left);
+    bidi-style(margin-left, 20px, margin-right, 0);
     set-smaller-font-size();
     opacity: 0;
 

--- a/kuma/static/styles/includes/mixins_indicators.styl
+++ b/kuma/static/styles/includes/mixins_indicators.styl
@@ -38,8 +38,9 @@ $indicator-block-heading {
 }
 
 $indicator-system {
-    border-width: 2px
-    border-style: solid;
+    /* need to specifically declare RTL to over-ride RTL inherited from set-message-base */
+    bidi-value(border-width, 2px, 2px);
+    bidi-value(border-style, solid, solid);
     font-size: $base-font-size;
 }
 


### PR DESCRIPTION
- Tabzilla
- indicator borders
- section edit buttons
- more room for items in quick-links (not specifically RTL but spotted because looking at page from new angle makes different things stand out)

[Test page](https://developer.mozilla.org/ar/docs/Web/Apps/Quickstart/Design/%D9%85%D9%81%D9%87%D9%88%D9%85_%D8%AA%D8%B7%D8%A8%D9%8A%D9%82_%D8%B9%D8%B8%D9%8A%D9%85 )