### PR TITLE
bug 1262541 - Add an "All Topics" filter that will clear out checkboxes on search page

### DIFF
--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -190,7 +190,8 @@ class DatabaseFilterBackend(BaseFilterBackend):
             else:
                 if filter_tags:
                     facet_params = F('term', tags=filter_tags[0])
-            active_facets.append((serialized_filter['slug'], facet_params))
+            if len(filter_tags):
+                active_facets.append((serialized_filter['slug'], facet_params))
 
         if active_filters:
             if len(active_filters) == 1:

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -20,7 +20,11 @@ def get_filters(getter_func):
 
     this will return `['css', 'html']`.
 
+    If the given URL contains 'none', then no filters should be applied.
+
     """
+    if getter_func("none"):
+        return [u'none']
     filters = collections.OrderedDict()
     for slug in FilterGroup.objects.values_list('slug', flat=True):
         for filters_slug in getter_func(slug, []):
@@ -184,7 +188,8 @@ class DatabaseFilterBackend(BaseFilterBackend):
             if len(filter_tags) > 1:
                 facet_params = F('terms', tags=list(filter_tags))
             else:
-                facet_params = F('term', tags=filter_tags[0])
+                if filter_tags:
+                    facet_params = F('term', tags=filter_tags[0])
             active_facets.append((serialized_filter['slug'], facet_params))
 
         if active_filters:

--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -171,6 +171,20 @@
       <!-- right filters -->
       <div class="column-strip search-results-filters">
         <fieldset>
+
+        <label>
+          <legend>
+          {% if "none" in selected_filters %}
+            <i aria-hidden="true" class="icon-check"></i>
+            <input id="no_filter" type="checkbox" class="offscreen" name="none" checked="checked" value="none">
+          {% else %}
+            <i aria-hidden="true" class="icon-check-empty"></i>
+            <input id="no_filter" type="checkbox" class="offscreen" name="none" value="none">
+          {% endif %}
+          <span class="filter-name">All Topics</span>
+          </legend>
+        </label>
+
         {% for filter_group in filters %}
           <fieldset>
             <legend><i aria-hidden="true" class="icon-th-list"></i><span class="offscreen">{{ _('Filter by') }} </span>{{ filter_group.name }}</legend>

--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -173,7 +173,6 @@
         <fieldset>
 
         <label>
-          <legend>
           {% if "none" in selected_filters %}
             <i aria-hidden="true" class="icon-check"></i>
             <input id="no_filter" type="checkbox" class="offscreen" name="none" checked="checked" value="none">
@@ -181,8 +180,7 @@
             <i aria-hidden="true" class="icon-check-empty"></i>
             <input id="no_filter" type="checkbox" class="offscreen" name="none" value="none">
           {% endif %}
-          <span class="filter-name">All Topics</span>
-          </legend>
+          <span class="filter-name">{{ _('All Topics') }}</span>
         </label>
 
         {% for filter_group in filters %}

--- a/kuma/static/js/search.js
+++ b/kuma/static/js/search.js
@@ -5,6 +5,10 @@
         Auto-submit the filters form on the search page when a checkbox is changed.
     */
     $('.search-results-filters').on('change', 'input', function() {
+        if (this.value != "none") {
+          // De-select the All Topics checkbox when another filter is selected
+          $("#no_filter").attr('checked', false);
+        }
         $('#search-form').submit();
         $(this).parents('fieldset').attr('disabled', 'disabled');
     });


### PR DESCRIPTION
Addresses https://bugzilla.mozilla.org/show_bug.cgi?id=1262541
Add an 'All Topics' filter that allows user to search all topics. 
Clear out that value when other topics are selected via search.js. 
Add a filter test.

Ready for review by @jwhitlock 