### PR TITLE
Bug 1279839 - Profile page cleanup, use IDs instead of created date for recent activity 

### DIFF
--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -26,7 +26,7 @@ def revisions(request):
     revisions = (Revision.objects.prefetch_related('creator__bans',
                                                    'document',
                                                    'akismet_submissions')
-                                 .order_by('-created')
+                                 .order_by('-id')
                                  .defer('content'))
 
     query_kwargs = False

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -190,7 +190,7 @@ class User(AbstractUser):
     def wiki_revisions(self, count=5):
         return (self.created_revisions.prefetch_related('document')
                                       .defer('content', 'summary')
-                                      .order_by('-created')[:count])
+                                      .order_by('-id')[:count])
 
     def allows_editing_by(self, user):
         return user.is_staff or user.is_superuser or user.pk == self.pk

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -95,12 +95,7 @@ def user_detail(request, username):
         return render(request, '403.html',
                       {'reason': 'bannedprofile'}, status=403)
 
-    docs_feed_items = None
-
-    context = {
-        'detail_user': detail_user,
-        'docs_feed_items': docs_feed_items,
-    }
+    context = {'detail_user': detail_user}
     return render(request, 'users/user_detail.html', context)
 
 

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -166,7 +166,7 @@ class DocumentsRecentFeed(DocumentsFeed):
                             .filter_for_list(tag_name=self.tag,
                                              locale=self.locale)
                             .filter(current_revision__isnull=False)
-                            .order_by('-current_revision__created')
+                            .order_by('-current_revision__id')
                             .values_list('pk', flat=True)[:MAX_FEED_ITEMS])
         return (Document.objects.filter(pk__in=list(item_pks))
                                 .defer('html')
@@ -201,7 +201,7 @@ class DocumentsReviewFeed(DocumentsRecentFeed):
         item_pks = (Document.objects
                             .filter_for_review(tag_name=tag, locale=self.locale)
                             .filter(current_revision__isnull=False)
-                            .order_by('-current_revision__created')
+                            .order_by('-current_revision__id')
                             .values_list('pk', flat=True)[:MAX_FEED_ITEMS])
         return (Document.objects.filter(pk__in=list(item_pks))
                                 .defer('html')
@@ -231,7 +231,7 @@ class DocumentsUpdatedTranslationParentFeed(DocumentsFeed):
                         .prefetch_related('parent')
                         .filter(locale=self.locale, parent__isnull=False)
                         .filter(modified__lt=F('parent__modified'))
-                        .order_by('-parent__current_revision__created')
+                        .order_by('-parent__current_revision__id')
                 [:MAX_FEED_ITEMS])
 
     def get_context_data(self, **kwargs):
@@ -241,7 +241,7 @@ class DocumentsUpdatedTranslationParentFeed(DocumentsFeed):
         obj = context.get('obj')
         trans_based_on_pk = (Revision.objects.filter(document=obj.parent)
                                              .filter(created__lte=obj.modified)
-                                             .order_by('created')
+                                             .order_by('id')
                                              .values_list('pk', flat=True)
                                              .first())
         mod_url = get_compare_url(obj.parent,
@@ -275,7 +275,7 @@ class RevisionsFeed(DocumentsFeed):
 
         # Temporarily storing the selected revision PKs in a list
         # to speed up retrieval (max MAX_FEED_ITEMS size)
-        item_pks = (items.order_by('-created')
+        item_pks = (items.order_by('-id')
                          .values_list('pk', flat=True)[start:finish])
         return (Revision.objects.filter(pk__in=list(item_pks))
                                 .prefetch_related('creator',

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -759,7 +759,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
         Does some specific things when the revision is fully saved.
         """
         # have to check for first edit before we save
-        is_first_edit = self.request.user.wiki_revisions().count() == 0
+        is_first_edit = not self.request.user.wiki_revisions().exists()
 
         # Making sure we don't commit the saving right away since we
         # want to do other things here.

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -156,7 +156,7 @@
 
         </header>
 
-        {% if request.user.wiki_revisions().count() == 0 and not revision_form.errors %}
+        {% if not revision_form.errors and not request.user.created_revisions.exists() %}
           <section class="first-contrib-welcome">
             <h2>{{ _('Thank you for taking the time to improve MDN!') }}</h2>
             <p>


### PR DESCRIPTION
Bring over the profile page cleanup from #3889, but retain the recent docs activity.

Switch to sorting by revision IDs instead of the ``created`` date for identifying recent documents. When tested against a local anonymized database, this gives the same result for every profile, but is much faster. In a worse-case scenario, sorting by ``created`` took 33 seconds, and by ``id`` 0.4 milliseconds.

Use this new sorting strategy on:
* The Recent Docs Activity section on the [user profile](https://developer.mozilla.org/en-US/profiles/jwhitlock)
* [The Revision Dashboard](https://developer.mozilla.org/en-US/dashboards/revisions)
* [Revision RSS feeds](https://developer.mozilla.org/en-US/feeds/rss/revisions)

There are additional places where sorting is done by ``created``, for example when viewing the revisions for a document, that are saved for future investigation, to see if the results are the same and if there is a speed improvement.