### PR TITLE
Bug 1239757: Only ask helpful on wiki docs

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -842,7 +842,6 @@ PIPELINE_JS = {
             'js/wiki.js',
             'js/wiki-samples.js',
             'js/social.js',
-            'js/helpfulness.js',
         ),
         'output_filename': 'build/js/wiki.js',
         'extra_context': {
@@ -872,6 +871,15 @@ PIPELINE_JS = {
         ),
         'output_filename': 'build/js/wiki-compat-tables.js',
         'template_name': 'pipeline/javascript-array.jinja',
+    },
+    'helpfulness': {
+        'source_filenames': (
+            'js/helpfulness.js',
+        ),
+        'output_filename': 'build/js/helpfulness.js',
+        'extra_context': {
+            'async': True,
+        },
     },
     'newsletter': {
         'source_filenames': (

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -381,6 +381,8 @@
 
 {% block js %}
 
+  {% javascript 'helpfulness' %}
+
   {% if waffle.flag('section_edit') %}
     <script type="text/javascript">
         (function($) {


### PR DESCRIPTION
Separated the helpfulness file back out of the wiki.js file and added it only to the document pages so we won't get asked on editing pages, etc anymore.