### PR TITLE
Fix bug 1239380: Switch to py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.pyo
 *.sw?
 .vagrant
+.cache
 kuma.box
 /settings_local.py
 pip-log.txt

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ endif
 
 # Note: these targets should be run from the kuma vm
 django-tests: in_vagrant
-	python manage.py test
+	py.test
 
 performance-tests: in_vagrant
 	locust -f tests/performance/smoke.py --host=https://developer.allizom.org

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -53,31 +53,32 @@ There are a bunch of ways to specify a subset of tests to run:
 
 * only tests marked with the 'spam' marker::
 
-    ./py.test -m spam
+    py.test -m spam
 
 * all the tests but those marked with the 'spam' marker::
 
-    ./py.test -m "not spam"
+    py.test -m "not spam"
 
 * all the tests but the ones in ``kuma/core``::
 
-    ./py.test --ignore kuma/core
+    py.test --ignore kuma/core
 
 * all the tests that have "foobar" in their names::
 
-    ./py.test -k foobar
+    py.test -k foobar
 
 * all the tests that don't have "foobar" in their names::
 
-    ./py.test -k "not foobar"
+    py.test -k "not foobar"
 
 * tests in a certain directory::
 
-    ./py.test kuma/wiki/
+    py.test kuma/wiki/
 
 * specific test::
 
-    ./py.test kuma/wiki/tests/test_views.py::RedirectTests::test_redirects_only_internal
+    py.test kuma/wiki/tests/test_views.py::RedirectTests::test_redirects_only_internal
+
 
 See http://pytest.org/latest/usage.html for more examples.
 
@@ -88,6 +89,33 @@ The Test Database
 The test suite will create a new database named ``test_%s`` where ``%s`` is
 whatever value you have for ``settings.DATABASES['default']['NAME']``. Make
 sure the user has ``ALL`` on the test database as well.
+
+
+Markers
+=======
+
+See::
+
+    py.test --markers
+
+
+for the list of available markers.
+
+To add a marker, add it to the ``pytest.ini`` file.
+
+To use a marker, add a decorator to the class or function. Examples::
+
+    import pytest
+
+    @pytest.mark.spam
+    class SpamTests(TestCase):
+        ...
+
+    class OtherSpamTests(TestCase):
+        @pytest.mark.spam
+        def test_something(self):
+            ...
+
 
 Adding Tests
 ============

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -20,49 +20,66 @@ Running the Test Suite
 If you followed the steps in :doc:`the installation docs <installation>`,
 then all you should need to do to run the test suite is::
 
-    ./manage.py test
+    py.test
 
-However, that doesn't provide the most sensible defaults. Here is a good
-command to alias to something short::
 
-    ./manage.py test -s --noinput --logging-clear-handlers
+Default options for running the test are in ``pytest.ini``. This is a
+good set of defaults.
 
-The ``-s`` flag is important if you want to be able to drop into PDB from
-within tests.
+If you ever need to change the defaults, you can do so at the command
+line.
 
-Some tests will fail.  See `Running a Subset`_ below for running the subset
-that is expected to pass.
+Helpful command-line arguments:
 
-Some other helpful flags are:
-
-``-x``:
-  Fast fail. Exit immediately on failure. No need to run the whole test suite
-  if you already know something is broken.
 ``--pdb``:
-  Drop into PDB on an uncaught exception. (These show up as ``E`` or errors in
-  the test results, not ``F`` or failures.)
-``--pdb-fail``:
-  Drop into PDB on a test failure. This usually drops you right at the
-  assertion.
+  Drop into pdb on test failure.
+
+``--create-db``:
+  Create a new test database.
+
+``--showlocals``:
+  Shows local variables in tracebacks on errors.
+
+``--exitfirst``:
+  Exits on the first failure.
+
+See ``./py.test --help`` for more arguments.
 
 
-Running a Subset
-----------------
+Running subsets of tests and specific tests
+-------------------------------------------
 
-You can run part of the test suite by specifying the apps you want to run,
-like::
+There are a bunch of ways to specify a subset of tests to run:
 
-    ./manage.py test kuma
+* only tests marked with the 'spam' marker::
 
-You can also exclude tests that match a regular expression with ``-e``::
+    ./py.test -m spam
 
-    ./manage.py test -e "search"
+* all the tests but those marked with the 'spam' marker::
 
-To run the subset of tests that should pass::
+    ./py.test -m "not spam"
 
-    ./manage.py test kuma
+* all the tests but the ones in ``kuma/core``::
 
-See the output of ``./manage.py test --help`` for more arguments.
+    ./py.test --ignore kuma/core
+
+* all the tests that have "foobar" in their names::
+
+    ./py.test -k foobar
+
+* all the tests that don't have "foobar" in their names::
+
+    ./py.test -k "not foobar"
+
+* tests in a certain directory::
+
+    ./py.test kuma/wiki/
+
+* specific test::
+
+    ./py.test kuma/wiki/tests/test_views.py::RedirectTests::test_redirects_only_internal
+
+See http://pytest.org/latest/usage.html for more examples.
 
 
 The Test Database

--- a/kuma/attachments/tests/test_models.py
+++ b/kuma/attachments/tests/test_models.py
@@ -1,9 +1,7 @@
-from nose.tools import ok_
-
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, ok_
 from kuma.users.tests import user
 from ..utils import allow_add_attachment_by
 

--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -1,11 +1,10 @@
 from constance import config
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
+from kuma.core.tests import eq_, ok_
+from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 from kuma.wiki.tests import revision, WikiTestCase
-from kuma.core.urlresolvers import reverse
 
 from ..models import Attachment
 from ..utils import make_test_file
@@ -22,7 +21,6 @@ class AttachmentTests(UserTestCase, WikiTestCase):
         super(AttachmentTests, self).tearDown()
         config.WIKI_ATTACHMENT_ALLOWED_TYPES = self.old_allowed_types
 
-    @attr('security')
     def test_xss_file_attachment_title(self):
         title = '"><img src=x onerror=prompt(navigator.userAgent);>'
         # use view to create new attachment

--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -1,3 +1,4 @@
+import pytest
 from constance import config
 from pyquery import PyQuery as pq
 
@@ -21,6 +22,7 @@ class AttachmentTests(UserTestCase, WikiTestCase):
         super(AttachmentTests, self).tearDown()
         config.WIKI_ATTACHMENT_ALLOWED_TYPES = self.old_allowed_types
 
+    @pytest.mark.security
     def test_xss_file_attachment_title(self):
         title = '"><img src=x onerror=prompt(navigator.userAgent);>'
         # use view to create new attachment

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -5,10 +5,10 @@ from django.conf import settings
 from django.core.files import temp as tempfile
 from django.core.files.base import ContentFile
 from django.utils.http import parse_http_date_safe
-from nose.tools import eq_, ok_
 
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
+from kuma.core.tests import eq_, ok_
 from kuma.users.tests import UserTestCase
 from kuma.wiki.models import Document, DocumentAttachment
 from kuma.wiki.tests import WikiTestCase, document, revision

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -4,9 +4,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from django.http import HttpRequest
 
-from nose.tools import eq_, ok_
-from nose.plugins.attrib import attr
-
+from kuma.core.tests import eq_, ok_
 from kuma.users.tests import user
 
 from ..models import Key
@@ -15,7 +13,6 @@ from ..decorators import accepts_auth_key
 
 class KeyDecoratorsTest(TestCase):
 
-    @attr('current')
     def test_key_auth_decorator(self):
 
         u = user(username="test23", email="test23@example.com", save=True)

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -1,5 +1,7 @@
 import base64
 
+import pytest
+
 from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from django.http import HttpRequest
@@ -13,6 +15,7 @@ from ..decorators import accepts_auth_key
 
 class KeyDecoratorsTest(TestCase):
 
+    @pytest.mark.current
     def test_key_auth_decorator(self):
 
         u = user(username="test23", email="test23@example.com", save=True)

--- a/kuma/authkeys/tests/test_models.py
+++ b/kuma/authkeys/tests/test_models.py
@@ -1,8 +1,6 @@
 from django.test import TestCase
 
-from nose.tools import ok_
-from nose.plugins.attrib import attr
-
+from kuma.core.tests import ok_
 from kuma.users.tests import user
 
 from ..models import Key
@@ -10,7 +8,6 @@ from ..models import Key
 
 class KeyViewsTest(TestCase):
 
