### PR TITLE
Fix bug 1237661: Fix wonky admin

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -55,7 +55,10 @@ class LocaleURLMiddleware(object):
 
         request.path_info = '/' + prefixer.shortened_path
         request.LANGUAGE_CODE = prefixer.locale or settings.LANGUAGE_CODE
-        translation.activate(prefixer.locale)
+        # prefixer.locale can be '', but we need a real locale code to activate
+        # otherwise the request uses the previously handled request's
+        # translations.
+        translation.activate(prefixer.locale or settings.LANGUAGE_CODE)
 
     def process_response(self, request, response):
         """Unset the thread-local var we set during `process_request`."""


### PR DESCRIPTION
This fixes the wonky admin problem where the language of the admin would
change between refreshes.

What's going on is that Django 1.8 introduced a fix to
trans_real.activate where if you pass in '', it does nothing and
returns. The prefixer will set the locale to '' for /admin/, so then
the locale-aware middleware calls translation.activate('') and
suddenly we're all standing in a pool of goo in the middle ages with
flaming arrows aimed at us.

This fixes that.

r?