### PR TITLE
fix bug 1281038 - Update flake8 and other linters

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -55,15 +55,15 @@ sqlparse==0.1.19 \
     --hash=sha256:d896be1a1c7f24bffe08d7a64e6f0176b260e281c5f3685afe7826f8bada4ee8
 
 # flake8
-mccabe==0.4.0 \
-    --hash=sha256:cbc2938f6c01061bc6d21d0c838c2489664755cb18676f0734d7617f4577d09e \
-    --hash=sha256:9a2b12ebd876e77c72e41ebf401cc2e7c5b566649d50105ca49822688642207b
-pep8==1.7.0 \
-    --hash=sha256:4fc2e478addcf17016657dff30b2d8d611e8341fac19ccf2768802f6635d7b8a \
-    --hash=sha256:a113d5f5ad7a7abacef9df5ec3f2af23a20a28005921577b15dd584d099d5900
-pyflakes==1.0.0 \
-    --hash=sha256:071d121e9e7b33058aa1ba5de7bce9b97bfa3149cfe1acbb6587c21fc1c8eda1 \
-    --hash=sha256:f39e33a4c03beead8774f005bd3ecf0c3f2f264fa0201de965fce0aff1d34263
+mccabe==0.5.0 \
+    --hash=sha256:6c1c06d7bb6bc24a85b11eabc8944c0f6a72e6f35f208d4796dcbb27dae75ee8 \
+    --hash=sha256:379358498f58f69157b53f59f46aefda0e9a3eb81365238f69fbedf7014e21ab
+pycodestyle==2.0.0 \
+    --hash=sha256:2ce83f2046f5ab85c652ceceddfbde7a64a909900989b4b43e92b10b743d0ce5 \
+    --hash=sha256:37f0420b14630b0eaaf452978f3a6ea4816d787c3e6dcbba6fb255030adae2e7
+pyflakes==1.2.3 \
+    --hash=sha256:e87bac26c62ea5b45067cc89e4a12f56e1483f1f2cda17e7c9b375b9fd2f40da \
+    --hash=sha256:2e4a1b636d8809d8f0a69f341acf15b2e401a3221ede11be439911d23ce2139e
 
 # Jinja2
 MarkupSafe==0.23 \

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -16,9 +16,9 @@ ndg-httpsclient==0.4.0 \
     --hash=sha256:e8c155fdebd9c4bcb0810b4ed01ae1987554b1ee034dd7532d7b8fdae38a6274
 
 # Code quality checker
-flake8==2.5.4 \
-    --hash=sha256:fb5a67af4024622287a76abf6b7fe4fb3cfacf765a790976ce64f52c44c88e4a \
-    --hash=sha256:cc1e58179f6cf10524c7bfdd378f5536d0a61497688517791639a5ecc867492f
+flake8==2.6.0 \
+    --hash=sha256:d37bae8d6c836ea9f29a670f870b1652ff08d9b52b371fe1b7a53eb95e335f29 \
+    --hash=sha256:5ae018121a495edeb83097ba1bdd1a8481db24e1f0d54e8a78edb26ba0df82cf
 
 # Better test runner, related plugins
 pytest==2.8.7 \

--- a/tox.ini
+++ b/tox.ini
@@ -33,4 +33,7 @@ commands = dennis-cmd lint --errorsonly locale/
 
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor
-ignore = E501,E731
+# E501 - line too long (82 > 79 characters)
+# E731 - do not assign a lambda expression, use a def
+# F405 - name may be undefined, or defined from star imports: module
+ignore = E501,E731,F405


### PR DESCRIPTION
* flake8 2.5.4 -> 2.6.0: Update to pycodestyle, add F405
* mccabe 0.4.0 -> 0.5.0: flake8 3.0 support
* pep8 1.7.0 -> pycodestyle 2.0.0: Name change, unary operator checks
* pyflakes 1.0.0 -> 1.2.3: Fixes, more checks

The new pyflakes warning ``F405`` is raised when a star import is used (``from common import *``), such as in the Django environment-specific configuration files. These files are going away during the 12factor updates for AWS, so disable the warning for now.