### PR TITLE
Fix bug 1287806 - X-Frame-Options header incorrect for attachments 

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -109,8 +109,8 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
 
         response = self.client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
         self.assertTrue(response.streaming)
-        self.assertEqual(response['x-frame-options'],
-                         'ALLOW-FROM: %s' % settings.DOMAIN)
+        self.assertEqual(response['Content-Security-Policy'],
+                         'frame-ancestors %s' % settings.DOMAIN)
         self.assertEqual(response.status_code, 200)
         self.assertIn('Last-Modified', response)
         self.assertNotIn('1970', response['Last-Modified'])

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -49,7 +49,9 @@ def raw_file(request, attachment_id, filename):
             response['Content-Length'] = rev.file.size
         except OSError:
             pass
-        response['X-Frame-Options'] = 'ALLOW-FROM: %s' % settings.DOMAIN
+        # Follow a recommendation emitted by April in bug 1287806
+        response['Content-Security-Policy'] = 'frame-ancestors %s' % settings\
+            .DOMAIN
         return response
     else:
         return redirect(attachment.get_file_url(), permanent=True)


### PR DESCRIPTION
Fix bug 1287806 [Bug 1287806 - X-Frame-Options header incorrect for attachments ](https://bugzilla.mozilla.org/show_bug.cgi?id=1287806)

- Change the XFO in favor of a CSP.
- Change the unit test to reflect the changes.