### PR TITLE
Fix Bug 1217085: remove the class tip

### DIFF
--- a/kuma/static/styles/components/content.styl
+++ b/kuma/static/styles/components/content.styl
@@ -254,12 +254,6 @@ p.footnote {
     color: #716d65;
 }
 
-div.tip {
-    border: 1px solid #e1f5f0;
-    padding: 10px 15px;
-    color: #6d675f;
-}
-
 /* Classes created by the WYSIWYG */
 .twocolumns {
     vendorize(column-count, 2);
@@ -279,4 +273,3 @@ div.tip {
 .readable-line-length {
     max-width: 60em;
 }
-


### PR DESCRIPTION
# Fix Bug 1217085: remove the class tip

This commit removes the tip class from the https://github.com/mozilla/kuma/blob/36220986307fd18eeac275b9c3058d7ccae40565/kuma/static/styles/components/content.styl#L257