### PR TITLE
Bug 1286541: Survey Gizmo task completion

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -30,11 +30,6 @@
         ga('set', 'dimension12', {{ analytics_page_revision }});
     {%- endif %}
 
-    // dimension13 == "Saw iPerceptions Survey"
-    {% if waffle.flag('iperceptions') %}
-        ga('set', 'dimension13', 'Yes');
-    {% endif %}
-
     (function() {
         // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
         var win = window;

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -885,6 +885,15 @@ PIPELINE_JS = {
             'async': True,
         },
     },
+    'task-completion': {
+        'source_filenames': (
+            'js/task-completion.js',
+        ),
+        'output_filename': 'build/js/task-completion.js',
+        'extra_context': {
+            'async': True,
+        },
+    },
     'fellowship': {
         'source_filenames': (
             'js/fellowship.js',

--- a/kuma/static/js/task-completion.js
+++ b/kuma/static/js/task-completion.js
@@ -1,0 +1,56 @@
+(function(win, doc, $) {
+
+    // this feature requires localStorage
+    if (win.mdn.features.localStorage) {
+        // true if ever clicked ignore on helpfulness widget
+        var ignore = localStorage.getItem('helpful-ignore') === 'true';
+        // asked helpfulness recently?
+        var helpfulnessAskedRecently = parseInt(localStorage.getItem('helpfulnessTracker'), 10) > Date.now();
+        // asked task completion survey recently?
+        var taskAskedRecently = parseInt(localStorage.getItem('taskTracker'), 10) > Date.now();
+
+        if (!ignore && !taskAskedRecently && !helpfulnessAskedRecently) {
+            inquire();
+        }
+    }
+
+    function inquire() {
+
+        // dimension14 is "Saw Survey Gizmo Task Completion survey"
+        if(win.ga) ga('set', 'dimension14', 'Yes');
+        ga('send', 'event', 'survey', 'prompt', 'impression', {
+            nonInteraction: true
+        });
+
+        // construct question
+        var path = encodeURIComponent(window.location.pathname);
+        var clickTime = Date.now() + (1000*60)*20; // 20 min from now
+        var surveyURL= 'https://www.surveygizmo.com/s3/2980494/do-or-do-not';
+        var surveyLink = surveyURL + '?' + '&t='+ clickTime + '&p=' + path;
+        var ask = "Would you answer 4 questions for us? <a id='task-link' target='_blank' href='" + surveyLink + "'>Open the survey in a new tab</a> and fill it out when you're done on the site. Thanks!";
+
+        // open notification
+        var notification = mdn.Notifier.growl(ask, {closable: true, duration: 0}).question();
+
+        // don't ask task completion again for 30 days
+        localStorage.setItem('taskTracker', Date.now() + (1000*60*60*24)*30);
+
+        // get ga to append the clientId once it has initialized
+        ga(function(tracker) {
+            var clientId = tracker.get('clientId');
+            surveyLink += '&c=' + clientId;
+            $('#task-link').attr('href', surveyLink);
+        });
+
+        // listen for clicks
+        $('#task-link').on('click', function() {
+            ga('send', 'event', 'survey', 'prompt', 'participate', {
+                nonInteraction: false
+            });
+
+            // dismiss notification after click
+            notification.success('We look forward to your feedback!', 2000);
+        });
+    }
+
+})(window, document, jQuery);

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -418,8 +418,8 @@
     </script>
   {% endif %}
 
-  {% if waffle.flag('iperceptions') %}
-    <script>/*Copyright 2011-2015 iPerceptions, Inc. All rights reserved. Do not distribute.iPerceptions provides this code 'as is' without warranty of any kind, either express or implied. */ window.iperceptionskey = 'a66f3d65-ba68-458d-b97c-df3af3d33d1c';(function () { var a = document.createElement('script'),b = document.getElementsByTagName('body')[0]; a.type = 'text/javascript'; a.async = true;a.src = '//universal.iperceptions.com/wrapper.js';b.appendChild(a);})();</script>
+  {% if waffle.flag('sg_task_completion') %}
+    {% javascript 'task-completion' %}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
- switching survey provider from iPerceptions to Survey Gizmo
- include task-completion file when user is randomly selected by waffle
- task-completion file checks for availability of local storage before popping up invitation using notifier
- url has query string to configure Survey Gizmo
- user will not be asked again for 30 days

Testing:
- enable `sg_task_completion` for yourself
- open dev tools console
- delete any Local Storage items relating to helpfulness
- visit an article 
- check you get notifier
- click on survey link, should open in a new window (CMD and right click should work too)
- fill out survey
-- should get 5 seconds of "please fill this out after" before questions are visible
-- clicking "I'm done" should also make questions visible
-- when submitted with errors check errors are displayed properly, without making you wait the 5 second
- check thank you message is displayed
- at no point should you see javascript errors in the dev tools console