### PR TITLE
Bug 1070001: Remove addpage-button

### DIFF
--- a/kuma/static/styles/components/wiki/mega.styl
+++ b/kuma/static/styles/components/wiki/mega.styl
@@ -16,26 +16,3 @@
         set-smaller-font-size();
     }
 }
-
-/* old customCSS classes, phasing out */
-div.addpage-button {
-    width: 100%;
-    text-align: center;
-}
-
-a.addpage-button {
-    margin-bottom: 20px;
-    padding: 18px 40px;
-    text-align: center;
-    border-radius: 6px;
-    set-font-size(28px);
-    display: inline-block;
-    background-color: $green;
-    white-space: nowrap;
-    color: #fff;
-    box-shadow: inset 0 -1px #486900;
-
-    div {
-        set-smaller-font-size();
-    }
-}


### PR DESCRIPTION
The macro has been transitioned to use the new classes outlined in https://github.com/mozilla/kuma/pull/3672 and there are no references* to the old class left on production. We can safely remove this.

* the search is turning up 3 references for some reason but I have viewed source on those pages and confirmed it is not in use. Caching?