### PR TITLE
bug 1295310: Improve display of Akismet data

### DIFF
--- a/kuma/wiki/templates/admin/wiki/revisionakismetsubmission/change_form.html
+++ b/kuma/wiki/templates/admin/wiki/revisionakismetsubmission/change_form.html
@@ -13,7 +13,16 @@
 {% endblock %}
 
 {% block after_field_sets %}
-{# Add submitted data, styled almost like it was a real field #}
+{% if submitted_data|truncatechars:7 == '<dl>...' %}
+{# Definition list, don't try to align it #}
+<div class="form-row field-submitted-data">
+  <div>
+    <label>Submitted Data:</label>
+    {{ submitted_data }}
+  </div>
+</div>
+{% else %}
+{# Styled almost like it was a real field #}
 <fieldset class="module aligned">
   <div class="form-row field-submitted-data">
     <div>
@@ -22,5 +31,6 @@
     </div>
   </div>
 </fieldset>
+{% endif %}
 {{ block.super }}
 {% endblock %}

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -98,7 +98,11 @@ class DocumentSpamAttemptAdminTestCase(UserTestCase):
         assert self.admin.submitted_data(dsa) == SUBMISSION_NOT_AVAILABLE
         data = '{"foo": "bar"}'
         dsa.data = data
-        assert self.admin.submitted_data(dsa) == data
+        expected = '\n'.join((
+            '<dl>',
+            '  <dt>foo</dt><dd>bar</dd>',
+            '</dl>'))
+        assert self.admin.submitted_data(dsa) == expected
 
     def assert_needs_review(self):
         dsa = DocumentSpamAttempt.objects.get()
@@ -356,7 +360,7 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
                       args=(submission.id,))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('{&quot;content&quot;: &quot;spam&quot;}',
+        self.assertIn('<dt>content</dt><dd>spam</dd>',
                       response.content)
 
     def test_view_changelist_existing(self):


### PR DESCRIPTION
In Django Admin, display Akismet data as a definition list (Unicode with escaped HTML) rather than as a JSON object. This will make it easier to read non-ASCII submissions. This is used in the admin for the wiki app:

* Akismet submissions
* Document spam attempts
* Revision IPs