### PR TITLE
fix bug 1233441 - code tag overflow on mobile

### DIFF
--- a/kuma/static/styles/base/elements/typography.styl
+++ b/kuma/static/styles/base/elements/typography.styl
@@ -159,6 +159,7 @@ mono space elements (pre, code, kbd)
 
 code {
     font-family: $code-inline-font-family;
+    word-wrap: break-word;
 }
 
 /* pre is a block element so it gets a bit more fancy styling */


### PR DESCRIPTION
This makes text in a `<code>` tag break so it doesn't overflow and create a huge amount of whitespace when on a mobile device (or small browser window)

![image](https://cloud.githubusercontent.com/assets/2252884/11877507/5555825a-a4b5-11e5-8540-0040d19fb770.png)