### PR TITLE
bug 1177264 - remove pagination from revision dashboard

### DIFF
--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -42,3 +42,6 @@ class RevisionDashboardForm(forms.Form):
         choices=PERIOD_CHOICES,
         required=False,
         label=_(u'Preceding Period:'))
+    last_id = forms.IntegerField(
+        widget=forms.HiddenInput
+    )

--- a/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/templates/dashboards/includes/revision_dashboard_body.html
@@ -1,5 +1,3 @@
-{{ revisions|paginator }}
-
 {% set show_ips = False %}
 {% if waffle.switch('store_revision_ips') and user.is_superuser %}
     {% set show_ips = True %}
@@ -67,4 +65,8 @@
 
 {% endif %}
 
-{{ revisions|paginator }}
+<ol class="pagination">
+  <li class="next">
+    <a href="#">Next</a>
+  </li>
+</ol>

--- a/kuma/dashboards/templates/dashboards/revisions.html
+++ b/kuma/dashboards/templates/dashboards/revisions.html
@@ -42,7 +42,7 @@
             </div>
 
             <button type="submit">{{ _('Filter') }}</button>
-            <input type="hidden" name="page" id="revision-page" value="{{ page }}" />
+            <input type="hidden" name="last_id" id="last-revision-id" value="{{ last_id }}" />
         </form>
 
 
@@ -64,7 +64,7 @@
     var $revisionReplaceBlock = $('#revision-replace-block');
     var $localeInput = $('#id_locale');
     var $filterForm = $('#revision-filter');
-    var $pageInput = $('#revision-page');
+    var $lastIDInput = $('#last-revision-id');
     var $showIPsButton = $('#show_ips_btn');
     var currentLocale = '{{ request.LANGUAGE_CODE }}';
     var controlsTemplate = '\
@@ -161,6 +161,7 @@
             label: linkText
         });
         $pageInput.val(pageNum);
+        $lastIDInput.val($('tr.dashboard-row').last().data('revision-id'));
         $filterForm.submit();
     });
 


### PR DESCRIPTION
Replace Django pagination with custom "last_id"-based links for
seeing the next page of results.

See http://www.xarg.org/2011/10/optimized-pagination-using-mysql/