### PR TITLE
bug 957802 - Vagrant install fixes

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
-web: gunicorn kuma.wsgi -b 0.0.0.0:8000
+web: gunicorn kuma.wsgi -w 2 -b 0.0.0.0:8000
 worker: python2.7 manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
 camera: python2.7 manage.py celerycam --freq=2.0
 kumascript: node kumascript/run.js

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,6 +26,7 @@ Vagrant.configure('2') do |config|
     IP = ENV['VAGRANT_IP'] || '192.168.10.55'
     GUI = (ENV['VAGRANT_GUI'] || 'false') == 'true'
     ANSIBLE_VERBOSE = (ENV['VAGRANT_ANSIBLE_VERBOSE'] || 'false') == 'true'
+    USE_CACHIER = (ENV['VAGRANT_CACHIER'] || 'false') == 'true'
 
     config.package.name = 'kuma-ubuntu.box'
     config.vm.box = 'ubuntu/trusty64'
@@ -35,16 +36,18 @@ Vagrant.configure('2') do |config|
     config.hostsupdater.aliases = ['mdn-local.mozillademos.org']
     config.ssh.forward_agent = true
 
-    config.cache.scope = :box
-    config.cache.auto_detect = false
-    config.cache.enable :apt
-    config.cache.enable :apt_lists
-    config.cache.enable :gem
-    config.cache.enable :generic, {
-      "pip" => { cache_dir: "/root/.cache/pip" },
-      "product_details" => { cache_dir: "/home/vagrant/product_details_json" },
-    }
-    if NFS
+    if USE_CACHIER
+        config.cache.scope = :box
+        config.cache.auto_detect = false
+        config.cache.enable :apt
+        config.cache.enable :apt_lists
+        config.cache.enable :gem
+        config.cache.enable :generic, {
+            "pip" => { cache_dir: "/root/.cache/pip" },
+            "product_details" => { cache_dir: "/home/vagrant/product_details_json" },
+        }
+    end
+    if NFS and USE_CACHIER
         config.cache.synced_folder_opts = {
             type: :nfs,
             # The nolock option can be useful for an NFSv3 client that wants to avoid the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,6 +7,8 @@ the entire MDN stack. (Django, KumaScript, Search, Celery, etc.)
 If you're on Mac OS X or Linux and looking for a quick way to get started, you
 should try these instructions.
 
+We are moving to a Docker-based deployment, in both development and production.
+This work is still in progress.
 If you are more familiar with Docker view the :doc:`Docker setup instructions <installation-docker>`.
 
 .. note:: **If you have problems getting vagrant up**, check Errors_ below.
@@ -17,14 +19,14 @@ If you are more familiar with Docker view the :doc:`Docker setup instructions <i
 Install and run everything
 ==========================
 
-#. Install VirtualBox >= 4.2.x from http://www.virtualbox.org/
+#. Install VirtualBox >= 5.0.x from http://www.virtualbox.org/
 
    .. note:: (Windows) After installing VirtualBox you need to set
               ``PATH=C:\\Program Files\\Oracle\\VirtualBox\\VBoxManage.exe;``
 
 #. Install Vagrant >= 1.7 using the installer from `vagrantup.com <http://vagrantup.com/>`_
 
-#. Install `Ansible <http://docs.ansible.com/>`_ 1.9.x on your machine so that
+#. Install `Ansible <http://docs.ansible.com/>`_ >= 1.9.x on your machine so that
    Vagrant is able to set up the VM the way we need it.
 
    See the `Ansible Installation docs <http://docs.ansible.com/intro_installation.html>`_
@@ -79,9 +81,12 @@ Install and run everything
     approx. 2GB. If it won't fit on your system drive, you will need
     to `change that directory to another drive <http://emptysquare.net/blog/moving-virtualbox-and-vagrant-to-an-external-drive/>`_.
 
-   At the end, you should see::
+   At the end, you should see something like::
 
-      Finished catalog run in .... seconds
+      PLAY RECAP ********************************************************************
+      developer-local            : ok=147  changed=90   unreachable=0    failed=0
+
+      ==> developer-local: Configuring cache buckets...
 
    If the above process fails with an error, check `Errors`_.
 
@@ -101,9 +106,9 @@ Install and run everything
        20:32:59 stylus.1     | started with pid 2247
        ...
 
-#. Visit `https://mdn-local.mozillademos.org/ <https://mdn-local.mozillademos.org/>`_ and add an exception for the security certificate if prompted.
+#. Visit https://mdn-local.mozillademos.org/ and add an exception for the security certificate if prompted.
 
-#. Visit the homepage at `https://developer-local.allizom.org <https://developer-local.allizom.org/>`_
+#. Visit the homepage at https://developer-local.allizom.org
 
 #. You've installed Kuma!
 
@@ -137,7 +142,7 @@ So, you need to create an admin user, sign in, and then use
 `the Django admin site`_ to enable the wiki so you can create pages.
 
 #. As the admin user you just created, visit the `waffle section`_ of the admin
-site.
+   site.
 
 #. Click "`Add flag`_".
 

--- a/kuma/wiki/management/commands/import_kumascript_modules.py
+++ b/kuma/wiki/management/commands/import_kumascript_modules.py
@@ -35,8 +35,7 @@ class Command(BaseCommand):
 
         for slug in KS_AUTOLOAD_MODULES:
             template_response = requests.get(RAW_TEMPLATE_URL % slug)
-            doc = Document(title=slug, slug=slug,
-                           category=Document.CATEGORIES[0][0])
+            doc = Document(title=slug, slug=slug)
             try:
                 doc.save()
                 loaded_docs.append(slug)


### PR DESCRIPTION
Tested on OS X 10.11.4, Vagrant 1.8.1, VirtualBox 5.0.16r105871, and Ansible 2.0.2.0.

* Add an environment variable ``VAGRANT_CACHIER=false`` to disable the cachier plugin config. Currently still enabled, but may fix some Linux issues.
* Bump tested version numbers
* Use Ansible output in docs
* Fix ``./manage.py import_kumascript_modules``
* Run two web workers, so that KumaScript can make Kuma API requests at the same time Kuma is asking to render a document.
* Allow Kuma to defer async tasks (``CELERY_ALWAYS_EAGER=False``)