### PR TITLE
bug 1268642 - Submit spam to Akismet when spam is clicked on the dashboard

### DIFF
--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -97,88 +97,6 @@ class RevisionsDashTest(UserTestCase):
         # Revisions available, admin has privileges to see this
         ok_(len(ip_button) > 0)
 
-    def test_submit_akismet_spam_post_required(self):
-        url = reverse('dashboards.submit_akismet_spam', locale='en-US')
-        response = self.client.get(url)
-        eq_(response.status_code, 405, "GET should not be allowed.")
-
-    def test_submit_akismet_spam_valid_response(self):
-        urlquery = '?' + urllib.urlencode({'page': 3})
-        urlnext = reverse('dashboards.revisions', locale='en-US') + urlquery
-        revision = Revision.objects.first()
-        data = {
-            'revision': revision.pk,
-            'next': urlnext
-        }
-        p1 = Permission.objects.get(codename='add_revisionakismetsubmission')
-        testuser = User.objects.get(username='testuser')
-        testuser.user_permissions.add(p1)
-        self.client.login(username='testuser', password='testpass')
-
-        # Response should redirect back to the revisions dash
-        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
-        response = self.client.post(urlpost, data=data)
-        eq_(response.status_code, 302)
-        eq_(response.url, 'http://testserver' + urlnext)
-
-        # 1 RevisionAkismetSubmission record should exist for this revision
-        ras = RevisionAkismetSubmission.objects.get(revision=revision)
-        eq_(ras.type, u'spam')
-
-    def test_submit_akismet_spam_no_permission(self):
-        urlnext = reverse('dashboards.revisions', locale='en-US')
-        revision = Revision.objects.first()
-        data = {
-            'revision': revision.pk,
-            'next': urlnext
-        }
-        self.client.login(username='testuser', password='testpass')
-
-        # Response should redirect back to the revisions dash
-        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
-        response = self.client.post(urlpost, data=data)
-        eq_(response.status_code, 302)
-
-        # No RevisionAkismetSubmission record should exist, user does not have permission
-        ras = RevisionAkismetSubmission.objects.filter(revision=revision)
-        eq_(ras.count(), 0)
-
-    def test_submit_akismet_spam_no_url_in_next_variable(self):
-        urlnext = reverse('dashboards.revisions')
-        revision = Revision.objects.first()
-        data = {
-            'revision': revision.pk,
-        }
-        self.client.login(username='admin', password='testpass')
-
-        # Response should redirect back to the revisions dash
-        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
-        response = self.client.post(urlpost, data=data)
-        eq_(response.status_code, 302)
-        eq_(response.url, 'http://testserver' + urlnext)
-
-        # 1 RevisionAkismetSubmission record should exist for this revision
-        ras = RevisionAkismetSubmission.objects.get(revision=revision)
-        eq_(ras.type, u'spam')
-
-    def test_submit_akismet_spam_revision_dne(self):
-        urlnext = reverse('dashboards.revisions')
-        revision_dne = '9999999'
-        data = {
-            'revision': revision_dne,
-        }
-        self.client.login(username='admin', password='testpass')
-
-        # Response should redirect back to the revisions dash
-        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
-        response = self.client.post(urlpost, data=data)
-        eq_(response.status_code, 302)
-        eq_(response.url, 'http://testserver' + urlnext)
-
-        # Zero RevisionAkismetSubmission records should exist for this nonexistent revision
-        ras = RevisionAkismetSubmission.objects.filter(revision__pk=revision_dne)
-        eq_(ras.count(), 0)
-
     def test_locale_filter(self):
         url = urlparams(reverse('dashboards.revisions', locale='fr'),
                         locale='fr')
@@ -313,3 +231,90 @@ class RevisionsDashTest(UserTestCase):
         revisions = page.find('.dashboard-row')
 
         eq_(5, revisions.length)
