### PR TITLE
Bug 1247498 - Fix spellings in docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -101,7 +101,7 @@ Kuma tracks its Python dependencies with pip_.
 
 The ``requirements`` directory contains the plaintext requirements files
 that are used in the Vagrant VM, during automatic tests with Travis-CI
-and duriing deployment to stage and prod.
+and during deployment to stage and prod.
 
 Here's what that folder contains:
 

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -58,7 +58,7 @@ way:
 
 - To actually enable that newly created search index you have to promote it
   now. On the search index list view again, select the just created index (the top
-  most) and select "Promote search index" from the actions dropwdown below.
+  most) and select "Promote search index" from the actions dropdown below.
 
 - Once the search index is promoted the "promoted" and the "is current index"
   field will show up as a green checkbox image. The index is now live.
@@ -66,7 +66,7 @@ way:
 Similarly you can also demote a search index and it will automatically fall
 back to the previously created index (by created date). That helps to figure
 out issues in production and should allow for a smooth deployment of search
-index changes. It's recommmended to keep a few search indexes around just in
+index changes. It's recommended to keep a few search indexes around just in
 case.
 
 If no index is created in the admin UI the fallback "main_index" index will be

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -256,7 +256,7 @@ installed and also note that you can't export anything via NFS inside an
 encrypted volume or home dir. On Windows NFS won't be used ever by the way.
 
 If that doesn't help you can disable NFS by setting the ``VAGRANT_NFS``
-configration value in a ``.env`` file. See the :ref:`Vagrant configuration
+configuration value in a ``.env`` file. See the :ref:`Vagrant configuration
 <vagrant-config>` options for more info.
 
 If you have other problems during ``vagrant up``, please check


### PR DESCRIPTION
In `docs/development.rst`

duriing - during

In `docs/elasticsearch.rst`

dropwdown - dropdown
recommmended - recommended

In `docs/installation.rst`

configration - configuration