### PR TITLE
Fix Bug 1228442 - Report errors from CDN served JS files.

### DIFF
--- a/templates/pipeline/js.jinja
+++ b/templates/pipeline/js.jinja
@@ -1,0 +1,1 @@
+<script{% if async %} async{% endif %}{% if defer %} defer{% endif %} type="{{ type }}" src="{{ url }}" charset="utf-8" crossorigin="anonymous"></script>


### PR DESCRIPTION
Simplified by the whitenoise changes! The CDN changes should already be handled, it's just a matter of adding the attribute to the script.

@groovecoder I'm not able to replicate the `net::ERR_INSECURE_RESPONSE` you reported on #3693. So maybe the whitenoise move fixed that as well, or the upgrade to SH256. 

https://raygun.io/blog/2015/05/fix-script-error-and-get-the-most-data-possible-from-cross-domain-js-errors/