### PR TITLE
bug 1275322 - Adjust message show to spam moderators when revision is blocked

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -679,7 +679,10 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
     @property
     def akismet_error_message(self):
-        return mark_safe(render_to_string('wiki/includes/spam_error.html', {}))
+        request = getattr(self, 'request', None)
+        user = request and request.user
+        return mark_safe(render_to_string('wiki/includes/spam_error.html',
+                                          {'user': user}))
 
     def akismet_error(self, parameters, exception=None):
         """

--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -14,8 +14,10 @@
     contact the site administrators</a>.
     {% endtrans %}
 </p>
+{% if user and user.has_perm('wiki.change_documentspamattempt') -%}
 <p>
     {% trans akismet_submission_url = url('admin:wiki_documentspamattempt_changelist') + '?review__exact=0' %}
     If you are a spam moderator, you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
     {% endtrans %}
 </p>
+{% endif -%}

--- a/kuma/wiki/jinja2/wiki/includes/spam_error.html
+++ b/kuma/wiki/jinja2/wiki/includes/spam_error.html
@@ -15,7 +15,7 @@
     {% endtrans %}
 </p>
 <p>
-    {% trans akismet_submission_url = url('admin:wiki_revisionakismetsubmission_changelist') %}
+    {% trans akismet_submission_url = url('admin:wiki_documentspamattempt_changelist') + '?review__exact=0' %}
     If you are a spam moderator, you can <a href="{{ akismet_submission_url }}" target="_blank">mark this submission as ham</a> and try submitting it again.
     {% endtrans %}
 </p>

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -9,6 +9,7 @@ import requests_mock
 from constance.test import override_config
 from waffle.models import Flag
 
+from kuma.core.urlresolvers import reverse
 from kuma.spam.constants import (CHECK_URL, SPAM_ADMIN_FLAG,
                                  SPAM_SPAMMER_FLAG, SPAM_TESTING_FLAG,
                                  SPAM_CHECKS_FLAG, VERIFY_URL)
@@ -479,6 +480,9 @@ class RevisionFormEditTests(RevisionFormViewTests):
         rev_form = self.setup_form(mock_requests, is_spam='true')
         assert not rev_form.is_valid()
         assert rev_form.errors == {'__all__': [rev_form.akismet_error_message]}
+        admin_path = reverse('admin:wiki_documentspamattempt_changelist')
+        admin_url = admin_path + '?review__exact=0'
+        assert admin_url in rev_form.akismet_error_message
 
         assert DocumentSpamAttempt.objects.count() > 0
         attempt = DocumentSpamAttempt.objects.latest()


### PR DESCRIPTION
When Akismet blocks an edit, show the admin link to the filtered ``DocumentSpamAttempt`` changelist, but only to spam moderators.