### PR TITLE
bug 957802 - Enable django-debug-toolbar

### DIFF
--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -9,6 +9,7 @@ ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1')
 
 DEBUG = True
+DEBUG_TOOLBAR = config('DEBUG_TOOLBAR', default=False, cast=bool)
 TEMPLATE_DEBUG = DEBUG
 SERVE_MEDIA = DEBUG
 DEBUG_PROPAGATE_EXCEPTIONS = DEBUG
@@ -29,3 +30,5 @@ ES_LIVE_INDEX = True
 # Don't cache non-versioned static files in DEBUG mode
 if DEBUG:
     WHITENOISE_MAX_AGE = 0
+    if DEBUG_TOOLBAR:
+        INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -50,6 +50,10 @@ anyjson==0.3.3 \
 click==6.6 \
     --hash=sha256:cc6a19da8ebff6e7074f731447ef7e112bd23adf3de5c597cf9989f2fd8defe9
 
+# django-debug-toolbar
+sqlparse==0.1.19 \
+    --hash=sha256:d896be1a1c7f24bffe08d7a64e6f0176b260e281c5f3685afe7826f8bada4ee8
+
 # flake8
 mccabe==0.4.0 \
     --hash=sha256:cbc2938f6c01061bc6d21d0c838c2489664755cb18676f0734d7617f4577d09e \

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -41,3 +41,8 @@ hashin==0.4.1 \
     --hash=sha256:b26ace086e24d84152a7e6d7d12b336383e835110d5e2e30dfbf22fa336a2e58 \
     --hash=sha256:e0266d240d589f2419ff669528934db5876d34a19f516fa8b39c42d8221c0591 \
     --hash=sha256:745623e60c649a6092cdbbb62b758e89654f4d69ec88ad76be8c20685f8ea1ab
+
+# Analyze Django performance during request
+django-debug-toolbar==1.4 \
+    --hash=sha256:0cbae8760f4851d480a70b72ace5b075f8191ecf899bc97427715e50fb0e90b9 \
+    --hash=sha256:852a37b80df9597048591ebc87d0ce85a4edceaef015dc5360ad89cc5960c27b


### PR DESCRIPTION
In developer VMs, setting environment ``DEBUG_TOOLBAR=1`` will enable the Django Debug Toolbar, useful for tracking database requests, cache usage, etc.