### PR TITLE
New issue 1275322 spam admin info on submission

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -14,3 +14,10 @@
     contact the site administrators</a>.
     {% endtrans %}
 </p>
+{% if perms.wiki.add_revisionakismetsubmission %}
+    <p>
+    {% trans akismet_submission_url = url('admin:wiki_revisionakismetsubmission') %}
+    As a spam moderator you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
+    {% endtrans %}
+    </p>
+{% endif %}

--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -14,10 +14,8 @@
     contact the site administrators</a>.
     {% endtrans %}
 </p>
-{% if perms.wiki.add_revisionakismetsubmission %}
-    <p>
+<p>
     {% trans akismet_submission_url = url('admin:wiki_revisionakismetsubmission_changelist') %}
-    As a spam moderator you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
+    If you are a spam moderator, you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
     {% endtrans %}
-    </p>
-{% endif %}
+</p>

--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -16,7 +16,7 @@
 </p>
 {% if perms.wiki.add_revisionakismetsubmission %}
     <p>
-    {% trans akismet_submission_url = url('admin:wiki_revisionakismetsubmission') %}
+    {% trans akismet_submission_url = url('admin:wiki_revisionakismetsubmission_changelist') %}
     As a spam moderator you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
     {% endtrans %}
     </p>


### PR DESCRIPTION
This addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1275322 and https://tree.taiga.io/project/viya-mdn-durable-team/task/137.

Add a paragraph with a link to the admin to allow spam moderators to mark submissions as ham and try to submit again.

cc @stephaniehobson 