### PR TITLE
1268040 dashboard filter known authors

### DIFF
--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -13,6 +13,11 @@ PERIOD_CHOICES = [
     ('week', _('Week')),
     ('month', _('30 days')),
 ]
+AUTHOR_CHOICES = [
+    ('All Authors', _('All Authors')),
+    ('Known Authors', _('Known Authors')),
+    ('Unknown Authors', _('Unknown Authors')),
+]
 
 
 class RevisionDashboardForm(forms.Form):
@@ -42,3 +47,7 @@ class RevisionDashboardForm(forms.Form):
         choices=PERIOD_CHOICES,
         required=False,
         label=_(u'Preceding Period:'))
+    authors = forms.ChoiceField(
+        choices=AUTHOR_CHOICES,
+        required=False,
+        label=_(u'Authors'))

--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -13,10 +13,13 @@ PERIOD_CHOICES = [
     ('week', _('Week')),
     ('month', _('30 days')),
 ]
+ALL_AUTHORS = 0
+KNOWN_AUTHORS = 1
+UNKNOWN_AUTHORS = 2
 AUTHOR_CHOICES = [
-    ('All Authors', _('All Authors')),
-    ('Known Authors', _('Known Authors')),
-    ('Unknown Authors', _('Unknown Authors')),
+    (ALL_AUTHORS, _('All Authors')),
+    (KNOWN_AUTHORS, _('Known Authors')),
+    (UNKNOWN_AUTHORS, _('Unknown Authors')),
 ]
 
 
@@ -51,3 +54,12 @@ class RevisionDashboardForm(forms.Form):
         choices=AUTHOR_CHOICES,
         required=False,
         label=_(u'Authors'))
+
+    ALL_AUTHORS = 0
+    KNOWN_AUTHORS = 1
+    UNKNOWN_AUTHORS = 2
+    AUTHOR_CHOICES = [
+        (ALL_AUTHORS, _('All Authors')),
+        (KNOWN_AUTHORS, _('Known Authors')),
+        (UNKNOWN_AUTHORS, _('Unknown Authors')),
+    ]

--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -13,17 +13,18 @@ PERIOD_CHOICES = [
     ('week', _('Week')),
     ('month', _('30 days')),
 ]
-ALL_AUTHORS = 0
-KNOWN_AUTHORS = 1
-UNKNOWN_AUTHORS = 2
-AUTHOR_CHOICES = [
-    (ALL_AUTHORS, _('All Authors')),
-    (KNOWN_AUTHORS, _('Known Authors')),
-    (UNKNOWN_AUTHORS, _('Unknown Authors')),
-]
 
 
 class RevisionDashboardForm(forms.Form):
+    ALL_AUTHORS = 0
+    KNOWN_AUTHORS = 1
+    UNKNOWN_AUTHORS = 2
+    AUTHOR_CHOICES = [
+        (ALL_AUTHORS, _('All Authors')),
+        (KNOWN_AUTHORS, _('Known Authors')),
+        (UNKNOWN_AUTHORS, _('Unknown Authors')),
+    ]
+
     locale = forms.ChoiceField(
         choices=LANG_CHOICES,
         # Required for non-translations, which is
@@ -54,12 +55,3 @@ class RevisionDashboardForm(forms.Form):
         choices=AUTHOR_CHOICES,
         required=False,
         label=_(u'Authors'))
-
-    ALL_AUTHORS = 0
-    KNOWN_AUTHORS = 1
-    UNKNOWN_AUTHORS = 2
-    AUTHOR_CHOICES = [
-        (ALL_AUTHORS, _('All Authors')),
-        (KNOWN_AUTHORS, _('Known Authors')),
-        (UNKNOWN_AUTHORS, _('Unknown Authors')),
-    ]

--- a/kuma/dashboards/jinja2/dashboards/revisions.html
+++ b/kuma/dashboards/jinja2/dashboards/revisions.html
@@ -41,6 +41,11 @@
                 {{ form.preceding_period }}
             </div>
 
