### PR TITLE
1268642 mark spam/ham with one click (Akismet submission)

### DIFF
--- a/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
@@ -88,11 +88,15 @@
                             <a class="button" href="{{ re_submission_url }}" target="_blank">{{ _('Resubmit') }}</a>
                         {% else %}
                             {{ _('Submit as:') }}<br>
-                            {% set spam_submission_url = url('admin:wiki_revisionakismetsubmission_add')|urlparams(revision=revision.id, type='spam') %}
-                            {% set ham_submission_url = url('admin:wiki_revisionakismetsubmission_add')|urlparams(revision=revision.id, type='ham') %}
 
-                            <a class="button" href="{{ spam_submission_url }}" target="_blank">{{ _('spam') }}</a>
-                            <a class="button" href="{{ ham_submission_url }}" target="_blank">{{ _('ham') }}</a>
+                            <form method="post" id="revision-filter" action="{{ url('dashboards.submit_akismet_spam') }}">
+                                {% csrf_token %}
+                                <input type="hidden" name="next" value="{{ request.get_full_path() }}" />
+                                <input type="hidden" name="revision" value="{{ revision.id }}" />
+                                <button type="submit" name="submit" value="spam">{{ _('spam') }}</button>
+                                <button type="submit" name="submit" value="ham">{{ _('ham') }}</button>
+                            </form>
+
 
                         {% endif %}
                     </td>

--- a/kuma/dashboards/jinja2/dashboards/revisions.html
+++ b/kuma/dashboards/jinja2/dashboards/revisions.html
@@ -132,8 +132,8 @@
         var $thisParent = $this.parent();
         var $detail;
 
-        // Don't interrupt links and stop if a request is already running
-        if (e.target.tagName == 'A' || $this.attr('data-running')) return;
+        // Don't interrupt links or spam buttons, and stop if a request is already running
+        if (e.target.tagName == 'A' || e.target.name == 'submit' || $this.attr('data-running')) return;
 
         if ($this.attr('data-loaded')) {
             $this.next('.dashboard-detail').find('.dashboard-detail-details').slideToggle();

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -94,7 +94,8 @@ class RevisionsDashTest(UserTestCase):
 
         page = pq(response.content)
         ip_button = page.find('td.dashboard-spam')
-        ok_(len(ip_button) > 0)
+        # User must be logged for spam button column to be visible
+        eq_(len(ip_button), 0)
 
     def test_submit_akismet_spam_post_required(self):
         url = reverse('dashboards.submit_akismet_spam', locale='en-US')

--- a/kuma/dashboards/urls.py
+++ b/kuma/dashboards/urls.py
@@ -19,4 +19,7 @@ urlpatterns = [
             url='/docs/MDN/Doc_status/Overview',
             permanent=True,
         )),
+    url(r'^dashboards/submit_akismet_spam$',
+        views.submit_akismet_spam,
+        name='dashboards.submit_akismet_spam'),
 ]

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -103,6 +103,7 @@ def revisions(request):
             request.user.is_superuser
         ),
         'show_spam_submission': (
+            request.user.is_authenticated() and
             request.user.has_akismet_submission_permission()
         ),
     }
@@ -156,7 +157,7 @@ def submit_akismet_spam(request):
     url = request.POST.get('next')
     if url is None or not is_safe_url(url, request.get_host()):
         url = reverse('dashboards.revisions')
-    if request.user.has_akismet_submission_permission():
+    if request.user.is_authenticated() and request.user.has_akismet_submission_permission():
         revision = request.POST.get('revision', 0)
         revision = Revision.objects.get(pk=revision)
         submission_type = request.POST.get('submit', 'spam')

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -2,6 +2,7 @@ import datetime
 import json
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
@@ -104,7 +105,7 @@ def revisions(request):
         ),
         'show_spam_submission': (
             request.user.is_authenticated() and
-            request.user.has_akismet_submission_permission()
+            request.user.has_perm('wiki.add_revisionakismetsubmission')
         ),
     }
 
