### PR TITLE
Fix bug 1172803: Remove revision content section and revision source …

### DIFF
--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -56,14 +56,16 @@
       {% include "wiki/includes/document_tag.html" %}
     </div>
 
-    <details open="open">
-      <summary><h2>{{ _('Revision Content') }}</h2></summary>
-      <article id="wikiArticle" class="text-content">
-        {{ revision.content_cleaned|safe }}
-      </article>
-    </details>
+    {% if not document.is_template %}
+      <details open="open">
+        <summary><h2>{{ _('Revision Content') }}</h2></summary>
+        <article id="wikiArticle" class="text-content">
+          {{ revision.content_cleaned|safe }}
+        </article>
+      </details>
+    {% endif %}
 
-    <details>
+    <details {% if document.is_template %}open="open"{% endif %}>
       <summary><h2>{{ _('Revision Source') }}</h2></summary>
       <div id="doc-source">
         <pre class="brush:js">{{ revision.content }}</pre>

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -349,6 +349,29 @@ class ViewTests(UserTestCase, WikiTestCase):
         ok_('<svg>' not in ct)
         ok_('<a href="#">Hahaha</a>' in ct)
 
+    def test_template_revision_content(self):
+        doc = document(title='Testing Template', slug='Template:Testing', save=True)
+        r = revision(save=True, document=doc, is_approved=True)
+
+        resp = self.client.get(r.get_absolute_url())
+        page = pq(resp.content)
+
+        ok_('Revision Source' in resp.content)
+        ok_('Revision Content' not in resp.content)
+        eq_(page.find('#doc-source').parent().attr('open'), 'open')
+
+    def test_article_revision_content(self):
+        doc = document(title='Testing Article', slug='Article', save=True)
+        r = revision(save=True, document=doc, is_approved=True)
+
+        resp = self.client.get(r.get_absolute_url())
+        page = pq(resp.content)
+
+        ok_('Revision Source' in resp.content)
+        ok_('Revision Content' in resp.content)
+        eq_(page.find('#wikiArticle').parent().attr('open'), 'open')
+        eq_(page.find('#doc-source').parent().attr('open'), None)
+
     def test_raw_css_view(self):
         """The raw source for a document can be requested"""
         self.client.login(username='admin', password='testpass')


### PR DESCRIPTION
…section's title from revision template. I also removed the test for revision content, as it's not being showed anymore.

I choose to remove the section title, as suggested in the bug report, because this way the revision view better resemble the document view.

I'm not completely familiarized with semantic markup, is the new version ok?