### PR TITLE
Bug 1256189 : Add new authorized attributes for <meter>

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -76,6 +76,8 @@ ALLOWED_ATTRIBUTES['li'] += ['data-default-state']
 ALLOWED_ATTRIBUTES['time'] += ['datetime']
 ALLOWED_ATTRIBUTES['ins'] = ['datetime']
 ALLOWED_ATTRIBUTES['del'] = ['datetime']
+ALLOWED_ATTRIBUTES['meter'] += ['max', 'min', 'value', 'low', 'high', 'optimum',
+                                'form']
 # MathML
 ALLOWED_ATTRIBUTES.update(dict((x, ['encoding', 'src']) for x in (
     'annotation', 'annotation-xml')))


### PR DESCRIPTION
Add new authorized attributes for <meter> (max, min, value, low, high, optimum, form).

It should be good. However I seem to have a caching issue, preventing me to test it. 