### PR TITLE
Bug 1206309: Heading in drop down.

### DIFF
--- a/kuma/static/js/wiki-compat-tables.js
+++ b/kuma/static/js/wiki-compat-tables.js
@@ -20,7 +20,7 @@
     var historyCount = 0;
 
     // The open button template
-    var $historyLink = $('<button title="' + gettext('Open') + '" class="bc-history-link only-icon" tabindex="-1"><span>' + gettext('Open') + '</span><i class="ic-history" aria-hidden="true"></i></button>');
+    var $historyLink = $('<button title="' + gettext('Open implementation notes') + '" class="bc-history-link only-icon" tabindex="-1"><span>' + gettext('Open') + '</span><i class="ic-history" aria-hidden="true"></i></button>');
     // The close button template
     var $historyCloseButton = $('<button class="bc-history-button"><abbr class="only-icon" title="' + gettext('Return to compatability table.') + '"><span>' + gettext('Close') + '</span><i class="icon-times" aria-hidden="true"></i></abbr></button>');
 

--- a/kuma/static/styles/components/compat-tables/bc-beta.styl
+++ b/kuma/static/styles/components/compat-tables/bc-beta.styl
@@ -3,7 +3,7 @@
     text-align: right;
 
     ul {
-        padding-left: 20px;
+        padding-left: $grid-spacing;
         list-style-type: none;
         text-align: left;
     }

--- a/kuma/static/styles/components/compat-tables/bc-footnotes.styl
+++ b/kuma/static/styles/components/compat-tables/bc-footnotes.styl
@@ -3,7 +3,7 @@ footnotes
 ====================================================================== */
 
 .bc-footnotes dt {
-    margin-top: 10px;
+    margin-top: $bc-grid-spacing;
     font-weight: bold;
 }
 

--- a/kuma/static/styles/components/compat-tables/bc-history.styl
+++ b/kuma/static/styles/components/compat-tables/bc-history.styl
@@ -7,6 +7,7 @@ History
     box-sizing: border-box;
     border-top: 4px solid $bc-color-border;
     border-bottom: 3px solid $bc-color-border;
+    padding-left: 200px;
     overflow: hidden;
     cursor: default;
 }
@@ -23,7 +24,6 @@ History
         display: block;
         visibility: visible;
         height: 0;
-        padding-left: 200px;
     }
 
     /* creates a block to fill the space under the absolutely
@@ -37,9 +37,17 @@ History
         float: right;
     }
 
+.bc-history-head {
+    padding-top: $bc-grid-spacing;
+    padding-left: $bc-grid-spacing;
+    margin-bottom: $bc-grid-spacing;
+    set-font-size($base-bump-font-size);
+    text-align: left;
+}
+
 .bc-history dl {
     text-align: left;
-    margin: 10px;
+    margin: $bc-grid-spacing;
     margin-left: 160px;
 }
 
@@ -60,7 +68,7 @@ History
     margin-bottom: 0; //override .text-content defaults
     padding-top: 4px;
     padding-left: 0; //override .text-content defaults
-    padding-bottom: 10px;
+    padding-bottom: $bc-grid-spacing;
     font-weight: normal; //override .text-content defaults
 }
 
@@ -72,8 +80,8 @@ History
 
 .bc-history-button {
     position: absolute;
-    top: 10px;
-    right: 10px;
+    top: $bc-grid-spacing;
+    right: $bc-grid-spacing;
 }
 
 .bc-supports {
@@ -111,13 +119,13 @@ bc-history-tablet-display() {
 @media $media-query-small-mobile {
 
     .bc-history dl {
-       margin-left: 10px;
+       margin-left: $bc-grid-spacing;
     }
 
     .bc-history dt {
-        margin-top: 10px;
+        margin-top: $bc-grid-spacing;
         margin-left: 0;
-        margin-bottom: 10px;
+        margin-bottom: $bc-grid-spacing;
     }
 
     .bc-history dd {

--- a/kuma/static/styles/components/compat-tables/bc-legend.styl
+++ b/kuma/static/styles/components/compat-tables/bc-legend.styl
@@ -12,12 +12,12 @@ legend
 
 .bc-legend dt {
     display: inline-block;
-    margin: 0 0 5px 0;
+    margin: 0 0 ($bc-grid-spacing / 2) 0;
 }
 
 .bc-legend dd {
     display: inline;
-    margin: 0 10px 5px 10px;
+    margin: 0 $bc-grid-spacing ($bc-grid-spacing / 2) $bc-grid-spacing;
 }
 
 .bc-legend dd:after {

--- a/kuma/static/styles/components/compat-tables/bc-table.styl
+++ b/kuma/static/styles/components/compat-tables/bc-table.styl
@@ -201,7 +201,7 @@ bc-table-tablet-display-flex() {
         max-width: 100%;
         display: block;
         border-right: 0;
-        padding-top: 10px;
+        padding-top: $bc-grid-spacing;
         padding-bottom: 0;
     }
 
@@ -246,7 +246,7 @@ mobile display
         max-width: 100%;
         display: block;
         border-right: 0;
-        padding-top: 10px;
+        padding-top: $bc-grid-spacing;
         padding-bottom: 0;
     }
 
@@ -261,7 +261,7 @@ mobile display
         border-top: 2px solid $bc-color-border;
         border-left: 0;
         padding-left: 70px;
-        padding-right: 10px;
+        padding-right: $bc-grid-spacing;
         text-align: left;
     }
 

--- a/kuma/static/styles/components/compat-tables/vars.styl
+++ b/kuma/static/styles/components/compat-tables/vars.styl
@@ -22,3 +22,5 @@ $bc-color-unknown = #bbbbbb;
 $bc-color-border = #ffffff;
 
 $bc-support = yes no partial unknown;
+
+$bc-grid-spacing = 10px;


### PR DESCRIPTION
- Style changes to accommodate heading in bc-history drop down
- Variablize $bc-grid-spacing
- Add "implementation notes" to title for button
- Fix problem with height of bc-history drop down in desktop display

Need to update embedCompatTable template for testing: https://gist.github.com/stephaniehobson/2b69ff6bb3be1a39b23a

Headsup: update staging when merged