### PR TITLE
Bug 1259151: Restore draft regression fix

### DIFF
--- a/kuma/static/styles/components/wiki/edit/draft-status.styl
+++ b/kuma/static/styles/components/wiki/edit/draft-status.styl
@@ -1,8 +1,9 @@
-.draft-container{
+.draft-container {
     margin-bottom: $content-vertical-spacing;
-}
-
-.draft-status {
     set-smaller-font-size();
     font-weight: bold;
+}
+
+.draft-container em {
+    font-weight: normal;
 }


### PR DESCRIPTION
When a draft was detected the code was still autosaving over top of it. This fixes that and exposes the autosave process to the user in the UI.

Testing:
no recovered draft, save draft button present but disabled
type and wait 3 seconds for auto save
local storage has correct content
type and click save button (in less than 3 seconds, got to be quick)
local storage has correct content
autosave disabled notification present
type and wait for 3 seconds, draft not autosaved
enable auto save
type and wait for 3 seconds, draft autosaved
hard refresh page
report draft to restore, no save button, no autosave
type and wait 3 seconds, no autosave
restore draft
restored correctly, autosave enabled
type and wait 3 seconds, autosave
hard refresh
draft to restore
discard draft
hard refresh
no draft
make new draft
press discard button next to preview button
return to edit page
no draft
create spam edit
submit spam and be rejected
no draft
click draft save
refresh
restore draft sucessfully
ditch your spam content
create legit edit
click publish and keep editing button
page disabled
draft saved
page renabled
draft published and autosave enabled