### PR TITLE
Bug 1216296: RTL Fixes

### DIFF
--- a/kuma/static/styles/components/structure/contentinfo.styl
+++ b/kuma/static/styles/components/structure/contentinfo.styl
@@ -27,7 +27,7 @@
     }
 
     li {
-        float: left;
+        bidi-value(float, left, right);
         bidi-style(padding-right, 10px, padding-left, 0);
         text-indent: -5px; /* to make space for bullet */
 

--- a/kuma/static/styles/components/tags.styl
+++ b/kuma/static/styles/components/tags.styl
@@ -8,7 +8,7 @@ ul.tags {
     border: none;
     clear: both;
     margin-bottom: 0; /* doesn't need bottom margin, each tag takes care of that */
-    padding-left: 0; /* overrides padding added to lists in content areas */
+    bidi-style(padding-left, 0, padding-right, 0); /* overrides padding added to lists in content areas */
     width: 100%;
 
     .wiki-block &,
@@ -23,7 +23,7 @@ ul.tags li {
     border: 1px solid #cee9f9;
     border-radius: 2px;
     display: inline-block;
-    margin: 0 ($grid-spacing / 2) ($grid-spacing / 2) 0;
+    bidi-value(margin, 0 ($grid-spacing / 2) ($grid-spacing / 2) 0, 0 0 ($grid-spacing / 2) ($grid-spacing / 2));
     padding: 3px ($grid-spacing / 2) 4px;
 
     label {
@@ -38,7 +38,7 @@ ul.tags li {
 $small-tag-spacing = 3px;
 
 ul.tags-small li {
-    margin: 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2) 0;
+    bidi-value(margin, 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2) 0, 0 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2));
     padding: 1px $small-tag-spacing;
 }
 

--- a/kuma/static/styles/components/wiki/content/card-grid.styl
+++ b/kuma/static/styles/components/wiki/content/card-grid.styl
@@ -2,7 +2,7 @@
 
 .text-content .card-grid {
     margin: 0 ($grid-spacing / 2) $grid-spacing;
-    padding: 0;
+    bidi-value(padding, 0, 0); /* need some extra specificity for RTL */
     list-style-type: none;
 
     > li {

--- a/kuma/static/styles/includes/mixins.styl
+++ b/kuma/static/styles/includes/mixins.styl
@@ -425,7 +425,7 @@ $checkbox-label-container {
     }
 
     > p {
-        clear: left;
+        bidi-value(clear, left, right);
     }
 }
 


### PR DESCRIPTION
Fixes for:
- footer (last line left aligned instead of right aligned)

![screen shot 2015-12-14 at 12 11 46](https://cloud.githubusercontent.com/assets/854701/11793145/cfd2da9a-a25e-11e5-8d62-a80b04a74bfd.png)
- card-grid (too much padding)

![screen shot 2015-12-14 at 12 11 33](https://cloud.githubusercontent.com/assets/854701/11793147/d4c3cf6e-a25e-11e5-9358-d4958501a425.png)
- tags in footer of articles (large blank space)

![screen shot 2015-12-14 at 12 11 43](https://cloud.githubusercontent.com/assets/854701/11793157/e2923c70-a25e-11e5-8b57-d4c6664d7e9a.png)
- check box on profile page (overlapping text - no screen shot)