### PR TITLE
bug 1287644: Add quotes around GA dim12, revision

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -27,7 +27,7 @@
 
     {%- if analytics_page_revision %}
         // dimension12 == 'Page Revision"
-        ga('set', 'dimension12', {{ analytics_page_revision }});
+        ga('set', 'dimension12', '{{ analytics_page_revision }}');
     {%- endif %}
 
     // dimension13 == "Saw iPerceptions Survey"


### PR DESCRIPTION
GA debug was complaining that the value for custom dimension 12 was expected to be a string, but instead was an integer. This fixes it.