### PR TITLE
fix bug 1287806 : Syntax correction on X-Frame-Options header

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -110,7 +110,7 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
         response = self.client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
         self.assertTrue(response.streaming)
         self.assertEqual(response['x-frame-options'],
-                         'ALLOW-FROM: %s' % settings.DOMAIN)
+                         'ALLOW-FROM %s' % settings.DOMAIN)
         self.assertEqual(response.status_code, 200)
         self.assertIn('Last-Modified', response)
         self.assertNotIn('1970', response['Last-Modified'])

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -49,7 +49,7 @@ def raw_file(request, attachment_id, filename):
             response['Content-Length'] = rev.file.size
         except OSError:
             pass
-        response['X-Frame-Options'] = 'ALLOW-FROM: %s' % settings.DOMAIN
+        response['X-Frame-Options'] = 'ALLOW-FROM %s' % settings.DOMAIN
         return response
     else:
         return redirect(attachment.get_file_url(), permanent=True)


### PR DESCRIPTION
[bug 1287806 : Syntax correction on X-Frame-Options header](https://bugzilla.mozilla.org/show_bug.cgi?id=1287806)

- Fix X-Frame-Options header syntax by removing an excedent ':'