### PR TITLE
bug 1201709 - /renamed$children returns error JSON

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -312,6 +312,14 @@ class ViewTests(UserTestCase, WikiTestCase):
         result = json.loads(resp.content)
         eq_(result, {'error': 'Document does not exist.'})
 
+        # Test error json if document is a redirect
+        _make_doc('Old Name', 'Old Name', is_redir=True)
+        redirect_doc_url = reverse('wiki.children', args=['Old Name'],
+                                   locale=settings.WIKI_DEFAULT_LANGUAGE)
+        resp = self.client.get(redirect_doc_url)
+        result = json.loads(resp.content)
+        eq_(result, {'error': 'Document has moved.'})
+
     def test_summary_view(self):
         """The ?summary option should restrict document view to summary"""
         d, r = doc_rev("""

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -262,6 +262,8 @@ def children(request, document_slug, document_locale):
         doc = Document.objects.get(locale=document_locale,
                                    slug=document_slug)
         result = _make_doc_structure(doc, 0, expand, depth)
+        if result is None:
+            result = {'error': 'Document has moved.'}
     except Document.DoesNotExist:
         result = {'error': 'Document does not exist.'}
 


### PR DESCRIPTION
When the $children API view is requested for a redirected page, return this error JSON:

```json
{"error": "Document has moved."}
```

Previously, a 500 error occurred due to ``JsonResponse`` refusing to encode a ``null``.