### PR TITLE
bug 1273007 - Fix indexing, paths ending in .json

### DIFF
--- a/media/robots.txt
+++ b/media/robots.txt
@@ -39,6 +39,6 @@ Disallow: /*docs*$restore
 Disallow: /*docs*$purge
 Disallow: /*docs*$subscribe
 Disallow: /*docs*$vote
-Disallow: /*docs*.json
+Disallow: /*docs.json
 Disallow: /*preview-wiki-content
 Disallow: /*move-requested


### PR DESCRIPTION
Fix the robots.txt rule so that paths like this are indexed:

``en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json``

but the API endpoint is still not indexed:

``en-US/docs.json?slug=Mozilla``