### PR TITLE
Save draft improvements.

### DIFF
--- a/jinja2/includes/error_list.html
+++ b/jinja2/includes/error_list.html
@@ -1,14 +1,16 @@
 {% macro errorlist(form) -%}
   {% if form.errors %}
-    <ul class="errorlist">
-      {% for field in form %}
-        {% for error in field.errors %}
-          <li><a href="#{{ form.auto_id % field.name }}">{{ error }}</a></li>
-        {% endfor %}
-      {% endfor %}
-      {% for error in form.non_field_errors() %}
-        <li>{{ error }}</li>
-      {% endfor %}
-    </ul>
+    <div class="notification error" data-level="error">
+        <ul class="errorlist">
+          {% for field in form %}
+            {% for error in field.errors %}
+              <li><a href="#{{ form.auto_id % field.name }}">{{ error }}</a></li>
+            {% endfor %}
+          {% endfor %}
+          {% for error in form.non_field_errors() %}
+            <li>{{ error }}</li>
+          {% endfor %}
+        </ul>
+    </div>
   {% endif %}
 {%- endmacro %}

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -186,6 +186,7 @@
   */
     var DRAFT_NAME;
     var DRAFT_TIMEOUT_ID;
+    var draftingEnabled = false;
 
     var supportsLocalStorage = win.mdn.features.localStorage;
     var $form = $('#wiki-page-edit');
