### PR TITLE
bug 1246967 - Add Document.uuid

### DIFF
--- a/kuma/wiki/migrations/0027_populate_document_uuid.py
+++ b/kuma/wiki/migrations/0027_populate_document_uuid.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from uuid import uuid4
+
+from django.db import migrations
+
+
+def populate_uuids(apps, schema_editor):
+    """Populate Document.uuid, without bumping last modified."""
+    Document = apps.get_model('wiki', 'Document')
+    docs = Document.objects.filter(uuid__isnull=True)
+    for document_id in docs.values_list('id', flat=True).iterator():
+        Document.objects.filter(id=document_id).update(uuid=uuid4())
+
+
+def clear_uuids(apps, schema_editor):
+    """Clear Document.uuid."""
+    Document = apps.get_model('wiki', 'Document')
+    Document.objects.exclude(uuid__isnull=True).update(uuid=None)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0026_document_uuid_default'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_uuids, clear_uuids)
+    ]

--- a/kuma/wiki/migrations/0028_require_document_uuid.py
+++ b/kuma/wiki/migrations/0028_require_document_uuid.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import uuid
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0027_populate_document_uuid'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='document',
+            name='uuid',
+            field=models.UUIDField(default=uuid.uuid4, editable=False),
+        ),
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -316,7 +316,7 @@ class Document(NotificationsMixin, models.Model):
 
     summary_text = models.TextField(editable=False, blank=True, null=True)
 
-    uuid = models.UUIDField(default=uuid4, editable=False, null=True)
+    uuid = models.UUIDField(default=uuid4, editable=False)
 
     class Meta(object):
         unique_together = (
@@ -613,10 +613,6 @@ class Document(NotificationsMixin, models.Model):
                     summary = revision.summary
                 else:
                     summary = translation.get_summary(strip_markup=False)
-                if translation.uuid:
-                    translation_uuid = str(translation.uuid)
-                else:
-                    translation_uuid = None
                 translations.append({
                     'last_edit': revision.created.isoformat(),
                     'locale': translation.locale,
@@ -627,7 +623,7 @@ class Document(NotificationsMixin, models.Model):
                     'tags': list(translation.tags.names()),
                     'title': translation.title,
                     'url': translation.get_absolute_url(),
-                    'uuid': translation_uuid
+                    'uuid': str(translation.uuid)
                 })
 
         if self.current_revision:
@@ -658,17 +654,12 @@ class Document(NotificationsMixin, models.Model):
         else:
             modified = now_iso
 
-        if self.uuid:
-            uuid = str(self.uuid)
-        else:
-            uuid = None
-
         return {
             'title': self.title,
             'label': self.title,
             'url': self.get_absolute_url(),
             'id': self.id,
-            'uuid': uuid,
+            'uuid': str(self.uuid),
             'slug': self.slug,
             'tags': tags,
             'review_tags': review_tags,

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -111,21 +111,6 @@ class DocumentTests(UserTestCase):
         assert de_data['title'] == de_doc.title
         assert de_data['uuid'] == str(de_doc.uuid)
 
-    def test_json_data_null_uuid(self):
-        """Test json data during the UUID transition period."""
-        rev = revision(is_approved=True, save=True, content='Sample document')
-        doc = rev.document
-        doc.uuid = None
-        doc.save()
-        de_doc = document(parent=doc, locale='de', uuid=None, save=True)
-        revision(document=de_doc, save=True)
-
-        data = doc.get_json_data()
-        assert data['uuid'] is None
-        assert 'translations' in data
-        assert len(data['translations']) == 1
-        assert data['translations'][0]['uuid'] is None
-
     def test_document_is_template(self):
         """is_template stays in sync with the title"""
         d = document(title='test')


### PR DESCRIPTION
Add a UUID to the Document model, which can first be used as an external ID for identifying features in the https://github.com/mdn/browsercompat project.

Because this PR includes database migrations, it needs to be manually merged and deployed in four parts:

1. [x] Update Kuma migrations to match the state of the models. Then add Document.uuid to the database, nullable with a default of null. *(first commit)*
2. [x] Add uuid to document model, and expose it in the ``$json`` page API (like [Web/CSS/display$json](https://developer.mozilla.org/en-US/docs/Web/CSS/display$json)). *(middle commits)*
3. [x] Manually populate null Document.uuid columns with new [Version 4 (random) UUIDs] (https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_4_.28random.29). 
4. [ ] Run an automated migration to ensure UUIDs are populated. Update the schema so that Document.uuid is not allowed to be null. *(final 2 commits)*