+            <div class="revision-field">
+                <label for="id_authors">{{ _('Authors:') }}</label>
+                {{ form.authors }}
+            </div>
+
             <button type="submit">{{ _('Filter') }}</button>
             <input type="hidden" name="page" id="revision-page" value="{{ page }}" />
         </form>

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -161,3 +161,52 @@ class RevisionsDashTest(UserTestCase):
         eq_(revisions.length, 7)
         for revision in revisions:
             ok_('lorem' not in pq(revision).find('.dashboard-title').html())
+
+    def test_known_authors_lookup(self):
+        # Only testuser01 is in the Known Authors group
+        url = urlparams(reverse('dashboards.revisions', locale='en-US'),
+                        authors='Known Authors')
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        eq_(200, response.status_code)
+
+        page = pq(response.content)
+        revisions = page.find('.dashboard-row')
+
+        for revision in revisions:
+            author = pq(revision).find('.dashboard-author').html()
+            ok_('testuser01' in author)
+            ok_('testuser2' not in author)
+
+    def test_known_authors_filter(self):
+        # There are a total of 11 revisions
+        url = urlparams(reverse('dashboards.revisions', locale='en-US'),
+                        authors='All Authors')
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        eq_(response.status_code, 200)
+
+        page = pq(response.content)
+        revisions = page.find('.dashboard-row')
+
+        eq_(11, revisions.length)
+
+        # Only testuser01 is in the Known Authors group, and has 2 revisions
+        url = urlparams(reverse('dashboards.revisions', locale='en-US'),
+                        authors='Known Authors')
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        eq_(response.status_code, 200)
+
+        page = pq(response.content)
+        revisions = page.find('.dashboard-row')
+
+        eq_(2, revisions.length)
+
+        # Of the 11 revisions, 9 are by users not in the Known Authors group
+        url = urlparams(reverse('dashboards.revisions', locale='en-US'),
+                        authors='Unknown Authors')
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        eq_(response.status_code, 200)
+
+        page = pq(response.content)
+        revisions = page.find('.dashboard-row')
+
+        eq_(9, revisions.length)

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -6,6 +6,7 @@ from waffle.models import Flag, Switch
 from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
+from kuma.dashboards.forms import RevisionDashboardForm
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
 from kuma.users.tests import UserTestCase
 from kuma.users.models import User, UserBan
@@ -165,7 +166,7 @@ class RevisionsDashTest(UserTestCase):
     def test_known_authors_lookup(self):
         # Only testuser01 is in the Known Authors group
         url = urlparams(reverse('dashboards.revisions', locale='en-US'),
-                        authors='Known Authors')
+                        authors=RevisionDashboardForm.KNOWN_AUTHORS)
         response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(200, response.status_code)
 
@@ -180,7 +181,7 @@ class RevisionsDashTest(UserTestCase):
     def test_known_authors_filter(self):
         # There are a total of 11 revisions
         url = urlparams(reverse('dashboards.revisions', locale='en-US'),
-                        authors='All Authors')
+                        authors=RevisionDashboardForm.ALL_AUTHORS)
         response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(response.status_code, 200)
 
@@ -191,7 +192,7 @@ class RevisionsDashTest(UserTestCase):
 
         # Only testuser01 is in the Known Authors group, and has 2 revisions
         url = urlparams(reverse('dashboards.revisions', locale='en-US'),
-                        authors='Known Authors')
+                        authors=RevisionDashboardForm.KNOWN_AUTHORS)
         response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(response.status_code, 200)
 
@@ -202,7 +203,7 @@ class RevisionsDashTest(UserTestCase):
 
         # Of the 11 revisions, 9 are by users not in the Known Authors group
         url = urlparams(reverse('dashboards.revisions', locale='en-US'),
-                        authors='Unknown Authors')
+                        authors=RevisionDashboardForm.UNKNOWN_AUTHORS)
         response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         eq_(response.status_code, 200)
 
