### PR TITLE
Bug 1188029 - Fix API issue in Akismet spam check.

### DIFF
--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -78,9 +78,12 @@ class AkismetCheckFormMixin(AkismetFormMixin):
 
     def akismet_call(self, parameters):
         try:
-            self.akismet_client.check_comment(**parameters)
+            is_spam = self.akismet_client.check_comment(**parameters)
         except akismet.AkismetError:
             self.akismet_error()
+        else:
+            if is_spam:
+                self.akismet_error()
 
 
 class AkismetSubmissionFormMixin(AkismetFormMixin):
@@ -111,7 +114,7 @@ class AkismetSubmissionFormMixin(AkismetFormMixin):
 
     def akismet_call(self, parameters):
         """"
-        Get the submission funciton and call it with the parameters.
+        Get the submission function and call it with the parameters.
         """
         submission_function = 'submit_%s' % self.akismet_submission_type()
         try:

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -22,6 +22,7 @@ class RevisionFormTests(UserTransactionTestCase):
 
     def setUp(self):
         super(RevisionFormTests, self).setUp()
+        self.testuser = self.user_model.objects.get(username='testuser')
         Flag.objects.update_or_create(
             name=SPAM_CHECKS_FLAG,
             defaults={'everyone': True},
@@ -77,10 +78,11 @@ class RevisionFormTests(UserTransactionTestCase):
         self.assertEqual(normalize_html(expected),
                          normalize_html(rev_form.initial['content']))
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_form_save_section(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='true')
+        mock_requests.post(CHECK_URL, content='false')
         rev = revision(save=True, is_approved=True, content="""
             <h1 id="s1">s1</h1>
             <p>test</p>
@@ -131,16 +133,17 @@ class RevisionFormTests(UserTransactionTestCase):
             'content': 'Content',
         }
         request = self.rf.get('/')
-        request.user = self.user_model.objects.get(username='testuser')
+        request.user = self.testuser
         rev_form = RevisionForm(data=data,
                                 request=request,
                                 parent_slug='User:groovecoder')
         self.assertFalse(rev_form.is_valid())
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_multiword_tags(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='true')
+        mock_requests.post(CHECK_URL, content='false')
         rev = revision(save=True)
         request = self.rf.get('/')
         request.user = rev.creator
@@ -153,6 +156,7 @@ class RevisionFormTests(UserTransactionTestCase):
         self.assertTrue(rev_form.is_valid())
         self.assertEqual(rev_form.cleaned_data['tags'], '"MDN Meta"')
 
+    @pytest.mark.spam
     @requests_mock.mock()
     def test_case_sensitive_tags(self, mock_requests):
         """
@@ -160,7 +164,7 @@ class RevisionFormTests(UserTransactionTestCase):
         that only differ by case.
         """
         mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='true')
+        mock_requests.post(CHECK_URL, content='false')
         rev = revision(save=True, tags='"JavaScript"')
         request = self.rf.get('/')
         request.user = rev.creator
@@ -180,8 +184,7 @@ class RevisionFormTests(UserTransactionTestCase):
         request = self.rf.get('/')
         # using a non-admin user here to make sure we can test the
         # exmption rule below
-        test_user = self.user_model.objects.get(username='testuser')
-        request.user = test_user
+        request.user = self.testuser
         data = {
             'slug': 'Title',
             'title': 'Title',
@@ -193,21 +196,50 @@ class RevisionFormTests(UserTransactionTestCase):
 
         # create the waffle flag and add the test user to it
         flag, created = Flag.objects.get_or_create(name=SPAM_EXEMPTED_FLAG)
-        flag.users.add(test_user)
+        flag.users.add(self.testuser)
 
         # now disabled because the test user is exempted from the spam check
         self.assertFalse(rev_form.akismet_enabled())
 
-    @pytest.mark.spam
     @requests_mock.mock()
-    def test_akismet_error(self, mock_requests):
+    @pytest.mark.spam
+    def test_akismet_ham(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='terrible')
+        mock_requests.post(CHECK_URL, content='false')  # false means it's ham
         request = self.rf.get('/')
         # using a non-admin user here to make sure we can test the
         # exmption rule below
-        test_user = self.user_model.objects.get(username='testuser')
-        request.user = test_user
+        request.user = self.testuser
+        data = {
+            'title': 'Title',
+            'slug': 'Slug',
+            'content': 'Content',
+            'toc_depth': Revision.TOC_DEPTH_ALL,
+        }
+        self.assertEqual(DocumentSpamAttempt.objects.count(), 0)
+        self.assertEqual(len(mail.outbox), 0)
+
+        rev_form = RevisionForm(data=data, request=request)
+        self.assertTrue(rev_form.is_valid())
+        self.assertEqual(DocumentSpamAttempt.objects.count(), 0)
+
+    @requests_mock.mock()
+    @pytest.mark.spam
+    def test_akismet_spam(self, mock_requests):
+        self._test_akismet_error(mock_requests, 'true')
+
+    @requests_mock.mock()
+    @pytest.mark.spam
+    def test_akismet_error(self, mock_requests):
+        self._test_akismet_error(mock_requests, 'terrible')
+
+    def _test_akismet_error(self, mock_requests, check_response):
+        mock_requests.post(VERIFY_URL, content='valid')
+        mock_requests.post(CHECK_URL, content=check_response)
+        request = self.rf.get('/')
+        # using a non-admin user here to make sure we can test the
+        # exmption rule below
+        request.user = self.testuser
         data = {
             'title': 'Title',
             'slug': 'Slug',
@@ -223,7 +255,7 @@ class RevisionFormTests(UserTransactionTestCase):
         attempt = DocumentSpamAttempt.objects.latest()
         self.assertEqual(attempt.title, 'Title')
         self.assertEqual(attempt.slug, 'Slug')
-        self.assertEqual(attempt.user, test_user)
+        self.assertEqual(attempt.user, self.testuser)
 
         # Test that one message has been sent.
         self.assertEqual(len(mail.outbox), 1)
@@ -240,10 +272,9 @@ class RevisionFormTests(UserTransactionTestCase):
     @requests_mock.mock()
     def test_akismet_parameters(self, mock_requests):
         mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='true')
+        mock_requests.post(CHECK_URL, content='false')
         request = self.rf.get('/')
-        test_user = self.user_model.objects.get(username='testuser')
-        request.user = test_user
+        request.user = self.testuser
         data = {
             'title': 'Title',
             'slug': 'Slug',
@@ -258,7 +289,8 @@ class RevisionFormTests(UserTransactionTestCase):
         self.assertTrue(rev_form.is_valid())
         parameters = rev_form.akismet_parameters()
         self.assertEqual(parameters['comment_author'], 'Test User')
-        self.assertEqual(parameters['comment_author_email'], test_user.email)
+        self.assertEqual(parameters['comment_author_email'],
+                         self.testuser.email)
         # The content contains just
         for value in data.values():
             self.assertIn(value, parameters['comment_content'])


### PR DESCRIPTION
This fixes a design issue in the spam package that was overlooked and never surfaced as part of the unittests since they only tests the error cases, and not specfically the success cases.