### PR TITLE
Bug 1243693 : HTML Tags are wrongly displayed in title's bar

### DIFF
--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -96,7 +96,7 @@ def entity_decode(str):
 
 @library.global_function
 def page_title(title):
-    return u'%s | MDN' % title
+    return jinja2.Markup(u'%s | MDN' % title)
 
 
 @library.filter


### PR DESCRIPTION
Bug 1243693 : HTML Tags are wrongly displayed in title's bar

For this bug, I didn't managed to find a "real" fix.
- I think the first escape happens when the Document is rendered and a second time when `page_title(title)` is called.
- To work around this bug, I unescaped the string using jinja2.Markup unescape() function which removes the escape.

To ensure it worked properly, I tried to trigger a `<script>` from the title and it wasn't triggered.

