### PR TITLE
bug 957802 - import_kumascript_modules command

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -111,6 +111,8 @@ Install and run everything
 
 .. _the badge: https://badges.mozilla.org/badges/badge/Installed-and-ran-Kuma
 
+.. _create a user:
+
 Create an admin user
 ====================
 
@@ -171,16 +173,16 @@ To enable KumaScript:
 #. Visit the `constance config admin panel`_
 #. Change ``KUMASCRIPT_TIMEOUT`` to 600
 #. Click "Save" at the bottom
+#. Import the `KumaScript auto-loaded modules`_::
 
-KumaScript is now enabled. You will also need to import the `KumaScript auto-loaded modules`_.
-You can simply copy & paste them from the production site to your local site at
-the same slugs. Or you can get a .json file to load in your local django admin
-interface as described in `this bugzilla comment`_.
+    vagrant ssh
+    python manage.py import_kumascript_modules
+
+.. note:: You must `create a user`_ to import kumascript modules.
 
 .. _KumaScript: https://developer.mozilla.org/en-US/docs/MDN/Contribute/Tools/KumaScript
 .. _constance config admin panel: https://developer-local.allizom.org/admin/constance/config/
 .. _KumaScript auto-loaded modules: https://developer.mozilla.org/en-US/docs/MDN/Kuma/Introduction_to_KumaScript#Auto-loaded_modules
-.. _this comment: https://github.com/mozilla/kuma/issues/2518#issuecomment-53665362
 
 .. _GitHub Auth:
 

--- a/kuma/wiki/management/commands/import_kumascript_modules.py
+++ b/kuma/wiki/management/commands/import_kumascript_modules.py
@@ -1,0 +1,56 @@
+"""
+Import KumaScript auto-loaded modules from production site.
+
+Run this when setting up a new dev box to get the latest required KumaScript
+modules from the production site.
+"""
+import requests
+
+from django.core.management.base import BaseCommand
+
+from kuma.users.models import User
+from kuma.wiki.exceptions import SlugCollision
+from kuma.wiki.models import Document, Revision
+
+KS_AUTOLOAD_MODULES = [
+    'Template:mdn:common',
+    'Template:DekiScript:Date',
+    'Template:DekiScript:Page',
+    'Template:DekiScript:String',
+    'Template:DekiScript:Uri',
+    'Template:DekiScript:Web',
+    'Template:DekiScript:Wiki',
+]
+
+RAW_TEMPLATE_URL = 'https://developer.mozilla.org/en-US/docs/%s?raw=1'
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        # get first user to be the creator
+        u = User.objects.all()[0]
+        loaded_docs = []
+        skipped_docs = []
+
+        for slug in KS_AUTOLOAD_MODULES:
+            template_response = requests.get(RAW_TEMPLATE_URL % slug)
+            doc = Document(title=slug, slug=slug,
+                           category=Document.CATEGORIES[0][0])
+            try:
+                doc.save()
+                loaded_docs.append(slug)
+            except SlugCollision:
+                # skip modules already in the db
+                skipped_docs.append(slug)
+                continue
+            rev = Revision(document=doc, content=template_response.content,
+                           creator=u)
+            rev.save()
+
+        print "Loaded docs:"
+        for slug in loaded_docs:
+            print "%s" % slug
+        print "\nSkipped docs that were already loaded:"
+        for slug in skipped_docs:
+            print "%s" % slug

--- a/kuma/wiki/views/misc.py
+++ b/kuma/wiki/views/misc.py
@@ -173,7 +173,7 @@ def load_documents(request):
         file_data = None
         form = ImportForm(request.POST, request.FILES)
         if form.is_valid():
-            uploaded_file = request.FILES['file']
+            uploaded_file = request.FILES['uploads']
             if uploaded_file.multiple_chunks():
                 file_data = open(uploaded_file.temporary_file_path(), 'r')
             else:


### PR DESCRIPTION
While working on #3631, I finally got tired enough of loading the KumaScript auto-load modules manually to write a command script to load them from the prod site automatically:
```
vagrant ssh
python manage.py import_kumascript_modules
```
I know @stephaniehobson has wanted this for a long time; sorry for taking this long to do it.

Updated the installation docs to include this too.