+
+
+@pytest.mark.spam
+class SubmitAkismetSpamViewTest(UserTestCase):
+    fixtures = UserTestCase.fixtures + ['wiki/documents.json']
+
+    def test_post_required(self):
+        url = reverse('dashboards.submit_akismet_spam', locale='en-US')
+        response = self.client.get(url)
+        eq_(response.status_code, 405, "GET should not be allowed.")
+
+    def test_valid_response(self):
+        urlquery = '?' + urllib.urlencode({'page': 3})
+        urlnext = reverse('dashboards.revisions', locale='en-US') + urlquery
+        revision = Revision.objects.first()
+        data = {
+            'revision': revision.pk,
+            'next': urlnext
+        }
+        p1 = Permission.objects.get(codename='add_revisionakismetsubmission')
+        testuser = User.objects.get(username='testuser')
+        testuser.user_permissions.add(p1)
+        self.client.login(username='testuser', password='testpass')
+
+        # Response should redirect back to the revisions dash
+        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
+        response = self.client.post(urlpost, data=data)
+        eq_(response.status_code, 302)
+        eq_(response.url, 'http://testserver' + urlnext)
+
+        # 1 RevisionAkismetSubmission record should exist for this revision
+        ras = RevisionAkismetSubmission.objects.get(revision=revision)
+        eq_(ras.type, u'spam')
+
+    def test_no_permission(self):
+        urlnext = reverse('dashboards.revisions', locale='en-US')
+        revision = Revision.objects.first()
+        data = {
+            'revision': revision.pk,
+            'next': urlnext
+        }
+        self.client.login(username='testuser', password='testpass')
+
+        # Response should redirect back to the revisions dash
+        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
+        response = self.client.post(urlpost, data=data)
+        eq_(response.status_code, 302)
+
+        # No RevisionAkismetSubmission record should exist, user does not have permission
+        ras = RevisionAkismetSubmission.objects.filter(revision=revision)
+        eq_(ras.count(), 0)
+
+    def test_no_url_in_next_variable(self):
+        urlnext = reverse('dashboards.revisions')
+        revision = Revision.objects.first()
+        data = {
+            'revision': revision.pk,
+        }
+        self.client.login(username='admin', password='testpass')
+
+        # Response should redirect back to the revisions dash
+        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
+        response = self.client.post(urlpost, data=data)
+        eq_(response.status_code, 302)
+        eq_(response.url, 'http://testserver' + urlnext)
+
+        # 1 RevisionAkismetSubmission record should exist for this revision
+        ras = RevisionAkismetSubmission.objects.get(revision=revision)
+        eq_(ras.type, u'spam')
+
+    def test_revision_dne(self):
+        urlnext = reverse('dashboards.revisions')
+        revision_dne = '9999999'
+        data = {
+            'revision': revision_dne,
+        }
+        self.client.login(username='admin', password='testpass')
+
+        # Response should redirect back to the revisions dash
+        urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
+        response = self.client.post(urlpost, data=data)
+        eq_(response.status_code, 302)
+        eq_(response.url, 'http://testserver' + urlnext)
+
+        # Zero RevisionAkismetSubmission records should exist for this nonexistent revision
+        ras = RevisionAkismetSubmission.objects.filter(revision__pk=revision_dne)
+        eq_(ras.count(), 0)

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -2,7 +2,9 @@ import urllib
 import pytest
 from pyquery import PyQuery as pq
 
+from constance.test import override_config
 from django.contrib.auth.models import Permission
+import requests_mock
 
 from waffle.models import Flag, Switch
 
@@ -10,7 +12,8 @@ from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
-from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
+from kuma.spam.akismet import Akismet
+from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
 from kuma.users.tests import UserTestCase
 from kuma.users.models import User, UserBan
 from kuma.wiki.models import Revision, RevisionAkismetSubmission
@@ -242,7 +245,9 @@ class SubmitAkismetSpamViewTest(UserTestCase):
         response = self.client.get(url)
         eq_(response.status_code, 405, "GET should not be allowed.")
 
-    def test_valid_response(self):
+    @override_config(AKISMET_KEY='dashboard')
+    @requests_mock.mock()
+    def test_valid_response(self, mock_requests):
         urlquery = '?' + urllib.urlencode({'page': 3})
         urlnext = reverse('dashboards.revisions', locale='en-US') + urlquery
         revision = Revision.objects.first()
@@ -250,10 +255,13 @@ class SubmitAkismetSpamViewTest(UserTestCase):
             'revision': revision.pk,
             'next': urlnext
         }
+        Flag.objects.create(name=SPAM_SUBMISSIONS_FLAG, everyone=True)
         p1 = Permission.objects.get(codename='add_revisionakismetsubmission')
         testuser = User.objects.get(username='testuser')
         testuser.user_permissions.add(p1)
         self.client.login(username='testuser', password='testpass')
+        mock_requests.post(VERIFY_URL, content='valid')
+        mock_requests.post(SPAM_URL, content=Akismet.submission_success)
 
         # Response should redirect back to the revisions dash
         urlpost = reverse('dashboards.submit_akismet_spam', locale='en-US')
@@ -264,6 +272,10 @@ class SubmitAkismetSpamViewTest(UserTestCase):
         # 1 RevisionAkismetSubmission record should exist for this revision
         ras = RevisionAkismetSubmission.objects.get(revision=revision)
         eq_(ras.type, u'spam')
+
+        # Akismet endpoints were called
+        ok_(mock_requests.called)
+        eq_(mock_requests.call_count, 2)
 
     def test_no_permission(self):
         urlnext = reverse('dashboards.revisions', locale='en-US')

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -160,6 +160,8 @@ class DocumentSpamAttemptAdminTestCase(UserTestCase):
         assert dsa.review == DocumentSpamAttempt.HAM
         assert dsa.reviewer == self.admin_user
         assert dsa.reviewed is not None
+        assert mock_requests.called
+        assert mock_requests.call_count == 2
 
     @override_config(AKISMET_KEY='')
     @requests_mock.mock()
@@ -275,6 +277,9 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
             ('user_ip', '0.0.0.0')
         ]
         self.assertEqual(sorted(query_pairs), expected)
+
+        assert mock_requests.called
+        assert mock_requests.call_count == 2
 
     @requests_mock.mock()
     def test_spam_submission_tags(self, mock_requests):


### PR DESCRIPTION
The code to submit missed spam to Akismet is in the form ``clean`` method, so the new "one-click" code doesn't submit to Akismet.

This PR:
* Moves the ``submit_akismet_spam`` tests into their own test class
* Converts ``submit_akismet_spam`` to use a form derived from ``RevisionAkismetSubmissionAdminForm``
* Verifies that Akismet is called in these and some other tests
* Update docstrings and drop an unused method