### PR TITLE
Bug 1238696: Update django-mozilla-product-details

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -27,7 +27,7 @@ django-flat-theme==1.1.3 --hash=sha256:323011c7eda4fb57604fd9feee568c5a789bff4c0
 django-honeypot==0.5.0 --hash=sha256:962304f21055f05c73c41f2506f5a94f5b941e831a203b68e54cb5016bdb8d5e
 django-jinja==1.4.1 --hash=sha256:6f4c2e8c5ada17039ff1c1e38bc51bea9317af3676e28466148c8df5fc78f132
 django-memcached-hashring==0.1.2 --hash=sha256:14c2dc29bc693feaf114dea8c871f4d25daca72bba8f37b159d552fed4ab6337
-django-mozilla-product-details==0.7.1 --hash=sha256:c50bffb9828a9139156904a11c508732d13dbf57ac25625ebc5edaa3ed312840
+django-mozilla-product-details==0.10.0 --hash=sha256:33add704683a5d7f9ff49c03e40a4d8c500882589aee970d5ed81ad11c7ae75c
 django-picklefield==0.3.2 --hash=sha256:5489fef164de43725242d56e65e016137d3df0d1a00672bda72d807f5b2b0d99
 django-pipeline==1.5.4 --hash=sha256:a5a909f403d0ea56f211618949ff4e378f16e5a996bde819bd2b5b0e7a9bb8fe
 django-ratelimit==0.6.0 --hash=sha256:f73b53b2c4fd342cbd4b983ffc33fdcf8f8a6f595d548865ea63c839ef38293c


### PR DESCRIPTION
This updates django-mozilla-product-details to 0.10 which was recently
released. This allows us to switch from the file system backend to the
db backend in a future commit.

To test:

1. wait for travis to run the tests
2. run "./manage.py update_product_details"

Pretty sure this should be fine. I want to land this before switching
the backend because @jezdez said MDN had problems updating it in the
past and had to revert.

Quick r?