### PR TITLE
bug 1259233 - Add more waffle flags for Akismet tuning

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -19,14 +19,17 @@ Switches
 
 `Waffle switches`_ are simple booleans - they are either on or off.
 
+* ``application_ACAO`` - Enable Access-Control-Allow-Origin=0 header
+* ``dumb_doc_urls`` - (deprecated) Disable the render-time changing of /docs/
+  URLs to the equivalent Zone URLs (see `PR 3331`_ for reasoning).
+* ``enable_optimizely`` - Enable the Optimizely JavaScript
+* ``store_revision_ips`` - Save request data, including the IP address, to
+  enable marking revisions as spam.
 * ``welcome_email`` - send welcome email to new user registrations
-* ``wiki_force_immediate_rendering`` - force wiki pages to render immediately in
-  the same http request in which they are saved (not in a background process)
 * ``wiki_error_on_delete`` - throw an error if a user tries to delete a page
-* ``render_stale_document_async`` - render stale documents in a background
-  sub-task
-* ``spam_checks_enabled`` - toggle spam checks site wide
-* ``spam_submissions_enabled`` - toggle Akismet spam/spam submission ability
+* ``wiki_force_immediate_rendering`` - force wiki pages to render immediately
+  in the same http request in which they are saved (not in a background
+  process)
 
 Flags
 -----
@@ -34,22 +37,27 @@ Flags
 `Waffle flags`_ control behavior by specific users, groups, percentages, and
 other advanced criteria.
 
-* ``events_map`` - show the map on the events page
+* ``compat_api`` - View the new API-backed compatibility tables
+* ``enable_customcss`` - enable/disable Template:CustomCSS styles in wiki
+  pages.
+* ``kumabanned`` - (deprecated) added to users to mark them as banned
+* ``kumaediting`` - enable/disable wiki editing
+* ``page_move`` - (deprecated) enable/disable page move feature
+* ``registration_disabled`` - enable/disable new user registration
 * ``search_doc_navigator`` - show the search doc navigator feature
-* ``search_drilldown_faceting`` - treat search filters as "drill-down" filters
-  - i.e., combine them with "AND" logic
 * ``search_suggestions`` - show the advanced search filter suggestions
   interface
-* ``registration_disabled`` - enable/disable new user registration
-* ``social_account_research`` - enable/disable social account research on the
-  "Sign in to Edit" page
-* ``kumaediting`` - enable/disable wiki editing
-* ``kumabanned`` - (deprecated) added to users to mark them as banned
-* ``enable_customcss`` - enable/disable Template:CustomCSS styles in wiki pages
-  pages
-* ``page_move`` - enable/disable page move feature
+* ``section_edit`` - Show section edit buttons
+* ``spam_admin_override`` - Tell Akismet that edits are never spam
+* ``spam_spammer_override`` - Tell Akismet that edits are always spam
+* ``spam_testing_mode`` - Tell Akismet that edits are tests, not real content
+* ``spam_checks_enabled`` - toggle spam checks site wide
+* ``spam_submissions_enabled`` - toggle Akismet spam/spam submission ability
+* ``wiki_samples`` - Add button to open samples in Codepen or jsFiddle
 * ``wiki_spam_exempted`` - exempt users and user groups from checking
   submissions for spam
+* ``wiki_spam_training`` - Call Akismet to check submissions, but don't block
+  due to detected spam or Akismet errors.
 
 Constance Features
 ------------------
@@ -65,3 +73,4 @@ and documented in the admin site's `constance section`_.
 .. _constance section: https://developer-local.allizom.org/admin/constance/config/
 .. _Waffle switches: http://waffle.readthedocs.org/en/latest/types/switch.html
 .. _Waffle flags: http://waffle.readthedocs.org/en/latest/types/flag.html
+.. _PR 3331: https://github.com/mozilla/kuma/pull/3331

--- a/kuma/spam/constants.py
+++ b/kuma/spam/constants.py
@@ -5,3 +5,6 @@ HAM_URL = '/1.1/submit-ham'
 
 SPAM_CHECKS_FLAG = 'spam_checks_enabled'
 SPAM_SUBMISSIONS_FLAG = 'spam_submissions_enabled'
+SPAM_ADMIN_FLAG = 'spam_admin_override'
+SPAM_SPAMMER_FLAG = 'spam_spammer_override'
+SPAM_TESTING_FLAG = 'spam_testing_mode'

--- a/kuma/spam/forms.py
+++ b/kuma/spam/forms.py
@@ -52,6 +52,19 @@ class AkismetFormMixin(object):
         """
         raise NotImplementedError
 
+    def akismet_parameter_overrides(self):
+        """
+        Get parameter overrides based on user's waffle flags.
+        """
+        parameters = {}
+        if flag_is_active(self.request, constants.SPAM_ADMIN_FLAG):
+            parameters['user_role'] = 'administrator'
+        if flag_is_active(self.request, constants.SPAM_SPAMMER_FLAG):
+            parameters['comment_author'] = 'viagra-test-123'
+        if flag_is_active(self.request, constants.SPAM_TESTING_FLAG):
+            parameters['is_test'] = True
+        return parameters
+
     def akismet_locale(self, language):
         """
         Convert a Django locale to a locale akismet expects.

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -252,6 +252,7 @@ KUMA_FILE_URL = re.compile(r'%s%s/files/(?P<file_id>\d+)/' %
                             re.escape(settings.ATTACHMENT_HOST)))
 
 SPAM_EXEMPTED_FLAG = 'wiki_spam_exempted'
+SPAM_TRAINING_FLAG = 'wiki_spam_training'
 SPAM_SUBMISSION_REVISION_FIELDS = [
     'title',
     'slug',


### PR DESCRIPTION
Updates the tests to:
* Use py.test's ``assert`` style instead of unittest's ``self.assertX`` style.
* Add ``_setup_akismet_post`` method to help setup a RevisionForm for Akismet testing

Adds some additional waffle flags to allow per-user alternate Akismet payloads:
* ``spam_admin_override`` - Sets ``"role=administrator"`` so Akismet never identifies changes as spam
* ``spam_spammer_override`` - Sets ``"username=viagra-test-123"`` so Akismet always identifies changes as spam
* ``spam_testing_mode`` - Sets ``"is_test=True"`` so Akismet doesn't train on the content

Adds one per-user flag to control the response:
* ``spam_training_mode`` - Don't block saving content if Akismet identifies as spam or returns an error (but still record as a ``DocumetSpamAttempt``).

See the [bug comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1259233#c2) for the planned scenarios for these new flags.
