### PR TITLE
bug 1260197 - Update "publish and keep editing" workflow

### DIFF
--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -484,7 +484,7 @@
             // record event
             mdn.analytics.trackEvent({
                     category: 'Wiki',
-                    action: 'Button',
+                    action: 'Button', // now "Publish and keep editing" but keeping label for analytics continuity
                     label: 'Save and Keep Editing'
                 });
 
@@ -512,14 +512,12 @@
                     var $responseLoginRequired = $parsedData.find('#login');
                     // If there are errors, saveNotification() for each of them
                     if ($responseErrors.length) {
-                        var liErrors = $responseErrors.find('li')
-                        for (var i = 0; i < liErrors.length; i++) {
-                            saveNotification.error(liErrors[i])
-                        }
+                        var $liErrors = $responseErrors.find('li');
+                        saveNotification.error($liErrors);
                         //$form.submit();
                     // Check if the session has timed out
                     } else if ($responseLoginRequired.length) {
-                        saveNotification.error('Publishing failed. You are not currently signed in. Please use a new tab to sign in and try publishing again.')
+                        saveNotification.error(gettext('Publishing failed. You are not currently signed in. Please use a new tab to sign in and try publishing again.'));
                     } else {
                         // assume it went well
                         saveNotification.success(gettext('Changes saved.'), 2000);
@@ -527,12 +525,12 @@
                         // We also need to update the form's current_rev to
                         // avoid triggering a conflict, since we just saved in
                         // the background.
-                        var responseData = JSON.parse(data)
-                        if (responseData['error'] == true) {
-                            saveNotification.error(responseData['error_message'])
+                        var responseData = JSON.parse(data);
+                        if (responseData['error'] === true) {
+                            saveNotification.error(responseData['error_message']);
                         } else {
                             var responseRevision = JSON.parse(data)['new_revision_id'];
-                            $("input[id=id_current_rev]").val(responseRevision)
+                            $("input[id=id_current_rev]").val(responseRevision);
 
                             // Clear the review comment
                             $('#id_comment').val('');
@@ -548,14 +546,13 @@
                 error: function(jqXHR, textStatus, errorThrown) {
                     // Try to display the error that comes back from the server
                     try {
-                        var errorMessage = JSON.parse(jqXHR['responseText'])['error_message']
+                        var errorMessage = JSON.parse(jqXHR['responseText'])['error_message'];
                     } catch (err) {
-                        errorMessage = "Publishing failed. Please copy and paste your changes into a safe place and try submitting the form using the 'Publish' button.";
+                        errorMessage = gettext("Publishing failed. Please copy and paste your changes into a safe place and try submitting the form using the 'Publish' button.");
                     }
                     saveNotification.error(errorMessage);
                     // Re-enable the form; it gets disabled to prevent double-POSTs
                     $form.attr('disabled', false);
-                    // save draft
                 }
             });
 /*

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -478,8 +478,11 @@
             // disable form
             $('#wiki-page-edit').attr('disabled', true);
 
+            // Clear previous notification messages, if any
+            $('.notification button.close').click();
+
             // give user feedback
-            var saveNotification = mdn.Notifier.growl('Saving changes…', { duration: 0 });
+            var saveNotification = mdn.Notifier.growl('Saving changes…', { duration: 0 , closable: true});
 
             // record event
             mdn.analytics.trackEvent({
@@ -510,11 +513,18 @@
                     var $parsedData = $($.parseHTML(data));
                     var $responseErrors = $parsedData.find('.errorlist');
                     var $responseLoginRequired = $parsedData.find('#login');
-                    // If there are errors, saveNotification() for each of them
+                    try {
+                      var jsonErrorMessage = JSON.parse(jqXHR['responseText'])['error_message'];
+                    } catch (err) {
+                      var jsonErrorMessage = undefined;
+                    }
+                    // If there are errors, saveNotification() for them
                     if ($responseErrors.length) {
                         var $liErrors = $responseErrors.find('li');
                         saveNotification.error($liErrors);
-                        //$form.submit();
+                    // If there was an error from the json response, saveNotification() for it
+                    } else if (typeof(jsonErrorMessage) !== 'undefined') {
+                        saveNotification.error(gettext(jsonErrorMessage));
                     // Check if the session has timed out
                     } else if ($responseLoginRequired.length) {
                         saveNotification.error(gettext('Publishing failed. You are not currently signed in. Please use a new tab to sign in and try publishing again.'));

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -459,6 +459,10 @@
     //
     function initSaveAndEditButtons () {
         var $form = $('#wiki-page-edit');
+        // Handle edits on the translate page
+        if ($form.length == 0 && $('#translate-document').length == 1) {
+            $form = $('#translate-document');
+        }
 
         // Save button submits to top-level
         $form.on('submit', function () {
@@ -471,7 +475,7 @@
 
         // save and edit attempts ajax submit
         $('.btn-save-and-edit').on('click', function(event) {
-            // TODO: diable form
+            // TODO: disable form
             console.log('save and edit triggered');
 
             // give user feedback

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -496,7 +496,6 @@
             var formURL = window.location.href; // submits to self
             console.log('posting this data: ', formData)
 
-            // ajax submit
             $.ajax({
                 url : formURL + '?async',
                 type: "POST",
@@ -528,16 +527,22 @@
                         // We also need to update the form's current_rev to
                         // avoid triggering a conflict, since we just saved in
                         // the background.
-                        var responseRevision = JSON.parse(data)['new_revision_id'];
-                        console.log('responseRevision: ', responseRevision);
-                        // TODO: why are there multiple <input id="id_current_rev">s?
-                        $("input[id=id_current_rev]").val(responseRevision)
+                        console.log('data is: ', data)
+                        var responseData = JSON.parse(data)
+                        if (responseData['error'] == true) {
+                            saveNotification.error(responseData['error_message'])
+                        } else {
+                            var responseRevision = JSON.parse(data)['new_revision_id'];
+                            console.log('responseRevision: ', responseRevision);
+                            // TODO: why are there multiple <input id="id_current_rev">s?
+                            $("input[id=id_current_rev]").val(responseRevision)
 
-                        // Clear the review comment
-                        $('#id_comment').val('');
+                            // Clear the review comment
+                            $('#id_comment').val('');
 
-                        // Trigger a `mdn:save-success` event so dirtiness can be reset throughout the page
-                        $form.trigger('mdn:save-success');
+                            // Trigger a `mdn:save-success` event so dirtiness can be reset throughout the page
+                            $form.trigger('mdn:save-success');
+                        }
 
                         // Re-enable the form; it gets disabled to prevent double-POSTs
                         $form.data('disabled', false).removeClass('disabled');
@@ -549,9 +554,13 @@
                     // console.log(jqXHR.status);
                     // console.log(textStatus);
                     // console.log(errorThrown);
-                    var msg = "Publishing failed. Please copy and paste your changes into a safe place and try submitting the form using the 'Publish' button.";
-
-                    saveNotification.error(msg);
+                    // Try to display the error that comes back from the server
+                    try {
+                        var errorMessage = JSON.parse(jqXHR['responseText'])['error_message']
+                    } catch (err) {
+                        errorMessage = "Publishing failed. Please copy and paste your changes into a safe place and try submitting the form using the 'Publish' button.";
+                    }
+                    saveNotification.error(errorMessage);
 //                    saveNotification.error(msg, {closable: true, duration: 0});
 
                     // save draft

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -458,89 +458,113 @@
     // Initialize logic for save and save-and-edit buttons.
     //
     function initSaveAndEditButtons () {
+        var $form = $('#wiki-page-edit');
+
         // Save button submits to top-level
-        $('.btn-save').on('click', function () {
-            if (draftingEnabled) {
+        $form.on('submit', function () {
+            if (supportsLocalStorage) {
                 enableAutoSave(false);
                 clearTimeout(DRAFT_TIMEOUT_ID);
             }
-            $form.attr('action', '').removeAttr('target');
             return true;
         });
 
-        // Save-and-edit submits to a hidden iframe, show loading message in notifier
-        var notifications = [];
-        $('.btn-save-and-edit').on('click', function () {
+        // save and edit attempts ajax submit
+        $('.btn-save-and-edit').on('click', function(event) {
+            // TODO: diable form
+            console.log('save and edit triggered');
 
-            notifications.push(mdn.Notifier.growl('Saving changes…', { duration: 0 }));
+            // give user feedback
+            var saveNotification = mdn.Notifier.growl('Saving changes…', { duration: 0 });
 
+            // record event
             mdn.analytics.trackEvent({
-                category: 'Wiki',
-                action: 'Button',
-                label: 'Save and Keep Editing' // now "Publish and keep editing" but keeping label for analytics continuity
-            });
+                    category: 'Wiki',
+                    action: 'Button',
+                    label: 'Save and Keep Editing'
+                });
 
+            // Preserve editor content incase something goes wrong
             var savedTa = $form.find('textarea[name=content]').val();
-            if (draftingEnabled) {
-                // Preserve editor content, because saving to the iframe can
-                // yield things like 403 / login-required errors that bust out
-                // of the frame
-                manualSaveDraft(savedTa);
-                startingContent = savedTa;
+            if (supportsLocalStorage) {
+                saveDraft(savedTa);
                 clearTimeout(DRAFT_TIMEOUT_ID);
             }
-            // Redirect the editor form to the iframe.
-            $form.attr('action', '?iframe=1').attr('target', 'save-and-edit-target');
-            return true;
+
+            // get form data
+            var formData = $form.serialize();
+            var formURL = window.location.href; // submits to self
+            //console.log(formData);
+            //console.log(formURL);
+
+            // ajax submit
+            $.ajax({
+                url : formURL + '?async',
+                type: "POST",
+                data : formData,
+                dataType : 'html',
+                success: function(data, textStatus, jqXHR) {
+                    // server came back 200
+                     console.log(data, data);
+                    // console.log(textStatus);
+                    // console.log(jqXHR);
+                    // was there an error?
+                    var $parsedData = $($.parseHTML(data));
+                    //console.log('parsedData:');
+                    //console.log($parsedData);
+                    var $responseErrors = $parsedData.filter('.errorlist');
+                    if($responseErrors.length) {
+                        console.log('error found');
+                        saveNotification.error('uh-oh');
+                        //$form.submit();
+                    }
+                    else {
+                        console.log('no errors - sucess!');
+                        // assume it went well
+                        saveNotification.success(gettext('Changes saved.'), 2000);
+
+                        // We also need to update the form's current_rev to
+                        // avoid triggering a conflict, since we just saved in
+                        // the background.
+                        var responseRevision = $parsedData.filter('#id_current_rev').val();
+                        console.log(responseRevision);
+                        $('#id_current_rev').val(responseRevision);
+
+                        // Clear the review comment
+                        $('#id_comment').val('');
+
+                        // Trigger a `mdn:save-success` event so dirtiness can be reset throughout the page
+                        $form.trigger('mdn:save-success');
+
+                        // Re-enable the form; it gets disabled to prevent double-POSTs
+                        $form.data('disabled', false).removeClass('disabled');
+                    }
+                },
+                error: function(jqXHR, textStatus, errorThrown) {
+                    //if fails
+                    // console.log(jqXHR);
+                    // console.log(jqXHR.status);
+                    // console.log(textStatus);
+                    // console.log(errorThrown);
+
+                    saveNotification.error('uh-oh', {closable: true, duration: 0});
+
+                    // save draft
+                }
+            });
+/*
+                //$form.find('input[name=current_rev]').val(
+
+                //ir.attr('data-current-revision'));
+
+                // Stop loading state on button
+                //$('.btn-save-and-edit').removeClass('loading');
+
+*/
+
         });
         $('.btn-save-and-edit').show();
 
