### PR TITLE
Fix bug 1246459 - Prioritize web by default

### DIFF
--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -40,7 +40,7 @@
                         <i class="icon-search" aria-hidden="true"></i>
                     </span>
                     <input class="search-input" type="search" id="home-q" name="q" placeholder="{{ _('Search the docs') }}" />
-                    <div class="filters"></div>
+                    <div class="filters" data-default="{{ default_filters|jsonencode|forceescape }}"></div>
                     <button class="show-topics only-icon" type="button">
                         <span>{{ _('Show topics') }}</span>
                         <i class="icon-caret-down" aria-hidden="true"></i>
@@ -58,6 +58,9 @@
                 </span>
                 <input class="search-input" type="search" id="home-q" name="q" placeholder="{{ _('Search the docs') }}" />
                 <button type="submit" class="offscreen">{{ _('Search') }}</button>
+                {% for group, tag, shortcut in default_filters %}
+                  <input type="hidden" name="{{ group }}" value="{{ shortcut|default(tag, true) }}">
+                {% endfor %}
             </div>
         </form>
     {% endif %}

--- a/kuma/landing/test_templates.py
+++ b/kuma/landing/test_templates.py
@@ -1,7 +1,9 @@
 from constance.test import override_config
+from pyquery import PyQuery as pq
 
 from kuma.core.tests import KumaTestCase, eq_, ok_
 from kuma.core.urlresolvers import reverse
+from kuma.search.models import Filter, FilterGroup
 
 
 class HomeTests(KumaTestCase):
@@ -9,11 +11,25 @@ class HomeTests(KumaTestCase):
         url = reverse('home')
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
-            r = self.client.get(url, follow=True)
-            eq_(200, r.status_code)
-            ok_('ga(\'create' not in r.content)
+            response = self.client.get(url, follow=True)
+            eq_(200, response.status_code)
+            ok_('ga(\'create' not in response.content)
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
-            r = self.client.get(url, follow=True)
-            eq_(200, r.status_code)
-            ok_('ga(\'create' in r.content)
+            response = self.client.get(url, follow=True)
+            eq_(200, response.status_code)
+            ok_('ga(\'create' in response.content)
+
+    def test_default_search_filters(self):
+        url = reverse('home')
+        group = FilterGroup.objects.create(name='Topic', slug='topic')
+        for name in ['CSS', 'HTML', 'JavaScript']:
+            Filter.objects.create(group=group, name=name, slug=name.lower(),
+                                  default=True)
+
+        response = self.client.get(url, follow=True)
+        page = pq(response.content)
+        filters = page.find('#home-search-form input[type=hidden]')
+        filter_vals = [p.val() for p in filters.items()]
+        eq_(filters.eq(0).attr('name'), 'topic')
+        eq_(sorted(filter_vals), ['css', 'html', 'javascript'])

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -5,7 +5,7 @@ from django.views import static
 from kuma.core.sections import SECTION_USAGE
 from kuma.core.cache import memcache
 from kuma.feeder.models import Bundle
-from kuma.search.models import FilterGroup
+from kuma.search.models import Filter, FilterGroup
 from kuma.search.serializers import GroupWithFiltersSerializer
 
 
@@ -22,11 +22,13 @@ def home(request):
 
     groups = FilterGroup.objects.all()
     serializer = GroupWithFiltersSerializer(groups, many=True)
+    default_filters = Filter.objects.default_filters()
 
     context = {
         'updates': updates,
         'stats': community_stats,
-        'command_search_filters': serializer.data
+        'command_search_filters': serializer.data,
+        'default_filters': default_filters,
     }
     return render(request, 'landing/homepage.html', context)
 

--- a/kuma/search/admin.py
+++ b/kuma/search/admin.py
@@ -67,10 +67,10 @@ class FilterGroupAdmin(admin.ModelAdmin):
 
 @admin.register(Filter)
 class FilterAdmin(admin.ModelAdmin):
-    list_display = ('name', 'slug', 'group', 'enabled')
+    list_display = ('name', 'slug', 'group', 'enabled', 'default')
     list_filter = ('group',)
     search_fields = ('name', 'slug')
-    list_editable = ('enabled',)
+    list_editable = ('enabled', 'default')
     list_select_related = True
     radio_fields = {
         'operator': admin.VERTICAL,

--- a/kuma/search/managers.py
+++ b/kuma/search/managers.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.db import models
-
 from elasticsearch.exceptions import RequestError
 
 from kuma.wiki.search import WikiDocumentType
@@ -11,6 +10,19 @@ class FilterManager(models.Manager):
 
     def visible_only(self):
         return self.filter(visible=True)
+
+    def default_filters(self):
+        """
+        Return default filters as a list of lists of the form::
+
+            [[<group_slug>, <filter_slug>], ...]
+
+        Converting to lists of lists so we can json encode it.
+
+        """
+        return [list(f) for f in
+                self.filter(default=True).values_list('group__slug', 'slug',
+                                                      'shortcut')]
 
 
 class IndexManager(models.Manager):

--- a/kuma/search/migrations/0002_filter_default.py
+++ b/kuma/search/migrations/0002_filter_default.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('search', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='filter',
+            name='default',
+            field=models.BooleanField(default=False, help_text=b'Whether this filter is applied in the absence of a user-chosen filter'),
+        ),
+    ]

