### PR TITLE
bug 1263157, 1263163 - Async caching and task fixes

### DIFF
--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -69,6 +69,16 @@ class GenerationKeyJob(Job):
         """Create a unique generation identifier."""
         return crypto.get_random_string(length=12)
 
+    def get_constructor_kwargs(self):
+        """
+        Get named arguments for re-initialization.
+
+        The async refresh task re-creates the GenerationKeyJob.
+        """
+        return {'age': self.age,
+                'for_class': self.for_class,
+                'generation_args': self.generation_args}
+
 
 class IPBanJob(KumaJob):
     lifetime = 60 * 60 * 3

--- a/kuma/core/jobs.py
+++ b/kuma/core/jobs.py
@@ -23,6 +23,7 @@ class GenerationJob(KumaJob):
     The purpose is to refresh several cached values when a generation changes.
     """
     generation_age = 60 * 60 * 24 * 365
+    lifetime = 60 * 60 * 12
 
     def __init__(self, generation_args=None, *args, **kwargs):
         """


### PR DESCRIPTION
* Adds ``GenerationKeyJob.get_constructor_args``, so that the async refresh task can recreate the generation key

To do:

- [x] Make sure cacheback jobs have reasonable lifetimes and refresh timeouts
- [x] Investigate [bug 1263163](https://bugzilla.mozilla.org/show_bug.cgi?id=1263163), see if there is a similar code fix needed.