### PR TITLE
bug 1267713, bug 1259173 - Fix Akismet for new translations, plus tag fix

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -224,7 +224,7 @@ class AkismetNewDocumentData(AkismetRevisionData):
 
     def __init__(self, request, cleaned_data, language=None):
         """
-        Initialize from a form submission by the author.
+        Initialize from a new document form submission by the author.
 
         Keyword Parameters:
         request - the Request for the author
@@ -238,17 +238,38 @@ class AkismetNewDocumentData(AkismetRevisionData):
         self.set_content(new_content)
 
 
+class AkismetNewTranslationData(AkismetRevisionData):
+    """Collect Akismet data for a user creating a new translation."""
+
+    def __init__(self, request, cleaned_data, english_document, language):
+        """
+        Initialize from a new translation form submission by the author.
+
+        Keyword Parameters:
+        request - the Request for the author
+        cleaned_data - the validated form data
+        english_document - the original English document
+        language - the language of the revision being created
+        """
+        super(AkismetNewTranslationData, self).__init__()
+        self.set_by_edit_request(request)
+        self.set_blog_lang(language)
+        new_content = self.content_from_form(cleaned_data)
+        existing_content = self.content_from_document(english_document)
+        self.set_content(new_content, existing_content)
+
+
 class AkismetEditDocumentData(AkismetRevisionData):
     """Collect Akismet data for a user editing an existing document."""
 
     def __init__(self, request, cleaned_data, document):
         """
-        Initialize from a form submission by the author.
+        Initialize from an edit page form submission by the author.
 
         Keyword Parameters:
         request - the Request for the author
         cleaned_data - the validated form data
-        instance - the form instance, including the base Document
+        document - the document the user is editing
         """
         super(AkismetEditDocumentData, self).__init__()
         self.set_by_edit_request(request)
@@ -719,8 +740,13 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                     self._akismet_data = AkismetEditDocumentData(
                         self.request, self.cleaned_data, document)
                 else:
-                    self._akismet_data = AkismetNewDocumentData(
-                        self.request, self.cleaned_data, self.data.get('locale'))
+                    # New translation, compare to English document
+                    based_on = self.cleaned_data.get('based_on')
+                    assert based_on, 'Expected a new translation.'
+                    document = based_on.document
+                    self._akismet_data = AkismetNewTranslationData(
+                        self.request, self.cleaned_data, document,
+                        self.data.get('locale'))
 
         parameters = self._akismet_data.parameters.copy()
         parameters.update(self.akismet_parameter_overrides())

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -114,13 +114,15 @@ class AkismetRevisionData(object):
     def content_from_document(self, document):
         """Create a combined content string from a document."""
         parts = []
+        current_revision = document.current_revision
+        assert current_revision, "document must have a current revision."
         for field in SPAM_SUBMISSION_REVISION_FIELDS:
             if field == 'comment':
                 value = u''
             elif field == 'content':
-                value = document.current_revision.content
+                value = current_revision.content
             elif field == 'tags':
-                value = u'\n'.join(sorted(document.tags.names()))
+                value = self.split_tags(current_revision.tags)
             else:
                 value = getattr(document, field, '')
             parts.append(value)

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -715,8 +715,13 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                 self._akismet_data = AkismetNewDocumentData(
                     self.request, self.cleaned_data, self.data.get('locale'))
             else:
-                self._akismet_data = AkismetEditDocumentData(
-                    self.request, self.cleaned_data, document)
+                if document.current_revision:
+                    self._akismet_data = AkismetEditDocumentData(
+                        self.request, self.cleaned_data, document)
+                else:
+                    self._akismet_data = AkismetNewDocumentData(
+                        self.request, self.cleaned_data, self.data.get('locale'))
+
         parameters = self._akismet_data.parameters.copy()
         parameters.update(self.akismet_parameter_overrides())
         return parameters

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -743,15 +743,10 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
         assert parameters['blog_lang'] == 'fr, en_us'
         expected_content = (
             u'Guide de développement HTML\n'
-            u'Web/Guide/HTML\n'
-            u'<h2 id="Summary">Summary</h2>\n'
             u'<p><strong>HyperText Markup Language (HTML)</strong>, ou'
             u' <em>langage de balisage hypertexte</em>, est le langage au cœur'
             u' de presque tout contenu Web.</p>\n'
-            u'Traduction initiale\n'
-            u'HTML\n'
-            u'Landing\n'
-            u'Web'
+            u'Traduction initiale'
         )
         assert parameters['comment_content'] == expected_content
 

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -695,6 +695,13 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
         original_data = self.original.copy()
         english_rev = revision(save=True, **original_data)
 
+        fr_web_doc = document(save=True, slug='Web', locale='fr')
+        revision(save=True, slug='Web', document=fr_web_doc)
+        fr_guide_doc = document(save=True, slug='Web/Guide', locale='fr')
+        revision(save=True, slug='Web/Guide', document=fr_guide_doc)
+        fr_html_doc = document(save=True, slug='Web/Guide/HTML', locale='fr',
+                               parent=english_rev.document)
+
         initial = {
             'based_on': english_rev.id,
             'comment': '',
@@ -722,6 +729,7 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
         rev_form = RevisionForm(request=request,
                                 data=data,
                                 parent_slug=parent_slug)
+        rev_form.instance.document = fr_html_doc
         return rev_form
 
     @pytest.mark.spam


### PR DESCRIPTION
A new translation is a little like an edit and a little like a new document, but not identical to either. This PR fixes the test code to setup the tests for new translations correctly, and implements a better process for creating an Akismet payload for new translations, fixing an ISE in the current code.

It also uses the previous revision's tags instead of the document tags, since document tags have different capitalization than revision tags in some cases.