### PR TITLE
bug 1277577: Stop using some deprecated requirements

### DIFF
--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -13,7 +13,6 @@ import time
 from itertools import islice
 
 from babel import dates, localedata
-import bitly_api
 from celery import chain, chord
 from django.conf import settings
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
@@ -32,10 +31,6 @@ from .jobs import IPBanJob
 
 
 log = logging.getLogger('kuma.core.utils')
-
-
-bitly = bitly_api.Connection(login=getattr(settings, 'BITLY_USERNAME', ''),
-                             api_key=getattr(settings, 'BITLY_API_KEY', ''))
 
 
 def paginate(request, queryset, per_page=20):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1102,10 +1102,6 @@ WIKI_DEFAULT_LANGUAGE = LANGUAGE_CODE
 TIDINGS_FROM_ADDRESS = 'notifications@developer.mozilla.org'
 TIDINGS_CONFIRM_ANONYMOUS_WATCHES = True
 
-# bit.ly
-BITLY_USERNAME = config('BITLY_USERNAME', default='')
-BITLY_API_KEY = config('BITLY_API_KEY', default='')
-
 CONSTANCE_BACKEND = 'constance.backends.database.DatabaseBackend'
 # must be an entry in the CACHES setting!
 CONSTANCE_DATABASE_CACHE_BACKEND = 'memcache'


### PR DESCRIPTION
After these changes, these requirements will be unused and can be removed:

* ``BeautifulSoup``
* ``bitly-api``

It will be safer to remove the requirements after there is no more code using them.