### PR TITLE
bug 1215199 - Display dates in spam email in UTC

### DIFF
--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -13,7 +13,7 @@ from django.utils.encoding import force_text
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
 from django_jinja import library
-from pytz import timezone
+from pytz import timezone, utc
 from soapbox.models import Message
 from statici18n.templatetags.statici18n import statici18n
 from urlobject import URLObject
@@ -249,3 +249,16 @@ def datetimeformat(context, value, format='shortdatetime', output='html'):
 @library.global_function
 def static(path):
     return staticfiles_storage.url(path)
+
+
+@library.filter
+def in_utc(dt):
+    """
+    Convert a datetime to the UTC timezone.
+
+    Assume that naive datetimes (without timezone info) are in system time.
+    """
+    if dt.utcoffset() is None:
+        tz = timezone(settings.TIME_ZONE)
+        dt = tz.localize(dt)
+    return dt.astimezone(utc)

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -1,12 +1,9 @@
 import datetime
 import HTMLParser
 import json
-import urllib
 
-import bleach
 import jinja2
-import pytz
-from babel import dates, localedata, numbers
+from babel import dates, localedata
 from django.conf import settings
 from django.contrib.messages.storage.base import LEVEL_TAGS
 from django.contrib.staticfiles.storage import staticfiles_storage
@@ -14,9 +11,7 @@ from django.template import defaultfilters
 from django.template.loader import get_template
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
-from django.utils.timezone import get_default_timezone
 from django.utils.translation import ugettext_lazy as _
-from django.utils.translation import ungettext
 from django_jinja import library
 from pytz import timezone
 from soapbox.models import Message
@@ -34,7 +29,6 @@ htmlparser = HTMLParser.HTMLParser()
 # Yanking filters from Django.
 library.filter(defaultfilters.linebreaksbr)
 library.filter(strip_tags)
-library.filter(defaultfilters.timesince)
 library.filter(defaultfilters.truncatewords)
 library.global_function(statici18n)
 
@@ -91,58 +85,6 @@ class Paginator(object):
 
 
 @library.filter
-def timesince(d, now=None):
-    """Take two datetime objects and return the time between d and now as a
-    nicely formatted string, e.g. "10 minutes".  If d is None or occurs after
-    now, return ''.
-
-    Units used are years, months, weeks, days, hours, and minutes. Seconds and
-    microseconds are ignored.  Just one unit is displayed.  For example,
-    "2 weeks" and "1 year" are possible outputs, but "2 weeks, 3 days" and "1
-    year, 5 months" are not.
-
-    Adapted from django.utils.timesince to have better i18n (not assuming
-    commas as list separators and including "ago" so order of words isn't
-    assumed), show only one time unit, and include seconds.
-
-    """
-    if d is None:
-        return u''
-    chunks = [
-        (60 * 60 * 24 * 365, lambda n: ungettext('%(number)d year ago',
-                                                 '%(number)d years ago', n)),
-        (60 * 60 * 24 * 30, lambda n: ungettext('%(number)d month ago',
-                                                '%(number)d months ago', n)),
-        (60 * 60 * 24 * 7, lambda n: ungettext('%(number)d week ago',
-                                               '%(number)d weeks ago', n)),
-        (60 * 60 * 24, lambda n: ungettext('%(number)d day ago',
-                                           '%(number)d days ago', n)),
-        (60 * 60, lambda n: ungettext('%(number)d hour ago',
-                                      '%(number)d hours ago', n)),
-        (60, lambda n: ungettext('%(number)d minute ago',
-                                 '%(number)d minutes ago', n)),
-        (1, lambda n: ungettext('%(number)d second ago',
-                                '%(number)d seconds ago', n))]
-    if not now:
-        if d.tzinfo:
-            now = datetime.datetime.now(get_default_timezone())
-        else:
-            now = datetime.datetime.now()
-
-    # Ignore microsecond part of 'd' since we removed it from 'now'
-    delta = now - (d - datetime.timedelta(0, 0, d.microsecond))
-    since = delta.days * 24 * 60 * 60 + delta.seconds
-    if since <= 0:
-        # d is in the future compared to now, stop processing.
-        return u''
-    for i, (seconds, name) in enumerate(chunks):
-        count = since // seconds
-        if count != 0:
-            break
-    return name(count) % {'number': count}
-
-
-@library.filter
 def yesno(boolean_value):
     return jinja2.Markup(_(u'Yes') if boolean_value else _(u'No'))
 
