### PR TITLE
Bug 957802 - Fix documentation build until RTD supports pip8 requirements files.

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,14 +1,14 @@
 # This is a standalone requirements file for the documentation requirements
 # used by ReadTheDocs to set up the documentation rendering environment
-alabaster==0.7.7 --hash=sha256:d57602b3d730c2ecb978a213face0b7a16ceaa4a263575361bd4fd9e2669a544
-Babel==2.2.0 --hash=sha256:fed07cbcdcb3de79b53a8220eebed21c93f8dbb3dbce1d9c6b1c4b09e8aecf2b
-docutils==0.12 --hash=sha256:c7db717810ab6965f66c8cf0398a98c9d8df982da39b4cd7f162911eb89596fa
-Jinja2==2.8 --hash=sha256:1cc03ef32b64be19e0a5b54578dd790906a34943fe9102cfdae0d4495bd536b4
-MarkupSafe==0.23 --hash=sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3
-mdn-sphinx-theme==2015.2 --hash=sha256:83354e5ab7a78fa1c5b98799f894583c45e9c2b1d8420c64c6a778b61ee4505e
-Pygments==2.0.2 --hash=sha256:0a3a2265e1efb0defa722d1f429730dc9df975adc3c60ac7d2b432bdf03c041d
-pytz==2015.7 --hash=sha256:3ede470d3d17ba3c07638dfa0d10452bc1b6e5ad326127a65ba77e6aaeb11bec
-six==1.10.0 --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1
-snowballstemmer==1.2.1 --hash=sha256:9f3bcd3c401c3e862ec0ebe6d2c069ebc012ce142cce209c098ccb5b09136e89
-Sphinx==1.3.3 --hash=sha256:3ad4cb89ab4baa5f9bb99548a9a1fb5127b3ee83a5213b83da4de7578afdc891
-sphinx-rtd-theme==0.1.9 --hash=sha256:3c38d037713bd78043486eea5bf771d71ed697ec25c09e16f49e44887f7fe184
+alabaster==0.7.7
+Babel==2.2.0
+docutils==0.12
+Jinja2==2.8
+MarkupSafe==0.23
+mdn-sphinx-theme==2015.2
+Pygments==2.0.2
+pytz==2015.7
+six==1.10.0
+snowballstemmer==1.2.1
+Sphinx==1.3.3
+sphinx-rtd-theme==0.1.9


### PR DESCRIPTION
See https://github.com/rtfd/readthedocs.org/issues/1958 for a follow-up.