--- a/kuma/search/models.py
+++ b/kuma/search/models.py
@@ -170,8 +170,8 @@ class Filter(models.Model):
     group = models.ForeignKey(FilterGroup, related_name='filters',
                               help_text='E.g. "Topic", "Skill level" etc')
     tags = TaggableManager(help_text='A comma-separated list of tags. '
-                                     'If more than one tag given a OR '
-                                     'query is executed')
+                                     'If more than one tag given the operator '
+                                     'specified is used')
     operator = models.CharField(max_length=3, choices=OPERATOR_CHOICES,
                                 default=OPERATOR_OR,
                                 help_text='The logical operator to use '
@@ -183,6 +183,10 @@ class Filter(models.Model):
                                   help_text='Whether this filter is shown '
                                             'at public places, e.g. the '
                                             'command and query UI')
+    default = models.BooleanField(default=False,
+                                  help_text='Whether this filter is applied in '
+                                            'the absence of a user-chosen '
+                                            'filter')
 
     objects = FilterManager()
 

--- a/kuma/search/tests/test_store.py
+++ b/kuma/search/tests/test_store.py
@@ -28,6 +28,14 @@ class RefererTests(KumaTestCase):
         request = self.generate_request('en-US', url)
         assert get_search_url_from_referer(request) == url
 
+    @mock.patch.object(Site.objects, 'get_current')
+    def test_basic_with_topics(self, get_current):
+        get_current.return_value.domain = 'testserver'
+
+        url = 'https://testserver/en-US/search?q=javascript&topic=js'
+        request = self.generate_request('en-US', url)
+        assert get_search_url_from_referer(request) == url
+
     # FIXME: These tests aren't great because we can't verify exactly why we
     # got a None so we can't distinguish between "right answer" and "right
     # answer, but for the wrong reasons".

--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -6,21 +6,20 @@ from django.http import HttpResponse, HttpResponseBadRequest
 from django.shortcuts import render
 from django.utils.translation import ugettext
 from django.views.decorators.cache import cache_page
-
 from rest_framework.generics import ListAPIView
 from rest_framework.renderers import JSONRenderer
 
 from kuma.wiki.search import WikiDocumentType
 
 from .filters import (AdvancedSearchQueryBackend, DatabaseFilterBackend,
-                      get_filters, HighlightFilterBackend,
-                      LanguageFilterBackend, SearchQueryBackend)
+                      HighlightFilterBackend, LanguageFilterBackend,
+                      SearchQueryBackend, get_filters)
 from .jobs import AvailableFiltersJob
-from .queries import Filter, FilterGroup
 from .pagination import SearchPagination
+from .queries import Filter, FilterGroup
 from .renderers import ExtendedTemplateHTMLRenderer
-from .serializers import (DocumentSerializer, FilterWithGroupSerializer,
-                          SearchQuerySerializer, FacetedFilterSerializer)
+from .serializers import (DocumentSerializer, FacetedFilterSerializer,
+                          FilterWithGroupSerializer, SearchQuerySerializer)
 from .utils import QueryURLObject
 
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1209,21 +1209,6 @@ CONSTANCE_CONFIG = dict(
         ]),
         "JSON array listing tag suggestions for documents"
     ),
-    SEARCH_FILTER_TAG_OPTIONS=(
-        json.dumps([
-            "Accessibility", "AJAX", "API", "Apps",
-            "Canvas", "CSS", "Device", "DOM", "Events",
-            "Extensions", "Firefox", "Firefox OS", "Games",
-            "Gecko", "Graphics", "Internationalization", "History", "HTML", "HTTP", "JavaScript", "Layout",
-            "Localization", "MDN", "Mobile", "Mozilla",
-            "Networking", "Persona", "Places", "Plugins", "Protocols",
-
-            "Reference", "Tutorial", "Landing",
-
-            "junk", "NeedsMarkupWork", "NeedsContent", "NeedsExample",
-        ]),
-        "JSON array of tags that are enabled for search faceting"
-    ),
     SESSION_CLEANUP_CHUNK_SIZE=(
         1000,
         'Number of expired sessions to cleanup up in one go.',

--- a/kuma/static/js/search-suggestions.js
+++ b/kuma/static/js/search-suggestions.js
@@ -22,7 +22,7 @@
             // Mixin options
             var settings = $.extend({
                 sizeLimit: 25,
-                filters: false,
+                filters: null,
                 onAddFilter: noop,
                 onRemoveFilter: noop,
             }, options);
@@ -196,7 +196,7 @@
             fnSuggestions.prepareInput();
 
             // load previouly selected filters
-            if (settings.filters) {
+            if (settings.filters !== null) {
                 $.each(settings.filters, function(sidx, sfilter) {
                     // foreach filters to get the correct shortcut
                     $.each(filtersData, function(index, group) {
@@ -210,7 +210,13 @@
                         }
                     });
                 });
-                $searchInput.focus();
+            } else {
+                var filterDefaults = $searchFilters.data('default');
+                $.each(filterDefaults, function(i, tuple) {
+                    // The tuple is [<group slug>, <filter slug>, <shortcut>]
+                    fnSuggestions.addFilter(tuple[1], tuple[0], tuple[2]);
+                    fnSuggestions.removeFilterFromList(tuple[1]);
+                });
             }
 
             // events


### PR DESCRIPTION
This adds a default boolean field to the search filter model. Upon deploy no default will be set and search will be as it is now. Once we are ready to add defaults we can do so in the admin and enable them.