### PR TITLE
bug 1291892 - Clear session on Persona signup fail

### DIFF
--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -159,3 +159,18 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         request.session['sociallogin_provider'] = (sociallogin
                                                    .account.provider)
         request.session.modified = True
+
+    def save_user(self, request, sociallogin, form):
+        """
+        Update the session after creating a new user account.
+
+        If the socialaccount_sociallogin remains in the session, then the user
+        will be unable to connect a second account unless they log out and
+        log in again.
+        """
+        super(KumaSocialAccountAdapter, self).save_user(request, sociallogin,
+                                                        form)
+        try:
+            del request.session['socialaccount_sociallogin']
+        except KeyError:  # pragma: no cover
+            pass

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -37,12 +37,18 @@ class SignupTests(UserTestCase, SocialTestMixin):
         self.assertContains(response,
                             'We are sorry, but you can not create a profile'
                             ' with Persona.')
+        session = response.context['request'].session
+        self.assertNotIn('socialaccount_sociallogin', session)
+        self.assertNotIn('sociallogin_provider', session)
 
     def test_signup_page_github(self):
         response = self.github_login()
         self.assertNotContains(response, 'Sign In Failure')
         for test_string in self.profile_create_strings:
             self.assertContains(response, test_string)
+        session = response.context['request'].session
+        self.assertIn('socialaccount_sociallogin', session)
+        self.assertEqual(session['sociallogin_provider'], 'github')
 
     def test_signup_page_disabled(self):
         registration_disabled = Flag.objects.create(
@@ -52,6 +58,9 @@ class SignupTests(UserTestCase, SocialTestMixin):
         response = self.github_login()
         self.assertNotContains(response, 'Sign In Failure')
         self.assertContains(response, 'Profile Creation Disabled')
+        session = response.context['request'].session
+        self.assertNotIn('socialaccount_sociallogin', session)
+        self.assertNotIn('sociallogin_provider', session)
 
         # re-enable registration
         registration_disabled.everyone = False
@@ -62,6 +71,9 @@ class SignupTests(UserTestCase, SocialTestMixin):
                         'having trouble']
         for test_string in test_strings:
             self.assertContains(response, test_string)
+        session = response.context['request'].session
+        self.assertIn('socialaccount_sociallogin', session)
+        self.assertEqual(session['sociallogin_provider'], 'github')
 
 
 class AccountEmailTests(UserTestCase):


### PR DESCRIPTION
When signup fails (due to registration being closed, or an attempt to signup with Persona), clear the social login from the session, so that it doesn't later interpret a new social login as an attempt to link accounts.

Here's the tests I did locally:

**Test 1**: Verify [bug 1063830](https://bugzilla.mozilla.org/show_bug.cgi?id=1063830) is still fixed:

1. Create an account associated with Persona and Github, both of which share an email.
2. Disconnect the GitHub account, log out
3. Login with the GitHub account, get a banner that "A profile already exists with an email address below."
4. Click the link in the banner to start a Persona login.
5. Sign in with a new, different Persona account, get message "Could not find profile matching that account." (fix for bug 1063830)
6. Sign in with the Persona account with the matching email, get to the Account Connections screen with the GitHub and Persona accounts associated.

**Test 2**: Verify [bug 1291892](https://bugzilla.mozilla.org/show_bug.cgi?id=1291892) is fixed:

First, clear out connection data by running ``./manage.py shell_plus``, and these commands:

```
Session.objects.all().delete()
SocialAccount.objects.all().delete()
me = User.objects.get(username='jwhitlock')  # Replace with your username
me.username = 'jwhitlock_old'  # Or another unique username
me.save()
(Ctrl-D to quit)
```

Reload the local MDN page, and confirm you are signed out.  Now:

1. Sign in with the Persona account. Get a "signup with Persona not allowed" message.
2. Click the link to "try again with a GitHub account". Sign in with Github. You are allowed to create an account.
3. Complete profile creation. If you have multiple GitHub emails, pick the one that matches the Persona email. Accept terms. "Create my MDN Profile".
4. Click the username in the header section to open the Profile page, then Edit to edit it. Select "Use your Persona account to sign in."
5. Pick the email that matches the GitHub / MDN profile email, Sign In. Get to the profile editing page with the GitHub and Persona accounts associated.