### PR TITLE
Fix bug 1284781 Samples opened in JSFiddle will fail if CSS includes HTML escapes like &nbsp;

### DIFF
--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -55,6 +55,8 @@
     }
 
     function openSample(sampleCodeHost, section, title, htmlCode, cssCode, jsCode) {
+        // replace &nbsp; in CSS Samples to fix bug 1284781
+        var cssCleanCode = cssCode.replace(/\xA0/g, " ");
         //track the click and sample code host as event
         mdn.analytics.trackEvent({
             category: 'Samples',
@@ -65,9 +67,9 @@
         if(win.ga) ga('set', 'dimension8', 'Yes');
 
         if(sampleCodeHost === 'jsfiddle') {
-            openJSFiddle(title, htmlCode, cssCode, jsCode);
+            openJSFiddle(title, htmlCode, cssCleanCode, jsCode);
         } else if(sampleCodeHost === 'codepen') {
-            openCodepen(title, htmlCode, cssCode, jsCode);
+            openCodepen(title, htmlCode, cssCleanCode, jsCode);
         }
     }
 

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -156,6 +156,8 @@ class Extractor(object):
             if src is not None:
                 # Bug 819999: &nbsp; gets decoded to \xa0, which trips up CSS
                 src = src.replace(u'\xa0', u' ')
+                # Bug 1284781: &nbsp; is incorrectly parsed on embed sample
+                src = src.replace(u'&nbsp;', u' ')
             if src:
                 data[part] = src
 

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -684,6 +684,26 @@ class ContentSectionToolTests(UserTestCase):
         result = rev.document.extract.code_sample('bug819999')
         ok_(result['css'].find(u'\xa0') == -1)
 
+    def test_bug1284781(self):
+        """
+        Non-breaking spaces are turned to normal spaces in code sample
+        extraction.
+        """
+        rev = revision(is_approved=True, save=True, content="""
+            <h2 id="bug1284781">Bug 1284781</h2>
+            <pre class="brush: css">
+            .widget select,
+            .no-widget .select {
+            &nbsp; position : absolute;
+            &nbsp; left&nbsp;&nbsp;&nbsp;&nbsp; : -5000em;
+            &nbsp; height&nbsp;&nbsp; : 0;
+            &nbsp; overflow : hidden;
+            }
+            </pre>
+        """)
+        result = rev.document.extract.code_sample('bug1284781')
+        ok_(result['css'].find(u'&nbsp;') == -1)
+
     def test_bug1173170(self):
         """
         Make sure the colons in sample ids doesn't trip up the code


### PR DESCRIPTION
Bug 1284781

Note : I haven't been able to fully reproduce the issue, I wasn't able to make the Codepen / JSFiddle buttons.

However, I think it should work.
PS : If someone knows how to make those buttons appear, I'm interested.