### PR TITLE
Fix Bug 1228442 - Report errors from CDN served JS files.

### DIFF
--- a/provisioning/roles/kuma/files/apache2/all-servers.conf
+++ b/provisioning/roles/kuma/files/apache2/all-servers.conf
@@ -12,6 +12,14 @@
     Header set Access-Control-Allow-Origin %{CORS}e env=CORS
 </Location>
 
+<Location /static/build/js>
+    # Only enable CORS for JavaScript when the request is coming from an approved domain
+    Header unset Access-Control-Allow-Origin
+    SetEnvIf Origin "https?://(.*\.(mozilla|allizom)\.(com|org|net))" CORS=$0
+    SetEnvIf Origin "https?://(mdn\.mozillademos\.org)" CORS=$0
+    Header set Access-Control-Allow-Origin %{CORS}e env=CORS
+</Location>
+
 # Bug 1078186 - Redirect old static canvas examples to wiki pages
 # canvas tutorial
 RewriteRule ^/samples/canvas-tutorial/2_1_canvas_rect.html$ /docs/Web/API/Canvas_API/Tutorial/Drawing_shapes#Rectangular_shape_example [NE,R=301,L,NC]

--- a/templates/pipeline/js.jinja
+++ b/templates/pipeline/js.jinja
@@ -1,0 +1,1 @@
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8" crossorigin="anonymous"></script>


### PR DESCRIPTION
Two pieces to this:
1) add `crossorigin="anonymous"` to our `<script>` tags
2) enable CORS for our domain on the CDN

https://raygun.io/blog/2015/05/fix-script-error-and-get-the-most-data-possible-from-cross-domain-js-errors/