### PR TITLE
Fix Bug 1177227: Add way to pull content aside.

### DIFF
--- a/kuma/static/styles/components/content.styl
+++ b/kuma/static/styles/components/content.styl
@@ -228,23 +228,20 @@ div.bug {
 }
 
 .callout-box {
+    pull-aside();
+    bidi-value(margin-bottom, $grid-spacing, $grid-spacing); /* override behaviour of pull-aside */
+    box-sizing: border-box;
     background: $light-background-color;
     border: 1px solid #f1f1f1;
-    bidi-value(float, right, left);
-    bidi-value(margin, 0 0 ($grid-spacing / 2) $grid-spacing, 0 $grid-spacing ($grid-spacing / 2) 0);
     padding: $grid-spacing;
     position: relative;
     text-align: center;
-    @extend $column-3;
     min-width: 200px;
     z-index: 2;
 
-    prevent-last-child-bottom-spacing();
-
+    /* override behaviour of pull-aside */
     @media $media-query-small-mobile {
-        width: 100%;
-        box-sizing: border-box;
-        bidi-value(margin, 0 0 ($grid-spacing / 2) 0, 0 0 ($grid-spacing / 2) 0);
+        bidi-value(margin-bottom, $grid-spacing, $grid-spacing);
     }
 }
 

--- a/kuma/static/styles/components/share.styl
+++ b/kuma/static/styles/components/share.styl
@@ -3,6 +3,7 @@
     bidi-value(text-align, right, left);
     position: relative;
     top: $grid-spacing;
+    clear: both;
 
     strong {
         display: inline-block;

--- a/kuma/static/styles/components/wiki/content/pull-aside.styl
+++ b/kuma/static/styles/components/wiki/content/pull-aside.styl
@@ -1,0 +1,3 @@
+.pull-aside {
+    pull-aside();
+}

--- a/kuma/static/styles/includes/mixins.styl
+++ b/kuma/static/styles/includes/mixins.styl
@@ -532,3 +532,21 @@ box-theme($color) {
     background: theme-pale-light($color);
     border-color: theme-pale-medium($color);
 }
+
+/* pull aside
+   - assumes content has a bottom margin of its own
+   - floats to the right until there's not enough space for it
+-------------------------------------------------------------- */
+
+pull-aside() {
+    @extend $column-4;
+    min-width: 200px;
+    bidi-value(float, right, left);
+    bidi-value(margin, 0 0 ($grid-spacing / 2) $grid-spacing, 0 $grid-spacing ($grid-spacing / 2) 0);
+
+    @media $media-query-small-mobile {
+        width: 100%;
+        bidi-value(margin, 0, 0);
+    }
+}
+

--- a/kuma/static/styles/wiki.styl
+++ b/kuma/static/styles/wiki.styl
@@ -67,6 +67,7 @@ Styling for article content
 @require 'components/wiki/content/summary';
 @require 'components/wiki/content/compact';
 @require 'components/wiki/content/card-grid';
+@require 'components/wiki/content/pull-aside';
 @require 'components/wiki/customcss';
 @require 'components/wiki/open-in-host';
 @require 'components/wiki/section-edit';


### PR DESCRIPTION
Abstracted declaration we already had to pull callout-box aside and made reusable. Added .pull-right class so it could also be used as a wrapper around, for example, .readmore.

Testing:
https://developer.allizom.org/en-US/docs/User%3Astephaniehobson%3Aaside

Headsup: publish in CSS style guide once live.