### PR TITLE
Bug 1267197 and bug 1270032 - Links to zones, Firefox OS->B2G OS

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -149,9 +149,9 @@
           <div class="submenu-column">
             <ul>
               <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
-              <li><a href="{{ wiki_url('Firefox') }}">{{ _('Firefox') }}</a></li>
+              <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
               <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
-              <li><a href="{{ wiki_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
+              <li><a href="{{ wiki_url('Mozilla/Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
               <li><a href="{{ wiki_url('Persona') }}">{{ _('Persona') }}</a></li>
             </ul>
           </div>

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -151,7 +151,7 @@
               <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
               <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
               <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
-              <li><a href="{{ wiki_url('Mozilla/Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
+              <li><a href="{{ wiki_url('Mozilla/B2G_OS') }}">{{ _('B2G OS') }}</a></li>
               <li><a href="{{ wiki_url('Persona') }}">{{ _('Persona') }}</a></li>
             </ul>
           </div>

--- a/kuma/core/translations/search/filter/b2g-os/name.py
+++ b/kuma/core/translations/search/filter/b2g-os/name.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from django.utils.translation import gettext
+
+gettext("""B2G OS""")

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -81,8 +81,8 @@
       <div class="column-home-features">
         <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Mozilla<br> Docs') }}</span></h3>
         <ul>
-          <li><a href="{{ wiki_url('Firefox') }}">{{ _('Firefox') }}</a></li>
-          <li><a href="{{ wiki_url('Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
+          <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
+          <li><a href="{{ wiki_url('Mozilla/Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
           <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
           <li><a href="{{ wiki_url('Apps') }}">{{ _('App Center') }}</a></li>
           <li><a href="{{ wiki_url('Mozilla/Add-ons') }}?menu">{{ _('Add-ons') }}</a></li>

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -82,7 +82,7 @@
         <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Mozilla<br> Docs') }}</span></h3>
         <ul>
           <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
-          <li><a href="{{ wiki_url('Mozilla/Firefox_OS') }}">{{ _('Firefox OS') }}</a></li>
+          <li><a href="{{ wiki_url('Mozilla/B2G_OS') }}">{{ _('B2G OS') }}</a></li>
           <li><a href="{{ wiki_url('Mozilla/Marketplace') }}">{{ _('Firefox Marketplace') }}</a></li>
           <li><a href="{{ wiki_url('Apps') }}">{{ _('App Center') }}</a></li>
           <li><a href="{{ wiki_url('Mozilla/Add-ons') }}?menu">{{ _('Add-ons') }}</a></li>

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1196,7 +1196,7 @@ CONSTANCE_CONFIG = dict(
     ),
     WIKI_DOCUMENT_TAG_SUGGESTIONS=(
         json.dumps([
-            "Accessibility", "AJAX", "API", "Apps",
+            "Accessibility", "AJAX", "API", "Apps", "B2G OS",
             "Canvas", "CSS", "Device", "DOM", "Events",
             "Extensions", "Firefox", "Firefox OS", "Games",
             "Gecko", "Graphics", "Internationalization", "History", "HTML", "HTTP", "JavaScript", "Layout",


### PR DESCRIPTION
* From PR #3844 - Update links on homepage so that localized homepage / toolbar will link to the localized variant of zones
* From PR #3857 - Update toolbar link from Firefox OS to B2G OS
* Update homepage link from Firefox OS to B2G OS
* Suggest "B2G OS" tag