### PR TITLE
Fix bug 1233185 - Remove explanation text from search results.

### DIFF
--- a/kuma/search/serializers.py
+++ b/kuma/search/serializers.py
@@ -61,10 +61,6 @@ class DocumentSerializer(BaseDocumentSerializer):
         source='meta.score',
         allow_null=True,
     )
-    explanation = serializers.ReadOnlyField(
-        source='meta.explanation',
-        allow_null=True,
-    )
     parent = BaseDocumentSerializer(read_only=True, allow_null=True)
 
 

--- a/kuma/search/templates/search/results.html
+++ b/kuma/search/templates/search/results.html
@@ -34,7 +34,7 @@
         <h4><a href="{{ doc.url }}"{% if index == 1 %} tabindex="1"{% endif %}>{{ doc.title }}</a></h4>
         <p>{{ doc.excerpt|safe }}</p>
         <p class="search-meta"><a href="{{ doc.url }}">{{ doc.url|replace('https://', '') }}</a>
-        {% if request.user.is_superuser %}Score: <span title="explanation: {{ doc.explanation }}">{{ doc.score }}</span>{% endif%}
+        {% if request.user.is_superuser %}Score: {{ doc.score }}{% endif %}
         {% if doc.parent %}
             {% trans parent_url=doc.parent.url, parent_title=doc.parent.title, parent_language=settings.LOCALES[doc.parent.locale].native %}
             translated from <a href="{{ parent_url }}" title="{{ parent_title }}">{{ parent_title }} ({{ parent_language }})</a>

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -225,3 +225,10 @@ class ViewTests(ElasticTestCase):
         self.assertContains(response,
                             ('Search index: %s' %
                              Index.objects.get_current().name))
+
+    def test_score(self):
+        response = self.client.get('/en-US/search.json')
+        self.assertEqual(response.status_code, 200)
+        self.assertGreater(response.data['documents'], 0)
+        for document in response.data['documents']:
+            self.assertIn('score', document)


### PR DESCRIPTION
This simplifies the rendering dramatically and fixes a regression in the DRF 3.x update.