@@ -315,9 +316,6 @@
 
         if ($('#article-head .metadata').length) {
             var show_meta = function () {
-                // Disable and hide the save-and-edit button when editing
-                // metadata, since that can change the URL of the page and
-                // tangle up where the iframe posts.
                 $('#article-head .doc-title').hide();
                 $('#article-head .metadata').show();
                 $('#article-head .metadata #id_title').focus();
@@ -397,22 +395,34 @@
 
     // Injects a DIV with language to the effect of "you had a previous draft, want to restore it?"
     // This takes the place of an ugly, ugly confirmation box :(
-    var $draftDiv;
-    function displayDraftBox(content, draft_time) {
+
+    var $draftDiv = $('<div/>', { class: 'draft-container' });
+    var $draftButton = $('<button/>', { class: 'button neutral', text: gettext('Save Draft'), 'type': 'button', 'disabled': 'disabled'})
+                     .append($('<i/>', { class: 'icon-save', 'aria-hidden': 'true'}));
+    var $draftStatus = $('<span/>', { class: 'draft-status' });
+    var $draftAction = $('<span/>', {id: 'draft-action'});
+    var $draftTime = $('<time/>', {id: 'draft-time', class: 'time-ago'});
+    var isErrors = $('.errorlist').length;
+    var startingContent;
+
+    // show restore and discard links for old draft
+    function displayRestoreDraft(content, draft_time) {
         var draft_time_str = draft_time ? draft_time : gettext('an unknown date');
         var draft = gettext('You have a draft from:');
         var restore = gettext('Restore the draft content');
         var discard = gettext('Discard the draft');
 
-        var text = draft + ' ' + draft_time_str + '. <a href="" class="restoreLink">' + restore + '</a>. <a href="" class="discardLink">'+ discard +'</a>.';
+        var text = draft + ' ' + draft_time_str + '. <a href="" class="js-restoreLink">' + restore + '</a>. <a href="" class="js-discardLink">'+ discard +'</a>.';
         var $contentNode = $('#id_content');
         var editor;
 
-        // Plan the draft into the page
-        $draftDiv = $('<div class="notice"><p>' + text + '</p></div>').insertBefore($contentNode);
+        // Place the recovered draft into the page
+        $draftStatus.empty();
+        $draftButton.hide();
+        $draftStatus.append(text);
 
         // Hook up the "restore" link
-        $draftDiv.find('.restoreLink').on('click', function(e) {
+        $draftDiv.find('.js-restoreLink').on('click', function(e) {
             e.preventDefault();
             $contentNode.val(content);
 
@@ -425,20 +435,14 @@
                 editor.setData(content);
             }
             editor.focus();
-
-            updateDraftState('loaded');
-            hideDraftBox();
+            updateDraftState(gettext('restored'));
         });
 
         // Hook up the "dispose" link
-        $draftDiv.find('.discardLink').on('click', function(e) {
+        $draftDiv.find('.js-discardLink').on('click', function(e) {
             e.preventDefault();
-            hideDraftBox();
-            clearDraft();
+            clearDraft(true);
         });
-    }
-    function hideDraftBox() {
-        $draftDiv && $draftDiv.css('display', 'none');
     }
 
 
@@ -448,11 +452,11 @@
     function initSaveAndEditButtons () {
         // Save button submits to top-level
         $('.btn-save').on('click', function () {
-            if (supportsLocalStorage) {
+            if (draftingEnabled) {
                 // Clear any preserved content.
-                clearDraft();
+                clearDraft(false);
+                clearTimeout(DRAFT_TIMEOUT_ID);
             }
-            clearTimeout(DRAFT_TIMEOUT_ID);
             $form.attr('action', '').removeAttr('target');
             return true;
         });
@@ -466,17 +470,17 @@
             mdn.analytics.trackEvent({
                 category: 'Wiki',
                 action: 'Button',
-                label: 'Save and Keep Editing'
+                label: 'Save and Keep Editing' // now "Publish and keep editing" but keeping label for analytics continuity
             });
 
             var savedTa = $form.find('textarea[name=content]').val();
-            if (supportsLocalStorage) {
+            if (draftingEnabled) {
                 // Preserve editor content, because saving to the iframe can
                 // yield things like 403 / login-required errors that bust out
                 // of the frame
                 saveDraft(savedTa);
+                clearTimeout(DRAFT_TIMEOUT_ID);
             }
-            clearTimeout(DRAFT_TIMEOUT_ID);
             // Redirect the editor form to the iframe.
             $form.attr('action', '?iframe=1').attr('target', 'save-and-edit-target');
             return true;
@@ -487,36 +491,36 @@
             if(notifications[0]) notifications[0].success(null, 2000);
             notifications.shift();
 
-            if (supportsLocalStorage) {
-                var if_doc = $(this).get(0).contentDocument;
-                if (typeof(if_doc) != 'undefined') {
+            var if_doc = $(this).get(0).contentDocument;
+            if (typeof(if_doc) != 'undefined') {
 
-                    var ir = $('#iframe-response', if_doc);
-                    if ('OK' == ir.attr('data-status')) {
+                var ir = $('#iframe-response', if_doc);
+                if ('OK' == ir.attr('data-status')) {
 
+                    if (draftingEnabled) {
                         // Dig into the iframe on load and look for "OK". If found,
                         // then it should be safe to throw away the preserved content.
                         localStorage.removeItem(DRAFT_NAME);
-
-                        // We also need to update the form's current_rev to
-                        // avoid triggering a conflict, since we just saved in
-                        // the background.
-                        $form.find('input[name=current_rev]').val(
-                            ir.attr('data-current-revision'));
-
-                    } else if ($form.add(if_doc).hasClass('conflict')) {
-                        // HACK: If we detect a conflict in the iframe while
-                        // doing save-and-edit, force a full-on save in order
-                        // to surface the issue. There's no easy way to bust
-                        // the iframe otherwise, since this was a POST.
-                        $form.attr('action', '').attr('target', '');
-                        $('.btn-save').click();
-
                     }
 
-                    // Anything else that happens (eg. 403 errors) should have
-                    // framebusting code to escape the hidden iframe.
+                    // We also need to update the form's current_rev to
+                    // avoid triggering a conflict, since we just saved in
+                    // the background.
+                    $form.find('input[name=current_rev]').val(
+                        ir.attr('data-current-revision'));
+
+                } else if ($form.add(if_doc).hasClass('conflict')) {
+                    // HACK: If we detect a conflict in the iframe while
+                    // doing save-and-edit, force a full-on save in order
+                    // to surface the issue. There's no easy way to bust
+                    // the iframe otherwise, since this was a POST.
+                    $form.attr('action', '').attr('target', '');
+                    $('.btn-save').click();
+
                 }
+
+                // Anything else that happens (eg. 403 errors) should have
+                // framebusting code to escape the hidden iframe.
             }
             // Stop loading state on button
             $('.btn-save-and-edit').removeClass('loading');
@@ -541,74 +545,149 @@
     }
 
     function updateDraftState(action) {
+        $draftButton.show();
         var now = new Date();
         var nowString = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
 
-        $('#draft-action').text(action);
-        $('#draft-time').attr('title', now.toISOString()).text(nowString);
+        $draftStatus.empty();
+        if(action){
+            var $updateAction = $draftAction.clone().text(action);
+            var $updateTime = $draftTime.clone().attr('title', now.toISOString()).text(nowString);
+            $draftStatus.append(gettext('draft') + ' ').append($updateAction).append(' ').append($updateTime);
+        }
     }
 
     function saveDraft(val) {
-        if (supportsLocalStorage) {
-            localStorage.setItem(DRAFT_NAME, val || $form.find('textarea[name=content]').val());
+        var currentContent = $form.find('textarea[name=content]').val();
+        var saveContent = val || currentContent;
+        var oldDraft = localStorage.getItem(DRAFT_NAME)
+
+        // need to be careful when saving that we're not deleting a draft
+        // that has been saved previously but not restored
+        // saves can be triggered by keyboard shortcuts (CTRL + A)
+        // that do not actually make changes to the content
+        // so we check that current content has changed from start
+        var currentMatchesStart = contentMatches(currentContent, startingContent);
+
+        // it looks a little weird to save a draft when no changes are made
+        // so check that what we're trying to save doesn't match what's
+        // already saved
+        var draftMatchesDraft = contentMatches(currentContent, oldDraft);
+
+        // also need to enable saves when there are errors on the page
+        // when there are errors starting content will likely match draft content
+
+        if(!currentMatchesStart || isErrors) {
+            localStorage.setItem(DRAFT_NAME, saveContent);
             var now = new Date();
             var nowString = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
             localStorage.setItem(DRAFT_NAME + '#save-time', nowString);
             updateDraftState(gettext('saved'));
+            $draftButton.attr('disabled', 'disabled');
         }
     }
 
-    function clearDraft() {
-        if (supportsLocalStorage) {
-           localStorage.removeItem(DRAFT_NAME);
+    function clearDraft(notify) {
+        localStorage.removeItem(DRAFT_NAME);
+        localStorage.removeItem(DRAFT_NAME + '#save-time');
+        if (notify) {
+            updateDraftState(gettext('discarded'));
+        }
+        else {
+            updateDraftState();
+        }
+    }
+
+    // returns true if draft matches starting content
+    // unless there were errors, because we don't know starting content
+    function contentMatches(ver1, ver2) {
+        var treatContent = function(content) {
+            // CKEditor likes to change spaces for &nbsp;
+            return content.replace(/\s/g, '&nbsp;');
+        };
+        var trim1 = $.trim(ver1);
+        var treated1 = treatContent(trim1);
+        var trim2 = $.trim(ver2);
+        var treated2 = treatContent(trim2);
+        if (treated1 == treated2) {
+            return true;
+        }
+        else {
+            return false;
         }
     }
 
     function initDrafting() {
         var editor;
-        DRAFT_NAME = getStorageKey();
         if (supportsLocalStorage) {
-            var prev_draft = localStorage.getItem(DRAFT_NAME),
-                treatDraft = function(content) {
-                    return (content || '').replace(/ /g, '&nbsp;');
-                },
+            draftingEnabled = true;
+            DRAFT_NAME = getStorageKey();
+            startingContent = $form.find('textarea[name=content]').val();
+            // add listeners
+            $draftButton.on('click', function() {
+                // can't just pass function name because
+                // that passes click event as first parameter which breaks things
+                saveDraft();
+            });
 
-                treatedDraft = $.trim(treatDraft(prev_draft)),
-                treatedServer = treatDraft($form.find('textarea[name=content]').val().trim());
-            if (prev_draft) {
-                // draft matches server so discard draft
-                if (treatedDraft == treatedServer) {
-                    clearDraft();
-                } else {
-                    var draft_time = localStorage.getItem(DRAFT_NAME + '#save-time');
-                    displayDraftBox(prev_draft, draft_time);
+            // insert draft div with button
+            $draftDiv.append($draftButton);
+            $draftDiv.append(' ');
+            $draftDiv.append($draftStatus);
+            $('#editor-wrapper').prepend($draftDiv);
+
+            // if there was an error publishing
+            // let the user save without making edits
+            if (isErrors) {
+                $draftButton.removeAttr('disabled');
+            }
+
+            // check for previous drafts, add recovery options
+            // but not if draft matches published version
+            var prevDraft = localStorage.getItem(DRAFT_NAME);
+            var draftMatchesStart = contentMatches(prevDraft, startingContent);
+            if (prevDraft && !draftMatchesStart) {
+                // display option to restore
+                var draft_time = localStorage.getItem(DRAFT_NAME + '#save-time');
+                displayRestoreDraft(prevDraft, draft_time);
+            }
+            else if (prevDraft && matchesStart) {
+                // don't need draft if it's a copy of the starting content
+                clearDraft(false);
+            }
+
+            // Add key listener for CKEditor and drafting
+            var callback = function() {
+                // don't save if still typing
+                clearTimeout(DRAFT_TIMEOUT_ID);
+                // begin countdown to auto save
+                DRAFT_TIMEOUT_ID = setTimeout(saveDraft, 3000);
+                // unsaved changes, enable button
+                $draftButton.removeAttr('disabled');
+            };
+            if(isTemplate) {
+                if (ace_editor.on) {
+                    ace_editor.on('change', callback);
                 }
             }
-        }
-
-        // Add key listener for CKEditor and drafting
-        var callback = function() {
-            clearTimeout(DRAFT_TIMEOUT_ID);
-            DRAFT_TIMEOUT_ID = setTimeout(saveDraft, 3000);
-        };
-        if(isTemplate) {
-            ace_editor.on && ace_editor.on('change', callback);
-        }
-        else {
-            try {
-                var $content = $('#id_content');
-                $content.ckeditorGet && $content.ckeditorGet().on('key', callback);
+            else {
+                try {
+                    var $content = $('#id_content');
+                    if($content.ckeditorGet) {
+                        $content.ckeditorGet().on('key', callback);
+                    }
+                }
+                catch(e) {
+                    console.log(e);
+                }
             }
-            catch(e) {
-                console.log(e);
-            }
-        }
 
-        // Clear draft upon discard
-       $('.btn-discard').on('click', function() {
-            clearTimeout(DRAFT_TIMEOUT_ID);
-           clearDraft();
-       });
+            // Clear draft upon discard
+           $('.btn-discard').on('click', function() {
+                clearTimeout(DRAFT_TIMEOUT_ID);
+                clearDraft(true);
+           });
+        }
     }
 
     function initAttachmentsActions() {

--- a/kuma/static/styles/components/doc-title.styl
+++ b/kuma/static/styles/components/doc-title.styl
@@ -21,6 +21,10 @@
     }
 }
 
+.doc-title-properties {
+    set-smaller-font-size();
+}
+
 /* small writing above the page title that says what action the user is
    performing on it Editing/Moving/Translating. In a perfect world this
    class wouild be doc-title-prefix but it's part of the translation

--- a/kuma/static/styles/components/errorlist.styl
+++ b/kuma/static/styles/components/errorlist.styl
@@ -6,3 +6,7 @@ ul.errorlist {
         margin: 5px 0;
     }
 }
+
+.error .errorlist {
+    color: $text-color;
+}

--- a/kuma/static/styles/components/wiki/edit/cke.styl
+++ b/kuma/static/styles/components/wiki/edit/cke.styl
@@ -1,7 +1,7 @@
 /* ckeditor / content area styles */
-.ckeditor-container {
-    padding: 6px;
+.editor-wrapper {
     border: 1px solid #eaeff2;
+    padding: $content-vertical-spacing;
 }
 
 .editor-container {

--- a/kuma/static/styles/components/wiki/edit/draft-status.styl
+++ b/kuma/static/styles/components/wiki/edit/draft-status.styl
@@ -1,0 +1,8 @@
+.draft-container{
+    margin-bottom: $content-vertical-spacing;
+}
+
+.draft-status {
+    set-smaller-font-size();
+    font-weight: bold;
+}

--- a/kuma/static/styles/components/wiki/edit/guide-links.styl
+++ b/kuma/static/styles/components/wiki/edit/guide-links.styl
@@ -1,6 +1,6 @@
 /* link to editor and style guide editor that appear above text editor */
 .guide-links{
-    float: right;
+    bidi-value(text-align, right, left);
     margin-top: $grid-spacing;
     padding: 0 4px 2px 0;
     color: #999;

--- a/kuma/static/styles/components/wiki/edit/save-state.styl
+++ b/kuma/static/styles/components/wiki/edit/save-state.styl
@@ -1,6 +1,0 @@
-.save-state {
-    set-smaller-font-size();
-    clear: both;
-    color: #888;
-    margin: 0;
-}

--- a/kuma/static/styles/font-awesome.styl
+++ b/kuma/static/styles/font-awesome.styl
@@ -27,7 +27,6 @@ icon-pseudo-lookup = {
     'icon-check-empty': 'icon-square-o',
     'icon-check-minus': 'icon-minus-square-o',
     'icon-check-sign': 'icon-check-square',
-    'icon-check': 'icon-check-square-o',
     'icon-chevron-sign-down': 'icon-chevron-circle-down',
     'icon-chevron-sign-left': 'icon-chevron-circle-left',
     'icon-chevron-sign-right': 'icon-chevron-circle-right',

--- a/kuma/static/styles/wiki-edit.styl
+++ b/kuma/static/styles/wiki-edit.styl
@@ -12,7 +12,7 @@
 @require 'components/wiki/edit/save-and-edit-target';
 @require 'components/wiki/edit/guide-links';
 @require 'components/wiki/edit/ace-content';
-@require 'components/wiki/edit/save-state';
+@require 'components/wiki/edit/draft-status';
 @require 'components/wiki/edit/first-contrib-welcome';
 @require 'components/wiki/edit/page-comment';
 @require 'components/wiki/edit/description';

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -148,7 +148,7 @@
     <div class="column-container">
       <div class="column-2"></div>
       <div class="column-half">
-        <p><button type="submit" class="positive">{{ _('Save Changes') }}<i aria-hidden="true" class="icon-save"></i></button></p>
+        <p><button type="submit" class="positive">{{ _('Publish') }}<i aria-hidden="true" class="icon-check"></i></button></p>
       </div>
     </div>
 

--- a/kuma/wiki/jinja2/wiki/create.html
+++ b/kuma/wiki/jinja2/wiki/create.html
@@ -30,9 +30,6 @@
 
         <div class="doc-title">
             <h1><span class="title-prefix">{{ _('Create a') }} </span><em>{{ _('New Document') }}</em></h1>
-            <p class="save-state" id="draft-status">
-              {{ _('Draft') }} <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>
-            </p>
         </div>
 
         <ul class="metadata">
@@ -59,12 +56,17 @@
 
       {% include 'wiki/includes/guide_links.html' %}
 
+
       {% if is_template %}
         {{ revision_form.content|safe }}
-        <div id="ace_content" class="editor-container"></div>
+        <div id="editor-wrapper" class="editor-wrapper">
+          <div id="ace_content" class="editor-container"></div>
+        </div>
       {% else %}
-        <div class="ckeditor-container editor-container">
-          {{ revision_form.content|safe }}
+        <div id="editor-wrapper" class="editor-wrapper">
+          <div class="ckeditor-container editor-container">
+            {{ revision_form.content|safe }}
+          </div>
         </div>
       {% endif %}
 

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -101,11 +101,10 @@
 
           <div class="doc-title">
             <h1>{{ _('<span class="title-prefix">Editing</span> <em>%(title)s</em>'|safe, title=revision.title) }}</h1>
-            <p class="save-state" id="draft-status">
+            <p class="doc-title-properties">
               {% if not section_id %}
                 <a href="" id="btn-properties">{{ _('Edit Page Title and Properties') }}</a><br />
               {% endif %}
-              {{ _('Draft') }} <span id="draft-action"></span> <time id="draft-time" class="timeago" title=""></time>
             </p>
           </div>
 
@@ -143,7 +142,7 @@
                   </div>
                 </li>
                 <li class="metadata-choose-parent clear">
-                    {{ _('Find the translation source with the lookup below and then click "Save Changes."') }}
+                    {{ _('Find the translation source with the lookup below and then click "Publish."') }}
                     <br />
                     <label for="parent_text">{{ _('Lookup:') }}</label> <input type="text" id="parent_text" />
                     <input type="hidden" name="parent_id" id="parent_id" value="{{ revision_form.instance.document.parent.id }}" />
@@ -175,9 +174,13 @@
 
             {% if document.is_template %}
               {{ revision_form.content | safe }}
-              <div id="ace_content" class="editor-container"></div>
+              <div id="editor-wrapper" class="editor-wrapper">
+                <div id="ace_content" class="editor-container"></div>
+              </div>
             {% else %}
-              <div class="ckeditor-container editor-container">{{ revision_form.content | safe }}</div>
+              <div id="editor-wrapper" class="editor-wrapper">
+                <div class="ckeditor-container editor-container">{{ revision_form.content | safe }}</div>
+              </div>
             {% endif %}
 
             <input type="hidden" name="form" value="rev" />

--- a/kuma/wiki/jinja2/wiki/includes/page_buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/page_buttons.html
@@ -20,19 +20,19 @@
 <ul class="page-buttons">
   {% if document %}
   <li>
-    <button type="submit" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Save and Keep Editing') }}</span><i aria-hidden="true" class="icon-edit"></i></button>
+    <button type="submit" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-pencil"></i></button>
   </li>
   {% endif %}
   <li>
-    <button type="submit" class="button positive btn-save">{{ _('Save Changes') }}<i aria-hidden="true" class="icon-save"></i></button>
+    <button type="submit" class="button positive btn-save">{{ _('Publish') }}<i aria-hidden="true" class="icon-check"></i></button>
   </li>
   {% if (not document and not is_template) or (document and not document.is_template) %}
   <li>
-    <button type="button" class="btn-preview" data-preview-url="{{ url('wiki.preview') }}">{{ _('Preview Changes') }}<i aria-hidden="true" class="icon-play-circle"></i></button>
+    <button type="button" class="btn-preview" data-preview-url="{{ url('wiki.preview') }}">{{ _('Preview') }}<i aria-hidden="true" class="icon-play-circle"></i></button>
   </li>
   {% endif %}
   <li>
-    <a href="{{ discard_href }}" class="button negative btn-discard">{{ _('Discard Changes') }}<i aria-hidden="true" class="icon-undo"></i></a>
+    <a href="{{ discard_href }}" class="button negative btn-discard">{{ _('Discard') }}<i aria-hidden="true" class="icon-undo"></i></a>
   </li>
 </ul>
 

--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -10,6 +10,7 @@
 <p>
     {% trans admin_email='mailto:mdn-admins@mozilla.org' %}
     If you believe you’ve received this message by mistake, please
-    <a href="{{ admin_email }}">contact the site administrators</a>.
+    save a draft of your content and <a href="{{ admin_email }}">
+    contact the site administrators</a>.
     {% endtrans %}
 </p>

--- a/kuma/wiki/jinja2/wiki/includes/translate_description.html
+++ b/kuma/wiki/jinja2/wiki/includes/translate_description.html
@@ -63,7 +63,7 @@
                     <input type="text" id="parent_text" />
                     <input type="hidden" name="parent_id" id="parent_id" value="{{ parent.id }}" />
                   </dt>
-                  <dd>{{ _('Find the translation source with the lookup above and then click "Save Changes.') }}</dd>
+                  <dd>{{ _('Find the translation source with the lookup above and then click "Save".') }}</dd>
                 </dl>
               </li>
               {% endif %}

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -95,11 +95,13 @@
               </article>
               <article class="localized">
                 <header>
-                  {% include 'wiki/includes/guide_links.html' %}
                   <h3>{{ _('%(locale)s translation:', locale=language) }}</h3>
                 </header>
-                <div class="ckeditor-container editor-container">
-                  {{ content_editor(revision_form.content) }}
+                {% include 'wiki/includes/guide_links.html' %}
+                <div id="editor-wrapper" class="editor-wrapper">
+                    <div class="ckeditor-container editor-container">
+                      {{ content_editor(revision_form.content) }}
+                    </div>
                 </div>
               </article>
             </div>

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -353,7 +353,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.post(reverse('wiki.create'), data,
                                     follow=True)
         doc = pq(response.content)
-        ul = doc('article > ul.errorlist')
+        ul = doc('article ul.errorlist')
         ok_(len(ul) > 0)
         ok_('Please provide a title.' in ul('li').text())
 
@@ -365,7 +365,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.post(reverse('wiki.create'), data,
                                     follow=True)
         doc = pq(response.content)
-        ul = doc('article > ul.errorlist')
+        ul = doc('article ul.errorlist')
         eq_(1, len(ul))
         eq_('Please provide content.', ul('li').text())
 
@@ -379,7 +379,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.post(reverse('wiki.create'), data)
         eq_(200, response.status_code)
         doc = pq(response.content)
-        ul = doc('article > ul.errorlist')
+        ul = doc('article ul.errorlist')
         eq_(1, len(ul))
         eq_('Document with this Slug and Locale already exists.',
             ul('li').text())


### PR DESCRIPTION
Fix Bug 1259151 - When edit is blocked as spam, save the draft content
Fix Bug 1259197 - Draft save notification does not appear on translation pages.
Fix Bug 1123616 - Allow to manually store a draft

- renamed page_buttons to support addition of draft button so no confusion over "save"
- moved localStorage checks around and abstracted a bit
- moved draft notifications to all be in one place above editor (and supporting HTML and CSS changes)
- added draft notification changes to translation pages

Testing:
- edit button (6x one each for en-US edit and new, non en-US edit and new, and a template edit and new)
- edit page title and properties still there
- no recovered draft, save draft button present but disabled
- type and click save button (in less than 3 seconds)
- local storage has correct content and save button disabled
- type and wait 3 seconds for auto save
- local storage has correct content
- hard refresh page
- report draft to restore and no save button
- restore draft
- restored correctly
- hard refresh
- draft to restore
- discard draft
- hard refresh
- no draft
- make new draft
- press discard button next to preview button
- return to edit page
- no draft
- create spam edit
- submit spam and be rejected
- no draft
- click draft save
- hard refresh
- restore draft sucessfully