### PR TITLE
bug 957802 - Vagrant build fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,7 +42,6 @@ Vagrant.configure('2') do |config|
     config.cache.enable :gem
     config.cache.enable :generic, {
       "pip" => { cache_dir: "/root/.cache/pip" },
-      "npm" => { cache_dir: "/root/.npm" },
       "product_details" => { cache_dir: "/home/vagrant/product_details_json" },
     }
     if NFS

--- a/provisioning/roles/kuma/tasks/node.yml
+++ b/provisioning/roles/kuma/tasks/node.yml
@@ -2,7 +2,7 @@
 - name: Install node dependencies
   npm: name={{ item.name }} version={{ item.version }} global=yes
   with_items:
-    - {name: 'fibers', version: '1.0.1'}
+    - {name: 'fibers', version: '1.0.10'}
     - {name: 'clean-css', version: '2.2.16'}
     - {name: 'csslint', version: '0.10.0'}
     - {name: 'jshint', version: '2.7.0'}


### PR DESCRIPTION
* Disable the npm cache. It should make building a VM faster, but permission errors are breaking provisioning.
* Upgrade fibers. It is a C++ package, and must have broke with recent system package updates.