### PR TITLE
Fix Bug 1284584: Standardize learn-box

### DIFF
--- a/kuma/static/styles/components/content.styl
+++ b/kuma/static/styles/components/content.styl
@@ -15,7 +15,7 @@ $table-blue = #d4dde4;
         border: solid #e0e0dc;
         border-width: 1px 0 0 1px;
 
-        &.standard-table {
+        &.standard-table:not('.learn-box') {
             border: 2px solid #fff;
 
             td {

--- a/kuma/static/styles/components/wiki/customcss.styl
+++ b/kuma/static/styles/components/wiki/customcss.styl
@@ -908,31 +908,4 @@ pre span.comment {
     display: inline;
 }
 
-/* This is styling for the Learning Box place on articles */
-.text-content table.learn-box {
-    border: 1px solid #f69855;
-    border-left: 5px solid #f69855;
-}
-.text-content table.learn-box th {
-    background-color: #fce1ce;
-    border: 1px solid #f69855;
-    border-right: none;
-    vertical-align: top;
-    padding: 6px;
-    text-align: right;
-
-    font-family: $site-font-family;
-    font-weight: bold;
-    {$selector-site-font-fallback} {
-        font-family: $site-font-family-fallback;
-    }
-}
-.text-content table.learn-box td {
-    border: 1px solid #f69855;
-    border-left: none;
-    box-shadow: none;
-    font-style: italic;
-    background-color: #fef9f5;
-}
-
 /*end!*/

--- a/kuma/static/styles/components/wiki/properties.styl
+++ b/kuma/static/styles/components/wiki/properties.styl
@@ -7,6 +7,7 @@ $properties-item-spacing = $content-horizontal-spacing;
 $properties-spacing = ($grid-spacing) - $properties-item-spacing;
 $properties-indent = ($grid-spacing * 2) - $properties-item-spacing;
 
+.learn-box, /* not part of .properties so not being phased out */
 .properties, /* writing team is transitioning to use only this class - bug 1207344 */
 .cssprop,
 .htmlelt,
@@ -72,9 +73,15 @@ $properties-indent = ($grid-spacing * 2) - $properties-item-spacing;
     }
 }
 
-/* small screen improvments to table display, only need to apply to .properties
+.text-content .learn-box {
+    border-color: #f69855;
+    background-color: #fce1ce;
+}
+
+/* small screen improvements to table display, only need to apply to .properties and .learn-box
 because we can be sure that is implemented with a table element */
 @media $media-query-small-mobile {
+    .learn-box,
     .properties {
         th,
         td {


### PR DESCRIPTION
Made .learn-box use the .properties styles but made it orange.

Removed old learn-box styles from customcss.styl

Updated .standard-table definition to exclude learn-boxes because .learn-box.standard-table is a very common combination.

Testing pages:
https://developer-local.allizom.org/en-US/Learn/HTML/Howto/Use_JavaScript_within_a_webpage
https://developer-local.allizom.org/en-US/Learn/HTML/Howto/Add_a_hit_map_on_top_of_an_image
https://developer-local.allizom.org/en-US/Learn/CSS/Using_CSS_in_a_web_page
https://developer-local.allizom.org/en-US/Learn/CSS/Basic_text_styling_in_CSS

When testing also edit a table to remove the standard-table class and make sure it displays properly.