### PR TITLE
Fix Bug 1258493: Account creation disabled notice

### DIFF
--- a/jinja2/includes/login.html
+++ b/jinja2/includes/login.html
@@ -14,17 +14,19 @@
       <div class="oauth-login-container">
           <div class="oauth-login-options" tabIndex="0">
               <span class="oauth-login-options-text">
-                <span class="oauth-login-options-text-icons">{{ _('Sign in with') }}</span>
-                <span class="oauth-login-options-text-no-icons">{{ _('Sign in') }}</span>
+                {{ _('Sign in') }}
               </span>
-              <span class="oauth-icon oauth-persona launch-persona-login wait-for-persona disabled" data-service="Persona" data-next="{{ next_url }}" title="{{ _('Persona') }}"><i class="icon-user" aria-hidden="true"></i></span>
               <span class="oauth-icon oauth-github" data-service="GitHub" data-href="{{ github_url }}" title="{{ _('GitHub') }}"><i class="icon-github" aria-hidden="true"></i></span>
+              <span class="oauth-icon oauth-persona launch-persona-login wait-for-persona disabled" data-service="Persona" data-next="{{ next_url }}" title="{{ _('Persona') }}"><i class="icon-user" aria-hidden="true"></i></span>
           </div>
           <div class="oauth-login-picker" aria-hidden="true">
               <ul>
                   <li class="wait-for-persona disabled"><a href="{{ url('account_login') }}" class="login-link launch-persona-login" data-next="{{ next_url }}" data-service="Persona"><i class="icon-user" aria-hidden="true"></i>Persona</a></li>
                   <li><a href="{{ github_url }}" class="login-link" data-service="GitHub"><i class="icon-github" aria-hidden="true"></i>GitHub</a></li>
               </ul>
+              {% if waffle.flag('registration_disabled') %}
+                <div class="notification error">{{ _("We are sorry, but profile creation is currently disabled.") }}</div>
+              {% endif %}
           </div>
       </div>
     </form>

--- a/kuma/static/js/auth.js
+++ b/kuma/static/js/auth.js
@@ -57,27 +57,18 @@
         var activeClass = 'active';
         var fadeSpeed = 300;
 
-        // The options text is only hidden on tablets and lower, so only do the
-        // JavaScript piece of the CSS is controlling text visibility
-        var $noIconsElement = $container.find('.oauth-login-options-text-no-icons');
-        var doMoveCloseButton = function() {
-            return $noIconsElement.css('display') !== 'none';
-        };
-
         $options.mozMenu({
             submenu: $picker,
             fadeInSpeed: fadeSpeed,
             fadeOutSpeed: fadeSpeed,
             onOpen: function() {
                 $options.addClass(activeClass);
-                if(doMoveCloseButton()) {
-                    $container.find('.submenu-close').attr('tabIndex', -1).appendTo($options);
-                }
+                $container.find('.submenu-close').attr('tabIndex', -1).appendTo($options);
+
             },
             onClose: function() {
-                if(doMoveCloseButton()) {
-                    $container.find('.submenu-close').removeAttr('tabIndex').appendTo($container.find('.oauth-login-picker'));
-                }
+                $container.find('.submenu-close').removeAttr('tabIndex').appendTo($container.find('.oauth-login-picker'));
+
                 $options.removeClass(activeClass);
             }
         });

--- a/kuma/static/styles/components/components.styl
+++ b/kuma/static/styles/components/components.styl
@@ -173,6 +173,10 @@ Notifications
     &.error {
         notification-theme($negative);
     }
+
+    .oauth-login-picker & {
+        margin-bottom: 0;
+    }
 }
 
 .notification-message {

--- a/kuma/static/styles/components/structure/oauth-login.styl
+++ b/kuma/static/styles/components/structure/oauth-login.styl
@@ -6,7 +6,8 @@ Login links in secondary navigation
     border-radius: 8px;
     border: 1px solid transparent;
     display: inline-block;
-    min-width: 90px;
+    width: 200px;
+
 
     {$selector-icon} {
         margin-left: 0;
@@ -37,6 +38,7 @@ Login links in secondary navigation
     border-radius: 8px;
     cursor: default;
     position: relative;
+    line-height: 23px; /* matches height of sign in icons */
 
     &.active {
         border-color: rgba-fallback(rgba(255, 255, 255, 0.3));
@@ -49,10 +51,6 @@ Login links in secondary navigation
     }
 }
 
-.oauth-login-options-text-no-icons {
-    display: none;
-}
-
 .oauth-icon {
     border-radius: 4px;
     text-align: center;
@@ -63,6 +61,7 @@ Login links in secondary navigation
     display: inline-block;
     create-gradient(#43a6e2, #287cc2);
     cursor: pointer;
+    bidi-value(float, right, left);
 
     {$selector-icon} {
     	bidi-style(margin-left, 0, margin-right, 0);
@@ -81,6 +80,7 @@ Login links in secondary navigation
     border-bottom-right-radius: 8px;
     overflow: hidden;
     padding: 0;
+    box-shadow: 0px 10px 10px 0px rgba(0, 0, 0, 0.5);
 
     a {
         display: block;
@@ -102,19 +102,6 @@ Login links in secondary navigation
 
 /* tablet updates */
 @media $media-query-tablet {
-
-    .oauth-login-options-text {
-        bidi-style(padding-right, 20px, padding-left, 0);
-    }
-
-    /* remove options to click icons to sign in on smaller screens where a corse pointer is more likely to be present */
-    .oauth-login-options-text-icons {
-        display: none;
-    }
-
-    .oauth-login-options-text-no-icons {
-        display: inline;
-    }
 
     .oauth-icon {
         display: none;


### PR DESCRIPTION
- add fixed width to login widget to prevent notice from pushing it too wide
- add notice to appear when registration_disabled waffle enabled
- switch to always using "sign in" label for sign in (simplifies code and makes label shorter to try to keep localization from running out of space in the widget)

Testing:
- home page and a wiki page (with a grey header)
- multiple locales
- RTL
- tablet and mobile views
- can still login
- can still 

![screen shot 2016-03-21 at 14 05 13](https://cloud.githubusercontent.com/assets/854701/13934257/6c31b616-ef6e-11e5-8b90-7fc2a8a45abd.png)