@@ -210,3 +211,18 @@ class RevisionsDashTest(UserTestCase):
         revisions = page.find('.dashboard-row')
 
         eq_(9, revisions.length)
+
+    def test_known_authors_filter_ignored_with_username(self):
+        """When user filters by username, the Known Authors filter is ignored"""
+        # Only testuser01 is in the Known Authors group, and has 2 revisions
+        # Filtering by testuser2 should return testuser2's revisions (5 of them)
+        # and ignore the "Known Authors" filter
+        url = urlparams(reverse('dashboards.revisions', locale='en-US'),
+                        user='testuser2', authors=RevisionDashboardForm.KNOWN_AUTHORS)
+        response = self.client.get(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        eq_(response.status_code, 200)
+
+        page = pq(response.content)
+        revisions = page.find('.dashboard-row')
+
+        eq_(5, revisions.length)

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -76,13 +76,13 @@ def revisions(request):
         authors_filter = filter_form.cleaned_data['authors']
         if authors_filter not in ['', 'All Authors']:
             # If the filter is 'Known Authors', then query for the
-            # 'Trusted writers' group
+            # 'Known Authors' group
             if authors_filter == 'Known Authors':
-                query_kwargs['creator__groups__name'] = 'Trusted writers'
+                query_kwargs['creator__groups__name'] = 'Known Authors'
             # Else query must be 'Unknown Authors', so exclude the
-            # 'Trusted writers' group
+            # 'Known Authors' group
             else:
-                exclude_kwargs['creator__groups__name'] = 'Trusted writers'
+                exclude_kwargs['creator__groups__name'] = 'Known Authors'
 
     if query_kwargs or exclude_kwargs:
         revisions = revisions.filter(**query_kwargs).exclude(**exclude_kwargs)

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -76,7 +76,7 @@ def revisions(request):
 
         authors_filter = filter_form.cleaned_data['authors']
         if (not filter_form.cleaned_data['user'] != '' and
-            authors_filter not in ['', str(RevisionDashboardForm.ALL_AUTHORS)]):
+           authors_filter not in ['', str(RevisionDashboardForm.ALL_AUTHORS)]):
 
             # The 'Known Authors' group
             group, created = Group.objects.get_or_create(name="Known Authors")

--- a/kuma/users/fixtures/test_users.json
+++ b/kuma/users/fixtures/test_users.json
@@ -32,6 +32,14 @@
     },
     {
         "fields": {
+            "name": "Trusted writers",
+            "permissions": []
+        },
+        "model": "auth.group",
+        "pk": 3
+    },
+    {
+        "fields": {
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser@test.com",
             "first_name": "Test",
@@ -174,7 +182,7 @@
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser01@test.com",
             "first_name": "Test",
-            "groups": [2],
+            "groups": [2, 3],
             "is_active": true,
             "is_staff": false,
             "is_superuser": false,

--- a/kuma/users/fixtures/test_users.json
+++ b/kuma/users/fixtures/test_users.json
@@ -32,7 +32,7 @@
     },
     {
         "fields": {
-            "name": "Trusted writers",
+            "name": "Known Authors",
             "permissions": []
         },
         "model": "auth.group",

--- a/kuma/users/fixtures/test_users.json
+++ b/kuma/users/fixtures/test_users.json
@@ -36,7 +36,7 @@
             "permissions": []
         },
         "model": "auth.group",
-        "pk": 3
+        "pk": 4
     },
     {
         "fields": {
@@ -182,7 +182,7 @@
             "date_joined": "2011-06-03 16:12:08",
             "email": "testuser01@test.com",
             "first_name": "Test",
-            "groups": [2, 3],
+            "groups": [2, 4],
             "is_active": true,
             "is_staff": false,
             "is_superuser": false,


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1268040

This pull request creates an extra filter for authors on the revisions dashboard, allowing authors to be filtered into "All Authors", "Known Authors" (part of the Known Authors group), and "Unknown Authors" (excluding everyone in the Known Authors group). 