@@ -164,35 +106,10 @@ def level_tag(message):
                                     strings_only=True))
 
 
-@library.filter
-def isotime(t):
-    """Date/Time format according to ISO 8601"""
-    if not hasattr(t, 'tzinfo'):
-        return
-    return _append_tz(t).astimezone(pytz.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _append_tz(t):
-    tz = pytz.timezone(settings.TIME_ZONE)
-    return tz.localize(t)
-
-
 @library.global_function
 def thisyear():
     """The current year."""
     return jinja2.Markup(datetime.date.today().year)
-
-
-@library.filter
-def cleank(txt):
-    """Clean and link some user-supplied text."""
-    return jinja2.Markup(bleach.linkify(bleach.clean(txt)))
-
-
-@library.filter
-def urlencode(txt):
-    """Url encode a path."""
-    return urllib.quote_plus(txt.encode('utf8'))
 
 
 @library.filter
@@ -327,20 +244,6 @@ def datetimeformat(context, value, format='shortdatetime', output='html'):
         return formatted
     return jinja2.Markup('<time datetime="%s">%s</time>' %
                          (tzvalue.isoformat(), formatted))
-
-
-@library.global_function
-@jinja2.contextfunction
-def number(context, number):
-    """
-    Return the localized representation of an integer or decimal.
-
-    For None, print nothing.
-    """
-    if number is None:
-        return ''
-    locale = _babel_locale(_contextual_locale(context))
-    return numbers.format_decimal(number, locale=locale)
 
 
 @library.global_function

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from collections import namedtuple
 from datetime import datetime
 
 import mock
@@ -16,54 +15,16 @@ from kuma.users.tests import UserTestCase
 
 from ..exceptions import DateTimeFormatError
 from ..templatetags.jinja_helpers import (datetimeformat, get_soapbox_messages,
-                                          jsonencode, number, soapbox_messages,
-                                          timesince, urlencode, yesno)
+                                          jsonencode, soapbox_messages, yesno)
 
 
-class TestHelpers(KumaTestCase):
-
-    def test_number(self):
-        context = {'request': namedtuple('R', 'LANGUAGE_CODE')('en-US')}
-        eq_('5,000', number(context, 5000))
-        eq_('', number(context, None))
+class TestYesNo(KumaTestCase):
 
     def test_yesno(self):
         eq_('Yes', yesno(True))
         eq_('No', yesno(False))
         eq_('Yes', yesno(1))
         eq_('No', yesno(0))
-
-
-class TimesinceTests(KumaTestCase):
-    """Tests for the timesince filter"""
-
-    def test_none(self):
-        """If None is passed in, timesince returns ''."""
-        eq_('', timesince(None))
-
-    def test_trunc(self):
-        """Assert it returns only the most significant time division."""
-        eq_('1 year ago',
-            timesince(datetime(2000, 1, 2), now=datetime(2001, 2, 3)))
-
-    def test_future(self):
-        """
-        Test behavior when date is in the future and also when omitting the
-        now kwarg.
-        """
-        eq_('', timesince(datetime(9999, 1, 2)))
-
-
-class TestUrlEncode(KumaTestCase):
-
-    def test_utf8_urlencode(self):
-        """Bug 689056: Unicode strings with non-ASCII characters should not
-        throw a KeyError when filtered through URL encoding"""
-        try:
-            s = u"Someguy Dude\xc3\xaas Lastname"
-            urlencode(s)
-        except KeyError:
-            self.fail("There should be no KeyError")
 
 
 class TestSoapbox(KumaTestCase):

