### PR TITLE
bug 1246967 - Add UUIDs to $json page API

### DIFF
--- a/kuma/wiki/migrations/0024_document_uuid_default.py
+++ b/kuma/wiki/migrations/0024_document_uuid_default.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0023_add_document_uuid'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='document',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, null=True, editable=False),
+        ),
+    ]

--- a/kuma/wiki/migrations/0025_populate_document_uuid.py
+++ b/kuma/wiki/migrations/0025_populate_document_uuid.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from uuid import uuid4
+
+from django.db import migrations
+
+
+def populate_uuids(apps, schema_editor):
+    """Populate Document.uuid, without bumping last modified."""
+    Document = apps.get_model('wiki', 'Document')
+    docs = Document.objects.filter(uuid__isnull=True)
+    for document_id in docs.values_list('id', flat=True).iterator():
+        Document.objects.filter(id=document_id).update(uuid=uuid4())
+
+
+def clear_uuids(apps, schema_editor):
+    """Clear Document.uuid."""
+    Document = apps.get_model('wiki', 'Document')
+    Document.objects.exclude(uuid__isnull=True).update(uuid=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0024_document_uuid_default'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_uuids, clear_uuids)
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -4,6 +4,7 @@ import sys
 import traceback
 from datetime import datetime, timedelta
 from functools import wraps
+from uuid import uuid4
 
 import newrelic.agent
 import waffle
@@ -318,8 +319,7 @@ class Document(NotificationsMixin, models.Model):
 
     summary_text = models.TextField(editable=False, blank=True, null=True)
 
-    # TODO bug 1246967: Enable field once migration is run in production
-    # uuid = models.UUIDField(default=uuid4, editable=False, null=True)
+    uuid = models.UUIDField(default=uuid4, editable=False, null=True)
 
     class Meta(object):
         unique_together = (

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -622,6 +622,10 @@ class Document(NotificationsMixin, models.Model):
                     summary = revision.summary
                 else:
                     summary = translation.get_summary(strip_markup=False)
+                if translation.uuid:
+                    translation_uuid = str(translation.uuid)
+                else:
+                    translation_uuid = None
                 translations.append({
                     'last_edit': revision.created.isoformat(),
                     'locale': translation.locale,
@@ -632,6 +636,7 @@ class Document(NotificationsMixin, models.Model):
                     'tags': list(translation.tags.names()),
                     'title': translation.title,
                     'url': translation.get_absolute_url(),
+                    'uuid': translation_uuid
                 })
 
         if self.current_revision:
@@ -662,11 +667,17 @@ class Document(NotificationsMixin, models.Model):
         else:
             modified = now_iso
 
+        if self.uuid:
+            uuid = str(self.uuid)
+        else:
+            uuid = None
+
         return {
             'title': self.title,
             'label': self.title,
             'url': self.get_absolute_url(),
             'id': self.id,
+            'uuid': uuid,
             'slug': self.slug,
             'tags': tags,
             'review_tags': review_tags,

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -84,6 +84,7 @@ class DocumentTests(UserTestCase):
         assert data['label'] == doc.title
         assert data['url'] == doc.get_absolute_url()
         assert data['id'] == doc.id
+        assert data['uuid'] == str(doc.uuid)
         assert data['slug'] == doc.slug
         result_tags = sorted([str(x) for x in data['tags']])
         assert result_tags == expected_tags
@@ -108,6 +109,21 @@ class DocumentTests(UserTestCase):
         assert result_review_tags == expected_review_tags
         assert de_data['summary'] == de_doc.current_revision.summary
         assert de_data['title'] == de_doc.title
+        assert de_data['uuid'] == str(de_doc.uuid)
+
+    def test_json_data_null_uuid(self):
+        """Test json data during the UUID transition period."""
+        doc, rev = doc_rev('Sample document')
+        doc.uuid = None
+        doc.save()
+        de_doc = document(parent=doc, locale='de', uuid=None, save=True)
+        revision(document=de_doc, save=True)
+
+        data = doc.get_json_data()
+        assert data['uuid'] is None
+        assert 'translations' in data
+        assert len(data['translations']) == 1
+        assert data['translations'][0]['uuid'] is None
 
     def test_document_is_template(self):
         """is_template stays in sync with the title"""

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -67,46 +67,47 @@ class DocumentTests(UserTestCase):
         de_doc.current_revision.review_tags.set(*expected_review_tags)
 
         # Ensure the doc's json field is empty at first
-        eq_(None, doc.json)
+        assert doc.json is None
 
         # Get JSON data for the doc, and ensure the doc's json field is now
         # properly populated.
         data = doc.get_json_data()
-        eq_(json.dumps(data), doc.json)
+        assert doc.json == json.dumps(data)
 
         # Load up another copy of the doc from the DB, and check json
         saved_doc = Document.objects.get(pk=doc.pk)
-        eq_(json.dumps(data), saved_doc.json)
+        assert saved_doc.json == json.dumps(data)
 
         # Check the fields stored in JSON of the English doc
         # (the fields are created in build_json_data in models.py)
-        eq_(doc.title, data['title'])
-        eq_(doc.title, data['label'])
-        eq_(doc.get_absolute_url(), data['url'])
-        eq_(doc.id, data['id'])
-        eq_(doc.slug, data['slug'])
+        assert data['title'] == doc.title
+        assert data['label'] == doc.title
+        assert data['url'] == doc.get_absolute_url()
+        assert data['id'] == doc.id
+        assert data['slug'] == doc.slug
         result_tags = sorted([str(x) for x in data['tags']])
-        eq_(expected_tags, result_tags)
+        assert result_tags == expected_tags
         result_review_tags = sorted([str(x) for x in data['review_tags']])
-        eq_(expected_review_tags, result_review_tags)
-        eq_(doc.locale, data['locale'])
-        eq_(doc.current_revision.summary, data['summary'])
-        eq_(doc.modified.isoformat(), data['modified'])
-        eq_(doc.current_revision.created.isoformat(), data['last_edit'])
+        assert result_review_tags == expected_review_tags
+        assert data['locale'] == doc.locale
+        assert data['summary'] == doc.current_revision.summary
+        assert data['modified'] == doc.modified.isoformat()
+        assert data['last_edit'] == doc.current_revision.created.isoformat()
 
         # Check fields of translated doc
-        ok_('translations' in data)
-        eq_(de_doc.locale, data['translations'][0]['locale'])
+        assert 'translations' in data
+        assert len(data['translations']) == 1
+        de_data = data['translations'][0]
+        assert de_data['locale'] == de_doc.locale
         result_l10n_tags = sorted([str(x) for x
-                                   in data['translations'][0]['localization_tags']])
-        eq_(expected_l10n_tags, result_l10n_tags)
-        result_tags = sorted([str(x) for x in data['translations'][0]['tags']])
-        eq_(expected_tags, result_tags)
-        result_review_tags = sorted([str(x) for x
-                                     in data['translations'][0]['review_tags']])
-        eq_(expected_review_tags, result_review_tags)
-        eq_(de_doc.current_revision.summary, data['translations'][0]['summary'])
-        eq_(de_doc.title, data['translations'][0]['title'])
+                                   in de_data['localization_tags']])
+        assert result_l10n_tags == expected_l10n_tags
+        result_tags = sorted([str(x) for x in de_data['tags']])
+        assert result_tags == expected_tags
+        result_review_tags = sorted([str(x) for x in de_data['review_tags']])
+        assert result_review_tags == expected_review_tags
+        assert de_data['summary'] == de_doc.current_revision.summary
+        assert de_data['title'] == de_doc.title
 
     def test_document_is_template(self):
         """is_template stays in sync with the title"""


### PR DESCRIPTION
Add uuid to document model, and expose it in the ``$json`` page API (like [Web/CSS/display$json](https://developer.mozilla.org/en-US/docs/Web/CSS/display$json)). Populate null Document.uuid columns with new [Version 4 (random) UUIDs](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29).

This is part 2 of 3 of adding Document.UUID. Each part needs to be pushed to production, and the included migrations run, before the next portion is merged and pushed.

1. PR #3793 - Add empty Document.uuid to database
2. PR #3794 (this PR) - Populate Document.uuid and use in $json API
3. PR #3795 - Require non-null Document.uuid and refresh $json API