### PR TITLE
Bug 1265151 - interpolate(gettext('Open in %(site)s'), {site: this}) doesn't work

### DIFF
--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,8 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-                    var $text = interpolate(gettext('Open in %(site)s '), {site: this});
+                    var $text = gettext('Open in ')+this;
+					
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);


### PR DESCRIPTION
OMG! There's a bug: interpolate(gettext('Open in %(site)s'), {site: this}); doesn't put a site in the string. It returns 'Open in %(site)s'. I don't know better solution than gettext('Open in ')+this;