### PR TITLE
bug 1268511 and bug 1259870 - Akismet integration fixes

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -213,12 +213,7 @@ class AkismetRevisionData(object):
 
     def split_tags(self, tag_string):
         """Turn '"Tag 2" "Tag 1"' into 'Tag 1\nTag 2'."""
-        if not tag_string:
-            return ''
-        else:
-            assert tag_string[0] == u'"'
-            assert tag_string[-1] == u'"'
-            return u'\n'.join(sorted(tag_string[1:-1].split(u'" "')))
+        return u'\n'.join(parse_tags(tag_string))
 
 
 class AkismetNewDocumentData(AkismetRevisionData):

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -573,6 +573,30 @@ class RevisionFormEditTests(RevisionFormViewTests):
         parameters = rev_form.akismet_parameters()
         assert parameters['is_test']
 
+    @pytest.mark.spam
+    @requests_mock.mock()
+    def test_akismet_disabled_template(self, mock_requests):
+        template = {
+            'content': (
+                '<% /* This is a template */ %>\n'
+                '<p>Hello, World!</p>\n'
+            ),
+            'slug': 'Template:HelloWorld',
+            'tags': '',
+            'title': 'Template:HelloWorld'
+        }
+        template_edit = template.copy()
+        template_edit['content'] = (
+            '<% /* This is a template */ %>\n'
+            '<p><strong>Hello, World!</strong></p>\n'
+        )
+        rev_form = self.setup_form(mock_requests,
+                                   override_original=template,
+                                   override_data=template_edit,
+                                   is_spam='true')
+        assert rev_form.is_valid()
+        assert not rev_form.akismet_enabled()
+
 
 class RevisionFormCreateTests(RevisionFormViewTests):
     """Test RevisionForm as used in create view."""

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -427,6 +427,30 @@ class RevisionFormEditTests(RevisionFormViewTests):
 
     @pytest.mark.spam
     @requests_mock.mock()
+    def test_quoteless_tags(self, mock_requests):
+        """
+        Test Akismet parameters when the tags are saved without quotes.
+
+        Tracked in bug 1268511.
+        """
+        tags = {'tags': 'CodingScripting, Glossary'}
+        rev_form = self.setup_form(mock_requests, override_original=tags)
+        assert rev_form.is_valid()
+        parameters = rev_form.akismet_parameters()
+        assert sorted(parameters.keys()) == self.akismet_keys_edit
+        expected_content = (
+            '<p>{{cssinfo}} and my changes.</p>\n'
+            '<p><a href="http://spam.example.com">Buy my product!</a></p>\n'
+            '<pre class="brush:css">display: none;</pre>\n'
+            'Comment\n'
+            'CSS\n'
+            'CSS Property\n'
+            'Reference'
+        )
+        assert parameters['comment_content'] == expected_content
+
+    @pytest.mark.spam
+    @requests_mock.mock()
     def test_akismet_enabled(self, mock_requests):
         rev_form = self.setup_form(mock_requests)
         assert rev_form.akismet_enabled()


### PR DESCRIPTION
Two fixes:
* [bug 1268511](https://bugzilla.mozilla.org/show_bug.cgi?id=1268511) - Sometime tags have quotes, sometimes they don't.
* [bug 1259870](https://bugzilla.mozilla.org/show_bug.cgi?id=1259870) - Templates are stored like pages, but shouldn't be checked by Akismet