### PR TITLE
Bug 1138173 : Escape tags in raw en-US version of an article while editing a local

### DIFF
--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -90,7 +90,7 @@
                   {{ based_on.content_cleaned|safe }}
                 </div>
                 <div class="boxed translate-source hidden">
-                    <textarea readonly>{{ based_on.content_cleaned|safe }}</textarea>
+                    <textarea readonly>{{ based_on.content_cleaned }}</textarea>
                 </div>
               </article>
               <article class="localized">


### PR DESCRIPTION
[Bug 1138173](https://bugzilla.mozilla.org/show_bug.cgi?id=1138173): Escape tags in raw en-US version of an article while editing a local

I remove the |safe because the goal here is to have this string escaped to be able to copy/paste them inside when updating or making a translation.