--- a/kuma/wiki/jinja2/wiki/email/spam.ltxt
+++ b/kuma/wiki/jinja2/wiki/email/spam.ltxt
@@ -1,15 +1,15 @@
 * SPAM ATTEMPT *
 
-{% if spam_attempt.title %}
+{% if spam_attempt.title -%}
 Title: {{ spam_attempt.title }}{% if not spam_attempt.document %} [NEW]{% endif %}
-{% else %}
+{% else -%}
 Title: n/a
-{% endif %}
-{% if spam_attempt.slug %}
+{% endif -%}
+{% if spam_attempt.slug -%}
 Slug: {{ spam_attempt.slug }}
-{% else %}
+{% else -%}
 Slug: n/a
-{% endif %}
+{% endif -%}
 Detected at: {{ spam_attempt.created|in_utc }}
 
 Admin link: {{ url('admin:wiki_documentspamattempt_change', spam_attempt.pk)|absolutify }}
@@ -25,7 +25,7 @@ Admin link: {{ url('admin:users_user_change', spam_attempt.user.pk)|absolutify }
 
 * DOCUMENT *
 
-{% if spam_attempt.document %}
+{% if spam_attempt.document -%}
 Title: {{ spam_attempt.document.title }}
 Slug: {{ spam_attempt.document.slug }}
 Language: {{ spam_attempt.document.language }}
@@ -33,6 +33,6 @@ Last modified: {{ spam_attempt.document.modified|in_utc }}
 
 Site link: {{ spam_attempt.document.get_absolute_url()|absolutify }}
 Admin link: {{ url('admin:wiki_document_change', spam_attempt.document.pk)|absolutify }}
-{% else %}
+{% else -%}
 The spam attempt doesn't have a document attached
-{% endif %}
+{% endif -%}

--- a/kuma/wiki/jinja2/wiki/email/spam.ltxt
+++ b/kuma/wiki/jinja2/wiki/email/spam.ltxt
@@ -10,7 +10,7 @@ Slug: {{ spam_attempt.slug }}
 {% else %}
 Slug: n/a
 {% endif %}
-Detected at: {{ spam_attempt.created }}
+Detected at: {{ spam_attempt.created|in_utc }}
 
 Admin link: {{ url('admin:wiki_documentspamattempt_change', spam_attempt.pk)|absolutify }}
 
@@ -18,7 +18,7 @@ Admin link: {{ url('admin:wiki_documentspamattempt_change', spam_attempt.pk)|abs
 
 Name: {{ user_display(spam_attempt.user) }}
 ID: {{ spam_attempt.user.pk }}
-Joined at: {{ spam_attempt.user.date_joined }}
+Joined at: {{ spam_attempt.user.date_joined|in_utc }}
 
 Profile link: {{ spam_attempt.user.get_absolute_url()|absolutify }}
 Admin link: {{ url('admin:users_user_change', spam_attempt.user.pk)|absolutify }}
@@ -29,7 +29,7 @@ Admin link: {{ url('admin:users_user_change', spam_attempt.user.pk)|absolutify }
 Title: {{ spam_attempt.document.title }}
 Slug: {{ spam_attempt.document.slug }}
 Language: {{ spam_attempt.document.language }}
-Last modified: {{ spam_attempt.document.modified }}
+Last modified: {{ spam_attempt.document.modified|in_utc }}
 
 Site link: {{ spam_attempt.document.get_absolute_url()|absolutify }}
 Admin link: {{ url('admin:wiki_document_change', spam_attempt.document.pk)|absolutify }}


### PR DESCRIPTION
This PR:
* Removes unused template functions and filters in kuma core.
* Adds a ``in_utc`` filter that converts datetimes to UTC
* Displays dates with UTC offsets (like ``2016-03-10 17:11:48.631245+00:00``) in the spam email.
* Collapses extra newlines from Jinja2 conditionals