### PR TITLE
fix bug 1012106: use language icon for switching languages

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -16,7 +16,7 @@
 
   <ul class="page-buttons" data-sticky="false">
       {% if not document.is_template %}
-      <li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-globe"></i></button>
+      <li><button id="languages-menu" class="transparent" aria-haspopup="true" aria-owns="languages-menu-submenu" aria-expanded="false"><span>{{ _('Languages') }}</span><i aria-hidden="true" class="icon-language"></i></button>
 
         <div class="submenu js-submenu" id="languages-menu-submenu">
           <div class="submenu-column">


### PR DESCRIPTION
Fix for [bug 1012106](https://bugzilla.mozilla.org/show_bug.cgi?id=1012106) -- seems very straightforward.