### PR TITLE
bug 1264361 - Require wiki.add_document permission

### DIFF
--- a/jinja2/403.html
+++ b/jinja2/403.html
@@ -16,7 +16,8 @@
 
   <section id="content-main" class="full" role="main">
 
-    <h1 class="page-title">{{ _('Permission Denied') }}</h1>
+    <h1 class="page-title">{% block page_title %}{{ _('Permission Denied') }}{% endblock %}</h1>
+    {% block reason -%}
 
     {% if reason == 'kumaediting' %}
       <p class="notice">{{ _('The wiki is in read-only mode.') }}</p>
@@ -27,9 +28,13 @@
     {% elif reason == 'revisions_login_required' %}
       <p class="notice">{{ _("You must sign in to view all history") }}</p>
     {% endif %}
+    {% endblock reason %}
 
+    {% block tumbeast %}
     <img src="{{ static('img/beast-403.png') }}" alt="" class="beast 403">
+    {% endblock tumbeast %}
 
+    {% block next_action %}
     {% if user.username %}
       {% trans name=user.username %}
       <p>We're sorry {{ name }}, we're afraid we can't do that.</p>
@@ -51,10 +56,13 @@
         {% endtrans %}
       {% endif %}
       </ul>
+    {% endblock %}
 
+    {% block tumbeast_attribution -%}
       {% trans %}
       <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>
       {% endtrans %}
+    {% endblock tumbeast_attribution %}
 
   </section>
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1232,7 +1232,11 @@ CONSTANCE_CONFIG = dict(
     RECAPTCHA_PRIVATE_KEY=(
         '',
         'ReCAPTCHA private key, leave empty to disable'
-    )
+    ),
+    EMAIL_LIST_MDN_ADMINS=(
+        'mdn-admins@mozilla.org',
+        'Email address to request admin intervention'
+    ),
 )
 
 KUMASCRIPT_URL_TEMPLATE = 'http://localhost:9080/docs/{path}'

--- a/kuma/users/fixtures/test_users.json
+++ b/kuma/users/fixtures/test_users.json
@@ -13,8 +13,8 @@
         "fields": {
             "name": "template-editors",
             "permissions": [
-                118,
-                119
+                ["add_template_document", "wiki", "document"],
+                ["change_template_document", "wiki", "document"]
             ]
         },
         "model": "auth.group",
