### PR TITLE
[Bug 1275387] CKEditor build script uses dev version, not release

### DIFF
--- a/kuma/static/js/libs/ckeditor/source/build.sh
+++ b/kuma/static/js/libs/ckeditor/source/build.sh
@@ -21,7 +21,7 @@ target="../build"
 echo ""
 echo "Pulling down CKEditor from GitHub..."
 rm -rf ckeditor/
-git clone https://github.com/ckeditor/ckeditor-dev.git ckeditor
+git clone -b $CKEDITOR_VERSION --single-branch https://github.com/ckeditor/ckeditor-dev.git ckeditor
 rm -rf ckeditor/.git
 
 


### PR DESCRIPTION
I can not understand how this script was used to build release version.
BTW, the version we use is ``4.5.8`` not ``4.5.7``

In the past, we added the submodule and we checkout according to the git commit hash, and then run the script to build the editor.
But, later we have removed the submodule but there was a little bug in the script.

@jwhitlock r?