@@ -152,16 +153,16 @@ def topic_lookup(request):
 
 
 @require_POST
+@permission_required('wiki.add_revisionakismetsubmission')
 def submit_akismet_spam(request):
     """Creates SPAM or HAM Akismet record for revision"""
     url = request.POST.get('next')
     if url is None or not is_safe_url(url, request.get_host()):
         url = reverse('dashboards.revisions')
-    if request.user.is_authenticated() and request.user.has_akismet_submission_permission():
-        revision = request.POST.get('revision', 0)
-        revision = Revision.objects.get(pk=revision)
-        submission_type = request.POST.get('submit', 'spam')
-        RevisionAkismetSubmission.objects.create(
-            sender=request.user, revision=revision, type=submission_type)
+    revision = request.POST.get('revision', 0)
+    revision = Revision.objects.get(pk=revision)
+    submission_type = request.POST.get('submit', 'spam')
+    RevisionAkismetSubmission.objects.create(
+        sender=request.user, revision=revision, type=submission_type)
 
     return redirect(url)

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -159,8 +159,12 @@ def submit_akismet_spam(request):
     url = request.POST.get('next')
     if url is None or not is_safe_url(url, request.get_host()):
         url = reverse('dashboards.revisions')
-    revision = request.POST.get('revision', 0)
-    revision = Revision.objects.get(pk=revision)
+    revision = request.POST.get('revision')
+    try:
+        revision = Revision.objects.get(pk=revision)
+    except Revision.DoesNotExist:
+        return redirect(url)
+
     submission_type = request.POST.get('submit', 'spam')
     RevisionAkismetSubmission.objects.create(
         sender=request.user, revision=revision, type=submission_type)

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -194,3 +194,7 @@ class User(AbstractUser):
 
     def allows_editing_by(self, user):
         return user.is_staff or user.is_superuser or user.pk == self.pk
+
+    def has_akismet_submission_permission(self):
+        return (self.groups.filter(permissions__codename=u'add_revisionakismetsubmission').count() or
+                self.user_permissions.filter(codename=u'add_revisionakismetsubmission').count())

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -194,7 +194,3 @@ class User(AbstractUser):
 
     def allows_editing_by(self, user):
         return user.is_staff or user.is_superuser or user.pk == self.pk
-
-    def has_akismet_submission_permission(self):
-        return (self.groups.filter(permissions__codename=u'add_revisionakismetsubmission').exists() or
-                 self.user_permissions.filter(codename=u'add_revisionakismetsubmission').exists())

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -196,5 +196,5 @@ class User(AbstractUser):
         return user.is_staff or user.is_superuser or user.pk == self.pk
 
     def has_akismet_submission_permission(self):
-        return (self.groups.filter(permissions__codename=u'add_revisionakismetsubmission').count() or
-                self.user_permissions.filter(codename=u'add_revisionakismetsubmission').count())
+        return (self.groups.filter(permissions__codename=u'add_revisionakismetsubmission').exists() or
+                 self.user_permissions.filter(codename=u'add_revisionakismetsubmission').exists())


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1268642

- Replaced Django admin links for Spam/Ham with form buttons that call a new view **submit_akismet_spam**
- New post view **submit_akismet_spam** that creates the spam/ham RevisionAkismetSubmission record with one click from the dashboard page. This new view checks that the user has the correct Akismet permissions before creating this record and redirecting back to the same dashboard page that they were on.
- Tests for this new view
- New model method on kuma.models.users.models.User, checks for Akismet permission: has_akismet_submission_permission
  - This new method used in dashboard view to determine show_spam_submission

Possible TODO's:
- Switch Spam/Ham submission to AJAX view. Right now it's a post with a redirect.
- Look into adding messages to the user for errors (ie. no Akismet permission) and success (ie. Spam submission sent). Might need more guidance on how & where to add these. 