### PR TITLE
bug 1188029 - Capture Akismet error data

### DIFF
--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -30,7 +30,7 @@ class AkismetFormMixin(object):
         """
         return self.akismet_client.ready
 
-    def akismet_error(self):
+    def akismet_error(self, parameters, exception=None):
         """
         Upon receiving an error from the API client raises an "invalid"
         form validation error with a predefined error message.
@@ -87,11 +87,11 @@ class AkismetCheckFormMixin(AkismetFormMixin):
     def akismet_call(self, parameters):
         try:
             is_spam = self.akismet_client.check_comment(**parameters)
-        except akismet.AkismetError:
-            self.akismet_error()
+        except akismet.AkismetError as exception:
+            self.akismet_error(parameters, exception)
         else:
             if is_spam:
-                self.akismet_error()
+                self.akismet_error(parameters)
 
 
 class AkismetSubmissionFormMixin(AkismetFormMixin):
@@ -127,5 +127,5 @@ class AkismetSubmissionFormMixin(AkismetFormMixin):
         submission_function = 'submit_%s' % self.akismet_submission_type()
         try:
             getattr(self.akismet_client, submission_function)(**parameters)
-        except akismet.AkismetError:
-            self.akismet_error()
+        except akismet.AkismetError as exception:
+            self.akismet_error(parameters, exception)

--- a/kuma/spam/tests/test_forms.py
+++ b/kuma/spam/tests/test_forms.py
@@ -121,6 +121,7 @@ class AkismetFormTests(SimpleTestCase):
             forms.ValidationError,
             force_unicode(form.akismet_error_message),
             form.akismet_error,
+            {}
         )
 
     @override_config(AKISMET_KEY='error')
@@ -137,6 +138,7 @@ class AkismetFormTests(SimpleTestCase):
             forms.ValidationError,
             force_unicode(form.akismet_error_message),
             form.akismet_error,
+            {}
         )
 
     @override_config(AKISMET_KEY='clean')

--- a/kuma/wiki/jinja2/wiki/email/spam.ltxt
+++ b/kuma/wiki/jinja2/wiki/email/spam.ltxt
@@ -1,4 +1,5 @@
-* SPAM ATTEMPT *
+{% set is_error = (spam_attempt.review == spam_attempt.AKISMET_ERROR) -%}
+* {% if is_error %}AKISMET ERROR{% else %}SPAM ATTEMPT{% endif %} *
 
 {% if spam_attempt.title -%}
 Title: {{ spam_attempt.title }}{% if not spam_attempt.document %} [NEW]{% endif %}
@@ -34,5 +35,5 @@ Last modified: {{ spam_attempt.document.modified|in_utc }}
 Site link: {{ spam_attempt.document.get_absolute_url()|absolutify }}
 Admin link: {{ url('admin:wiki_document_change', spam_attempt.document.pk)|absolutify }}
 {% else -%}
-The spam attempt doesn't have a document attached
+The {% if is_error %}Akismet error{% else %}spam attempt{% endif %} doesn't have a document attached
 {% endif -%}

--- a/kuma/wiki/migrations/0029_add_dsa_review_type_error.py
+++ b/kuma/wiki/migrations/0029_add_dsa_review_type_error.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0028_require_document_uuid'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='documentspamattempt',
+            name='review',
+            field=models.IntegerField(default=0, verbose_name="Review of Akismet's classification as spam", choices=[(0, 'Needs Review'), (1, 'Ham / False Positive'), (2, 'Confirmed as Spam'), (3, 'Review Unavailable'), (4, 'Akismet Error')]),
+        ),
+    ]

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1936,11 +1936,13 @@ class DocumentSpamAttempt(SpamAttempt):
     HAM = 1
     SPAM = 2
     REVIEW_UNAVAILABLE = 3
+    AKISMET_ERROR = 4
     REVIEW_CHOICES = (
         (NEEDS_REVIEW, _('Needs Review')),
         (HAM, _('Ham / False Positive')),
         (SPAM, _('Confirmed as Spam')),
         (REVIEW_UNAVAILABLE, _('Review Unavailable')),
+        (AKISMET_ERROR, _('Akismet Error')),
     )
     review = models.IntegerField(
         choices=REVIEW_CHOICES,


### PR DESCRIPTION
If Akismet returns an error from check-comment, continue to block the edit, but save the details of the error for debugging, and adjust the notification sent to the spam watchers list.