### PR TITLE
bug 1265151 - Add space back to sample buttons

### DIFF
--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -94,7 +94,7 @@
                     // create icon
                     var $icon = $('<i />', { 'class': 'icon-' + sampleCodeHost, 'aria-hidden': 'true' });
                     // create text
-                    var $text = interpolate(gettext('Open in %(site)s'), {site: this}, true);
+                    var $text = interpolate(gettext('Open in %(site)s'), {site: this}, true) + ' ';
 
                     // add button icon and text to DOM
                     $button.append($text).append($icon).appendTo($buttonContainer);


### PR DESCRIPTION
While marking the text "Open in Codepen" for translation, the space between the text and the icon was lost. It doesn't really belong in the translated string, adding it as a literal string to the button.

[Live on MDN](https://developer.mozilla.org/en-US/docs/User:stephaniehobson:code#Code_sample_template):

<img width="345" alt="without_space" src="https://cloud.githubusercontent.com/assets/286017/15585083/4d4a3904-2343-11e6-9b2f-a295fca31aa7.png">

With this change:

<img width="346" alt="with_space" src="https://cloud.githubusercontent.com/assets/286017/15585051/24a98e0a-2343-11e6-8d6a-6df0e6f94dc5.png">

