### PR TITLE
bug 1255608 - Add Groups to user filter

### DIFF
--- a/kuma/users/admin.py
+++ b/kuma/users/admin.py
@@ -27,7 +27,7 @@ class UserAdmin(BaseUserAdmin):
     list_display = ('username', 'fullname', 'email',
                     'bio', 'website', 'revisions',
                     'date_joined', 'is_staff', 'is_active')
-    list_filter = ('is_staff', 'is_superuser', 'is_active', 'date_joined')
+    list_filter = ('is_staff', 'is_superuser', 'is_active', 'date_joined', 'groups')
     ordering = ('-date_joined',)
     search_fields = ('username', 'homepage', 'title', 'fullname',
                      'organization', 'location', 'bio', 'email', 'tags__name')


### PR DESCRIPTION
Adds groups to the Django admin list view for users, to allow admins to easily see user accounts assigned to a group.