### PR TITLE
bug 1268609 - Do not delete draft after save click, to prevent data loss

### DIFF
--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -4,6 +4,8 @@
     var articleTracker = doc.location.pathname + '#answered-helpful';
     // this feature requires localStorage
     if (win.mdn.features.localStorage) {
+        // clear out any drafts from localStorage, now that we are not on the edit page
+        localStorage.removeItem('draft/edit' + location.pathname);
         var ignore = localStorage.getItem('helpful-ignore') === 'true'; // true if ever clicked ignore
         var articleAskedRecently = parseInt(localStorage.getItem(articleTracker), 10) > Date.now();
         var helpfulnessAskedRecently = parseInt(localStorage.getItem('helpfulnessTracker'), 10) > Date.now();

--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -4,8 +4,10 @@
     var articleTracker = doc.location.pathname + '#answered-helpful';
     // this feature requires localStorage
     if (win.mdn.features.localStorage) {
-        // clear out any drafts from localStorage, now that we are not on the edit page
-        localStorage.removeItem('draft/edit' + location.pathname);
+        // clear out any drafts from localStorage, now that the document has been saved
+        if (document_saved) {
+          localStorage.removeItem('draft/edit' + location.pathname);
+        }
         var ignore = localStorage.getItem('helpful-ignore') === 'true'; // true if ever clicked ignore
         var articleAskedRecently = parseInt(localStorage.getItem(articleTracker), 10) > Date.now();
         var helpfulnessAskedRecently = parseInt(localStorage.getItem('helpfulnessTracker'), 10) > Date.now();

--- a/kuma/static/js/helpfulness.js
+++ b/kuma/static/js/helpfulness.js
@@ -4,10 +4,6 @@
     var articleTracker = doc.location.pathname + '#answered-helpful';
     // this feature requires localStorage
     if (win.mdn.features.localStorage) {
-        // clear out any drafts from localStorage, now that the document has been saved
-        if (document_saved) {
-          localStorage.removeItem('draft/edit' + location.pathname);
-        }
         var ignore = localStorage.getItem('helpful-ignore') === 'true'; // true if ever clicked ignore
         var articleAskedRecently = parseInt(localStorage.getItem(articleTracker), 10) > Date.now();
         var helpfulnessAskedRecently = parseInt(localStorage.getItem('helpfulnessTracker'), 10) > Date.now();

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -462,7 +462,7 @@
         $('.btn-save').on('click', function () {
             if (draftingEnabled) {
                 // Clear any preserved content.
-                clearDraft('publish');
+                enableAutoSave(false);
                 clearTimeout(DRAFT_TIMEOUT_ID);
             }
             $form.attr('action', '').removeAttr('target');

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -462,7 +462,6 @@
         $('.btn-save').on('click', function () {
             if (draftingEnabled) {
                 enableAutoSave(false);
-                // Clear any preserved content.
                 clearTimeout(DRAFT_TIMEOUT_ID);
             }
             $form.attr('action', '').removeAttr('target');

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -461,8 +461,8 @@
         // Save button submits to top-level
         $('.btn-save').on('click', function () {
             if (draftingEnabled) {
-                // Clear any preserved content.
                 enableAutoSave(false);
+                // Clear any preserved content.
                 clearTimeout(DRAFT_TIMEOUT_ID);
             }
             $form.attr('action', '').removeAttr('target');

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -941,4 +941,9 @@
         initDetailsTags();
     }
 
+    // clear out any drafts from localStorage, now that the document has been saved
+    if (typeof document_saved !== 'undefined' && document_saved) {
+      localStorage.removeItem('draft/edit' + location.pathname);
+    }
+
 })(window, document, jQuery);

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -944,6 +944,7 @@
     // clear out any drafts from localStorage, now that the document has been saved
     if (typeof document_saved !== 'undefined' && document_saved) {
       localStorage.removeItem('draft/edit' + location.pathname);
+      localStorage.removeItem('draft/edit' + location.pathname + '#save-time');
     }
 
 })(window, document, jQuery);

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -1,3 +1,12 @@
+<!-- if this document was saved, we need to clear out the cached draft in wiki.js, need to get the value from the request if it exists -->
+<script type="text/javascript">
+  {% if request.GET.document_saved %}
+    var document_saved = 1;
+  {% else %}
+    var document_saved = 0;
+  {% endif %}
+</script>
+
 {% extends "wiki/base.html" %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 
@@ -385,16 +394,6 @@
 {% endblock %}
 
 {% block js %}
-
-  <!-- if this document was saved, we need to clear out the cached draft in helpfulness -->
-  <script type="text/javascript">
-    {% if request.GET.document_saved %}
-      var document_saved = 1;
-    {% else %}
-      var document_saved = 0;
-    {% endif %}
-  </script>
-  {% javascript 'helpfulness' %}
 
   {% if waffle.flag('section_edit') %}
     <script type="text/javascript">

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -386,6 +386,16 @@
 
 {% block js %}
 
+  <!-- if this document was saved, we need to clear out the cached draft in helpfulness -->
+  <script type="text/javascript">
+    {% if request.GET.document_saved %}
+      var document_saved = 1;
+    {% else %}
+      var document_saved = 0;
+    {% endif %}
+  </script>
+  {% javascript 'helpfulness' %}
+
   {% if waffle.flag('section_edit') %}
     <script type="text/javascript">
         (function($) {

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -3,6 +3,7 @@ import base64
 import datetime
 import json
 import time
+from urllib import urlencode
 from urlparse import urlparse
 
 import mock
@@ -1763,9 +1764,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                            locale=settings.WIKI_DEFAULT_LANGUAGE)
         response = self.client.post(edit_url, child_data)
         eq_(302, response.status_code)
-        self.assertRedirects(response, reverse('wiki.document',
-                                               args=['length/length'],
-                                               locale=settings.WIKI_DEFAULT_LANGUAGE))
+        url = reverse('wiki.document',
+                      args=['length/length'],
+                      locale=settings.WIKI_DEFAULT_LANGUAGE)
+        params = {'document_saved': 'true'}
+        url = '%s?%s' % (url, urlencode(params))
+        self.assertRedirects(response, url)
 
         # Creating a new translation of "length" and "length/length"
         # doesn't cause errors

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -259,13 +259,13 @@ def edit(request, document_slug, document_locale, revision_id=None):
                             # If a section was edited, and we're using the raw
                             # content API, constrain to that section.
                             params['section'] = section_id
-                    if params:
-                        url = '%s?%s' % (url, urlencode(params))
+                    # Parameter for the document saved, so that we can delete the cached draft on load
+                    params['document_saved'] = 'true'
+                    url = '%s?%s' % (url, urlencode(params))
                     if not is_raw and section_id:
                         # If a section was edited, jump to the section anchor
                         # if we're not getting raw content.
                         url = '%s#%s' % (url, section_id)
-
                     return redirect(url)
 
     parent_path = parent_slug = ''


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1268609

Remove call to clearDraft() method on save click.
Disable auto save on save click (which is part of the clearDraft() method).

Line 509 clears out this draft when we return to the edit page, after saving.
https://github.com/mozilla/kuma/compare/master...caktus:new-issue-1268609-save-draft-before-publish?expand=1#diff-e318b5ff8f27b6a7605c11e49310b1aaR509 

cc @stephaniehobson @jwhitlock 