### PR TITLE
Fix bug 1265151 - Missing translation of some strings

### DIFF
--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -92,7 +92,7 @@
                     action: 'Clicked',
                     label: label
                 });
-                notification[type](gettext(msg), 2000);
+                notification[type](msg, 2000);
             }
         }
     }

--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -42,7 +42,7 @@
         // answers to the simple question include...
         $('#helpful-yes').on('click', function(e) {
             e.preventDefault();
-            confirm('Thanks for your feedback!', 'success', 'Yes');
+            confirm(gettext('Thanks for your feedback!'), 'success', 'Yes');
         });
         $('#helpful-no').on('click', function(e) {
             e.preventDefault();
@@ -51,7 +51,7 @@
         $('#helpful-ignore').on('click', function(e) {
             e.preventDefault();
             localStorage.setItem('helpful-ignore', 'true');
-            confirm("We won't bug you again.", 'info', 'Ignore');
+            confirm(gettext("We won't bug you again."), 'info', 'Ignore');
         });
 
         // create a dropdown in case the page is unhelpful

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -580,14 +580,14 @@
         var nowString = now.toLocaleDateString() + ' ' + now.toLocaleTimeString();
         localStorage.setItem(DRAFT_NAME + '#save-time', nowString);
         // update UI
-        updateDraftState(gettext(draftState));
+        updateDraftState(draftState);
         $draftButton.attr('disabled', 'disabled');
     }
 
     function manualSaveDraft(val) {
         var currentContent = $form.find('textarea[name=content]').val();
         // save draft
-        saveDraft(currentContent, 'saved');
+        saveDraft(currentContent, gettext('saved'));
         // disable autosave when saving manually
         enableAutoSave(false);
     }
@@ -606,7 +606,7 @@
             var currentMatchesStart = contentMatches(currentContent, startingContent);
 
             if(!draftMatchesDraft && !currentMatchesStart) {
-                saveDraft(currentContent, 'autosaved');
+                saveDraft(currentContent, gettext('autosaved'));
             }
         }
     }

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,6 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-					var $text = interpolate(gettext('Open in %(site)s '), {site: this});
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,7 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-                    var $text = gettext('Open in ') + this + ' ';
+                    var $text = ngettext('Open in %(site)s ', this);
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,6 +94,7 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
+                    var $text = interpolate(gettext('Open in %(site)s '), {site: this});
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,7 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-                    var $text = ngettext('Open in %(site)s ', this);
+					var $text = interpolate(gettext('Open in %(site)s '), {site: this});
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,7 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-                    var $text = 'Open in ' + this + ' ';
+                    var $text = gettext('Open in ') + this + ' ';
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);

--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -29,7 +29,7 @@
         {% elif tag|string == 'technical' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_a_technical_review') + '#core-steps' %}
-            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.
+            Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.
             {% endtrans %}
           </p>
         {% endif %}

--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -23,13 +23,13 @@
         {% if tag|string=='editorial' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') + '#core-steps' %}
-            {{ _('Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="{{ url }}">See more detailed instructions</a>.') }}
+            {{ _('Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="%(url)s">See more detailed instructions</a>.', url=url) }}
             {% endtrans %}
           </p>
         {% elif tag|string == 'technical' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_a_technical_review') + '#core-steps' %}
-            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.') }}
+            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="%(url)s">See more detailed instructions</a>.', url=url) }}
             {% endtrans %}
           </p>
         {% endif %}

--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -23,13 +23,13 @@
         {% if tag|string=='editorial' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') + '#core-steps' %}
-            Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="{{ url }}">See more detailed instructions</a>.
+            {{ _('Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="{{ url }}">See more detailed instructions</a>.') }}
             {% endtrans %}
           </p>
         {% elif tag|string == 'technical' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_a_technical_review') + '#core-steps' %}
-            Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.
+            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.') }}
             {% endtrans %}
           </p>
         {% endif %}

--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -23,13 +23,13 @@
         {% if tag|string=='editorial' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_an_editorial_review') + '#core-steps' %}
-            {{ _('Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="%(url)s">See more detailed instructions</a>.', url=url) }}
+            Please review these articles for spelling, grammar, formatting, layout, etc., and then clear the Editorial review flag. <a href="{{ url }}">See more detailed instructions</a>.
             {% endtrans %}
           </p>
         {% elif tag|string == 'technical' %}
           <p>
             {% trans url=wiki_url('MDN/Contribute/Howto/Do_a_technical_review') + '#core-steps' %}
-            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="%(url)s">See more detailed instructions</a>.', url=url) }}
+            {{ _('Please review these articles for technical accuracy and completeness, and then clear the Technical review flag. <a href="{{ url }}">See more detailed instructions</a>.
             {% endtrans %}
           </p>
         {% endif %}


### PR DESCRIPTION
I added localization for strings 'Thanks for your feedback!' and "We
won't bug you again."