### PR TITLE
bug 1272790 - akismet submission in admin make revision link to public site

### DIFF
--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -485,10 +485,9 @@ class RevisionAkismetSubmissionAdmin(DisabledDeletionMixin, admin.ModelAdmin):
                          self).get_fields(request, obj)
 
     def revision_with_link(self, obj):
-        """Admin link to the revision"""
+        """Link to the revision public page"""
         if obj.revision_id:
-            admin_link = reverse('admin:wiki_revision_change',
-                                 args=[obj.revision.id])
+            admin_link = obj.revision.get_absolute_url()
             return ('<a target="_blank" href="%s">%s</a>' %
                     (admin_link, escape(obj.revision)))
         else:

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -369,7 +369,6 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
         url = reverse('admin:wiki_revisionakismetsubmission_changelist')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        revision_url = reverse('admin:wiki_revision_change',
-                               args=[revision.id])
+        revision_url = revision.get_absolute_url()
         self.assertIn(revision_url, response.content)
         self.assertIn('None', response.content)


### PR DESCRIPTION
This pull request changes the link in the Akimset submissions django admin view under “REVISION” from the revision’s admin page to the revision’s public page and updates the related test.