### PR TITLE
Fix bug 1289589 : Remove edit button from templates if the user cannot edit them

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -37,7 +37,9 @@
         </div>
       </li>{% endif %}
 
+      {% if (not document.is_template) or (user.has_perm('wiki.change_template_document')) %}
       <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button" data-optimizely-hook="button-edit-doc" id="edit-button">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
+      {% endif %}
 
         {% if user.is_authenticated() and document %}
         <li><button id="watch-menu" class="only-icon" aria-haspopup="true" aria-owns="watch-menu-submenu" aria-expanded="false"><span>{{ _('Watch') }}</span><i aria-hidden="true" class="icon-eye"></i></button>

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -57,8 +57,6 @@
             <div class="title">{{ _('Advanced') }}</div>
             <ul>
                 <li><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow, noindex">{{_('History')}}</a></li>
-                {% if user.is_authenticated() and document %}
-                </li>{% endif %}
                 {% if user.is_authenticated() and not document.is_template %}
                   <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow, noindex">{{ _('New sub-article') }}</a></li>
                   <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow, noindex">{{ _('Clone this article') }}</a></li>


### PR DESCRIPTION
Fix bug 1289589 : [Bug 1289589 - Edit button shows up when user doesn't have edit permission for a page ](https://bugzilla.mozilla.org/show_bug.cgi?id=1289589)

- Remove edit button from templates if the user cannot edit them.
- Remove part of code which was forgot during a clean-up

I separated this into two different commits because removing the old code didn't seem to have a reason to be in the same commit, though I might be wrong.