### PR TITLE
bug 1272793 - spam admins can ban users without django admin

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1209,6 +1209,12 @@ CONSTANCE_CONFIG = dict(
         ]),
         "JSON array listing tag suggestions for documents"
     ),
+    COMMON_REASONS_TO_BAN_USERS=(
+        json.dumps([
+            'Spam', 'Profile Spam ', 'Sandboxing', 'Incorrect Translation', 'Penetration Testing',
+        ]),
+        "JSON array listing some common reasons to ban users",
+    ),
     SESSION_CLEANUP_CHUNK_SIZE=(
         1000,
         'Number of expired sessions to cleanup up in one go.',

--- a/kuma/static/styles/user-banned.styl
+++ b/kuma/static/styles/user-banned.styl
@@ -10,3 +10,7 @@
         }
     }
 }
+
+.ban-common-reason{
+    margin-bottom: 4px;
+}

--- a/kuma/users/jinja2/users/ban_user.html
+++ b/kuma/users/jinja2/users/ban_user.html
@@ -9,6 +9,7 @@
 {% block site_css %}
   {{ super() }}
   {% stylesheet 'users' %}
+  {% stylesheet 'user-banned' %}
 {% endblock %}
 
 {% block content %}
@@ -23,7 +24,7 @@
         <div class="column-4">
           <h5>{{ _('Choose a reason') }}:</h5>
           {% for reason in common_reasons %}
-            <div><a class="ban-common-reason">{{ _(reason) }}</a></div>
+            <div><button class="ban-common-reason">{{ _(reason) }}</button></div>
           {% endfor %}
         </div>
 

--- a/kuma/users/jinja2/users/ban_user.html
+++ b/kuma/users/jinja2/users/ban_user.html
@@ -18,7 +18,7 @@
     <section id="user-head" class="column-container column-container-reverse vcard user-head">
       <div class="column-10">
         <h1 class="user-title">
-          {{ _('Why are you banning') }} {{user_to_ban }}?
+          {{ _('Why are you banning %(user)s', user=user_to_ban) }}?
         </h1>
         <div class="column-4">
           <h5>{{ _('Choose a reason') }}:</h5>
@@ -30,6 +30,7 @@
         <h5>{{ _('or enter a reason in the text box below') }}:</h5>
         <form method="post" id="ban-user-form" action="{{ url('users.ban_user',user_to_ban.id) }}">
           {% csrf_token %}
+          {{ form.reason.errors }}
           <div>{{ form.reason }}</div>
           <input type="hidden" name="previous-url" value={{ previous_url }}></input>
           <button type="submit">{{ _('Ban user') }}</button>

--- a/kuma/users/jinja2/users/ban_user.html
+++ b/kuma/users/jinja2/users/ban_user.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block body_attributes %}{% endblock %}
+
+{% block bodyclass %}user ban-user{% endblock %}
+
+{% block title %}Ban {{ user_to_ban }}{% endblock %}
+
+{% block site_css %}
+  {{ super() }}
+  {% stylesheet 'users' %}
+{% endblock %}
+
+{% block content %}
+<section id="content">
+<div class="wrap">
+  <section id="content-main" class="full">
+    <section id="user-head" class="column-container column-container-reverse vcard user-head">
+      <div class="column-10">
+        <h1 class="user-title">
+          {{ _('Why are you banning') }} {{user_to_ban }}?
+        </h1>
+        <div class="column-4">
+          <h5>{{ _('Choose a reason') }}:</h5>
+          {% for reason in common_reasons %}
+            <div><a class="ban-common-reason">{{ _(reason) }}</a></div>
+          {% endfor %}
+        </div>
+
+        <h5>{{ _('or enter a reason in the text box below') }}:</h5>
+        <form method="post" id="ban-user-form" action="{{ url('users.ban_user',user_to_ban.id) }}">
+          {% csrf_token %}
+          <div>{{ form.reason }}</div>
+          <input type="hidden" name="previous-url" value={{ previous_url }}></input>
+          <button type="submit">{{ _('Ban user') }}</button>
+        </form>
+      </div>
+    </section>
+  </section>
+</div>
+</section>
+{% endblock %}
+
+{% block js %}
+<script>
+(function (jQuery) {
+    'use strict';
+    $('.ban-common-reason').on('click', function(){
+      $('#id_reason').val($(this).html())
+    });
+})(jQuery);
+</script>
+{% endblock %}

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -41,9 +41,7 @@ def ban_link(context, ban_user, banner_user):
                     '<i aria-hidden="true" class="icon-ban"></i></a>'
                     % (url, title, ugettext('Banned')))
         else:
-            url = '%s?user=%s&by=%s' % (
-                reverse('admin:users_userban_add'), ban_user.id,
-                banner_user.id)
+            url = reverse('users.ban_user', kwargs={'user_id': ban_user.id})
             link = ('<a href="%s" class="button negative ban-link">%s'
                     '<i aria-hidden="true" class="icon-ban"></i></a>'
                     % (url, ugettext('Ban User')))

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -109,6 +109,26 @@ class BanTestCase(UserTestCase):
         response = self.client.get(url, follow=True)
         self.assertNotEqual(response.status_code, 403)
 
