### PR TITLE
fix bug 1276929 - Unset config.vm.hostname in the Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,8 +32,9 @@ Vagrant.configure('2') do |config|
     config.vm.box = 'ubuntu/trusty64'
     config.vm.define 'developer-local'
     config.vm.network :private_network, ip: IP
-    config.vm.hostname = 'developer-local.allizom.org'
-    config.hostsupdater.aliases = ['mdn-local.mozillademos.org']
+    # Vagrant will mangle the line for 127.0.0.1 in the VM's /etc/hosts if this option is set.
+    # config.vm.hostname = 'developer-local.allizom.org'
+    config.hostsupdater.aliases = ['developer-local.allizom.org', 'mdn-local.mozillademos.org']
     config.ssh.forward_agent = true
 
     if USE_CACHIER


### PR DESCRIPTION
Unset config.vm.hostname in the Vagrantfile.

Having this option set (currently) causes Vagrant to destructively
edit the guest's /etc/hosts file, removing the localhost alias for
127.0.0.1.

This option shouldn't be needed, since the kuma role is copying over
/etc/hostname anyway.