### PR TITLE
Bug 1273028: Persona shutdown banner

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -70,6 +70,17 @@
 
   {{ soapbox_messages(get_soapbox_messages(request.path)) }}
 
+  {% if user.is_authenticated() %}
+      {% if request.session.sociallogin_provider == 'persona' %}
+          <div class="notification warning" data-level="warning">
+              {% trans persona_info='/docs/MDN/Contribute/Persona_Sign_In_on_MDN' %}
+                You signed in with Persona.
+                <a href="{{ persona_info }}">Persona is being turned off. Read more.</a>
+              {% endtrans %}
+          </div>
+      {% endif %}
+  {% endif %}
+
   <ul id="nav-access">
     <li><a href="#{% block main_content_id %}content{% endblock %}" id="skip-main">{{ _('Skip to main content') }}</a></li>
     <li><a id="skip-language" href="#language">{{ _('Select language') }}</a></li>

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -72,7 +72,7 @@
 
   {% if user.is_authenticated() and request.session.sociallogin_provider == 'persona' %}
       <div class="notification warning" data-level="warning">
-          {% trans persona_info='/docs/MDN/Contribute/Persona_Sign_In_on_MDN' %}
+          {% trans persona_info='/docs/MDN/Contribute/Persona_sign-in' %}
             You signed in with Persona.
             <a href="{{ persona_info }}">Persona is being turned off. Read more.</a>
           {% endtrans %}

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -70,15 +70,13 @@
 
   {{ soapbox_messages(get_soapbox_messages(request.path)) }}
 
-  {% if user.is_authenticated() %}
-      {% if request.session.sociallogin_provider == 'persona' %}
-          <div class="notification warning" data-level="warning">
-              {% trans persona_info='/docs/MDN/Contribute/Persona_Sign_In_on_MDN' %}
-                You signed in with Persona.
-                <a href="{{ persona_info }}">Persona is being turned off. Read more.</a>
-              {% endtrans %}
-          </div>
-      {% endif %}
+  {% if user.is_authenticated() and request.session.sociallogin_provider == 'persona' %}
+      <div class="notification warning" data-level="warning">
+          {% trans persona_info='/docs/MDN/Contribute/Persona_Sign_In_on_MDN' %}
+            You signed in with Persona.
+            <a href="{{ persona_info }}">Persona is being turned off. Read more.</a>
+          {% endtrans %}
+      </div>
   {% endif %}
 
   <ul id="nav-access">

--- a/jinja2/includes/login.html
+++ b/jinja2/includes/login.html
@@ -17,12 +17,17 @@
                 {{ _('Sign in') }}
               </span>
               <span class="oauth-icon oauth-github" data-service="GitHub" data-href="{{ github_url }}" title="{{ _('GitHub') }}"><i class="icon-github" aria-hidden="true"></i></span>
-              <span class="oauth-icon oauth-persona launch-persona-login wait-for-persona disabled" data-service="Persona" data-next="{{ next_url }}" title="{{ _('Persona') }}"><i class="icon-user" aria-hidden="true"></i></span>
           </div>
           <div class="oauth-login-picker" aria-hidden="true">
               <ul>
-                  <li class="wait-for-persona disabled"><a href="{{ url('account_login') }}" class="login-link launch-persona-login" data-next="{{ next_url }}" data-service="Persona"><i class="icon-user" aria-hidden="true"></i>Persona</a></li>
-                  <li><a href="{{ github_url }}" class="login-link" data-service="GitHub"><i class="icon-github" aria-hidden="true"></i>GitHub</a></li>
+                  <li>
+                    {{ _('Sign in or create an account:') }}<br>
+                    <a href="{{ github_url }}" class="login-link" data-service="GitHub"><i class="icon-github" aria-hidden="true"></i>GitHub</a>
+                  </li>
+                  <li class="wait-for-persona disabled">
+                      {{ _('Sign in:') }} <a href="/docs/MDN/Contribute/Persona_Sign_In_on_MDN"><i aria-hidden="true" title="{{ _('Why is Persona sign in only?') }}" class="icon-question-sign"></i></a><br>
+                      <a href="{{ url('account_login') }}" class="login-link launch-persona-login" data-next="{{ next_url }}" data-service="Persona"><i class="icon-user" aria-hidden="true"></i>Persona</a>
+                  </li>
               </ul>
               {% if waffle.flag('registration_disabled') %}
                 <div class="notification error">{{ _("We are sorry, but profile creation is currently disabled.") }}</div>

--- a/kuma/static/styles/components/structure/oauth-login.styl
+++ b/kuma/static/styles/components/structure/oauth-login.styl
@@ -75,27 +75,34 @@ Login links in secondary navigation
 #nav-sec .oauth-login-picker {
     display: none;
     background: #fff;
+    color: $text-color;
     position: relative;
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
     overflow: hidden;
     padding: 0;
     box-shadow: 0px 10px 10px 0px rgba(0, 0, 0, 0.5);