-    @attr('current')
     def test_secret_generation(self):
         """Generated secret should be saved as a hash and pass a check"""
         u = user(username="tester23",

--- a/kuma/authkeys/tests/test_models.py
+++ b/kuma/authkeys/tests/test_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from django.test import TestCase
 
 from kuma.core.tests import ok_
@@ -8,6 +10,7 @@ from ..models import Key
 
 class KeyViewsTest(TestCase):
 
+    @pytest.mark.current
     def test_secret_generation(self):
         """Generated secret should be saved as a hash and pass a check"""
         u = user(username="tester23",

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -1,10 +1,10 @@
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import TestCase
 
+from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import user
 

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -8,12 +8,29 @@ from django.test import TestCase, TransactionTestCase
 from django.test.client import Client
 from django.utils.translation import trans_real
 
-from nose import SkipTest
-from nose.tools import eq_
-
 from ..cache import memcache
 from ..exceptions import FixtureMissingError
 from ..urlresolvers import split_path
+
+
+def eq_(first, second, msg=None):
+    """Rough reimplementation of nose.tools.eq_
+
+    Note: This should be removed as soon as we no longer use it.
+
+    """
+    msg = msg or '%r != %r' % (first, second)
+    assert first == second, msg
+
+
+def ok_(pred, msg=None):
+    """Rough reimplementation of nose.tools.ok_
+
+    Note: This should be removed as soon as we no longer use it.
+
+    """
+    msg = msg or '%r != True' % pred
+    assert pred, msg
 
 
 def attrs_eq(received, **expected):
@@ -108,8 +125,6 @@ class KumaTestMixin(object):
 
     @classmethod
     def setUpClass(cls):
-        if cls.skipme:
-            raise SkipTest
         if cls.localizing_client:
             cls.client_class = LocalizingClient
         super(KumaTestMixin, cls).setUpClass()
@@ -140,7 +155,3 @@ class KumaTestCase(KumaTestMixin, TestCase):
 
 class KumaTransactionTestCase(KumaTestMixin, TransactionTestCase):
     pass
-
-
-class SkippedTestCase(KumaTestCase):
-    skipme = True

--- a/kuma/core/tests/test_anonymous_middleware.py
+++ b/kuma/core/tests/test_anonymous_middleware.py
@@ -1,10 +1,8 @@
-from nose.tools import eq_
-
 from django.http import HttpResponse
 from django.conf import settings
 from django.test import RequestFactory
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 
 from ..anonymous import AnonymousIdentityMiddleware
 

--- a/kuma/core/tests/test_commands.py
+++ b/kuma/core/tests/test_commands.py
@@ -27,5 +27,5 @@ class TestIHavePowerCommand(UserTestCase):
         call_command('ihavepower', 'fordprefect', stdout=out)
 
         ford = self.user_model.objects.get(username='fordprefect')
-        assert ford.is_staff == True
-        assert ford.is_superuser == True
+        assert ford.is_staff is True
+        assert ford.is_superuser is True

--- a/kuma/core/tests/test_commands.py
+++ b/kuma/core/tests/test_commands.py
@@ -1,8 +1,6 @@
 from django.core.management import call_command, CommandError
 from django.utils.six import StringIO
 
-from nose.tools import eq_
-
 from kuma.users.tests import user, UserTestCase
 
 
@@ -13,7 +11,7 @@ class TestIHavePowerCommand(UserTestCase):
             call_command('ihavepower', stdout=out)
 
         commanderror = commanderror_cm.exception
-        eq_(commanderror.message, 'Error: too few arguments')
+        assert commanderror.message == 'Error: too few arguments'
 
     def test_user_doesnt_exist(self):
         out = StringIO()
@@ -21,7 +19,7 @@ class TestIHavePowerCommand(UserTestCase):
             call_command('ihavepower', 'fordprefect', stdout=out)
 
         commanderror = commanderror_cm.exception
-        eq_(commanderror.message, 'User fordprefect does not exist.')
+        assert commanderror.message == 'User fordprefect does not exist.'
 
     def test_user_exists(self):
         out = StringIO()
@@ -29,5 +27,5 @@ class TestIHavePowerCommand(UserTestCase):
         call_command('ihavepower', 'fordprefect', stdout=out)
 
         ford = self.user_model.objects.get(username='fordprefect')
-        eq_(ford.is_staff, True)
-        eq_(ford.is_superuser, True)
+        assert ford.is_staff == True
+        assert ford.is_superuser == True

--- a/kuma/core/tests/test_decorators.py
+++ b/kuma/core/tests/test_decorators.py
@@ -2,13 +2,12 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 
 from django.test import RequestFactory
-from nose.tools import eq_, ok_
 
 from kuma.core.decorators import (block_user_agents, logout_required,
                                   login_required, never_cache,
                                   permission_required)
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.users.tests import UserTestCase
 
 

--- a/kuma/core/tests/test_form_fields.py
+++ b/kuma/core/tests/test_form_fields.py
@@ -1,8 +1,6 @@
 from django.utils import translation
 
-from nose.tools import eq_
-
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 
 from ..form_fields import _format_decimal
 

--- a/kuma/core/tests/test_forms.py
+++ b/kuma/core/tests/test_forms.py
@@ -1,9 +1,8 @@
 from django import forms
 
-from nose.tools import eq_
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 
 from ..form_fields import StrippedCharField
 

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -2,15 +2,15 @@
 from collections import namedtuple
 from datetime import datetime
 
+import pytest
 import pytz
 from babel.dates import format_date, format_datetime, format_time
 from django.conf import settings
 from django.test import RequestFactory
-from nose.tools import assert_raises, eq_, ok_
 from pyquery import PyQuery as pq
 from soapbox.models import Message
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
@@ -164,12 +164,13 @@ class TestDateTimeFormat(UserTestCase):
     def test_unknown_format(self):
         """Unknown format raises DateTimeFormatError."""
         date_today = datetime.today()
-        assert_raises(DateTimeFormatError, datetimeformat, self.context,
-                      date_today, format='unknown')
+        with pytest.raises(DateTimeFormatError):
+            datetimeformat(self.context, date_today, format='unknown')
 
     def test_invalid_value(self):
         """Passing invalid value raises ValueError."""
-        assert_raises(ValueError, datetimeformat, self.context, 'invalid')
+        with pytest.raises(ValueError):
+            datetimeformat(self.context, 'invalid')
 
     def test_json_helper(self):
         eq_('false', jsonencode(False))

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -1,7 +1,6 @@
-from nose.tools import eq_
 from django.test import RequestFactory
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 from ..middleware import SetRemoteAddrFromForwardedFor
 
 

--- a/kuma/core/tests/test_misc.py
+++ b/kuma/core/tests/test_misc.py
@@ -4,9 +4,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.handlers.wsgi import WSGIRequest
 from django.test import RequestFactory
 
-from nose.tools import eq_
-
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 
 from ..context_processors import next_url
 

--- a/kuma/core/tests/test_models.py
+++ b/kuma/core/tests/test_models.py
@@ -1,9 +1,8 @@
 from datetime import date, timedelta
 
-from nose.tools import eq_
-
 from django.test import TestCase
 
+from kuma.core.tests import eq_
 from ..models import IPBan
 
 

--- a/kuma/core/tests/test_pagination.py
+++ b/kuma/core/tests/test_pagination.py
@@ -1,7 +1,7 @@
 from django.test import RequestFactory
-from nose.tools import eq_
 import pyquery
 
+from kuma.core.tests import eq_
 from ..urlresolvers import reverse
 from ..utils import paginate, urlparams
 from ..templatetags.jinja_helpers import paginator

--- a/kuma/core/tests/test_templates.py
+++ b/kuma/core/tests/test_templates.py
@@ -6,10 +6,9 @@ from django.template.backends.jinja2 import Jinja2
 from django.template.loader import render_to_string
 from django.test import RequestFactory
 from django.utils import translation
-from nose.tools import eq_
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 
 
 class MockRequestTests(KumaTestCase):

--- a/kuma/core/tests/test_urlresolvers.py
+++ b/kuma/core/tests/test_urlresolvers.py
@@ -1,7 +1,6 @@
-from nose.tools import eq_
-from nose.plugins.skip import SkipTest
+import pytest
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 from ..urlresolvers import get_best_language
 
 
@@ -36,9 +35,9 @@ class BestLanguageTests(KumaTestCase):
         best = get_best_language('pt, fr;q=0.5')
         eq_('pt-PT', best)
 
+    @pytest.mark.xfail(reason='no clue what is up with norwegian locales')
     def test_nonprefix_alias(self):
         """We only have a single Norwegian locale."""
-        raise SkipTest("Figure out what's up with the Norwegian locales")
         best = get_best_language('nn-NO, nb-NO;q=0.7, fr;q=0.3')
         eq_('no', best)
 

--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -1,7 +1,6 @@
 from django.test import TestCase
 
-from nose.tools import eq_
-
+from kuma.core.tests import eq_
 from ..utils import smart_int
 
 

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -1,5 +1,4 @@
 import logging
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from soapbox.models import Message
 
@@ -7,7 +6,7 @@ from django.core import mail
 from django.test import override_settings
 from django.utils.log import AdminEmailHandler
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 
 from ..urlresolvers import reverse
 

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -1,9 +1,8 @@
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 
 from waffle.models import Flag, Switch
 
+from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
@@ -11,7 +10,6 @@ from kuma.users.tests import UserTestCase
 from kuma.users.models import User, UserBan
 
 
-@attr('dashboards')
 class RevisionsDashTest(UserTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
 
@@ -23,7 +21,6 @@ class RevisionsDashTest(UserTestCase):
         ok_('dashboards/revisions.html' in
             [template.name for template in response.templates])
 
-    @attr('bug1203403')
     def test_main_view_with_banned_user(self):
         testuser = User.objects.get(username='testuser')
         admin = User.objects.get(username='admin')

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -1,3 +1,4 @@
+import pytest
 from pyquery import PyQuery as pq
 
 from waffle.models import Flag, Switch
@@ -10,6 +11,7 @@ from kuma.users.tests import UserTestCase
 from kuma.users.models import User, UserBan
 
 
+@pytest.mark.dashboards
 class RevisionsDashTest(UserTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
 

--- a/kuma/humans/tests.py
+++ b/kuma/humans/tests.py
@@ -3,10 +3,10 @@ from os import makedirs
 from os.path import dirname, exists, isdir
 
 import fileinput
-from nose.tools import assert_equal, ok_
 
 from django.test import TestCase
 
+from kuma.core.tests import ok_
 from .models import HumansTXT, Human
 
 APP_DIR = dirname(__file__)
@@ -18,7 +18,7 @@ class HumansTest(TestCase):
         ht = HumansTXT()
 
         name = 'buddyl@example.org'
-        assert_equal('buddyl', ht.split_name(name))
+        assert 'buddyl' == ht.split_name(name)
 
     def test_basic_get_github(self):
         """
@@ -27,7 +27,7 @@ class HumansTest(TestCase):
         data = json.load(open(CONTRIBUTORS_JSON, 'rb'))
         ht = HumansTXT()
         humans = ht.get_github(data)
-        assert_equal(len(humans), 19)
+        assert len(humans) == 19
 
     def test_for_login_name_when_no_name(self):
         """
@@ -41,7 +41,7 @@ class HumansTest(TestCase):
             if h.name == "chengwang":
                 human = h
 
-        assert_equal(human.name, "chengwang")
+        assert human.name == "chengwang"
 
     def test_write_to_file(self):
         if not isdir("%s/tmp/" % APP_DIR):

--- a/kuma/landing/test_templates.py
+++ b/kuma/landing/test_templates.py
@@ -1,9 +1,7 @@
-from nose.tools import eq_, ok_
-
 from constance.test import override_config
 
+from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.core.urlresolvers import reverse
-from kuma.core.tests import KumaTestCase
 
 
 class HomeTests(KumaTestCase):

--- a/kuma/landing/test_views.py
+++ b/kuma/landing/test_views.py
@@ -1,6 +1,4 @@
-from nose.tools import eq_, ok_
-
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.core.urlresolvers import reverse
 
 

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -1,5 +1,4 @@
-from nose.tools import ok_, eq_
-
+from kuma.core.tests import eq_, ok_
 from kuma.wiki.models import Document
 from kuma.wiki.signals import render_done
 

--- a/kuma/search/tests/test_indexes.py
+++ b/kuma/search/tests/test_indexes.py
@@ -1,10 +1,9 @@
-from nose.tools import eq_, ok_
-
 from django.conf import settings
 
 from elasticsearch_dsl.connections import connections
 from elasticsearch.exceptions import RequestError
 
+from kuma.core.tests import eq_, ok_
 from kuma.wiki.models import Document
 from kuma.wiki.search import WikiDocumentType
 

--- a/kuma/search/tests/test_plugin.py
+++ b/kuma/search/tests/test_plugin.py
@@ -2,9 +2,8 @@ from __future__ import absolute_import
 from django.contrib.sites.models import Site
 
 import mock
-from nose.tools import eq_
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_
 from kuma.core.urlresolvers import reverse
 
 

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -1,10 +1,10 @@
 import mock
-from nose.tools import ok_, eq_
 
 from django.utils import translation
 from rest_framework import serializers
 from rest_framework.test import APIRequestFactory
 
+from kuma.core.tests import eq_, ok_
 from kuma.wiki.search import WikiDocumentType
 
 from . import ElasticTestCase

--- a/kuma/search/tests/test_tasks.py
+++ b/kuma/search/tests/test_tasks.py
@@ -1,5 +1,4 @@
-from nose.tools import eq_
-
+from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 from kuma.wiki.tests import revision
 

--- a/kuma/search/tests/test_types.py
+++ b/kuma/search/tests/test_types.py
@@ -1,7 +1,6 @@
-from nose.tools import ok_, eq_
-
 from elasticsearch_dsl import query
 
+from kuma.core.tests import eq_, ok_
 from kuma.wiki.models import Document
 from kuma.wiki.search import WikiDocumentType
 

--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
-from nose.tools import eq_, ok_
 
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 
 from ..store import referrer_url
 from ..utils import QueryURLObject

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import elasticsearch
-from nose.tools import eq_
 
+from kuma.core.tests import eq_
 from . import ElasticTestCase
 from ..pagination import SearchPagination
 from ..models import Index, Filter, FilterGroup

--- a/kuma/spam/tests/test_akismet.py
+++ b/kuma/spam/tests/test_akismet.py
@@ -1,6 +1,5 @@
 from django.test import SimpleTestCase
 from constance.test import override_config
-from nose.plugins.attrib import attr
 from waffle.models import Flag
 import mock
 import requests
@@ -11,7 +10,6 @@ from ..constants import (CHECK_URL, HAM_URL, SPAM_CHECKS_FLAG,
                          SPAM_URL, VERIFY_URL)
 
 
-@attr('spam')
 @override_config(AKISMET_KEY='api-key')
 class AkismetClientTests(SimpleTestCase):
 

--- a/kuma/spam/tests/test_akismet.py
+++ b/kuma/spam/tests/test_akismet.py
@@ -1,15 +1,19 @@
-from django.test import SimpleTestCase
+
 from constance.test import override_config
 from waffle.models import Flag
 import mock
+import pytest
 import requests
 import requests_mock
+
+from django.test import SimpleTestCase
 
 from ..akismet import Akismet, AkismetError
 from ..constants import (CHECK_URL, HAM_URL, SPAM_CHECKS_FLAG,
                          SPAM_URL, VERIFY_URL)
 
 
+@pytest.mark.spam
 @override_config(AKISMET_KEY='api-key')
 class AkismetClientTests(SimpleTestCase):
 

--- a/kuma/spam/tests/test_forms.py
+++ b/kuma/spam/tests/test_forms.py
@@ -4,6 +4,7 @@ from django.utils import six
 from django.utils.encoding import force_unicode
 
 import requests_mock
+import pytest
 from constance.test.utils import override_config
 from waffle.models import Flag
 
@@ -32,6 +33,7 @@ class AkismetContentTestForm(AkismetCheckTestForm):
     content = forms.CharField()
 
 
+@pytest.mark.spam
 @requests_mock.mock()
 class AkismetFormTests(SimpleTestCase):
     rf = RequestFactory()

--- a/kuma/spam/tests/test_forms.py
+++ b/kuma/spam/tests/test_forms.py
@@ -5,7 +5,6 @@ from django.utils.encoding import force_unicode
 
 import requests_mock
 from constance.test.utils import override_config
-from nose.plugins.attrib import attr
 from waffle.models import Flag
 
 from ..constants import CHECK_URL, SPAM_CHECKS_FLAG, VERIFY_URL
@@ -33,7 +32,6 @@ class AkismetContentTestForm(AkismetCheckTestForm):
     content = forms.CharField()
 
 
-@attr('spam')
 @requests_mock.mock()
 class AkismetFormTests(SimpleTestCase):
     rf = RequestFactory()

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -1,12 +1,10 @@
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
-
 from django.contrib import messages as django_messages
 from django.test import RequestFactory
 
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.models import SocialLogin, SocialAccount
 
+from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.users.adapters import KumaSocialAccountAdapter, KumaAccountAdapter
 
@@ -21,7 +19,6 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         super(KumaSocialAccountAdapterTestCase, self).setUp()
         self.adapter = KumaSocialAccountAdapter()
 
-    @attr('bug1055870')
     def test_pre_social_login_overwrites_session_var(self):
         """ https://bugzil.la/1055870 """
         # Set up a pre-existing GitHub sign-in session
@@ -43,7 +40,6 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
             "receiver should have over-written sociallogin_provider "
             "session variable")
 
-    @attr('bug1063830')
     def test_pre_social_login_error_for_unmatched_login(self):
         """ https://bugzil.la/1063830 """
 
@@ -81,7 +77,6 @@ class KumaAccountAdapterTestCase(UserTestCase):
         super(KumaAccountAdapterTestCase, self).setUp()
         self.adapter = KumaAccountAdapter()
 
-    @attr('bug1054461')
     def test_account_connected_message(self):
         """ https://bugzil.la/1054461 """
         message_template = 'socialaccount/messages/account_connected.txt'

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -1,8 +1,6 @@
 from django import forms
 
-from nose.tools import eq_, ok_
-
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 
 from . import user
 from ..adapters import (KumaAccountAdapter, USERNAME_CHARACTERS,

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -3,8 +3,7 @@ from hashlib import md5
 
 from django.conf import settings
 
-from nose.tools import eq_, ok_
-
+from kuma.core.tests import eq_, ok_
 from . import UserTestCase
 from ..templatetags.jinja_helpers import gravatar_url, public_email
 

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -1,6 +1,4 @@
-from nose.tools import eq_, ok_
-from nose.plugins.attrib import attr
-
+from kuma.core.tests import eq_, ok_
 from kuma.wiki.tests import revision
 
 from . import UserTestCase
@@ -82,7 +80,6 @@ class TestUser(UserTestCase):
 
 class BanTestCase(UserTestCase):
 
-    @attr('bans')
     def test_ban_user(self):
         testuser = self.user_model.objects.get(username='testuser')
         admin = self.user_model.objects.get(username='admin')

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -1,3 +1,5 @@
+import pytest
+
 from kuma.core.tests import eq_, ok_
 from kuma.wiki.tests import revision
 
@@ -80,6 +82,7 @@ class TestUser(UserTestCase):
 
 class BanTestCase(UserTestCase):
 
+    @pytest.mark.bans
     def test_ban_user(self):
         testuser = self.user_model.objects.get(username='testuser')
         admin = self.user_model.objects.get(username='admin')

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -1,9 +1,9 @@
 import requests_mock
 from django.conf import settings
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from waffle.models import Flag
 
+from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1,7 +1,8 @@
-import mock
 import json
 from urlparse import urlparse, parse_qs
 
+import mock
+import pytest
 from pyquery import PyQuery as pq
 
 from django.conf import settings
@@ -33,6 +34,7 @@ class OldProfileTestCase(UserTestCase):
         eq_(404, response.status_code)
 
 
+@pytest.mark.bans
 class BanTestCase(UserTestCase):
     localizing_client = True
 

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -2,8 +2,6 @@ import mock
 import json
 from urlparse import urlparse, parse_qs
 
-from nose.tools import eq_, ok_
-from nose.plugins.attrib import attr
 from pyquery import PyQuery as pq
 
 from django.conf import settings
@@ -16,7 +14,7 @@ from allauth.socialaccount.models import SocialAccount, SocialApp
 from allauth.socialaccount.providers import registry
 from allauth.tests import MockedResponse, mocked_response
 
-from kuma.core.tests import mock_lookup_user
+from kuma.core.tests import eq_, mock_lookup_user, ok_
 from kuma.core.urlresolvers import reverse
 
 from . import UserTestCase, user, email
@@ -38,7 +36,6 @@ class OldProfileTestCase(UserTestCase):
 class BanTestCase(UserTestCase):
     localizing_client = True
 
-    @attr('bans')
     def test_ban_permission(self):
         """The ban permission controls access to the ban view."""
         admin = self.user_model.objects.get(username='admin')
@@ -62,7 +59,6 @@ class BanTestCase(UserTestCase):
         resp = self.client.get(ban_url)
         eq_(200, resp.status_code)
 
-    @attr('bans')
     def test_ban_view(self):
         testuser = self.user_model.objects.get(username='testuser')
         admin = self.user_model.objects.get(username='admin')
@@ -85,7 +81,6 @@ class BanTestCase(UserTestCase):
                                       reason='Banned by unit test.')
         ok_(bans.count())
 
-    @attr('bans')
     def test_bug_811751_banned_user(self):
         """A banned user should not be viewable"""
         testuser = self.user_model.objects.get(username='testuser')
@@ -138,7 +133,6 @@ class UserViewsTest(UserTestCase):
         form[prefix + 'format'] = 'html'
         return form
 
-    @attr('docs_activity')
     def test_user_detail_view(self):
         """A user can be viewed"""
         testuser = self.user_model.objects.get(username='testuser')

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -6,7 +6,6 @@ from django.contrib.auth.models import Group, Permission
 from django.utils.text import slugify
 
 from html5lib.filters._base import Filter as html5lib_Filter
-from nose.tools import nottest
 from waffle.models import Flag
 
 from kuma.core.tests import get_user, KumaTestCase
@@ -150,7 +149,6 @@ def normalize_html(input):
             .serialize(alphabetical_attributes=True))
 
 
-@nottest
 def create_template_test_users():
     perms = dict(
         (x, [Permission.objects.get(codename='%s_template_document' % x)])

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -1,4 +1,3 @@
-from nose.plugins.attrib import attr
 from pyquery import PyQuery as pq
 
 from constance.test import override_config
@@ -15,7 +14,6 @@ from kuma.wiki.models import RevisionAkismetSubmission
 
 
 @override_config(AKISMET_KEY='admin')
-@attr('spam')
 class AdminTestCase(UserTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
 

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -1,3 +1,4 @@
+import pytest
 from pyquery import PyQuery as pq
 
 from constance.test import override_config
@@ -13,6 +14,7 @@ from kuma.users.models import User
 from kuma.wiki.models import RevisionAkismetSubmission
 
 
+@pytest.mark.spam
 @override_config(AKISMET_KEY='admin')
 class AdminTestCase(UserTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -2,6 +2,7 @@
 from urlparse import urljoin
 
 import bleach
+import pytest
 from cssselect.parser import SelectorSyntaxError
 from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
@@ -409,6 +410,7 @@ class ContentSectionToolTests(UserTestCase):
         for original, slugified in headers:
             ok_(slugified == section_filter.slugify(original))
 
+    @pytest.mark.toc
     def test_generate_toc(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>
@@ -458,6 +460,7 @@ class ContentSectionToolTests(UserTestCase):
                   .filter(SectionTOCFilter).serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
+    @pytest.mark.toc
     def test_generate_toc_h2(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>
@@ -485,6 +488,7 @@ class ContentSectionToolTests(UserTestCase):
                   .filter(H2TOCFilter).serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
+    @pytest.mark.toc
     def test_generate_toc_h3(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -4,12 +4,10 @@ from urlparse import urljoin
 import bleach
 from cssselect.parser import SelectorSyntaxError
 from jinja2 import escape, Markup
-from nose.tools import eq_, ok_
-from nose.plugins.attrib import attr
 from pyquery import PyQuery as pq
 
 import kuma.wiki.content
-from kuma.core.tests import KumaTestCase
+from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.users.tests import UserTestCase
 
 from . import doc_rev, document, normalize_html
@@ -411,7 +409,6 @@ class ContentSectionToolTests(UserTestCase):
         for original, slugified in headers:
             ok_(slugified == section_filter.slugify(original))
 
-    @attr('toc')
     def test_generate_toc(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>
@@ -461,7 +458,6 @@ class ContentSectionToolTests(UserTestCase):
                   .filter(SectionTOCFilter).serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
-    @attr('toc')
     def test_generate_toc_h2(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>
@@ -489,7 +485,6 @@ class ContentSectionToolTests(UserTestCase):
                   .filter(H2TOCFilter).serialize())
         eq_(normalize_html(expected), normalize_html(result))
 
-    @attr('toc')
     def test_generate_toc_h3(self):
         doc_src = """
             <h2 id="HTML">HTML</h2>
@@ -897,7 +892,6 @@ class ContentSectionToolTests(UserTestCase):
                                             .serialize())
             self.assertHTMLEqual(normalize_html(expected_line), normalize_html(result_line))
 
-    @attr('bug821986')
     def test_editor_safety_filter(self):
         """Markup that's hazardous for editing should be stripped"""
         doc_src = """

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -1,7 +1,6 @@
 import mock
-from nose.tools import eq_
 
-from kuma.core.tests import get_user
+from kuma.core.tests import eq_, get_user
 from kuma.users.tests import UserTestCase
 from . import WikiTestCase, revision
 from ..events import context_dict, EditDocumentEvent

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -2,6 +2,7 @@ from django import forms
 from django.core import mail
 from django.test import RequestFactory
 
+import pytest
 import requests_mock
 from constance.test import override_config
 from waffle.models import Flag
@@ -172,6 +173,7 @@ class RevisionFormTests(UserTransactionTestCase):
         self.assertTrue(rev_form.is_valid())
         self.assertEqual(rev_form.cleaned_data['tags'], '"JavaScript"')
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_akismet_enabled(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
@@ -196,6 +198,7 @@ class RevisionFormTests(UserTransactionTestCase):
         # now disabled because the test user is exempted from the spam check
         self.assertFalse(rev_form.akismet_enabled())
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_akismet_error(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
@@ -233,6 +236,7 @@ class RevisionFormTests(UserTransactionTestCase):
         except forms.ValidationError as exc:
             self.assertHTMLEqual(exc.message, rev_form.akismet_error_message)
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_akismet_parameters(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -4,7 +4,6 @@ from django.test import RequestFactory
 
 import requests_mock
 from constance.test import override_config
-from nose.plugins.attrib import attr
 from waffle.models import Flag
 
 from kuma.spam.constants import CHECK_URL, SPAM_CHECKS_FLAG, VERIFY_URL
@@ -35,11 +34,12 @@ class RevisionFormTests(UserTransactionTestCase):
             defaults={'everyone': None},
         )
 
-    @attr('bug821986')
     def test_form_onload_attr_filter(self):
         """
         RevisionForm should strip out any harmful onload attributes from
         input markup
+
+        bug 821986
         """
         rev = revision(save=True, is_approved=True, content="""
             <svg><circle onload=confirm(3)>
@@ -172,7 +172,6 @@ class RevisionFormTests(UserTransactionTestCase):
         self.assertTrue(rev_form.is_valid())
         self.assertEqual(rev_form.cleaned_data['tags'], '"JavaScript"')
 
-    @attr('spam')
     @requests_mock.mock()
     def test_akismet_enabled(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
@@ -197,7 +196,6 @@ class RevisionFormTests(UserTransactionTestCase):
         # now disabled because the test user is exempted from the spam check
         self.assertFalse(rev_form.akismet_enabled())
 
-    @attr('spam')
     @requests_mock.mock()
     def test_akismet_error(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
@@ -235,7 +233,6 @@ class RevisionFormTests(UserTransactionTestCase):
         except forms.ValidationError as exc:
             self.assertHTMLEqual(exc.message, rev_form.akismet_error_message)
 
-    @attr('spam')
     @requests_mock.mock()
     def test_akismet_parameters(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import mock
-from nose.tools import eq_
 
 from django.contrib.sites.models import Site
 
 from kuma.core.cache import memcache
+from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
 from . import WikiTestCase, document, revision

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -1,8 +1,8 @@
 from datetime import timedelta
 
 from django.test.utils import override_settings
-from nose.tools import eq_, ok_
 
+from kuma.core.tests import eq_, ok_
 from kuma.users.tests import UserTestCase, user
 
 from . import revision

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-import json
 import base64
+import json
 
 import mock
-from nose.tools import eq_, ok_
 
+from kuma.core.tests import eq_, ok_
 from kuma.wiki import kumascript
 from . import WikiTestCase, document
 

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
-from nose.plugins.attrib import attr
-from nose.tools import eq_
 
 from kuma.core.cache import memcache
+from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 from kuma.wiki.models import DocumentZone
 from kuma.wiki.tests import revision
@@ -114,9 +113,11 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
 
-    @attr('bug1189596')
     def test_zone_url_ends_with_slash(self):
-        """Ensure urls only rewrite with a '/' at the end of url_root"""
+        """Ensure urls only rewrite with a '/' at the end of url_root
+
+        bug 1189596
+        """
         zone_url_root = 'Firéfox'
         zone_root_content = 'This is the Firéfox zone'
 

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -5,6 +5,7 @@ from datetime import date, datetime, timedelta
 from xml.sax.saxutils import escape
 
 import mock
+import pytest
 from constance import config
 from constance.test import override_config
 from waffle.models import Switch
@@ -250,6 +251,7 @@ class DocumentTests(UserTestCase):
         d3.save()
         ok_(d3.parents == [d1, d2])
 
+    @pytest.mark.redirect
     def test_redirect_url_allows_site_url(self):
         href = "%s/en-US/Mozilla" % settings.SITE_URL
         title = "Mozilla"
@@ -257,6 +259,7 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(href, d.get_redirect_url())
 
+    @pytest.mark.redirect
     def test_redirect_url_allows_domain_relative_url(self):
         href = "/en-US/Mozilla"
         title = "Mozilla"
@@ -264,6 +267,7 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(href, d.get_redirect_url())
 
+    @pytest.mark.redirect
     def test_redirect_url_rejects_protocol_relative_url(self):
         href = "//evilsite.com"
         title = "Mozilla"
@@ -271,6 +275,7 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(None, d.get_redirect_url())
 
+    @pytest.mark.redirect
     def test_redirect_url_works_for_home_path(self):
         """bug 1082034"""
         href = "/"
@@ -498,6 +503,7 @@ class DocumentTestsWithFixture(UserTestCase):
 class TaggedDocumentTests(UserTestCase):
     """Tests for tags in Documents and Revisions"""
 
+    @pytest.mark.tags
     def test_revision_tags(self):
         """Change tags on Document by creating Revisions"""
         d, _ = doc_rev('Sample document')
@@ -605,6 +611,7 @@ class RevisionTests(UserTestCase):
         last_rev.save()
         eq_(next_rev, last_rev.previous)
 
+    @pytest.mark.toc
     def test_show_toc(self):
         """Setting toc_depth appropriately affects the Document's
         show_toc property."""
@@ -1119,6 +1126,7 @@ class RenderExpiresTests(UserTestCase):
 class PageMoveTests(UserTestCase):
     """Tests for page-moving and associated functionality."""
 
+    @pytest.mark.move
     def test_children_simple(self):
         """A basic tree with two direct children and no sub-trees on
         either."""
@@ -1188,6 +1196,7 @@ class PageMoveTests(UserTestCase):
 
         ok_([c1, gc1, c2, gc2, gc3, ggc1] == top.get_descendants())
 
+    @pytest.mark.move
     def test_circular_dependency(self):
         """Make sure we can detect potential circular dependencies in
         parent/child relationships."""
@@ -1208,6 +1217,7 @@ class PageMoveTests(UserTestCase):
 
         ok_(child.is_child_of(grandparent))
 
+    @pytest.mark.move
     def test_move_tree(self):
         """Moving a tree of documents does the correct thing"""
 
@@ -1302,6 +1312,7 @@ class PageMoveTests(UserTestCase):
                 slug='first-level/second-level/third-level/grandchild'
             ).get_redirect_url())
 
+    @pytest.mark.move
     def test_conflicts(self):
         top = revision(title='Test page-move conflict detection',
                        slug='test-move-conflict-detection',
@@ -1346,6 +1357,7 @@ class PageMoveTests(UserTestCase):
         eq_([child_conflict.document],
             top_doc._tree_conflicts('moved/test-move-conflict-detection'))
 
+    @pytest.mark.move
     def test_additional_conflicts(self):
         top = revision(title='WebRTC',
                        slug='WebRTC',
@@ -1371,6 +1383,7 @@ class PageMoveTests(UserTestCase):
         eq_([],
             top_doc._tree_conflicts('NativeRTC'))
 
+    @pytest.mark.move
     def test_preserve_tags(self):
             tags = "'moving', 'tests'"
             rev = revision(title='Test page-move tag preservation',
@@ -1395,6 +1408,7 @@ class PageMoveTests(UserTestCase):
             eq_(['technical'],
                 [str(tag) for tag in new_rev.review_tags.all()])
 
+    @pytest.mark.move
     def test_move_tree_breadcrumbs(self):
         """Moving a tree of documents under an existing doc updates breadcrumbs"""
 
@@ -1444,6 +1458,7 @@ class PageMoveTests(UserTestCase):
                                          slug='grandpa/grandma/mom')
         ok_(mom_moved.parent_topic == grandma_moved)
 
+    @pytest.mark.move
     def test_move_tree_no_new_parent(self):
         """Moving a tree to a slug that doesn't exist throws error."""
 
@@ -1457,6 +1472,7 @@ class PageMoveTests(UserTestCase):
         except Exception:
             pass
 
+    @pytest.mark.move
     def test_move_top_level_docs(self):
         """Moving a top document to a new slug location"""
         page_to_move_title = 'Page Move Root'
@@ -1502,6 +1518,7 @@ class PageMoveTests(UserTestCase):
         # TODO: Fix this assertion?
         # eq_('admin', page_moved_doc.current_revision.creator.username)
 
+    @pytest.mark.move
     def test_mid_move(self):
         root_title = 'Root'
         root_slug = 'Root'
@@ -1547,6 +1564,7 @@ class PageMoveTests(UserTestCase):
         ok_('REDIRECT' in redirected_grandchild.html)
         ok_(moved_grandchild_slug in redirected_grandchild.html)
 
+    @pytest.mark.move
     def test_move_special(self):
         root_slug = 'User:foo'
         child_slug = '%s/child' % root_slug

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -7,8 +7,6 @@ from xml.sax.saxutils import escape
 import mock
 from constance import config
 from constance.test import override_config
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
 from waffle.models import Switch
 
 from django.conf import settings
@@ -16,7 +14,7 @@ from django.core.exceptions import ValidationError
 from django.test.utils import override_settings
 
 from kuma.core.exceptions import ProgrammingError
-from kuma.core.tests import KumaTestCase, get_user
+from kuma.core.tests import KumaTestCase, eq_, get_user, ok_
 from kuma.users.tests import UserTestCase
 
 from . import (create_document_tree, create_template_test_users,
@@ -49,8 +47,8 @@ def redirect_rev(title, redirect_to):
 class DocumentTests(UserTestCase):
     """Tests for the Document model"""
 
-    @attr('bug875349')
     def test_json_data(self):
+        """bug 875349"""
         # Set up a doc with tags
         doc, rev = doc_rev('Sample document')
         doc.save()
@@ -220,7 +218,6 @@ class DocumentTests(UserTestCase):
         d.save()
         assert not d.is_localizable
 
-    @attr('doc_translations')
     def test_other_translations(self):
         """
         parent doc should list all docs for which it is parent
@@ -253,7 +250,6 @@ class DocumentTests(UserTestCase):
         d3.save()
         ok_(d3.parents == [d1, d2])
 
-    @attr('redirect')
     def test_redirect_url_allows_site_url(self):
         href = "%s/en-US/Mozilla" % settings.SITE_URL
         title = "Mozilla"
@@ -261,7 +257,6 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(href, d.get_redirect_url())
 
-    @attr('redirect')
     def test_redirect_url_allows_domain_relative_url(self):
         href = "/en-US/Mozilla"
         title = "Mozilla"
@@ -269,7 +264,6 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(href, d.get_redirect_url())
 
-    @attr('redirect')
     def test_redirect_url_rejects_protocol_relative_url(self):
         href = "//evilsite.com"
         title = "Mozilla"
@@ -277,9 +271,8 @@ class DocumentTests(UserTestCase):
         d = document(is_redirect=True, html=html)
         eq_(None, d.get_redirect_url())
 
-    @attr('bug1082034')
-    @attr('redirect')
     def test_redirect_url_works_for_home_path(self):
+        """bug 1082034"""
         href = "/"
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
@@ -505,7 +498,6 @@ class DocumentTestsWithFixture(UserTestCase):
 class TaggedDocumentTests(UserTestCase):
     """Tests for tags in Documents and Revisions"""
 
-    @attr('tags')
     def test_revision_tags(self):
         """Change tags on Document by creating Revisions"""
         d, _ = doc_rev('Sample document')
@@ -613,7 +605,6 @@ class RevisionTests(UserTestCase):
         last_rev.save()
         eq_(next_rev, last_rev.previous)
 
-    @attr('toc')
     def test_show_toc(self):
         """Setting toc_depth appropriately affects the Document's
         show_toc property."""
@@ -863,11 +854,12 @@ class DeferredRenderingTests(UserTestCase):
         ok_(not mock_kumascript_get.called)
         eq_(self.rendered_content, result_rendered)
 
-    @attr('bug875349')
     @mock.patch('kuma.wiki.models.render_done')
     def test_build_json_on_render(self, mock_render_done):
         """
         A document's json field is refreshed on render(), but not on save()
+
+        bug 875349
         """
         self.d1.save()
         ok_(not mock_render_done.send.called)
@@ -1127,7 +1119,6 @@ class RenderExpiresTests(UserTestCase):
 class PageMoveTests(UserTestCase):
     """Tests for page-moving and associated functionality."""
 
-    @attr('move')
     def test_children_simple(self):
         """A basic tree with two direct children and no sub-trees on
         either."""
@@ -1164,7 +1155,6 @@ class PageMoveTests(UserTestCase):
         eq_(len(child2.get_descendants(10)), 0)
         eq_(len(grandchild.get_descendants(4)), 1)
 
-    @attr('move')
     def test_children_complex(self):
         """A slightly more complex tree, with multiple children, some
         of which do/don't have their own children."""
@@ -1198,7 +1188,6 @@ class PageMoveTests(UserTestCase):
 
         ok_([c1, gc1, c2, gc2, gc3, ggc1] == top.get_descendants())
 
-    @attr('move')
     def test_circular_dependency(self):
         """Make sure we can detect potential circular dependencies in
         parent/child relationships."""
@@ -1219,7 +1208,6 @@ class PageMoveTests(UserTestCase):
 
         ok_(child.is_child_of(grandparent))
 
-    @attr('move')
     def test_move_tree(self):
         """Moving a tree of documents does the correct thing"""
 
@@ -1314,7 +1302,6 @@ class PageMoveTests(UserTestCase):
                 slug='first-level/second-level/third-level/grandchild'
             ).get_redirect_url())
 
-    @attr('move')
     def test_conflicts(self):
         top = revision(title='Test page-move conflict detection',
                        slug='test-move-conflict-detection',
@@ -1359,7 +1346,6 @@ class PageMoveTests(UserTestCase):
         eq_([child_conflict.document],
             top_doc._tree_conflicts('moved/test-move-conflict-detection'))
 
-    @attr('move')
     def test_additional_conflicts(self):
         top = revision(title='WebRTC',
                        slug='WebRTC',
@@ -1385,7 +1371,6 @@ class PageMoveTests(UserTestCase):
         eq_([],
             top_doc._tree_conflicts('NativeRTC'))
 
-    @attr('move')
     def test_preserve_tags(self):
             tags = "'moving', 'tests'"
             rev = revision(title='Test page-move tag preservation',
@@ -1410,7 +1395,6 @@ class PageMoveTests(UserTestCase):
             eq_(['technical'],
                 [str(tag) for tag in new_rev.review_tags.all()])
 
-    @attr('move')
     def test_move_tree_breadcrumbs(self):
         """Moving a tree of documents under an existing doc updates breadcrumbs"""
 
@@ -1460,7 +1444,6 @@ class PageMoveTests(UserTestCase):
                                          slug='grandpa/grandma/mom')
         ok_(mom_moved.parent_topic == grandma_moved)
 
-    @attr('move')
     def test_move_tree_no_new_parent(self):
         """Moving a tree to a slug that doesn't exist throws error."""
 
@@ -1474,8 +1457,6 @@ class PageMoveTests(UserTestCase):
         except Exception:
             pass
 
-    @attr('move')
-    @attr('top')
     def test_move_top_level_docs(self):
         """Moving a top document to a new slug location"""
         page_to_move_title = 'Page Move Root'
@@ -1521,7 +1502,6 @@ class PageMoveTests(UserTestCase):
         # TODO: Fix this assertion?
         # eq_('admin', page_moved_doc.current_revision.creator.username)
 
-    @attr('move')
     def test_mid_move(self):
         root_title = 'Root'
         root_slug = 'Root'
@@ -1567,7 +1547,6 @@ class PageMoveTests(UserTestCase):
         ok_('REDIRECT' in redirected_grandchild.html)
         ok_(moved_grandchild_slug in redirected_grandchild.html)
 
-    @attr('move')
     def test_move_special(self):
         root_slug = 'User:foo'
         child_slug = '%s/child' % root_slug

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -5,9 +5,8 @@ import os
 from django.conf import settings
 from django.test import override_settings
 
-from nose.tools import ok_
-
 from kuma.core.cache import memcache
+from kuma.core.tests import ok_
 from kuma.users.tests import UserTestCase, user
 
 from . import document, revision

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -67,6 +67,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         ok_(config.KUMA_CUSTOM_CSS_PATH in response.content)
 
+    @pytest.mark.breadcrumbs
     def test_document_breadcrumbs(self):
         """Create docs with topical parent/child rel, verify breadcrumbs."""
         d1, d2 = create_topical_parents_docs()
@@ -198,6 +199,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         doc = pq(resp.content)
         assert 'Add a translation' not in doc('.page-buttons #translations li').text()
 
+    @pytest.mark.toc
     def test_toc_depth(self):
         """Toggling show_toc on/off through the toc_depth field should
         cause table of contents to appear/disappear."""
@@ -218,6 +220,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         ok_('<div class="page-toc">' not in response.content)
 
+    @pytest.mark.toc
     def test_show_toc_hidden_input_for_templates(self):
         """Toggling show_toc on/off through the toc_depth field should
         cause table of contents to appear/disappear."""
@@ -638,6 +641,7 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         eq_(Document.objects.filter(locale=self.locale).count(),
             len(doc('#document-list ul.document-list li')))
 
+    @pytest.mark.tags
     def test_tag_list(self):
         """Verify the tagged documents list view."""
         tag = DocumentTag(name='Test Tag', slug='test-tag')
@@ -649,6 +653,7 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.document-list li')))
 
+    @pytest.mark.tags
     def test_tag_list_duplicates(self):
         """
         Verify the tagged documents list view, even for duplicate tags

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -4,6 +4,7 @@ import urllib
 from datetime import datetime
 
 import mock
+import pytest
 from BeautifulSoup import BeautifulSoup
 from constance import config
 from django.conf import settings
@@ -11,12 +12,10 @@ from django.contrib.sites.models import Site
 from django.core import mail
 from django.test.utils import override_settings
 from django.utils.http import urlquote
-from nose import SkipTest
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from waffle.models import Flag
 
+from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.tests import UserTestCase
@@ -68,7 +67,6 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         ok_(config.KUMA_CUSTOM_CSS_PATH in response.content)
 
-    @attr("breadcrumbs")
     def test_document_breadcrumbs(self):
         """Create docs with topical parent/child rel, verify breadcrumbs."""
         d1, d2 = create_topical_parents_docs()
@@ -200,7 +198,6 @@ class DocumentTests(UserTestCase, WikiTestCase):
         doc = pq(resp.content)
         assert 'Add a translation' not in doc('.page-buttons #translations li').text()
 
-    @attr('toc')
     def test_toc_depth(self):
         """Toggling show_toc on/off through the toc_depth field should
         cause table of contents to appear/disappear."""
@@ -221,7 +218,6 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         ok_('<div class="page-toc">' not in response.content)
 
-    @attr('toc')
     def test_show_toc_hidden_input_for_templates(self):
         """Toggling show_toc on/off through the toc_depth field should
         cause table of contents to appear/disappear."""
@@ -273,7 +269,6 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(1, len(doc('form#wiki-page-edit input[name="title"]')))
 
-    @attr('bug1052047')
     def test_new_document_includes_review_block(self):
         """
         New document page includes 'Review Needed?' section.
@@ -643,7 +638,6 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         eq_(Document.objects.filter(locale=self.locale).count(),
             len(doc('#document-list ul.document-list li')))
 
-    @attr('tags')
     def test_tag_list(self):
         """Verify the tagged documents list view."""
         tag = DocumentTag(name='Test Tag', slug='test-tag')
@@ -655,11 +649,11 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.document-list li')))
 
-    # http://bugzil.la/871638
-    @attr('tags')
     def test_tag_list_duplicates(self):
         """
         Verify the tagged documents list view, even for duplicate tags
+
+        http://bugzil.la/871638
         """
         en_tag = DocumentTag(name='CSS Reference', slug='css-reference')
         en_tag.save()
@@ -905,13 +899,13 @@ class TranslateTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(0, len(doc('form input[name="slug"]')))
 
+    @pytest.mark.xfail(reason='Figure out wtf is going on with this test')
     def test_translate_form_maintains_based_on_rev(self):
         """
         Revision.based_on should be the rev that was current when the
         Translate button was clicked, even if other revisions happen while the
         user is editing.
         """
-        raise SkipTest("Figure out WTF is going on with this one.")
         _test_form_maintains_based_on_rev(self.client,
                                           self.d,
                                           'wiki.translate',
@@ -973,8 +967,8 @@ class TranslateTests(UserTestCase, WikiTestCase):
         existing_rev = document.revisions.all()[0]
         eq_(existing_rev.content, doc('#id_content').text())
 
+    @pytest.mark.xfail(reason='Figure out wtf is going on with this test.')
     def test_translate_based_on(self):
-        raise SkipTest("Figure out WTF is going on with this one.")
         """Test translating based on a non-current revision."""
         # Create the base revision
         base_rev = self._create_and_approve_first_translation()
@@ -1048,8 +1042,8 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_('Test Content', doc('article#wikiArticle h1').text())
 
+    @pytest.mark.xfail(reason='broken test')
     def test_preview_locale(self):
-        raise SkipTest
         """Preview the wiki syntax content."""
         # Create a test document and translation.
         d = _create_document()

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,8 +17,6 @@ from django.test.client import (BOUNDARY, CONTENT_TYPE_RE, MULTIPART_CONTENT,
                                 FakePayload, encode_multipart)
 from django.test.utils import override_settings
 from django.utils.encoding import smart_str
-from nose.plugins.attrib import attr
-from nose.tools import eq_, ok_
 from pyquery import PyQuery as pq
 from waffle.models import Flag, Switch
 
@@ -27,7 +25,7 @@ from kuma.attachments.utils import make_test_file
 from kuma.authkeys.models import Key
 from kuma.core.cache import memcache as cache
 from kuma.core.models import IPBan
-from kuma.core.tests import get_user
+from kuma.core.tests import eq_, get_user, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.tests import UserTestCase, user
@@ -135,8 +133,8 @@ class ViewTests(UserTestCase, WikiTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
     localizing_client = True
 
-    @attr('bug875349')
     def test_json_view(self):
+        """bug 875349"""
         expected_tags = sorted(['foo', 'bar', 'baz'])
         expected_review_tags = sorted(['tech', 'editorial'])
 
@@ -223,8 +221,8 @@ class ViewTests(UserTestCase, WikiTestCase):
             '<ol><li><a href="#Head_3" rel="internal">Head 3</a>'
             '</ol></li></ol>')
 
-    @attr('bug875349')
     def test_children_view(self):
+        """bug 875349"""
         test_content = '<p>Test <a href="http://example.com">Summary</a></p>'
 
         def _make_doc(title, slug, parent=None, is_redir=False):
@@ -924,7 +922,6 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         except UnicodeDecodeError:
             self.fail("Data wasn't posted as utf8")
 
-    @attr('bug1197971')
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=600)
     @mock.patch('kuma.wiki.kumascript.post')
     def test_dont_render_previews_for_deferred_docs(self, mock_post):
@@ -932,6 +929,8 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         When a user previews a document with deferred rendering,
         we want to force the preview to skip the kumascript POST,
         so that big previews can't use up too many kumascript connections.
+
+        bug 1197971
         """
         self.d.defer_rendering = True
         self.d.save()
@@ -949,8 +948,8 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
     """Tests for the document seo logic"""
     localizing_client = True
 
-    @attr('bug1190212')
     def test_get_seo_parent_doesnt_throw_404(self):
+        """bug 1190212"""
         slug_dict = {'seo_root': 'Root/Does/Not/Exist'}
         try:
             _get_seo_parent_title(slug_dict, 'bn-BD')
@@ -1064,9 +1063,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                            locale=settings.WIKI_DEFAULT_LANGUAGE))
         eq_(response['X-Robots-Tag'], 'noindex')
 
-    @attr('bug821986')
     def test_editor_safety_filter(self):
-        """Safety filter should be applied before rendering editor"""
+        """Safety filter should be applied before rendering editor
+
+        bug 821986
+        """
         self.client.login(username='admin', password='testpass')
 
         r = revision(save=True, content="""
@@ -1134,7 +1135,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc = Document.objects.get(slug=slug, locale=loc)
         eq_(comment, doc.current_revision.comment)
 
-    @attr('toc')
     def test_toc_initial(self):
         self.client.login(username='admin', password='testpass')
 
@@ -1153,7 +1153,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         if not found_selected:
             raise AssertionError("No ToC depth initially selected.")
 
-    @attr('retitle')
     def test_retitling_solo_doc(self):
         """ Editing just title of non-parent doc:
             * Changes title
@@ -1182,7 +1181,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         except Document.DoesNotExist:
             pass
 
-    @attr('retitle')
     def test_retitling_parent_doc(self):
         """ Editing just title of parent doc:
             * Changes title
@@ -1233,7 +1231,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                            locale=d.locale).slug)
         assert "REDIRECT" not in Document.objects.get(slug=old_slug).html
 
-    @attr('clobber')
     def test_slug_collision_errors(self):
         """When an attempt is made to retitle an article and another with that
         title already exists, there should be form errors"""
@@ -1266,7 +1263,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(p.find('.errorlist').length > 0)
         ok_(p.find('.errorlist a[href="#id_slug"]').length > 0)
 
-    @attr('clobber')
     def test_redirect_can_be_clobbered(self):
         """When an attempt is made to retitle an article, and another article
         with that title exists but is a redirect, there should be no errors and
@@ -1986,7 +1982,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(content('li.metadata-choose-parent'))
         ok_(str(parent.id) in content.html())
 
-    @attr('tags')
     @mock.patch.object(Site.objects, 'get_current')
     def test_document_tags(self, get_current):
         """Document tags can be edited through revisions"""
@@ -2047,7 +2042,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                  args=[path]), data)
         assert_tag_state(ts2, ts1)
 
-    @attr('review_tags')
     @mock.patch.object(Site.objects, 'get_current')
     def test_review_tags(self, get_current):
         """Review tags can be managed on document revisions"""
@@ -2152,7 +2146,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                            args=('atom', 'editorial', )))
         ok_('<entry><title>%s</title>' % doc.title in response.content)
 
-    @attr('review-tags')
     def test_quick_review(self):
         """Test the quick-review button."""
         self.client.login(username='admin', password='testpass')
@@ -2210,7 +2203,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                 ok_(expected_str in rev.comment)
             eq_(data_dict['expected_tags'], review_tags)
 
-    @attr('midair')
     def test_edit_midair_collision(self):
         self.client.login(username='admin', password='testpass')
 
@@ -2254,7 +2246,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(unicode(MIDAIR_COLLISION).encode('utf-8') in resp.content,
             "Midair collision message should appear")
 
-    @attr('toc')
     def test_toc_toggle_off(self):
         """Toggling of table of contents in revisions"""
         self.client.login(username='admin', password='testpass')
@@ -2271,7 +2262,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc = Document.objects.get(slug=d.slug, locale=d.locale)
         eq_(0, doc.current_revision.toc_depth)
 
-    @attr('toc')
     def test_toc_toggle_on(self):
         """Toggling of table of contents in revisions"""
         self.client.login(username='admin', password='testpass')
@@ -2541,7 +2531,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         _check_message_for_headers(testuser_message, 'testuser')
         _check_message_for_headers(admin_message, 'admin')
 
-    @attr('edit_emails')
     @mock.patch.object(Site.objects, 'get_current')
     def test_email_for_watched_edits(self, get_current):
         """
@@ -2593,7 +2582,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert rev.document.title in message.body
         assert 'sub-articles' not in message.body
 
-    @attr('edit_emails')
     @mock.patch.object(Site.objects, 'get_current')
     def test_email_for_child_edit_in_watched_tree(self, get_current):
         """
@@ -2620,7 +2608,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert testuser2.email in message.to
         assert 'sub-articles' in message.body
 
-    @attr('edit_emails')
     @mock.patch.object(Site.objects, 'get_current')
     def test_email_for_grandchild_edit_in_watched_tree(self, get_current):
         """
@@ -2647,7 +2634,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert testuser2.email in message.to
         assert 'sub-articles' in message.body
 
-    @attr('edit_emails')
     @mock.patch.object(Site.objects, 'get_current')
     def test_single_email_when_watching_doc_and_tree(self, get_current):
         """
@@ -2769,9 +2755,11 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         eq_(normalize_html(expected),
             normalize_html(response.content))
 
-    @attr('bug821986')
     def test_raw_editor_safety_filter(self):
-        """Safety filter should be applied before rendering editor"""
+        """Safety filter should be applied before rendering editor
+
+        bug 821986
+        """
         self.client.login(username='admin', password='testpass')
         d, r = doc_rev("""
             <p onload=alert(3)>FOO</p>
@@ -2845,8 +2833,6 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         eq_(normalize_html(expected),
             normalize_html(response.content))
 
-    @attr('midair')
-    @attr('rawsection')
     def test_raw_section_edit(self):
         self.client.login(username='admin', password='testpass')
         d, r = doc_rev("""
@@ -2900,7 +2886,6 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         eq_(normalize_html(expected),
             normalize_html(response.content))
 
-    @attr('midair')
     def test_midair_section_merge(self):
         """If a page was changed while someone was editing, but the changes
         didn't affect the specific section being edited, then ignore the midair
@@ -3003,7 +2988,6 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                                     .current_revision.id),
             unicode(response['x-kuma-revision']))
 
-    @attr('midair')
     def test_midair_section_collision(self):
         """If both a revision and the edited section has changed, then a
         section edit is a collision."""
@@ -3593,7 +3577,6 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         p = pq(resp.content)
         eq_(1, p.find('#doc-render-raw-fallback').length)
 
-    @attr('schedule_rendering')
     @mock.patch.object(Document, 'schedule_rendering')
     @mock.patch('kuma.wiki.kumascript.get')
     def test_schedule_rendering(self, mock_kumascript_get,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+addopts = -rsxX --reuse-db --tb=native
+testpaths = kuma
+python_files = test*.py
+DJANGO_SETTINGS_MODULE = settings_test

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,17 @@ addopts = -rsxX --tb=native
 testpaths = kuma
 python_files = test*.py
 DJANGO_SETTINGS_MODULE = settings_test
+markers =
+    bans: (kuma)
+    current: (kuma)
+    dashboards: (kuma) 
+    edit_emails: (kuma)
+    midair: (kuma)
+    move: (kuma)
+    redirect: (kuma)
+    retitle: (kuma)
+    review_tags: (kuma)
+    security: (kuma)
+    spam: (kuma)
+    tags: (kuma)
+    toc: (kuma)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -rsxX --reuse-db --tb=native
+addopts = -rsxX --tb=native
 testpaths = kuma
 python_files = test*.py
 DJANGO_SETTINGS_MODULE = settings_test

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,20 +1,26 @@
 # sha256: hbEnW216YczIAkpOmkyeiWOUd27c4aXQdewRb5GSVGI
 coverage==4.0.3
 
-# sha256: kvdDM2cBF0bMPL09XmfcwRBmyLhWe5pRSUju6hH6WEM
-django-nose==1.4.3
-
 # sha256: Ig4fl-zi3vNFSu7MUHBBlRjk4Wxao50h61CaOPR4R-w
 locustio==0.7.3
-
-# sha256: 2tzdwK77-Z7qIU4PEjK5Ty-pvZj6g1NxHayxEr_Luyo
-nose==1.3.7
 
 # sha256: SqEp342QB7GSv4IBP0FVM5lGUtfKqTDQAmh-tCpsKkE
 pep8==1.6.2
 
+# sha256: B-IKuQpVC9PCGJHg2IfwkxtAmPFIrsleKbUYjxYbsHU
+py==1.4.30
+
 # sha256: Bx0SHp57MwWKobpd57zpuXv6MUnP4ay7ZYfCH8HI7aE
 pyflakes==1.0.0
+
+# sha256: hpnSrjQvIR0cxn3QURG5GSVgmu99KUgxWE9zf2Wk9B0
+pytest==2.8.2
+
+# sha256: 7sNbsO8qfb6Vj1C2Z0A6tKutU6F8xPGlhbKqusb2gIg
+pytest-cov==2.2.0
+
+# sha256: dD0AVuEn70JIUOp22T1FySwxPaDlZ2WAaln8doDCWrc
+pytest-django==2.9.1
 
 # sha256: GCPJPKN4CSwQu95CghPT9QZrMK2wnlwAEIeoPj4KQCo
 tox==2.3.1

--- a/settings_test.py
+++ b/settings_test.py
@@ -8,8 +8,6 @@ ES_URLS = ['localhost:9200']
 
 INSTALLED_APPS += (
     'kuma.core.tests.taggit_extras',
-    # testing.
-    'django_nose',
 )
 BANISH_ENABLED = False
 

--- a/settings_test.py
+++ b/settings_test.py
@@ -23,9 +23,3 @@ LOGGING['loggers'].update({
         'level': 'CRITICAL',
     },
 })
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
-
-NOSE_ARGS = [
-    '--traverse-namespace',  # make sure `./manage.py test kuma` works
-]

--- a/tox.ini
+++ b/tox.ini
@@ -10,8 +10,7 @@ deps=
 commands =
     python manage.py compilejsi18n
     python manage.py collectstatic --noinput --verbosity=0
-    coverage run manage.py test --noinput -v 2 {posargs:kuma}
-    coverage report
+    py.test --cov=kuma {posargs:kuma}
 setenv =
     PYTHONPATH = .
     CFLAGS = -O0


### PR DESCRIPTION
This is the bare minimum amount of work required to switch from
nose/django-nose to py.test/pytest-django.

Several things to know:

1. I changed the SkipTest things to xfail since that's closer to what
   they are (i.e. "This thing fails and we don't know why--look at it
   later")

2. I removed the attr() things because they seemed arbitrary,
   inconsistent and not documented anywhere I could find. I'll make sure
   to note this in the email I send after this lands.

3. I reimplemented eq_ and ok_ rather than go through and change these
   to their py.test equivalents. We can change them over as a code
   cleanup step done on a future rainy day.

Outstanding things to do:

1. [x] test with travis (which this PR will do)
2. [x] update documentation
3. [x] update Makefile
4. [x] fix arguments in pytest.ini
5. [x] find missing 2 tests
6. [x] re-add marks
7. [ ] write up bugs for ditching eq_/ok_