### PR TITLE
bug 1296305 - Don't cache the connections page

### DIFF
--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -93,6 +93,8 @@ def permission_required(perm, login_url=None, redirect=REDIRECT_FIELD_NAME,
 # http://stackoverflow.com/a/2095648/571420
 # http://stackoverflow.com/a/2068407/571420
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching_FAQ
+# Fixed in Django 1.9:
+# https://docs.djangoproject.com/en/1.9/topics/http/decorators/#caching
 def never_cache(view_func):
     def _wrapped_view_func(request, *args, **kwargs):
         resp = view_func(request, *args, **kwargs)

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -76,8 +76,9 @@ class KumaAccountAdapter(DefaultAccountAdapter):
             user_url = reverse('users.user_edit',
                                kwargs={'username': request.user.username},
                                locale=request.LANGUAGE_CODE)
+            connections_url = reverse('socialaccount_connections')
             next_url = request.session.get('sociallogin_next_url', None)
-            if next_url != user_url:
+            if next_url not in (user_url, connections_url):
                 return
 
         # and add an extra tag to the account messages

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -180,19 +180,13 @@ class KumaAccountAdapterTestCase(UserTestCase):
         assert messages[0].tags == 'account success'
 
     def test_account_connected_message_connection_page(self):
-        """
-        Connection message does not appear on the connections page.
-
-        bug 1229906
-        """
+        """Message appears on the connections page (bug 1229906)."""
         next_url = reverse('socialaccount_connections')
-        self.test_account_connected_message(next_url, False)
+        self.test_account_connected_message(next_url, True)
 
     def test_extra_tags(self):
         """Extra tags can be added to the message."""
-        next_url = reverse('users.user_edit',
-                           kwargs={'username': self.user.username},
-                           locale='en-US')
+        next_url = reverse('socialaccount_connections')
         messages = self.test_account_connected_message(next_url, True,
                                                        extra_tags='congrats')
         assert messages[0].tags == 'congrats account success'

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -4,9 +4,10 @@ from django.test import RequestFactory
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.models import SocialLogin, SocialAccount
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.core.urlresolvers import reverse
 from kuma.users.adapters import KumaSocialAccountAdapter, KumaAccountAdapter
+
 
 from . import UserTestCase
 
@@ -134,45 +135,64 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
 class KumaAccountAdapterTestCase(UserTestCase):
     localizing_client = True
     rf = RequestFactory()
+    message_template = 'socialaccount/messages/account_connected.txt'
 
     def setUp(self):
         """ extra setUp to make a working session """
         super(KumaAccountAdapterTestCase, self).setUp()
         self.adapter = KumaAccountAdapter()
+        self.user = self.user_model.objects.get(username='testuser')
 
-    def test_account_connected_message(self):
-        """ https://bugzil.la/1054461 """
-        message_template = 'socialaccount/messages/account_connected.txt'
+    def test_account_connected_message(
+            self, next_url='/', has_message=False, extra_tags=''):
+        """
+        Test that the account connection message depends on the next URL.
+
+        https://bugzil.la/1054461
+        """
         request = self.rf.get('/')
-
-        # first check for the case in which the next url in the account
-        # connection process is the frontpage, there shouldn't be a message
+        request.user = self.user
         session = self.client.session
-        session['sociallogin_next_url'] = '/'
-        session.save()
-        request.session = session
-        request.user = self.user_model.objects.get(username='testuser')
-        request.LANGUAGE_CODE = 'en-US'
-        messages = self.get_messages(request)
-
-        self.adapter.add_message(request, django_messages.INFO,
-                                 message_template)
-        eq_(len(messages), 0)
-
-        # secondly check for the case in which the next url in the connection
-        # process is the profile edit page, there should be a message
-        session = self.client.session
-        next_url = reverse('users.user_edit',
-                           kwargs={'username': request.user.username},
-                           locale=request.LANGUAGE_CODE)
         session['sociallogin_next_url'] = next_url
         session.save()
         request.session = session
+        request.LANGUAGE_CODE = 'en-US'
         messages = self.get_messages(request)
-
         self.adapter.add_message(request, django_messages.INFO,
-                                 message_template)
+                                 self.message_template, extra_tags=extra_tags)
+
         queued_messages = list(messages)
-        eq_(len(queued_messages), 1)
-        eq_(django_messages.SUCCESS, queued_messages[0].level)
-        ok_('connected' in queued_messages[0].message)
+        if has_message:
+            assert len(queued_messages) == 1
+            message_data = queued_messages[0]
+            assert message_data.level == django_messages.SUCCESS
+            assert 'connected' in message_data.message
+        else:
+            assert not queued_messages
+        return queued_messages
+
+    def test_account_connected_message_user_edit(self):
+        """Connection message appears if the profile edit is the next page."""
+        next_url = reverse('users.user_edit',
+                           kwargs={'username': self.user.username},
+                           locale='en-US')
+        messages = self.test_account_connected_message(next_url, True)
+        assert messages[0].tags == 'account success'
+
+    def test_account_connected_message_connection_page(self):
+        """
+        Connection message does not appear on the connections page.
+
+        bug 1229906
+        """
+        next_url = reverse('socialaccount_connections')
+        self.test_account_connected_message(next_url, False)
+
+    def test_extra_tags(self):
+        """Extra tags can be added to the message."""
+        next_url = reverse('users.user_edit',
+                           kwargs={'username': self.user.username},
+                           locale='en-US')
+        messages = self.test_account_connected_message(next_url, True,
+                                                       extra_tags='congrats')
+        assert messages[0].tags == 'congrats account success'

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -5,6 +5,7 @@ from django.conf.urls import include, url
 from allauth.account import views as account_views
 from allauth.socialaccount import providers, views as socialaccount_views
 
+from kuma.core.decorators import never_cache
 from . import views
 
 
@@ -19,7 +20,7 @@ account_patterns = [
         views.signup,
         name='socialaccount_signup'),
     url(r'^connections/?$',
-        socialaccount_views.connections,
+        never_cache(socialaccount_views.connections),
         name='socialaccount_connections'),
     url(r'^inactive/?$',
         account_views.account_inactive,

--- a/provisioning/roles/Mayeu.RabbitMQ/tasks/install/debian.yml
+++ b/provisioning/roles/Mayeu.RabbitMQ/tasks/install/debian.yml
@@ -7,7 +7,7 @@
 
 - name: add the official rabbitmq repository
   copy:
-    src=rabbitmq.list
+    src={{ role_path }}/files/rabbitmq.list
     dest=/etc/apt/sources.list.d/
     backup=yes
   register: aptrepo


### PR DESCRIPTION
Add a header to the [Account Connections page](https://developer.mozilla.org/en-US/users/account/connections) to prevent it from being cached:

```
Cache-Control: no-cache, no-store, must-revalidate
```

Also note that our custom ``never_cache`` decorator will not be needed after an upgrade to Django 1.9 or later.