### PR TITLE
Fix bug 1244308: Return 404 content if user can't restore the document

### DIFF
--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -149,6 +149,30 @@ def normalize_html(input):
             .serialize(alphabetical_attributes=True))
 
 
+def create_document_editor_user():
+    """Creates a user empowered with document editing"""
+    perms = []
+    for action in ('add', 'change', 'delete', 'view', 'restore'):
+        perms.append(Permission.objects.get(codename='%s_document' % action))
+
+    group, group_created = Group.objects.get_or_create(name='editor')
+    if group_created:
+        group.permissions = perms
+        group.save()
+
+    User = get_user_model()
+    user, user_created = User.objects.get_or_create(
+        username='conantheeditor',
+        defaults=dict(email='user_%s@example.com',
+                      is_active=True, is_staff=False, is_superuser=False))
+    if user_created:
+        user.set_password('testpass')
+        user.groups = [group]
+        user.save()
+
+    return user
+
+
 def create_template_test_users():
     perms = dict(
         (x, [Permission.objects.get(codename='%s_template_document' % x)])

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -486,12 +486,18 @@ def _document_redirect_to_create(document_slug, document_locale, slug_dict):
 @allow_CORS_GET
 @prevent_indexing
 def _document_deleted(request, deletion_logs):
+    """When a Document has been deleted return a 404.
+
+    If the user can restore documents, then return a 404 but also include the
+    template with the form to restore the document.
+
     """
-    When a Document has been deleted, display a notice.
-    """
-    deletion_log = deletion_logs.order_by('-pk')[0]
-    context = {'deletion_log': deletion_log}
-    return render(request, 'wiki/deletion_log.html', context, status=404)
+    if request.user and request.user.has_perm('wiki.restore_document'):
+        deletion_log = deletion_logs.order_by('-pk')[0]
+        context = {'deletion_log': deletion_log}
+        return render(request, 'wiki/deletion_log.html', context, status=404)
+
+    raise Http404
 
 
 @newrelic.agent.function_trace()


### PR DESCRIPTION
Previously, MDN would return an HTTP 404 with an HTML document that
has some stuff on it and lets people restore the document. That's not
great because somehow those pages are getting indexed or otherwise
making search bots grumpy.

Instead of doing that, this changes MDN to return a straight-up
regular 404 page unless the user can restore documents in which case
they get the HTML page that lets them restore documents.

@jezdez r?