### PR TITLE
Linux statd doc update

### DIFF
--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -74,7 +74,7 @@ Errors after switching branches
 Errors in Linux (versions newer than 14.04)
 -------------------------------------------
 
-If you are running Linux and you see the message  IOError: [Errno 37] No locks available, that indicates that the host machine isn't running rpc.statd or statd. This has been seen to affect Ubuntu >= 15.04 (running systemd).
+If you are running Linux and you see the message `IOError: [Errno 37] No locks available`, that indicates that the host machine isn't running rpc.statd or statd. This has been seen to affect Ubuntu >= 15.04 (running systemd).
 
 -  In order to address this issue, run the following commands to start & enable rpc-statd   and start and stop your ::
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -71,6 +71,19 @@ Errors after switching branches
       provisioning.
 
 
+Errors in Linux (versions newer than 14.04)
+-------------------------------------------
+
+If you are running Linux and you see the message  IOError: [Errno 37] No locks available, that indicates that the host machine isn't running rpc.statd or statd. This has been seen to affect Ubuntu >= 15.04 (running systemd).
+
+-  In order to address this issue, run the following commands to start & enable rpc-statd   and start and stop your ::
+
+       vagrant halt
+       sudo systemctl start rpc-statd.service
+       sudo systemctl enable rpc-statd.service
+       vagrant up
+
+
 Errors with KumaScript
 ----------------------
 

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -74,7 +74,7 @@ Errors after switching branches
 Errors in Linux (versions newer than 14.04)
 -------------------------------------------
 
-If you are running Linux and you see the message `IOError: [Errno 37] No locks available`, that indicates that the host machine isn't running rpc.statd or statd. This has been seen to affect Ubuntu >= 15.04 (running systemd).
+If you are running Linux and you see the message ``IOError: [Errno 37] No locks available``, that indicates that the host machine isn't running rpc.statd or statd. This has been seen to affect Ubuntu >= 15.04 (running systemd).
 
 -  In order to address this issue, run the following commands to start & enable rpc-statd   and start and stop your ::
 


### PR DESCRIPTION
Adding information for Linux to the troubleshooting docs regarding statd and locks error.

This fix is required for Linux set-ups that see the following error after running ``foreman start`` and trying to load the website locally:
IOError: [Errno 37] No locks available

