### PR TITLE
Work around MySQL's case-insensitive collation logic for tag assignment

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -586,29 +586,32 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
         tags = self.cleaned_data['tags']
         cleaned_tags = []
 
-        if tags:
-            for tag in parse_tags(tags):
-                # Note: The exact match query doesn't work correctly with
-                # MySQL with regards to case-sensitivity. If we move to
-                # Postgresql in the future this code may need to change.
-                doc_tag = (DocumentTag.objects.filter(name__exact=tag)
-                                              .values_list('name', flat=True))
+        for tag in parse_tags(tags):
+            # Note: The exact match query doesn't work correctly with MySQL
+            # with regards to case-sensitivity, due to the case-insensitive
+            # collation.  If we move to Postgresql in the future this code will
+            # need to change.
+            doc_tag = (DocumentTag.objects.filter(name__exact=tag)
+                                          .values_list('name', flat=True))
 
-                # Write a log we can grep to help find pre-existing duplicate
-                # document tags for cleanup.
-                if len(doc_tag) > 1:
-                    log.warn('Found duplicate document tags: %s' % doc_tag)
+            # Write a log we can grep to help find pre-existing duplicate
+            # document tags for cleanup.
+            if len(doc_tag) > 1:
+                log.warn('Found duplicate document tags: %s' % doc_tag)
 
-                if doc_tag:
-                    if doc_tag[0] != tag and doc_tag[0].lower() == tag.lower():
-                        # The tag differs only by case. Do not add a new one,
-                        # add the existing one.
-                        cleaned_tags.append(doc_tag[0])
-                        continue
-
+            if doc_tag:
+                if tag in doc_tag:
+                    # We have an exact match, so use it.
+                    cleaned_tags.append(tag)
+                else:
+                    # The casing doesn't match anything here, but the tag was a
+                    # match under the collation rules, so just pick one.
+                    cleaned_tags.append(doc_tag[0])
+            else:
+                # A new tag, so we'll be creating it.
                 cleaned_tags.append(tag)
 
-        return ' '.join([u'"%s"' % t for t in cleaned_tags])
+        return ' '.join(u'"%s"' % t for t in cleaned_tags)
 
     def clean_content(self):
         """

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1726,9 +1726,32 @@ class Revision(models.Model):
         self.document.render_max_age = self.render_max_age
         self.document.current_revision = self
 
+        tags = []
+
         # Since Revision stores tags as a string, we need to parse them first
         # before setting on the Document.
-        self.document.tags.set(*parse_tags(self.tags))
+        for tag in parse_tags(self.tags):
+            doc_tag = DocumentTag.objects.filter(name=tag)
+
+            if not doc_tag:
+                # If the current tag didn't in some sense match, create it.
+                tags.append(DocumentTag.objects.create(name=tag))
+            else:
+                for instance in doc_tag:
+                    # Use Python string matching to get the case-sensitive match
+                    # we can't achieve with the Django query.
+                    if instance.name == tag:
+                        # Found an exact match
+                        tags.append(instance)
+                        break
+                else:
+                    # No exact match found, so just pick the first one.
+                    tags.append(doc_tag[0])
+
+        # The Taggit tag manager will tag instances as well as
+        # strings, and won't do bonkers things if we've already
+        # determined which instances we want.
+        self.document.tags.set(*tags)
 
         self.document.save()
 


### PR DESCRIPTION
Previously, if there were duplicate tags under the case-insensitive matching rules (e.g. JavaScript and javascript), both tags would get applied even when only one was intended.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1271552