### PR TITLE
Fix Bug 1232379 - Make .quicklinks workable on zone landings

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.styl
+++ b/kuma/static/styles/components/wiki/quick-links.styl
@@ -4,10 +4,16 @@ $see-also-outdent = 6px;
 
     margin-bottom: $grid-spacing;
     position: relative;
+    background-color: #fff;
 
     set-smaller-font-size();
     {$selector-heading-font-fallback} {
         letter-spacing: -0.002em;
+    }
+
+    /* need to give it a fake border when appearing on zones */
+    .zone-landing-header-preview-base & {
+        box-shadow: ($see-also-outdent * -1) 0 0 #fff;
     }
 
     a {


### PR DESCRIPTION
Writers want to move to quick links menus as part of preparation to migrate off of zones, right now at tablet and smaller that means grey links end up on the blue background and are un-readable. 

Added a white background and a fake left border to account for the negative margin on the see-also heading. 

Test page:
https://developer.allizom.org/en-US/Add-ons