### PR TITLE
Fix bug 1277388 :  Missing space in French translation on edit pages

### DIFF
--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -80,7 +80,7 @@
             <div id="content-fields">
               <article class="approved text-content">
                 <header>
-                    <h3 class="approved-title">{{ _('Approved %(locale)s version', locale=default_locale) }}:</h3>
+                    <h3 class="approved-title">{{ _('Approved %(locale)s version:', locale=default_locale) }}</h3>
                     <div class="translate-buttons">
                         <button class="doc-mode-btn" data-alternate-message="{{ _('View Rendered') }}">{{ _('View Source') }}</button>
                         <button class="hide-original-btn" data-alternate-message="{{ _('Show %(locale)s', locale=default_locale) }}">{{ _('Hide %(locale)s', locale=default_locale) }}</button>


### PR DESCRIPTION
Fix bug 1277388 : [Bug 1277388 - Missing space in French translation on edit pages ](https://bugzilla.mozilla.org/show_bug.cgi?id=1277388)

- I removed the comma.
- Translators will have to add it, I don't think we can (and if we can I don't know how) do a mass edit.