-        $('#save-and-edit-target').on('load', function () {
-            if(notifications[0]) notifications[0].success(null, 2000);
-            notifications.shift();
-
-            var if_doc = $(this).get(0).contentDocument;
-            if (typeof(if_doc) != 'undefined') {
-
-                var ir = $('#iframe-response', if_doc);
-                if ('OK' == ir.attr('data-status')) {
-
-                    if (draftingEnabled) {
-                        // Dig into the iframe on load and look for "OK". If found,
-                        // then it should be safe to throw away the preserved content.
-                        clearDraft('publish');
-                        enableAutoSave(true);
-                    }
-
-                    // We also need to update the form's current_rev to
-                    // avoid triggering a conflict, since we just saved in
-                    // the background.
-                    $form.find('input[name=current_rev]').val(
-                        ir.attr('data-current-revision'));
-
-                } else if ($form.add(if_doc).hasClass('conflict')) {
-                    // HACK: If we detect a conflict in the iframe while
-                    // doing save-and-edit, force a full-on save in order
-                    // to surface the issue. There's no easy way to bust
-                    // the iframe otherwise, since this was a POST.
-                    $form.attr('action', '').attr('target', '');
-                    $('.btn-save').click();
-
-                }
-
-                // Anything else that happens (eg. 403 errors) should have
-                // framebusting code to escape the hidden iframe.
-            }
-            // Stop loading state on button
-            $('.btn-save-and-edit').removeClass('loading');
-            // Clear the review comment
-            $('#id_comment').val('');
-            // Re-enable the form; it gets disabled to prevent double-POSTs
-            $form.data('disabled', false).removeClass('disabled');
-            // Trigger a `mdn:save-success` event so dirtiness can be reset throughout the page
-            $form.trigger('mdn:save-success');
-            return true;
-        });
 
         // Track submissions of the edit page form
         $form.on('submit', function() {

--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -494,8 +494,7 @@
             // get form data
             var formData = $form.serialize();
             var formURL = window.location.href; // submits to self
-            //console.log(formData);
-            //console.log(formURL);
+            console.log('posting this data: ', formData)
 
             // ajax submit
             $.ajax({
@@ -505,30 +504,34 @@
                 dataType : 'html',
                 success: function(data, textStatus, jqXHR) {
                     // server came back 200
-                     console.log(data, data);
+                    console.log('data is: ', data);
                     // console.log(textStatus);
                     // console.log(jqXHR);
                     // was there an error?
                     var $parsedData = $($.parseHTML(data));
-                    //console.log('parsedData:');
-                    //console.log($parsedData);
-                    var $responseErrors = $parsedData.filter('.errorlist');
+                    var $responseErrors = $parsedData.find('.errorlist');
+                    console.log('$responseErrors: ', $responseErrors);
+                    // If there are errors, saveNotification() for each of them
                     if($responseErrors.length) {
                         console.log('error found');
-                        saveNotification.error('uh-oh');
+                        var liErrors = $responseErrors.find('li')
+                        for (var i = 0; i < liErrors.length; i++) {
+                            saveNotification.error(liErrors[i])
+                        }
                         //$form.submit();
                     }
                     else {
-                        console.log('no errors - sucess!');
+                        console.log('no errors - sucesss!');
                         // assume it went well
                         saveNotification.success(gettext('Changes saved.'), 2000);
 
                         // We also need to update the form's current_rev to
                         // avoid triggering a conflict, since we just saved in
                         // the background.
-                        var responseRevision = $parsedData.filter('#id_current_rev').val();
-                        console.log(responseRevision);
-                        $('#id_current_rev').val(responseRevision);
+                        var responseRevision = JSON.parse(data)['new_revision_id'];
+                        console.log('responseRevision: ', responseRevision);
+                        // TODO: why are there multiple <input id="id_current_rev">s?
+                        $("input[id=id_current_rev]").val(responseRevision)
 
                         // Clear the review comment
                         $('#id_comment').val('');
@@ -546,8 +549,10 @@
                     // console.log(jqXHR.status);
                     // console.log(textStatus);
                     // console.log(errorThrown);
+                    var msg = "Publishing failed. Please copy and paste your changes into a safe place and try submitting the form using the 'Publish' button.";
 
-                    saveNotification.error('uh-oh', {closable: true, duration: 0});
+                    saveNotification.error(msg);
+//                    saveNotification.error(msg, {closable: true, duration: 0});
 
                     // save draft
                 }

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -17,6 +17,7 @@ from taggit.utils import parse_tags
 
 import kuma.wiki.content
 from kuma.core.form_fields import StrippedCharField
+from kuma.core.urlresolvers import reverse
 from kuma.spam.akismet import AkismetError
 from kuma.spam.forms import AkismetCheckFormMixin, AkismetSubmissionFormMixin
 
@@ -64,8 +65,10 @@ COMMENT_LONG = _(u'Please keep the length of the comment to '
 SLUG_COLLIDES = _(u'Another document with this slug already exists.')
 OTHER_COLLIDES = _(u'Another document with this metadata already exists.')
 
-MIDAIR_COLLISION = _(u'This document was modified while you were '
-                     u'editing it.')
+MIDAIR_COLLISION = _(u'Publishing failed. Conflicting edit attempts detected. '
+                     u'Please copy and paste your edits to a safe place and '
+                     u'visit the <a href="%(url)s">revision history</a> page '
+                     u'to see what was changed before making further edits.')
 MOVE_REQUIRED = _(u"Changing this document's slug requires "
                   u"moving it and its children.")
 
@@ -659,13 +662,21 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                     if orig_ct != curr_ct:
                         # Oops. Looks like the section did actually get
                         # changed, so yeah this is a collision.
-                        raise forms.ValidationError(MIDAIR_COLLISION)
+                        url = reverse(
+                            'wiki.document_revisions',
+                            kwargs={'document_path': self.instance.document.slug}
+                        )
+                        raise forms.ValidationError(MIDAIR_COLLISION % {'url': url})
 
                     return current_rev
 
                 else:
                     # No section edit, so this is a flat-out collision.
-                    raise forms.ValidationError(MIDAIR_COLLISION)
+                    url = reverse(
+                        'wiki.document_revisions',
+                        kwargs={'document_path': self.instance.document.slug}
+                    )
+                    raise forms.ValidationError(MIDAIR_COLLISION % {'url': url})
 
         except Document.DoesNotExist:
             # If there's no document yet, just bail.

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -495,7 +495,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.section_id = kwargs.pop('section_id', None)
-        self.is_iframe_target = kwargs.pop('is_iframe_target', None)
+        self.is_async_submit = kwargs.pop('is_async_submit', None)
 
         # when creating a new document with a parent, this will be set
         self.parent_slug = kwargs.pop('parent_slug', None)
@@ -536,7 +536,7 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
     def clean_slug(self):
         # Since this form can change the URL of the page on which the editing
         # happens, changes to the slug are ignored for an iframe submissions
-        if self.is_iframe_target:
+        if self.is_async_submit:
             return self.instance.document.slug
 
         # Get the cleaned slug

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -183,7 +183,7 @@
               </div>
             {% endif %}
 
-            <input type="hidden" name="form" value="rev" />
+            <input type="hidden" name="form-type" value="rev" />
             {{ revision_form.hidden_fields()|join|safe }}
 
             {% set tags = document.tags.all().order_by('name') %}

--- a/kuma/wiki/jinja2/wiki/includes/page_buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/page_buttons.html
@@ -19,8 +19,9 @@
 
 <ul class="page-buttons">
   {% if document %}
+  {# No save-and-edit on new pages because slug changes confuse it #}
   <li>
-    <button type="submit" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-pencil"></i></button>
+    <button type="submit" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-edit"></i></button>
   </li>
   {% endif %}
   <li>

--- a/kuma/wiki/jinja2/wiki/includes/page_buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/page_buttons.html
@@ -21,7 +21,7 @@
   {% if document %}
   {# No save-and-edit on new pages because slug changes confuse it #}
   <li>
-    <button type="button" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-edit"></i></button>
+    <button type="button" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-pencil"></i></button>
   </li>
   {% endif %}
   <li>

--- a/kuma/wiki/jinja2/wiki/includes/page_buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/page_buttons.html
@@ -21,7 +21,7 @@
   {% if document %}
   {# No save-and-edit on new pages because slug changes confuse it #}
   <li>
-    <button type="submit" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-edit"></i></button>
+    <button type="button" class="button positive btn-save-and-edit" data-optimizely-hook="button-save-and-keep-editing button-save-and-keep-editing-{{ location }}"><span>{{ _('Publish and Keep Editing') }}</span><i aria-hidden="true" class="icon-edit"></i></button>
   </li>
   {% endif %}
   <li>

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -21,7 +21,7 @@
 {% block content %}
     <form action="" method="post" data-json-url="{{ url('wiki.json') }}" id="translate-document">
       {% csrf_token %}
-      <input type="hidden" name="form" value="both" />
+      <input type="hidden" name="form-type" value="both" />
 
       <div id="localize-document" class="editing">
         <header id="article-head">

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -342,10 +342,10 @@ class RevisionFormEditTests(RevisionFormViewTests):
         mock_requests.post(CHECK_URL, content=is_spam)
 
         section_id = None
-        is_iframe_target = False
+        is_async_submit = False
         rev_form = RevisionForm(request=request,
                                 data=data,
-                                is_iframe_target=is_iframe_target,
+                                is_async_submit=is_async_submit,
                                 section_id=section_id)
         rev_form.instance.document = previous_revision.document
         return rev_form

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -456,7 +456,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
             'slug': self.d.slug,
             'toc_depth': 1,
             'based_on': self.d.current_revision.id,
-            'form': 'rev',
+            'form-type': 'rev',
         }
         edit_url = reverse('wiki.edit', args=[self.d.slug])
         response = self.client.post(edit_url, data)
@@ -508,7 +508,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         self.d.save()
         tags = ['tag1', 'tag2', 'tag3']
         data = new_document_data(tags)
-        data['form'] = 'rev'
+        data['form-type'] = 'rev'
         response = self.client.post(reverse('wiki.edit',
                                     args=[self.d.slug]), data)
         eq_(302, response.status_code)
@@ -531,7 +531,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         eq_(tags, result_tags)
         tags = [u'tag1', u'tag4']
         data = new_document_data(tags)
-        data['form'] = 'rev'
+        data['form-type'] = 'rev'
         self.client.post(reverse('wiki.edit',
                                  args=[self.d.slug]),
                          data)
@@ -545,7 +545,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         editing."""
         _test_form_maintains_based_on_rev(
             self.client, self.d, 'wiki.edit',
-            {'summary': 'Windy', 'content': 'gerbils', 'form': 'rev',
+            {'summary': 'Windy', 'content': 'gerbils', 'form-type': 'rev',
              'slug': self.d.slug, 'toc_depth': 1},
             locale='en-US')
 
@@ -572,7 +572,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         new_title = 'A brand new title'
         data.update(title=new_title)
-        data.update(form='doc')
+        data['form-type'] = 'doc'
         data.update(is_localizable='True')
         response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data, follow=True)
@@ -585,7 +585,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         new_slug = 'Test-Document'
         data.update(slug=new_slug)
-        data.update(form='doc')
+        data['form-type'] = 'doc'
         response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data, follow=True)
         eq_(200, response.status_code)
@@ -597,7 +597,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         new_title = 'TeST DoCuMent'
         data.update(title=new_title)
-        data.update(form='doc')
+        data['form-type'] = 'doc'
         response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data, follow=True)
         eq_(200, response.status_code)
@@ -911,7 +911,7 @@ class TranslateTests(UserTestCase, WikiTestCase):
         data = _translation_data()
         new_title = 'Un nuevo titulo'
         data['title'] = new_title
-        data['form'] = 'doc'
+        data['form-type'] = 'doc'
         response = self.client.post(translate_uri, data)
         eq_(302, response.status_code)
         eq_('http://testserver/es/docs/un-test-articulo$edit'

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -500,7 +500,7 @@ class PermissionTests(UserTestCase, WikiTestCase):
                         url = reverse('wiki.create', locale=locale)
                         resp = self.client.post(url, data, follow=False)
                     else:
-                        data['form'] = 'rev'
+                        data['form-type'] = 'rev'
                         url = reverse('wiki.edit', args=(slug,), locale=locale)
                         resp = self.client.post(url, data, follow=False)
 
@@ -1240,7 +1240,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         old_title = doc.title
         data = new_document_data()
         data.update({'title': new_title,
-                     'form': 'rev'})
+                     'form-type': 'rev'})
         data['slug'] = ''
         url = reverse('wiki.edit', args=[doc.slug])
         self.client.post(url, data)
@@ -1274,7 +1274,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         new_title = 'Some New Title'
         data = new_document_data()
         data.update({'title': new_title,
-                     'form': 'rev'})
+                     'form-type': 'rev'})
         data['slug'] = ''
         url = reverse('wiki.edit', args=[d.slug])
         self.client.post(url, data)
@@ -1326,7 +1326,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Now, post an update with duplicate slug
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'slug': exist_slug
         })
         resp = self.client.post(reverse('wiki.edit',
@@ -1357,7 +1357,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         eq_(302, resp.status_code)
 
         # Change title and slug
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'title': changed_title,
                      'slug': changed_slug})
         resp = self.client.post(reverse('wiki.edit',
@@ -1366,7 +1366,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         eq_(302, resp.status_code)
 
         # Change title and slug back to originals, clobbering the redirect
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'title': exist_title,
                      'slug': exist_slug})
         resp = self.client.post(reverse('wiki.edit',
@@ -1625,7 +1625,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                 # ensure the slug stays the same (i.e. no parent prepending)
                 def test_invalid_slug_translate(inv_slug, url, data):
                     data['slug'] = inv_slug
-                    data['form'] = 'both'
+                    data['form-type'] = 'both'
                     response = self.client.post(url, data)
                     eq_(200, response.status_code)  # 200 = bad, invalid data
                     page = pq(response.content)
@@ -1640,7 +1640,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
                 # Push a valid translation
                 translate_data['slug'] = translate_slug
-                translate_data['form'] = 'both'
+                translate_data['form-type'] = 'both'
                 response = self.client.post(foreign_url, translate_data)
                 eq_(302, response.status_code)
                 # Ensure no redirect
@@ -1671,7 +1671,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                 # Attempt an invalid edit of the root, ensure the slug stays
                 # the same (i.e. no parent prepending)
                 edit_data['slug'] = invalid_slug
-                edit_data['form'] = 'both'
+                edit_data['form-type'] = 'both'
                 response = self.client.post(reverse('wiki.edit',
                                                     args=[edit_doc.slug],
                                                     locale=foreign_locale),
@@ -1707,7 +1707,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             def _run_slug_edit_tests(edit_slug, edit_data, edit_doc, loc):
 
                 edit_data['slug'] = edit_data['slug'] + '_Updated'
-                edit_data['form'] = 'rev'
+                edit_data['form-type'] = 'rev'
                 response = self.client.post(reverse('wiki.edit',
                                                     args=[edit_doc.slug],
                                                     locale=loc),
@@ -1758,7 +1758,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                      locale=settings.WIKI_DEFAULT_LANGUAGE))
 
         # Editing "length/length" document doesn't cause errors
-        child_data['form'] = 'rev'
+        child_data['form-type'] = 'rev'
         child_data['slug'] = ''
         edit_url = reverse('wiki.edit', args=['length/length'],
                            locale=settings.WIKI_DEFAULT_LANGUAGE)
@@ -1773,7 +1773,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Creating a new translation of "length" and "length/length"
         # doesn't cause errors
-        child_data['form'] = 'both'
+        child_data['form-type'] = 'both'
         child_data['slug'] = 'length'
         translate_url = reverse('wiki.document', args=[child_data['slug']],
                                 locale=settings.WIKI_DEFAULT_LANGUAGE)
@@ -2030,7 +2030,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(pq(response.content)('li.metadata-choose-parent'))
 
         # Set the parent
-        data.update({'form': 'rev', 'parent_id': en_d.id})
+        data.update({'form-type': 'rev', 'parent_id': en_d.id})
         resp = self.client.post(url, data)
         eq_(302, resp.status_code)
         ok_('fr/docs/a-test-article' in resp['Location'])
@@ -2116,7 +2116,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert_tag_state(ts1, ts2)
 
         # Now, update the tags.
-        data.update({'form': 'rev', 'tags': ', '.join(ts2)})
+        data.update({'form-type': 'rev', 'tags': ', '.join(ts2)})
         self.client.post(reverse('wiki.edit',
                                  args=[path]), data)
         assert_tag_state(ts2, ts1)
@@ -2142,7 +2142,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Now, post an update with two tags
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'review_tags': ['editorial', 'technical'],
         })
         response = self.client.post(reverse('wiki.edit',
@@ -2189,7 +2189,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Post an edit that removes one of the tags.
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'review_tags': ['editorial', ]
         })
         response = self.client.post(reverse('wiki.edit',
@@ -2307,7 +2307,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Edit #2 submits successfully
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': 'This edit got there first',
             'current_rev': rev_id2
         })
@@ -2317,7 +2317,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # Edit #1 submits, but receives a mid-aired notification
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': 'This edit gets mid-aired',
             'current_rev': rev_id1
         })
@@ -2325,7 +2325,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                         args=[doc.slug]), data)
         eq_(200, resp.status_code)
 
-        ok_(unicode(MIDAIR_COLLISION).encode('utf-8') in resp.content,
+        history_url = reverse(
+            'wiki.document_revisions',
+            kwargs={'document_path': doc.slug}, locale=doc.locale)
+        midair_collission_error = (unicode(MIDAIR_COLLISION) % {'url': history_url}).encode('utf-8')
+        ok_(midair_collission_error in resp.content,
             "Midair collision message should appear")
 
     @pytest.mark.toc
@@ -2336,7 +2340,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc = rev.document
         data = new_document_data()
         ok_(Document.objects.get(slug=doc.slug, locale=doc.locale).show_toc)
-        data['form'] = 'rev'
+        data['form-type'] = 'rev'
         data['toc_depth'] = 0
         data['slug'] = doc.slug
         data['title'] = doc.title
@@ -2356,7 +2360,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(not Document.objects.get(slug=rev.document.slug,
                                      locale=rev.document.locale).show_toc)
         data = new_document_data()
-        data['form'] = 'rev'
+        data['form-type'] = 'rev'
         data['slug'] = rev.document.slug
         data['title'] = rev.document.title
         self.client.post(reverse('wiki.edit', args=[rev.document.slug]),
@@ -2547,7 +2551,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc = Document.objects.get(locale=settings.WIKI_DEFAULT_LANGUAGE,
                                    slug=slug)
 
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'content': 'This revision should NOT record IP',
                      'comment': 'This revision should NOT record IP'})
 
@@ -2589,7 +2593,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc = Document.objects.get(
             locale=settings.WIKI_DEFAULT_LANGUAGE, slug=slug)
 
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'content': 'This edit should not send an email',
                      'comment': 'This edit should not send an email'})
 
@@ -2632,7 +2636,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         testuser2 = get_user(username='testuser2')
         EditDocumentEvent.notify(testuser2, rev.document)
 
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'slug': rev.document.slug,
                      'title': rev.document.title,
                      'content': 'This edit should send an email',
@@ -2656,7 +2660,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         testuser01 = get_user(username='testuser01')
         EditDocumentEvent.notify(testuser01, rev.document)
 
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'slug': rev.document.slug,
                      'content': 'This edit should send 2 emails',
                      'comment': 'This edit should send 2 emails'})
@@ -2689,7 +2693,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'slug': child_doc.slug,
                      'content': 'This edit should send an email',
                      'comment': 'This edit should send an email'})
@@ -2716,7 +2720,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'slug': grandchild_doc.slug,
                      'content': 'This edit should send an email',
                      'comment': 'This edit should send an email'})
@@ -2745,7 +2749,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()
-        data.update({'form': 'rev',
+        data.update({'form-type': 'rev',
                      'slug': child_doc.slug,
                      'content': 'This edit should send an email',
                      'comment': 'This edit should send an email'})
@@ -2931,7 +2935,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             normalize_html(response.content))
 
     @pytest.mark.midair
-    def test_raw_section_edit(self):
+    def test_raw_section_edit_ajax(self):
         self.client.login(username='admin', password='testpass')
         rev = revision(is_approved=True, save=True, content="""
             <h1 id="s1">s1</h1>
@@ -2950,20 +2954,16 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <h1 id="s2">s2</h1>
             <p>replace</p>
         """
-        expected = """
-            <h1 id="s2">s2</h1>
-            <p>replace</p>
-        """
         response = self.client.post('%s?section=s2&raw=true' %
                                     reverse('wiki.edit',
                                             args=[rev.document.slug]),
-                                    {"form": "rev",
+                                    {"form-type": "rev",
                                      "slug": rev.document.slug,
                                      "content": replace},
                                     follow=True,
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(normalize_html(expected),
-            normalize_html(response.content))
+        eq_({'error': False, 'new_revision_id': rev.id + 1},
+            json.loads(response.content))
 
         expected = """
             <h1 id="s1">s1</h1>
@@ -2985,7 +2985,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             normalize_html(response.content))
 
     @pytest.mark.midair
-    def test_midair_section_merge(self):
+    def test_midair_section_merge_ajax(self):
         """If a page was changed while someone was editing, but the changes
         didn't affect the specific section being edited, then ignore the midair
         warning"""
@@ -3024,7 +3024,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>test</p>
         """
         data = {
-            'form': 'rev',
+            'form-type': 'rev',
             'content': rev.content,
             'slug': ''
         }
@@ -3046,7 +3046,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
 
         # Edit #2 submits successfully
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': replace_2,
             'current_rev': rev_id2,
             'slug': rev.document.slug
@@ -3055,12 +3055,13 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                                 reverse('wiki.edit', args=[rev.document.slug]),
                                 data,
                                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(302, resp.status_code)
+
+        eq_(json.loads(resp.content)['error'], False)
 
         # Edit #1 submits, but since it's a different section, there's no
         # mid-air collision
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': replace_1,
             'current_rev': rev_id1
         })
@@ -3087,7 +3088,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             unicode(response['x-kuma-revision']))
 
     @pytest.mark.midair
-    def test_midair_section_collision(self):
+    def test_midair_section_collision_ajax(self):
         """If both a revision and the edited section has changed, then a
         section edit is a collision."""
         self.client.login(username='admin', password='testpass')
@@ -3114,7 +3115,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>first replace</p>
         """
         data = {
-            'form': 'rev',
+            'form-type': 'rev',
             'content': rev.content
         }
 
@@ -3134,7 +3135,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
 
         # Edit #2 submits successfully
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': replace_2,
             'slug': rev.document.slug,
             'current_rev': rev_id2
@@ -3142,7 +3143,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         resp = self.client.post('%s?section=s2&raw=true' %
                                 reverse('wiki.edit', args=[rev.document.slug]),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(302, resp.status_code)
+        eq_(False, json.loads(resp.content)['error'])
 
         # Edit #1 submits, but since it's the same section, there's a collision
         data.update({
@@ -3155,6 +3156,13 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         # With the raw API, we should get a 409 Conflict on collision.
         eq_(409, resp.status_code)
+        # We receive the midair collission message
+        history_url = reverse(
+            'wiki.document_revisions',
+            kwargs={'document_path': rev.document.slug}, locale=rev.document.locale)
+        midair_collission_error = (unicode(MIDAIR_COLLISION) % {'url': history_url}).encode('utf-8')
+        ok_(midair_collission_error in json.loads(resp.content)['error_message'],
+            "Midair collision message should appear")
 
     def test_raw_include_option(self):
         doc_src = u"""
@@ -3209,7 +3217,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         """
         self.client.post('%s?section=s2&raw=true' %
                          reverse('wiki.edit', args=[rev.document.slug]),
-                         {"form": "rev", "slug": rev.document.slug, "content": replace},
+                         {"form-type": "rev", "slug": rev.document.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
         ok_(rev.id != changed.id)
@@ -3242,7 +3250,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         """
         self.client.post('%s?section=s2&raw=true' %
                          reverse('wiki.edit', args=[rev.document.slug]),
-                         {"form": "rev", "slug": rev.document.slug, "content": replace},
+                         {"form-type": "rev", "slug": rev.document.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
         ok_(rev.id != changed.id)
@@ -3691,7 +3699,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
 
         data = new_document_data()
         data.update({
-            'form': 'rev',
+            'form-type': 'rev',
             'content': 'This is an update',
         })
 
@@ -3703,7 +3711,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         mock_document_schedule_rendering.reset_mock()
 
         data.update({
-            'form': 'both',
+            'form-type': 'both',
             'content': 'This is a translation',
         })
         translate_url = (reverse('wiki.translate', args=[data['slug']],

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -208,6 +208,14 @@ def edit(request, document_slug, document_locale, revision_id=None):
                 if not rev_form.is_valid():
                     # Was there a mid-air collision?
                     if 'current_rev' in rev_form._errors:
+                        # If this was an Ajax POST, then return a JSONReponse
+                        if is_async_submit:
+                            data = {
+                                "error": True,
+                                "error_message": rev_form.errors['current_rev'],
+                                "new_revision_id": curr_rev.id,
+                            }
+                            return JsonResponse(data=data, status=500)
                         # Jump out to a function to escape indentation hell
                         return _edit_document_collision(
                             request, orig_rev, curr_rev, is_async_submit,

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
@@ -208,6 +209,10 @@ def edit(request, document_slug, document_locale, revision_id=None):
                 if not rev_form.is_valid():
                     # Was there a mid-air collision?
                     if 'current_rev' in rev_form._errors:
+                        # Make the error message safe so the '<' and '>' don't
+                        # get turned into '&lt;' and '&gt;', respectively
+                        rev_form.errors['current_rev'][0] = mark_safe(rev_form.errors['current_rev'][0])
+
                         # If this was an Ajax POST, then return a JSONReponse
                         if is_async_submit:
                             data = {

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -152,7 +152,7 @@ def edit(request, document_slug, document_locale, revision_id=None):
 
         # Comparing against localized names for the Save button bothers me, so
         # I embedded a hidden input:
-        which_form = request.POST.get('form')
+        which_form = request.POST.get('form-type')
 
         if which_form == 'doc':
             if doc.allows_editing_by(request.user):
@@ -173,10 +173,9 @@ def edit(request, document_slug, document_locale, revision_id=None):
                     if is_async_submit:
                         data = {
                             "error" : False,
-                            "new_revision_id" : 13 #TODO: get next revision number
+                            "new_revision_id" : rev.document.revisions.order_by('-id').first().id # This is the most recent revision id
                         }
-                        json_data = json.dumps(data)
-                        return JsonResponse(json_data)
+                        return JsonResponse(data)
 
                     return redirect(urlparams(doc.get_edit_url(),
                                               opendescription=1))
@@ -221,10 +220,9 @@ def edit(request, document_slug, document_locale, revision_id=None):
                     if is_async_submit:
                         data = {
                             "error" : False,
-                            "new_revision_id" : 13 #TODO: get next revision number
+                            "new_revision_id" : rev.document.revisions.order_by('-id').first().id # This is the most recent revision id
                         }
-                        json_data = json.dumps(data)
-                        return JsonResponse(json_data)
+                        return JsonResponse(data)
 
                     if (is_raw and orig_rev is not None and
                             curr_rev.id != orig_rev.id):

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-import textwrap
-import json
 from urllib import urlencode
 
 import newrelic.agent
@@ -172,9 +170,11 @@ def edit(request, document_slug, document_locale, revision_id=None):
 
                     # save-and-edit button
                     if is_async_submit:
+                        # This is the most recent revision id
+                        new_rev_id = rev.document.revisions.order_by('-id').first().id
                         data = {
-                            "error" : False,
-                            "new_revision_id" : rev.document.revisions.order_by('-id').first().id # This is the most recent revision id
+                            "error": False,
+                            "new_revision_id": new_rev_id
                         }
                         return JsonResponse(data)
 
@@ -250,9 +250,11 @@ def edit(request, document_slug, document_locale, revision_id=None):
                             response.status_code = 205
                             return response
                         # This must be an Ajax POST, but no need to refresh
+                        # This is the most recent revision id
+                        new_rev_id = rev.document.revisions.order_by('-id').first().id
                         data = {
-                            "error" : False,
-                            "new_revision_id" : rev.document.revisions.order_by('-id').first().id # This is the most recent revision id
+                            "error": False,
+                            "new_revision_id": new_rev_id
                         }
                         return JsonResponse(data)
 

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -129,6 +129,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
     if user_has_rev_perm:
         initial = {
             'based_on': based_on_rev.id,
+            'current_rev': doc.current_or_latest_revision().id if doc else None,
             'comment': '',
             'toc_depth': based_on_rev.toc_depth,
             'localization_tags': ['inprogress'],
@@ -228,9 +229,15 @@ def translate(request, document_slug, document_locale, revision_id=None):
             else:
                 # If this is an Ajax POST, then return a JsonResponse with error
                 if request.is_ajax():
+                    if 'current_rev' in rev_form._errors:
+                        # Make the error message safe so the '<' and '>' don't
+                        # get turned into '&lt;' and '&gt;', respectively
+                        rev_form.errors['current_rev'][0] = mark_safe(
+                            rev_form.errors['current_rev'][0])
+                    errors = [rev_form.errors[key][0] for key in rev_form.errors.keys()]
                     data = {
                         "error": True,
-                        "error_message": mark_safe(rev_form.errors['current_rev'][0]),
+                        "error_message": errors,
                         "new_revision_id": rev_form.instance.id,
                     }
                     return JsonResponse(data=data)

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -202,7 +202,6 @@ def translate(request, document_slug, document_locale, revision_id=None):
                                     parent_slug=slug_dict['parent'])
             rev_form.instance.document = doc  # for rev_form.clean()
 
-#            import ipdb;ipdb.set_trace()
             if rev_form.is_valid() and not doc_form_invalid:
                 parent_id = request.POST.get('parent_id', '')
 
@@ -234,7 +233,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
                         "error_message": mark_safe(rev_form.errors['current_rev'][0]),
                         "new_revision_id": rev_form.instance.id,
                     }
-                    return JsonResponse(data=data, status=500)
+                    return JsonResponse(data=data)
 
     if doc:
         from_id = smart_int(request.GET.get('from'), None)

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
+from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 
 import kuma.wiki.content
@@ -201,6 +202,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
                                     parent_slug=slug_dict['parent'])
             rev_form.instance.document = doc  # for rev_form.clean()
 
+#            import ipdb;ipdb.set_trace()
             if rev_form.is_valid() and not doc_form_invalid:
                 parent_id = request.POST.get('parent_id', '')
 
@@ -227,8 +229,6 @@ def translate(request, document_slug, document_locale, revision_id=None):
             else:
                 # If this is an Ajax POST, then return a JsonResponse with error
                 if request.is_ajax():
-                    import ipdb;ipdb.set_trace()
-                    from django.utils.safestring import mark_safe
                     data = {
                         "error": True,
                         "error_message": mark_safe(rev_form.errors['current_rev'][0]),

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -147,7 +147,7 @@ def translate(request, document_slug, document_locale, revision_id=None):
                                 parent_slug=slug_dict['parent'])
 
     if request.method == 'POST':
-        which_form = request.POST.get('form', 'both')
+        which_form = request.POST.get('form-type', 'both')
         doc_form_invalid = False
 
         # Grab the posted slug value in case it's invalid


### PR DESCRIPTION
Pull request begun by @stephaniehobson, which I continued.
https://bugzilla.mozilla.org/show_bug.cgi?id=1260197
When editing a document and clicking "Publish and Keep Editing" (ajax request) the user is no longer always told that the changes were saved successfully. Instead, upon an unsuccessful edit (spam edit, session timeout, midair collision, or something strange), an error message is shown to the user. Back-end errors (spam, midair collision) are returned as JSON and handled by front-end code. Feedback welcome from @jwhitlock and @stephaniehobson or others.