### PR TITLE
Fix bug 1237072 - Fix issue with whitenoise and settings

### DIFF
--- a/kuma/wsgi.py
+++ b/kuma/wsgi.py
@@ -1,7 +1,6 @@
 # Fix the settings so that Whitenoise is happy
 import os
-if 'DJANGO_SETTINGS_MODULE' not in os.environ:
-    os.environ['DJANGO_SETTINGS_MODULE'] = 'settings_local'
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'settings_local')
 
 # Enable WhiteNoise
 from django.core.wsgi import get_wsgi_application

--- a/kuma/wsgi.py
+++ b/kuma/wsgi.py
@@ -1,3 +1,8 @@
+# Fix the settings so that Whitenoise is happy
+import os
+if 'DJANGO_SETTINGS_MODULE' not in os.environ:
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'settings_local'
+
 # Enable WhiteNoise
 from django.core.wsgi import get_wsgi_application
 from whitenoise.django import DjangoWhiteNoise


### PR DESCRIPTION
whitenoise needs DJANGO_SETTINGS_MODULE to be set in the environment
otherwise it raises an ImproperlyConfigured exception.

This adds that variable to the environment for the vagrant vm. Doing
that causes the DJANGO_SETTINGS_MODULE hackery in manage.py to do the
wrong thing for the "./manage.py test", so this also updates the
Makefile rule and docs to specify
DJANGO_SETTINGS_MODULE=settings_test.

Feedback? This fixes one issue and creates new ones. I'm game for better
suggestions.