### PR TITLE
Bug 1259173 - Adjust Akismet payload 

### DIFF
--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -235,7 +235,7 @@ class RevisionIPManager(models.Manager):
         old_rev_ips = self.filter(revision__created__lte=cutoff_date)
         old_rev_ips.delete()
 
-    def log(self, revision, headers):
+    def log(self, revision, headers, data):
         """
         Records the IP and some more data for the given revision and the
         request headers.
@@ -245,4 +245,5 @@ class RevisionIPManager(models.Manager):
             ip=headers.get('REMOTE_ADDR'),
             user_agent=headers.get('HTTP_USER_AGENT', ''),
             referrer=headers.get('HTTP_REFERER', ''),
+            data=data
         )

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1838,13 +1838,12 @@ class RevisionIP(models.Model):
         editable=False,
         blank=True,
     )
-    # TODO: Uncomment this after production database has the column
-    # data = models.TextField(
-    #    editable=False,
-    #    blank=True,
-    #    null=True,
-    #    verbose_name=_('Data submitted to Akismet')
-    # )
+    data = models.TextField(
+        editable=False,
+        blank=True,
+        null=True,
+        verbose_name=_('Data submitted to Akismet')
+    )
     objects = RevisionIPManager()
 
     def __unicode__(self):

--- a/kuma/wiki/templates/admin/wiki/revisionakismetsubmission/change_form.html
+++ b/kuma/wiki/templates/admin/wiki/revisionakismetsubmission/change_form.html
@@ -11,3 +11,16 @@
     {% endif %}
     {{ block.super }}
 {% endblock %}
+
+{% block after_field_sets %}
+{# Add submitted data, styled almost like it was a real field #}
+<fieldset class="module aligned">
+  <div class="form-row field-submitted-data">
+    <div>
+        <label>Submitted Data:</label>
+        <p>{{ submitted_data }}</p>
+    </div>
+  </div>
+</fieldset>
+{{ block.super }}
+{% endblock %}


### PR DESCRIPTION
Rewrite the RevisionForm tests to setup forms for validation in the same way the views set them up (create, edit, and translate). Then:

Update the Akismet payload:
* Add HTTP headers
* Add ``blog`` parameter (front page of site), and fix default if omitted
* Add ``permalink`` parameter (page that is being edited
* Minimize ``comment_content`` to the changed and new content

Further improvements:
* Move payload generation to new ``AkismetRevisionData`` class, so the same logic can be used in the  ``RevisionForm`` as other places
* Save Akismet data in ``RevisionIP`` instance, and replay for ``submit-ham`` and ``submit-spam``.
* Add read-only displays of Akismet data to admin detail views.

This PR should be manually merged:
* [x] The first commit rewrites the tests, and the PR will be easier to understand after merging (optional)
* [x] The second-to-last commit includes a database migration that should be applied in production before the last commit
* [ ] The last commit adds the code that uses the new database column.