### PR TITLE
bug 1255609 - Fixes for spam dashboard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ test:
 coveragetest: clean
 	py.test --cov=$(target) $(target)
 
+coveragetesthtml: coveragetest
+	coverage html
+
 locust:
 	locust -f tests/performance/smoke.py --host=https://developer.allizom.org
 
@@ -37,6 +40,8 @@ intern:
 clean:
 	rm -rf .coverage build/
 	find kuma -name '*.pyc' -exec rm {} \;
+	mkdir -p build/assets
+	mkdir -p build/locale
 
 locale:
 	@mkdir -p locale/$(LOCALE)/LC_MESSAGES && \

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1217,9 +1217,9 @@ CONSTANCE_CONFIG = dict(
         "Janet Swisher <no-reply@mozilla.org>",
         'Email address from which welcome emails will be sent',
     ),
-    EMAIL_LIST_FOR_FIRST_EDITS=(
+    EMAIL_LIST_SPAM_WATCH=(
         "mdn-spam-watch@mozilla.com",
-        "Email address to which emails will be sent for users' first edits",
+        "Email address to notify of possible spam (first edits, blocked edits)",
     ),
     AKISMET_KEY=(
         '',

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -152,4 +152,4 @@ class WikiConfig(AppConfig):
         body = render_to_string('wiki/email/spam.ltxt',
                                 {'spam_attempt': instance})
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  [config.EMAIL_LIST_FOR_FIRST_EDITS])
+                  [config.EMAIL_LIST_SPAM_WATCH])

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -1,3 +1,5 @@
+from constance import config
+
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
@@ -137,7 +139,11 @@ class WikiConfig(AppConfig):
         from .tasks import tidy_revision_content
         tidy_revision_content.delay(instance.pk)
 
-    def on_document_spam_attempt_save(self, sender, instance, **kwargs):
+    def on_document_spam_attempt_save(
+            self, sender, instance, created, raw, **kwargs):
+        if raw or not created:
+            # Only send for new instances, not fixtures or edits
+            return
         subject = u'[MDN] Wiki spam attempt recorded'
         if instance.document:
             subject = u'%s for document %s' % (subject, instance.document)
@@ -146,4 +152,4 @@ class WikiConfig(AppConfig):
         body = render_to_string('wiki/email/spam.ltxt',
                                 {'spam_attempt': instance})
         send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  ['mdn-spam-watch@mozilla.com'])
+                  [config.EMAIL_LIST_FOR_FIRST_EDITS])

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -293,7 +293,7 @@ def send_first_edit_email(revision_pk):
                                context_dict(revision))
     doc_url = absolutify(doc.get_absolute_url())
     email = EmailMessage(subject, message, settings.DEFAULT_FROM_EMAIL,
-                         to=[config.EMAIL_LIST_FOR_FIRST_EDITS],
+                         to=[config.EMAIL_LIST_SPAM_WATCH],
                          headers={'X-Kuma-Document-Url': doc_url,
                                   'X-Kuma-Editor-Username': user.username})
     email.send()

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -491,7 +491,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         time.sleep(1)
         eq_(2, len(mail.outbox))
         first_edit_email = mail.outbox[0]
-        expected_to = [config.EMAIL_LIST_FOR_FIRST_EDITS]
+        expected_to = [config.EMAIL_LIST_SPAM_WATCH]
         expected_subject = u'[MDN] %(username)s made their first edit, to: %(title)s' % ({'username': new_rev.creator.username, 'title': self.d.title})
         eq_(expected_subject, first_edit_email.subject)
         eq_(expected_to, first_edit_email.to)


### PR DESCRIPTION
Fix issues with PR #3816:

* On the "dashboard" (the Django admin list view), the Document name is length-restricted, so that long names do not cause the list view to become overly long and require scrolling to get to the review dropdown.
* An email is sent to the "first edits" email list when an edit is blocked, but not again when the block is reviewed.

Also improves ``make coveragetest``, to generate the HTML coverage docs and to recreate the skeleton of the 'cleaned' ``build`` folder. 