### PR TITLE
bug 1272787 - remove 2 of the 3 admin links from email template

### DIFF
--- a/kuma/wiki/jinja2/wiki/email/spam.ltxt
+++ b/kuma/wiki/jinja2/wiki/email/spam.ltxt
@@ -22,7 +22,6 @@ ID: {{ spam_attempt.user.pk }}
 Joined at: {{ spam_attempt.user.date_joined|in_utc }}
 
 Profile link: {{ spam_attempt.user.get_absolute_url()|absolutify }}
-Admin link: {{ url('admin:users_user_change', spam_attempt.user.pk)|absolutify }}
 
 * DOCUMENT *
 
@@ -33,7 +32,6 @@ Language: {{ spam_attempt.document.language }}
 Last modified: {{ spam_attempt.document.modified|in_utc }}
 
 Site link: {{ spam_attempt.document.get_absolute_url()|absolutify }}
-Admin link: {{ url('admin:wiki_document_change', spam_attempt.document.pk)|absolutify }}
 {% else -%}
 The {% if is_error %}Akismet error{% else %}spam attempt{% endif %} doesn't have a document attached
 {% endif -%}


### PR DESCRIPTION
This pull request removes 2 of the 3 admin links from the spam attempt email.