@@ -22,10 +22,20 @@
     },
     {
         "fields": {
+            "name": "Page Creators",
+            "permissions": [
+                ["add_document", "wiki", "document"]
+            ]
+        },
+        "model": "auth.group",
+        "pk": 2
+    },
+    {
+        "fields": {
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser@test.com",
             "first_name": "Test",
-            "groups": [],
+            "groups": [2],
             "is_active": true,
             "is_staff": false,
             "is_superuser": false,
@@ -79,7 +89,7 @@
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser2@test.com",
             "first_name": "Test2",
-            "groups": [],
+            "groups": [2],
             "is_active": true,
             "is_staff": false,
             "is_superuser": false,
@@ -164,7 +174,7 @@
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser01@test.com",
             "first_name": "Test",
-            "groups": [],
+            "groups": [2],
             "is_active": true,
             "is_staff": false,
             "is_superuser": false,

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -26,10 +26,13 @@ def user(save=False, **kwargs):
     if 'username' not in kwargs:
         kwargs['username'] = get_random_string(length=15)
     password = kwargs.pop('password', 'password')
+    groups = kwargs.pop('groups', [])
     user = get_user_model()(**kwargs)
     user.set_password(password)
     if save:
         user.save()
+    if groups:
+        user.groups = groups
     return user
 
 

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -270,3 +270,5 @@ CODE_SAMPLE_MACROS = [
     'LiveSampleLink',
     'FXOSUXLiveSampleEmbed',
 ]
+
+DEV_DOC_REQUEST_FORM = 'https://bugzilla.mozilla.org/form.doc'

--- a/kuma/wiki/jinja2/403-create-page.html
+++ b/kuma/wiki/jinja2/403-create-page.html
@@ -4,10 +4,13 @@
 
 {% block reason %}
 <p class="notice">
-  {% trans %}
+  {% trans email_link=(
+  'mailto:{email}?subject=Page Creation permission&'
+  'body=My username is {username}. I want the page creation permission on {host} because...'.format(email=email_address, username=request.user.username, host=request.get_host() )) %}
+
   Creating a new page is a restricted action.
   To request a new page, please <a href="{{ request_page_url }}">file a bug</a>.
-  If you need permission to create new pages, please <a href="{{ request_access_url }}">contact us</a>.
+  If you need permission to create new pages, please <a href="{{ email_link }}">contact us</a>.
   {% endtrans %}
 </p>
 

--- a/kuma/wiki/jinja2/403-create-page.html
+++ b/kuma/wiki/jinja2/403-create-page.html
@@ -1,0 +1,30 @@
+{% extends "403.html" %}
+
+{% block page_title %}{{ _("You're trying to create a new page.") }}{% endblock %}
+
+{% block reason %}
+<p class="notice">
+  {% trans %}
+  Creating a new page is a restricted action.
+  To request a new page, please <a href="{{ request_page_url }}">file a bug</a>.
+  If you need permission to create new pages, please <a href="{{ request_access_url }}">contact us</a>.
+  {% endtrans %}
+</p>
+
+{% trans %}
+<p>You are more likely to be granted permission to create new pages if you:</p>
+<ul>
+  <li>Tell us your MDN username.</li>
+  <li>Tell us why you'd like to create new pages
+      (Are you documenting a new feature? What feature?
+       Is there a glossary term you’d like to add? What term?).
+  </li>
+  <li>Have made some good edits to existing pages.</li>
+  <li>Have been contributing to the site for a while.</li>
+</ul>
+{% endtrans %}
+{% endblock %}
+
+{% block tumbeast %}{% endblock %}
+{% block tumbeast_attribution %}{% endblock %}
+{% block next_action %}{% endblock %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -56,12 +56,14 @@ class BaseDocumentManager(models.Manager):
         """
         Determine whether the user can create a document with the given
         slug. Mainly for enforcing Template: editing permissions
+
+        TODO: Convert to a method that raises exceptions that are handled
+        by an exception middleware.
         """
         if (slug.startswith(TEMPLATE_TITLE_PREFIX) and
                 not user.has_perm('wiki.add_template_document')):
             return False
-        # NOTE: We could enforce wiki.add_document here, but it's implicitly
-        # assumed everyone is allowed.
+        # TODO: Add wiki.add_document check
         return True
 
     def filter_for_list(self, locale=None, tag=None, tag_name=None,

--- a/kuma/wiki/migrations/0030_add_page_creators_group.py
+++ b/kuma/wiki/migrations/0030_add_page_creators_group.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+from django.db.models import Count
+from django.core.management.sql import emit_post_migrate_signal
+
+
+def create_page_creators_group(apps, schema_editor):
+    # Ensure wiki.add_document permission is created in a fresh database
+    # https://code.djangoproject.com/ticket/23422#comment:20
+    db_alias = schema_editor.connection.alias
+    emit_post_migrate_signal(2, False, 'default', db_alias)
+
+    # Grab the wiki.add_document permission
+    Permission = apps.get_model('auth', 'Permission')
+    add_perm = Permission.objects.get(codename='add_document',
+                                      content_type__app_label='wiki')
+
+    # Create the Page Creators group, if needed
+    Group = apps.get_model('auth', 'Group')
+    group, created = Group.objects.get_or_create(name='Page Creators')
+    group.permissions.add(add_perm)
+
+    # Add existing unbanned users to Page Creators
+    User = apps.get_model('users', 'User')
+    unbanned = (User.objects.annotate(ban_count=Count('bans'))
+                            .exclude(ban_count__gt=0)
+                            .values_list('id', flat=True))
+    group.user_set.add(*unbanned)
+
+
+def delete_page_creators_group(apps, schema_editor):
+    Group = apps.get_model('auth', 'Group')
+    Group.objects.filter(name='Page Creators').delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0029_add_dsa_review_type_error'),
+        ('users', '0005_update_tz'),
+        ('contenttypes', '__latest__'),
+        ('sites', '__latest__'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_page_creators_group,
+                             delete_page_creators_group),
+    ]

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -142,17 +142,20 @@ def normalize_html(input):
             .serialize(alphabetical_attributes=True))
 
 
-def create_document_editor_user():
-    """Creates a user empowered with document editing"""
-    perms = []
-    for action in ('add', 'change', 'delete', 'view', 'restore'):
-        perms.append(Permission.objects.get(codename='%s_document' % action))
-
+def create_document_editor_group():
+    """Get or create a group that can edit documents."""
     group, group_created = Group.objects.get_or_create(name='editor')
     if group_created:
+        actions = ('add', 'change', 'delete', 'view', 'restore')
+        perms = [Permission.objects.get(codename='%s_document' % action)
+                 for action in actions]
         group.permissions = perms
         group.save()
+    return group
 
+
+def create_document_editor_user():
+    """Get or create a user empowered with document editing."""
     User = get_user_model()
     user, user_created = User.objects.get_or_create(
         username='conantheeditor',
@@ -160,13 +163,14 @@ def create_document_editor_user():
                       is_active=True, is_staff=False, is_superuser=False))
     if user_created:
         user.set_password('testpass')
-        user.groups = [group]
+        user.groups = [create_document_editor_group()]
         user.save()
 
     return user
 
 
 def create_template_test_users():
+    """Create users for template editing tests."""
     perms = dict(
         (x, [Permission.objects.get(codename='%s_template_document' % x)])
         for x in ('add', 'change',)
@@ -181,6 +185,7 @@ def create_template_test_users():
             group.permissions = perms[x]
             group.save()
         groups[x] = [group]
+    editor_group = create_document_editor_group()
 
     users = {}
     User = get_user_model()
@@ -191,7 +196,7 @@ def create_template_test_users():
                           is_active=True, is_staff=False, is_superuser=False))
         if created:
             user.set_password('testpass')
