### PR TITLE
bug 1272796 - Remove HAM option from dashboard

### DIFF
--- a/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
@@ -93,8 +93,7 @@
                                 {% csrf_token %}
                                 <input type="hidden" name="next" value="{{ request.get_full_path() }}" />
                                 <input type="hidden" name="revision" value="{{ revision.id }}" />
-                                <button type="submit" name="submit" value="spam">{{ _('spam') }}</button>
-                                <button type="submit" name="submit" value="ham">{{ _('ham') }}</button>
+                                <button type="submit" name="submit">{{ _('spam') }}</button>
                             </form>
 
 

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -108,7 +108,6 @@ class RevisionsDashTest(UserTestCase):
         revision = Revision.objects.first()
         data = {
             'revision': revision.pk,
-            'submit': u'spam',
             'next': urlnext
         }
         p1 = Permission.objects.get(codename='add_revisionakismetsubmission')
@@ -131,7 +130,6 @@ class RevisionsDashTest(UserTestCase):
         revision = Revision.objects.first()
         data = {
             'revision': revision.pk,
-            'submit': u'spam',
             'next': urlnext
         }
         self.client.login(username='testuser', password='testpass')
@@ -150,7 +148,6 @@ class RevisionsDashTest(UserTestCase):
         revision = Revision.objects.first()
         data = {
             'revision': revision.pk,
-            'submit': u'spam',
         }
         self.client.login(username='admin', password='testpass')
 
@@ -169,7 +166,6 @@ class RevisionsDashTest(UserTestCase):
         revision_dne = '9999999'
         data = {
             'revision': revision_dne,
-            'submit': u'spam',
         }
         self.client.login(username='admin', password='testpass')
 

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -165,8 +165,7 @@ def submit_akismet_spam(request):
     except Revision.DoesNotExist:
         return redirect(url)
 
-    submission_type = request.POST.get('submit', 'spam')
     RevisionAkismetSubmission.objects.create(
-        sender=request.user, revision=revision, type=submission_type)
+        sender=request.user, revision=revision, type='spam')
 
     return redirect(url)


### PR DESCRIPTION
Refers to bug https://bugzilla.mozilla.org/show_bug.cgi?id=1272796

- Remove HAM option from form. 
- Don't check for the spam/ham option in the submit_akismet_spam view, default to spam. 
- Remove spam submit value from tests.