### PR TITLE
bug 1260257 - Disable Persona signup unless switch is active

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -23,6 +23,7 @@ Switches
 * ``dumb_doc_urls`` - (deprecated) Disable the render-time changing of /docs/
   URLs to the equivalent Zone URLs (see `PR 3331`_ for reasoning).
 * ``enable_optimizely`` - Enable the Optimizely JavaScript
+* ``enable_persona_signup`` - Enable account signup with Persona
 * ``store_revision_ips`` - Save request data, including the IP address, to
   enable marking revisions as spam.
 * ``welcome_email`` - send welcome email to new user registrations

--- a/kuma/users/constants.py
+++ b/kuma/users/constants.py
@@ -7,3 +7,5 @@ USERNAME_CHARACTERS = _(u'Username may contain only letters, numbers, and '
                         u'these characters: . - _ +')
 USERNAME_REGEX = re.compile(r'^[\w.+-]+$')
 USERNAME_LEGACY_REGEX = re.compile(r'^.+$')
+
+PERSONA_SIGNUP_SWITCH = 'enable_persona_signup'

--- a/kuma/users/jinja2/account/signup_closed.html
+++ b/kuma/users/jinja2/account/signup_closed.html
@@ -1,13 +1,18 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Profile Creation Disabled")) }}{% endblock %}
+{% set subtitle = _('Profile Creation Disabled') %}
+{% if request.used_persona %}
+  {% set message = _('We are sorry, but you can not create a profile with Persona. <a href="%(url)s">Please try again with a GitHub account</a>.',
+                     url=provider_login_url('github')) %}
+{% else %}
+  {% set message = _('We are sorry, but profile creation is currently disabled.') %}
+{% endif %}
+
+{% block title %}{{ page_title(subtitle) }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">
-  <h1>{{ _("Profile Creation Disabled") }}</h1>
-
-  <p>{{ _("We are sorry, but profile creation is currently disabled.") }}</p>
+  <h1>{{ subtitle }}</h1>
+  <p>{{ message }} </p>
 </div>
 {% endblock %}
-
-

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -1,9 +1,18 @@
-from django.contrib.auth import get_user_model
-from django.utils.crypto import get_random_string
+import requests_mock
 from allauth.account.models import EmailAddress
+from allauth.socialaccount.providers import registry
+from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+from allauth.socialaccount.models import SocialApp
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
+from django.utils.crypto import get_random_string
+from django.utils.six.moves.urllib_parse import urlparse, parse_qs
 
 from kuma.core.tests import KumaTestCase, KumaTransactionTestCase
+from kuma.core.urlresolvers import reverse
 from kuma.wiki.tests import revision as create_revision, document as create_document
+from ..providers.github.provider import KumaGitHubProvider
 
 
 class UserTestMixin(object):
@@ -82,3 +91,149 @@ class SampleRevisionsMixin(object):
                 save=True)
             revisions_created.append(new_revision)
         return revisions_created
+
+
+class SocialTestMixin(object):
+
+    persona_verifier_data = {
+        'status': 'okay',
+        'email': 'new_persona_user@example.com',
+        'audience': 'https://developer-local.allizom.org',
+    }
+
+    def persona_login(self, verifier_data=None, next_url=None):
+        """
+        Mock a login to Persona and return the response.
+
+        Keyword Arguments:
+        verifier_data - Persona data, or None for default
+        next_url - Post-login URL
+        """
+        url = reverse('persona_login', locale=settings.WIKI_DEFAULT_LANGUAGE)
+        if next_url:
+            post_data = {'next': next_url}
+        else:
+            post_data = None
+
+        # Mock the response from the Persona server
+        with requests_mock.Mocker() as mock_requests:
+            # The login view will POST to the Persona server:
+            # Request for login state and email
+            mock_requests.post(
+                settings.PERSONA_VERIFIER_URL,
+                json=verifier_data or self.persona_verifier_data,
+                headers={'content_type': 'application/json'}
+            )
+
+            # Start the Persona login process
+            response = self.client.post(url, follow=True, data=post_data)
+        return response
+
+    github_token_data = {
+        'uid': 1,
+        'access_token': 'github_token',
+    }
+    github_profile_data = {
+        'login': 'octocat',
+        'id': 1,
+        'email': 'octocat@example.com',
+        # Unused profile items
+        'avatar_url': 'https://github.com/images/error/octocat_happy.gif',
+        'gravatar_id': 'somehexcode',
+        'url': 'https://api.github.com/users/octocat',
+        'html_url': 'https://github.com/octocat',
+        'followers_url': 'https://api.github.com/users/octocat/followers',
+        'following_url': 'https://api.github.com/users/octocat/following{/other_user}',
+        'gists_url': 'https://api.github.com/users/octocat/gists{/gist_id}',
+        'starred_url': 'https://api.github.com/users/octocat/starred{/owner}{/repo}',
+        'subscriptions_url': 'https://api.github.com/users/octocat/subscriptions',
+        'organizations_url': 'https://api.github.com/users/octocat/orgs',
+        'repos_url': 'https://api.github.com/users/octocat/repos',
+        'events_url': 'https://api.github.com/users/octocat/events{/privacy}',
+        'received_events_url': 'https://api.github.com/users/octocat/received_events',
+        'type': 'User',
+        'site_admin': False,
+        'name': 'monalisa octocat',
+        'company': 'GitHub',
+        'blog': 'https://github.com/blog',
+        'location': 'San Francisco',
+        'hireable': False,
+        'public_repos': 2,
+        'public_gists': 1,
+        'followers': 20,
+        'following': 0,
+        'created_at': '2008-01-14T04:33:35Z',
+        'updated_at': '2008-01-14T04:33:35Z'
+    }
+    github_email_data = [
+        {
+            'email': 'octocat-private@example.com',
+            'verified': True,
+            'primary': True
+        }
+    ]
+
+    def github_login(
+            self, token_data=None, profile_data=None, email_data=None,
+            process='login'):
+        """
+        Mock a login to GitHub and return the response.
+
+        Keyword Arguments:
+        token_data - OAuth token data, or None for default
+        profile_data - GitHub profile data, or None for default
+        email_data - GitHub email data, or None for default
+        process - 'login', 'connect', or 'redirect'
+        """
+        login_url = reverse('github_login',
+                            locale=settings.WIKI_DEFAULT_LANGUAGE)
+        callback_url = reverse('github_callback', unprefixed=True)
+
+        # Ensure GitHub is setup as an auth provider
+        self.ensure_github_app()
+
+        # Start the login process
+        # Store state in the session, and redirect the user to GitHub
+        login_response = self.client.get(login_url, {'process': process})
+        assert login_response.status_code == 302
+        location = urlparse(login_response['location'])
+        query = parse_qs(location.query)
+        assert callback_url in query['redirect_uri'][0]
+        state = query['state'][0]
+
+        # Callback from GitHub, mock follow-on GitHub responses
+        with requests_mock.Mocker() as mock_requests:
+            # The callback view will make requests back to Github:
+            # The OAuth2 authentication token (or error)
+            mock_requests.post(
+                GitHubOAuth2Adapter.access_token_url,
+                json=token_data or self.github_token_data,
+                headers={'content-type': 'application/json'})
+            # The authenticated user's profile data
+            mock_requests.get(
+                GitHubOAuth2Adapter.profile_url,
+                json=profile_data or self.github_profile_data)
+            # The user's emails, which could be an empty list
+            if email_data is None:
+                email_data = self.github_email_data
+            mock_requests.get(GitHubOAuth2Adapter.emails_url, json=email_data)
+
+            # Simulate the callback from Github
+            data = {'code': 'github_code', 'state': state}
+            response = self.client.get(callback_url, data, follow=True)
+
+        return response
+
+    def ensure_github_app(self):
+        """Ensure a GitHub SocialApp is installed, configured."""
+        provider = registry.by_id(KumaGitHubProvider.id)
+        app, created = SocialApp.objects.get_or_create(
+            provider=provider.id,
+            defaults={
+                'name': provider.id,
+                'client_id': 'app123id',
+                'key': provider.id,
+                'secret': 'dummy'})
+        if created:
+            app.sites.add(Site.objects.get_current())
+        return app

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -14,6 +14,7 @@ from django.http import Http404
 from django.test import RequestFactory
 from pyquery import PyQuery as pq
 from waffle.models import Flag
