### PR TITLE
Fix Bug 1232404: Contributor bar visual design

### DIFF
--- a/kuma/static/styles/components/wiki/contributor-avatars.styl
+++ b/kuma/static/styles/components/wiki/contributor-avatars.styl
@@ -1,18 +1,27 @@
 /* contributor avatars at top of articles */
+
+$avatar-max-width = 20px;
+$avatar-margin = 5px;
+$avatar-limit = 6;
+
 .contributor-avatars {
-    set-smaller-font-size();
+    bidi-value(float, right, left);
+    position: relative;
+    max-width: ($avatar-limit * ($avatar-max-width + $avatar-margin));
+    margin-top: 23px;
+    bidi-style(margin-left, $grid-spacing, margin-right, 0);
+    margin-bottom: $grid-spacing;
     color: #777;
-    padding: 10px 10px $content-vertical-spacing;
-    border-bottom: 1px solid rgb(241, 241, 241);
-    border-top: 1px solid rgb(241, 241, 241);
-    background: none repeat scroll 0 0 rgba-fallback(rgba(234, 239, 243, 0.4));
-    margin-top: -20px;
-    margin-bottom: 20px;
+    set-smaller-font-size();
+
+    .from-search &,
+    .no-js & {
+        display: none;
+    }
 
     ul {
-        display: inline;
+        display: inline-block;
         opacity: 0.7;
-        margin-left: 2px;
         vendorize(transition, opacity .3s ease-in-out);
 
         &:hover,
@@ -21,11 +30,10 @@
         }
 
         li {
-            margin: 0 5px 4px 0;
+            bidi-value(float, left, right);
+            bidi-value(margin, 0 0 4px $avatar-margin, 0 $avatar-margin 4px 0);
+            display: inline-block;
 
-            &, .no-js  &.hidden {
-                display: inline-block;
-            }
 
             &.hidden {
                 display: none;
@@ -47,7 +55,7 @@
     .avatar {
         vertical-align: text-bottom;
         border-radius: 2px;
-        max-width: 20px;
+        max-width: $avatar-max-width;
         opacity: 0;
 
         &.loaded {
@@ -56,16 +64,13 @@
     }
 
     button {
-        set-smaller-font-size();
-        margin-left: -2px;
-        color: #777;
+        position: absolute;
+        top: 100%;
+        bidi-style(right, 0, left, auto);
+        margin-top: -5px;
+        padding: 0;
+        color: $link-color;
         text-transform: none;
-        padding: 5px 0;
-
-        &:hover,
-        &:focus {
-            color: #4D4E53;
-        }
     }
 }
 

--- a/kuma/wiki/templates/wiki/document.html
+++ b/kuma/wiki/templates/wiki/document.html
@@ -37,6 +37,7 @@
 {% set crumbs = build_document_crumbs(document) %}
 {% set share_links = build_share_links(document) %}
 
+
 {% set content_class = 'column-all' %}
 {% if show_left and show_right %}
   {% set content_class = 'column-half' %}
@@ -176,17 +177,8 @@
             <a class="button from-search-next only-icon disabled" title="{{ _('Next Search Result') }}" data-empty-title="{{ _('No Previous Search Result') }}"><i aria-hidden="true" class="icon-chevron-right"></i></a>
           </span>
 
-        <h1>{{ document.title }}</h1>
-
         {% if has_contributors %}
-        <div class="contributor-avatars" data-all-text="{{ _('Show all') }}&hellip;<span class='hidden'>{{ _('contributors') }}</span>" {% if contributors_count > contributors_limit %}data-has-hidden="1"{% endif %}>
-            <span class="quickstat">
-            {% trans count=contributors_count %}
-            by {{ count }} contributor:
-            {% pluralize %}
-            by {{ count }} contributors:
-            {% endtrans %}
-            </span>
+        <div class="contributor-avatars" data-all-text="{{ _('see all contributors') }}" data-alternate-message="{{ _('hide contributors') }}" {% if contributors_count > contributors_limit %}data-has-hidden="1"{% endif %}>
             <ul>
             {% for contributor in contributors %}
                 <li class="{% if loop.index > contributors_limit %}hidden{% else %}shown{% endif %}">
@@ -197,6 +189,8 @@
             </ul>
         </div>
         {% endif %}
+
+        <h1>{{ document.title }}</h1>
 
       </div>
       {% endif %}

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -662,7 +662,7 @@ def document(request, document_slug, document_locale):
         'body_html': body_html,
         'contributors': contributors,
         'contributors_count': contributors_count,
-        'contributors_limit': 13,
+        'contributors_limit': 6,
         'has_contributors': has_contributors,
         'fallback_reason': fallback_reason,
         'kumascript_errors': ks_errors,


### PR DESCRIPTION
Testing: 
- wiki page
- zone page
- zone landing
- RTL
- less than 6 avatars
- more than 6 avatars (show all button should appear)
- arriving on article from search (should not display)
- smaller screen sizes (should not display)
- long page title (title should wrap to avoid contributors)

Make sure it expands and collapses when "show all" clicked/tapped/keyed.