+    def test_get_ban_user_view(self):
+        # For an unbanned user get the ban_user view
+        testuser = self.user_model.objects.get(username='testuser')
+        admin = self.user_model.objects.get(username='admin')
+
+        self.client.login(username='admin', password='testpass')
+        ban_url = reverse('users.ban_user',
+                          kwargs={'user_id': testuser.id})
+
+        resp = self.client.get(ban_url)
+        eq_(200, resp.status_code)
+
+        # For a banned user redirect to user detail page
+        UserBan.objects.create(user=testuser, by=admin,
+                               reason='Banned by unit test.',
+                               is_active=True)
+        resp = self.client.get(ban_url)
+        eq_(302, resp.status_code)
+        ok_(testuser.get_absolute_url() in resp['Location'])
+
 
 class UserViewsTest(UserTestCase):
     localizing_client = True

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -142,7 +142,7 @@ class BanTestCase(UserTestCase):
         eq_(200, resp.status_code)
         page = pq(resp.content)
 
-        reasons_to_ban_found = page.find('a.ban-common-reason')
+        reasons_to_ban_found = page.find('.ban-common-reason')
         reasons_to_ban_expected = json.loads(
             constance_config.COMMON_REASONS_TO_BAN_USERS
         )
@@ -151,6 +151,8 @@ class BanTestCase(UserTestCase):
         for reason in reasons_to_ban_found:
             ok_(reason.text in reasons_to_ban_expected)
 
+    @override_config(COMMON_REASONS_TO_BAN_USERS='Not valid JSON')
+    def test_common_reasons_error(self):
         # If there is an error in getting the common reasons from constance,
         # then 'Spam' should still show up in the template as the default
         testuser = self.user_model.objects.get(username='testuser')
@@ -159,19 +161,19 @@ class BanTestCase(UserTestCase):
         ban_url = reverse('users.ban_user',
                           kwargs={'user_id': testuser.id})
 
-        constance_config.COMMON_REASONS_TO_BAN_USERS = 'not valid JSON'
-
         resp = self.client.get(ban_url)
         eq_(200, resp.status_code)
         page = pq(resp.content)
 
-        reasons_to_ban_found = page.find('a.ban-common-reason')
+        reasons_to_ban_found = page.find('.ban-common-reason')
         reasons_to_ban_expected = ['Spam']
 
         eq_(len(reasons_to_ban_found), len(reasons_to_ban_expected))
         for reason in reasons_to_ban_found:
             ok_(reason.text in reasons_to_ban_expected)
 
+    @override_config(COMMON_REASONS_TO_BAN_USERS='[]')
+    def test_common_reasons_empty(self):
         # If the list of common reasons to ban users in constance is empty,
         # then 'Spam' should still show up in the template as the default
         testuser = self.user_model.objects.get(username='testuser')
@@ -180,13 +182,11 @@ class BanTestCase(UserTestCase):
         ban_url = reverse('users.ban_user',
                           kwargs={'user_id': testuser.id})
 
-        constance_config.COMMON_REASONS_TO_BAN_USERS = '[]'
-
         resp = self.client.get(ban_url)
         eq_(200, resp.status_code)
         page = pq(resp.content)
 
-        reasons_to_ban_found = page.find('a.ban-common-reason')
+        reasons_to_ban_found = page.find('.ban-common-reason')
         reasons_to_ban_expected = ['Spam']
 
         eq_(len(reasons_to_ban_found), len(reasons_to_ban_expected))

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -64,11 +64,17 @@ def ban_user(request, user_id):
                           is_active=True)
             ban.save()
             return redirect(user)
+    if user.active_ban:
+        return redirect(user)
     form = UserBanForm()
+    # A list of common reasons for banning a user
+    common_reasons = ['Spam', 'Profile Spam ', 'Sandboxing',
+                      'Incorrect Translation', 'Penetration Testing']
     return render(request,
                   'users/ban_user.html',
                   {'form': form,
-                   'user': user})
+                   'user_to_ban': user,
+                   'common_reasons': common_reasons})
 
 
 def user_detail(request, username):

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -65,9 +65,12 @@ def ban_user(request, user_id):
                           is_active=True)
             ban.save()
             return redirect(user)
-    if user.active_ban:
-        return redirect(user)
-    form = UserBanForm()
+        else:
+            form = UserBanForm(request.POST)
+    else:
+        if user.active_ban:
+            return redirect(user)
+        form = UserBanForm()
     # A list of common reasons for banning a user, loaded from constance
     try:
         common_reasons = json.loads(config.COMMON_REASONS_TO_BAN_USERS)

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,4 +1,5 @@
 import collections
+import json
 import operator
 
 from allauth.account.adapter import get_adapter
@@ -67,9 +68,14 @@ def ban_user(request, user_id):
     if user.active_ban:
         return redirect(user)
     form = UserBanForm()
-    # A list of common reasons for banning a user
-    common_reasons = ['Spam', 'Profile Spam ', 'Sandboxing',
-                      'Incorrect Translation', 'Penetration Testing']
+    # A list of common reasons for banning a user, loaded from constance
+    try:
+        common_reasons = json.loads(config.COMMON_REASONS_TO_BAN_USERS)
+    except (TypeError, ValueError):
+        common_reasons = ['Spam']
+    else:
+        if not common_reasons:
+            common_reasons = ['Spam']
     return render(request,
                   'users/ban_user.html',
                   {'form': form,

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -65,8 +65,6 @@ def ban_user(request, user_id):
                           is_active=True)
             ban.save()
             return redirect(user)
-        else:
-            form = UserBanForm(request.POST)
     else:
         if user.active_ban:
             return redirect(user)


### PR DESCRIPTION
This pull request uses the previously-created-but-unused `users.ban_user` view. A GET to this url will display the UserBanForm (with only a 'reason' field) and several common reasons for banning users.
A POST to this url will attempt to save the `UserBan` and return the user to the profile page of the user being banned. Banning requires the `users.add_userban` permission.