+    text-indent: $content-horizontal-spacing;
 
     a {
-        display: block;
-        padding: $content-vertical-spacing $content-horizontal-spacing;
-        position: relative;
         color: $link-color !important;
-
-        &:hover, &:active, &:focus {
-            background: rgba-fallback(rgba($link-color, 0.1));
-        }
+        text-indent: 0;
     }
 
     {$selector-icon} {
         background: none;
         bidi-style(margin-right, $icon-margin, margin-left, 0);
+    }
+}
+
+.login-link {
+    display: block;
+    padding: $content-vertical-spacing $content-horizontal-spacing;
+    position: relative;
+    text-indent: 0;
+
+    &:hover, &:active, &:focus {
+        background: rgba-fallback(rgba($link-color, 0.1));
     }
 }
 

--- a/kuma/users/jinja2/account/login.html
+++ b/kuma/users/jinja2/account/login.html
@@ -4,6 +4,8 @@
 
 {% set classes = 'login' %}
 
+{% set socialaccount_providers = get_providers() %}
+
 {% block content %}
 <div class="text-content readable-line-length">
   <article id="login">
@@ -11,17 +13,30 @@
       <h1>{{ _("Please sign in") }}</h1>
 
       <p>{% trans %}
-      In order to contribute, you need to sign in to MDN. You can sign in using
-      any of the services below. A MDN profile will be created for you if you
-      don't already have one.
+      All content on MDN is free and available without signing in.
       {% endtrans %}</p>
 
-  {% set socialaccount_providers = get_providers() %}
-  {% if socialaccount_providers  %}
-      {% with process="login" %}
-        {% include "socialaccount/snippets/provider_list.html" %}
-      {% endwith %}
-  {% endif %}
+      <p>{% trans %}
+      In order to contribute, you need to sign in to MDN. You can sign in using
+      GitHub and a MDN profile will be created for you if you don't already
+      have one.
+      {% endtrans %}</p>
+
+      {% if socialaccount_providers  %}
+          {% with process="create" %}
+            {% include "socialaccount/snippets/provider_list.html" %}
+          {% endwith %}
+      {% endif %}
+
+      <p>{% trans %}
+      If you already have a MDN profile sign in:
+      {% endtrans %}</p>
+
+      {% if socialaccount_providers  %}
+          {% with process="login" %}
+            {% include "socialaccount/snippets/provider_list.html" %}
+          {% endwith %}
+      {% endif %}
 
     {# hidden form to measure bot submissions from this page #}
     <form class="hidden" method="post" action="{{ url('users.honeypot') }}">

--- a/kuma/users/jinja2/socialaccount/snippets/provider_list.html
+++ b/kuma/users/jinja2/socialaccount/snippets/provider_list.html
@@ -2,7 +2,7 @@
 {% if socialaccount_providers %}
   <ul class="no-bullets socialaccount-providers">
     {% for provider in socialaccount_providers %}
-        {% if provider.id == "openid" %}
+        {% if provider.id == "openid" and process != 'create' %}
             {% for brand in provider.get_brands() %}
               <li><a title="{{ brand.name }}"
                  class="socialaccount_provider {{ provider.id }} {{ brand.id }}"
@@ -10,7 +10,7 @@
                  >{{ brand.name }}</a></li>
             {% endfor %}
         {% endif %}
-        {% if provider.id == "persona" %}
+        {% if provider.id == "persona" and process != 'create' %}
           <li class="wait-for-persona disabled"><a href="{{ url('account_login') }}" class="persona-button login-link launch-persona-login" data-next="{{ next_url }}" data-service="{{ provider.name }}" data-process="{{ process }}">
             <span class="persona-icon"><i aria-hidden="true"></i></span>
             <span class="signin">
@@ -27,6 +27,8 @@
               <span class="signin">
               {% if process == "connect" %}
                 {{ _('Connect with GitHub') }}
+              {% elif process == "create" %}
+                {{ _('Create MDN profile with GitHub') }}
               {% else %}
                 {{ _('Sign in with GitHub') }}
               {% endif %}


### PR DESCRIPTION
Adds banner across top of all pages when a user has logged in with persona "You logged in with Persona. [Persona is being turned off. Read more.](https://developer.mozilla.org/en-US/docs/MDN/Contribute/Persona_Sign_In_on_MDN)"

Changes sign in drop down and sign in page to say account creation can only happen with Github (but there are no back end changes to enforce this).

Some things to test:
- Banner shows up when signed in with Persona and not when signed in with GitHub or signed out.
- I used "sign in" and "MDN profile" in all copy (not log in and MDN account).
- Create account with GitHub button works (probably good enough to test that you can sign in using that button)
- No spelling mistakes in copy.
- Sign in with Persona has not been broken.
- Other stuff I haven't thought of.