-            user.groups = groups.get(x, [])
+            user.groups = groups.get(x, []) + [editor_group]
             user.save()
         users[x] = user
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -32,7 +32,8 @@ from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.tests import UserTestCase, user
 
-from . import (WikiTestCase, create_document_editor_user, create_document_tree,
+from . import (WikiTestCase, create_document_editor_group,
+               create_document_editor_user, create_document_tree,
                create_template_test_users, document, make_translation,
                new_document_data, normalize_html, revision)
 from ..content import get_seo_description
@@ -508,6 +509,15 @@ class PermissionTests(UserTestCase, WikiTestCase):
                         eq_(403, resp.status_code,
                             "%s should not be able to %s %s" %
                             (user, msg[is_add], slug))
+
+    def test_add_document_permission(self):
+        newuser = user(save=True, username='newuser', password='password')
+        assert not newuser.has_perm('wiki.add_document')
+        url = reverse('wiki.create', locale='en-US')
+        assert self.client.login(username='newuser',
+                                 password='password'), 'Failed to login.'
+        response = self.client.get(url, slug='NewPage')
+        assert response.status_code == 403
 
 
 class ConditionalGetTests(UserTestCase, WikiTestCase):
@@ -3782,6 +3792,7 @@ class APITests(UserTestCase, WikiTestCase):
         self.user = user(username=self.username,
                          email=self.email,
                          password=self.password,
+                         groups=[create_document_editor_group()],
                          save=True)
 
         self.key = Key(user=self.user, description='Test Key 1')

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -34,18 +34,10 @@ def create(request):
         raise PermissionDenied
     # TODO: Integrate this into a new exception-handling middleware
     if not request.user.has_perm('wiki.add_document'):
-        email_url = (
-            'mailto:%s?'
-            'subject=Page Creation permission&'
-            'body=My username is %s.'
-            ' I want the page creation permission on %s because...'
-        ) % (config.EMAIL_LIST_MDN_ADMINS,
-             request.user.username,
-             request.get_host())
         context = {
             'reason': 'create-page',
             'request_page_url': DEV_DOC_REQUEST_FORM,
-            'request_access_url': email_url
+            'email_address': config.EMAIL_LIST_MDN_ADMINS
         }
         return render(request, '403-create-page.html', context=context,
                       status=403)

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import newrelic.agent
 
+from constance import config
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import render, redirect
 
@@ -8,7 +9,8 @@ from kuma.attachments.forms import AttachmentRevisionForm
 from kuma.core.decorators import never_cache, login_required, block_user_agents
 from kuma.core.urlresolvers import reverse
 
-from ..constants import (TEMPLATE_TITLE_PREFIX,
+from ..constants import (DEV_DOC_REQUEST_FORM,
+                         TEMPLATE_TITLE_PREFIX,
                          REVIEW_FLAG_TAGS_DEFAULT)
 from ..decorators import check_readonly, prevent_indexing
 from ..forms import DocumentForm, RevisionForm
@@ -30,6 +32,23 @@ def create(request):
     # Try to head off disallowed Template:* creation, right off the bat
     if not Document.objects.allows_add_by(request.user, initial_slug):
         raise PermissionDenied
+    # TODO: Integrate this into a new exception-handling middleware
+    if not request.user.has_perm('wiki.add_document'):
+        email_url = (
+            'mailto:%s?'
+            'subject=Page Creation permission&'
+            'body=My username is %s.'
+            ' I want the page creation permission on %s because...'
+        ) % (config.EMAIL_LIST_MDN_ADMINS,
+             request.user.username,
+             request.get_host())
+        context = {
+            'reason': 'create-page',
+            'request_page_url': DEV_DOC_REQUEST_FORM,
+            'request_access_url': email_url
+        }
+        return render(request, '403-create-page.html', context=context,
+                      status=403)
 
     # if the initial slug indicates the creation of a new template
     is_template = initial_slug.startswith(TEMPLATE_TITLE_PREFIX)


### PR DESCRIPTION
A user must have the ``wiki.add_document permission`` in order to add a page.

If this strategy works, then there is some follow-on tasks, including:
* Decide criteria for adding new users to Page Creators
* Automatically adding new users to Page Creators
* Adding an exception middleware to make it easier to return permission-based templates.

_Update 1_: Added a migration, manual steps are no longer needed