+from waffle.testutils import override_switch
 
 from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
@@ -25,6 +26,7 @@ from kuma.wiki.tests import document as create_document
 
 
 from . import SampleRevisionsMixin, SocialTestMixin, UserTestCase, email, user
+from ..constants import PERSONA_SIGNUP_SWITCH
 from ..models import UserBan
 from ..signup import SignupForm
 from ..views import delete_document, revert_document
@@ -1030,6 +1032,7 @@ class AllauthPersonaTestCase(UserTestCase, SocialTestMixin):
 
     @override_config(RECAPTCHA_PRIVATE_KEY='private_key',
                      RECAPTCHA_PUBLIC_KEY='public_key')
+    @override_switch(PERSONA_SIGNUP_SWITCH, active=True)
     def test_persona_signin_captcha(self):
         persona_signup_email = self.persona_verifier_data['email']
         persona_signup_username = 'views_persona_django_user'
@@ -1050,6 +1053,7 @@ class AllauthPersonaTestCase(UserTestCase, SocialTestMixin):
             {'captcha': [u'Incorrect, please try again.']})
 
     @mock.patch.dict(os.environ, {'RECAPTCHA_TESTING': 'True'})
+    @override_switch(PERSONA_SIGNUP_SWITCH, active=True)
     def test_persona_signup_create_django_user(self):
         """
         Signing up with Persona creates a new Django User instance.
@@ -1086,6 +1090,7 @@ class AllauthPersonaTestCase(UserTestCase, SocialTestMixin):
         ok_(testuser.password.startswith(UNUSABLE_PASSWORD_PREFIX))
 
     @mock.patch.dict(os.environ, {'RECAPTCHA_TESTING': 'True'})
+    @override_switch(PERSONA_SIGNUP_SWITCH, active=True)
     def test_persona_signup_create_socialaccount(self):
         """
         Signing up with Persona creates a new SocialAccount instance.


### PR DESCRIPTION
This is an alternate for PR #3913, which removes Persona signups, related code, and tests.  However, there isn't a good documented alternate for manual testing ([bug 1286289](https://bugzilla.mozilla.org/show_bug.cgi?id=1286289)), so it may be worthwhile to keep Persona around.

In the first commit, the social login tests have been refactored to use a a new mixin, ``SocialTestMixin``, that provides class functions ``persona_login()`` and ``github_login()`` to execute a mocked social authentication with good defaults, and the ability to override the defaults as needed.  These result in big changes to the test code, and an ugly diff.

The second commit changes the production code, in ``kuma/users/adapters.py``, which now forbids creating a new account with Persona unless the waffle switch ``enable_persona_signup`` is enabled (default off), and in ``kuma/users/jinja2/account/signup_closed.html``, which has a custom message for Persona users:

![profile creation disabled](https://cloud.githubusercontent.com/assets/286017/17151786/85ddc3cc-533a-11e6-8d34-ca56a1957088.png)

Disabling Persona signups requires explicitly setting the ``enable_persona_signup`` switch for tests that exercise Persona signups.  This second commit is cleaner because of the work in the first commit.