### PR TITLE
bug 1260264 - Spam dashboard

### DIFF
--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -1,0 +1,1 @@
+{% extends 'base.html' %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -1,1 +1,53 @@
 {% extends 'base.html' %}
+{% set title = 'Spam Dashboard' %}
+
+{% block title %}{{ page_title(title) }}{% endblock %}
+
+{% block content %}
+<h1>{{ title }}</h1>
+{% if processing %}
+  <p>The report is being processed. Please reload in a minute.</p>
+{% else %}
+
+  {% if recent_spam %}
+  <table>
+    <caption>Published Spam</caption>
+    <colgroup>
+      <col span="1" class="data" />
+      <col span="1" class="data" />
+      <col span="1" class="data" />
+      <col span="1" class="data" />
+      <col span="1" class="name" />
+      <col span="1" class="path" />
+    </colgroup>
+    <thead>
+      <tr>
+        <th class="data">Date</th>
+        <th class="data">Time Active (seconds)</th>
+        <th class="data">Estimated Viewers</th>
+        <th class="data">Revision</th>
+        <th class="name">Change Type</th>
+        <th class="path">Path</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for rs in recent_spam -%}
+      <tr>
+        <td class="data">{{ rs.date }}</td>
+        <td class="data">{{ rs.time_active }}</td>
+        <td class="data">0</td>{# FIXME: make use of the Google Analytics query #}
+        <td class="data"><a href="{{ rs.revision_path }}">{{ rs.revision_id }}</a></td>
+        <td class="name">{{ rs.change_type }}</td>
+        <td class="path"><a href="{{ rs.document_path }}">{{ rs.document_path }}</a></td>
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
+  {% else %}
+  <p>No recent published spam.</p>
+  {% endif %}{# recent spam #}
+  <ul>
+    <li>Recent event data generated at {{ now }}</li>
+  </ul>
+{% endif %}{# processing #}
+{% endblock %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -89,7 +89,7 @@
   <p>No recent published spam.</p>
   {% endif %}{# recent spam #}
   <ul>
-    <li>Recent event data generated at {{ now }}</li>
+    <li>Recent event data generated at {{ events_generated }}</li>
   </ul>
 {% endif %}{# processing #}
 {% endblock %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -5,7 +5,7 @@
 
 {% set stat_ids=(('spam_viewers_change', '% Change', 'rate'),
                  ('spam_viewers', 'Spam Viewers', 'data'),
-                 ('spam_viewers_daily_average', 'Daily Average Viewers', 'data'),
+                 ('spam_viewers_daily_average', 'Daily Average Viewers', 'float'),
                  ('published_spam', 'Published Spam', 'data'),
                  ('blocked_spam', 'Blocked Spam', 'data'),
                  ('blocked_ham', 'Blocked Ham', 'data'),
@@ -36,6 +36,8 @@
         {%- for stat, stat_name, stat_class in stat_ids %}
         {%- if stat_class == 'rate' %}
         <td class="{{ stat_class }}">{{ "%0.1f%%" | format(100 * period.stats.get(stat, 0.0)) }}</td>
+        {%- elif stat_class == 'float' %}
+        <td class="{{ stat_class }}">{{ "%0.1f" | format(period.stats.get(stat, 0.0)) }}</td>
         {%- else %}
         <td class="{{ stat_class }}">{{ period.stats[stat] | default(0) }}</td>
         {%- endif %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -48,7 +48,7 @@
   </table>
 
   {% if recent_spam %}
-  <table>
+  <table id="recent-spam-table">
     <caption>Published Spam</caption>
     <colgroup>
       <col span="1" class="data" />

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -13,6 +13,9 @@
                  ('true_negative_rate', 'True Negative Rate', 'rate')) %}
 {% block content %}
 <h1>{{ title }}</h1>
+{% if improperly_configured %}
+  <p>{{ improperly_configured }}</p>
+{% endif %}
 {% if processing %}
   <p>The report is being processed. Please reload in a minute.</p>
 {% else %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -1,4 +1,5 @@
 {% extends 'base.html' %}
+{% set styles = ('dashboards',) %}
 {% set title = 'Spam Dashboard' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
@@ -51,7 +52,7 @@
   </table>
 
   {% if recent_spam %}
-  <table id="recent-spam-table">
+  <table id="spam-events-table">
     <caption>Published Spam</caption>
     <colgroup>
       <col span="1" class="data" />

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -3,11 +3,47 @@
 
 {% block title %}{{ page_title(title) }}{% endblock %}
 
+{% set stat_ids=(('spam_viewers_change', '% Change', 'rate'),
+                 ('spam_viewers', 'Spam Viewers', 'data'),
+                 ('spam_viewers_daily_average', 'Daily Average Viewers', 'data'),
+                 ('published_spam', 'Published Spam', 'data'),
+                 ('blocked_spam', 'Blocked Spam', 'data'),
+                 ('blocked_ham', 'Blocked Ham', 'data'),
+                 ('true_positive_rate', 'True Positive Rate', 'rate'),
+                 ('true_negative_rate', 'True Negative Rate', 'rate')) %}
 {% block content %}
 <h1>{{ title }}</h1>
 {% if processing %}
   <p>The report is being processed. Please reload in a minute.</p>
 {% else %}
+
+  <table class="spam-trends-table">
+    <caption>{{ _('Trends Over Time, Ending %(date)s', date=end_date ) }}</caption>
+    <thead>
+      <tr>
+        <th class="stat-header">Period</th>
+        <th class="stat-header">Start</th>
+        {% for stat, stat_name, stat_class in stat_ids -%}
+        <th class="stat-header">{{ stat_name }}</th>
+        {% endfor -%}
+      </tr>
+    </thead>
+    <tbody>
+      {% for period in trends -%}
+      <tr>
+        <th scope="row">{{ period.name }}</th>
+        <th scope="row">{{ period.start }}</th>
+        {%- for stat, stat_name, stat_class in stat_ids %}
+        {%- if stat_class == 'rate' %}
+        <td class="{{ stat_class }}">{{ "%0.1f%%" | format(100 * period.stats.get(stat, 0.0)) }}</td>
+        {%- else %}
+        <td class="{{ stat_class }}">{{ period.stats[stat] | default(0) }}</td>
+        {%- endif %}
+        {%- endfor %}
+      </tr>
+      {% endfor -%}
+    </tbody>
+  </table>
 
   {% if recent_spam %}
   <table>

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -52,7 +52,7 @@
   </table>
 
   {% if recent_spam %}
-  <table id="spam-events-table">
+  <table class="spam-events-table">
     <caption>Published Spam</caption>
     <colgroup>
       <col span="1" class="data" />

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -71,7 +71,7 @@
       <tr>
         <td class="data">{{ rs.date }}</td>
         <td class="data">{{ rs.time_active }}</td>
-        <td class="data">0</td>{# FIXME: make use of the Google Analytics query #}
+        <td class="data">{{ rs.viewers }}</td>
         <td class="data"><a href="{{ rs.revision_path }}">{{ rs.revision_id }}</a></td>
         <td class="name">{{ rs.change_type }}</td>
         <td class="path"><a href="{{ rs.document_path }}">{{ rs.document_path }}</a></td>

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -30,5 +30,6 @@ class SpamDashboardRecentEvents(KumaJob):
     fetch_on_miss = True
     version = 2
 
-    def fetch(self):
-        return spam_dashboard_recent_events()
+    def fetch(self, start_date, end_date):
+        return spam_dashboard_recent_events(start_date=start_date,
+                                            end_date=end_date)

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -1,5 +1,7 @@
 from kuma.core.jobs import KumaJob
-from .utils import spam_day_stats, spam_dashboard_recent_events
+from .utils import (spam_day_stats,
+                    spam_dashboard_historical_stats,
+                    spam_dashboard_recent_events)
 
 
 class SpamDayStats(KumaJob):
@@ -10,6 +12,16 @@ class SpamDayStats(KumaJob):
 
     def fetch(self, day):
         return spam_day_stats(day)
+
+
+class SpamDashboardHistoricalStats(KumaJob):
+    """Cache historical spam stats for multiple days."""
+    lifetime = 60 * 60 * 24
+    fetch_on_miss = False
+    version = 12
+
+    def fetch(self, end_date):
+        return spam_dashboard_historical_stats(end_date=end_date)
 
 
 class SpamDashboardRecentEvents(KumaJob):

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -8,7 +8,7 @@ class SpamDayStats(KumaJob):
     """Cache spam stats for multiple days."""
     lifetime = 60 * 60 * 24 * 7
     fetch_on_miss = True
-    version = 8
+    version = 1
 
     def fetch(self, day):
         return spam_day_stats(day)
@@ -18,7 +18,7 @@ class SpamDashboardHistoricalStats(KumaJob):
     """Cache historical spam stats for multiple days."""
     lifetime = 60 * 60 * 24
     fetch_on_miss = False
-    version = 12
+    version = 1
 
     def fetch(self, end_date):
         return spam_dashboard_historical_stats(end_date=end_date)
@@ -28,7 +28,7 @@ class SpamDashboardRecentEvents(KumaJob):
     """Cache recent event data for a very short time."""
     lifetime = 60
     fetch_on_miss = True
-    version = 2
+    version = 1
 
     def fetch(self, start_date, end_date):
         return spam_dashboard_recent_events(start=start_date,

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -1,5 +1,15 @@
 from kuma.core.jobs import KumaJob
-from .utils import spam_dashboard_recent_events
+from .utils import spam_day_stats, spam_dashboard_recent_events
+
+
+class SpamDayStats(KumaJob):
+    """Cache spam stats for multiple days."""
+    lifetime = 60 * 60 * 24 * 7
+    fetch_on_miss = True
+    version = 8
+
+    def fetch(self, day):
+        return spam_day_stats(day)
 
 
 class SpamDashboardRecentEvents(KumaJob):

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -1,0 +1,12 @@
+from kuma.core.jobs import KumaJob
+from .utils import spam_dashboard_recent_events
+
+
+class SpamDashboardRecentEvents(KumaJob):
+    """Cache recent event data for a very short time."""
+    lifetime = 60
+    fetch_on_miss = True
+    version = 2
+
+    def fetch(self):
+        return spam_dashboard_recent_events()

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -31,5 +31,5 @@ class SpamDashboardRecentEvents(KumaJob):
     version = 2
 
     def fetch(self, start_date, end_date):
-        return spam_dashboard_recent_events(start_date=start_date,
-                                            end_date=end_date)
+        return spam_dashboard_recent_events(start=start_date,
+                                            end=end_date)

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -356,7 +356,6 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         thirtyfive_days_ago = today - datetime.timedelta(days=35)
         quarterly_start_date = today - datetime.timedelta(days=days_in_quarter)
         hundred_days_ago = today - datetime.timedelta(days=100)
-        a_year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
 
         # Revisions made by self.testuser: 3 made today, 3 made 3 days ago,
         # 3 made 10 days ago, 3 made 35 days ago, 3 made 100 days ago

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -1,6 +1,9 @@
+import datetime
+import mock
 import pytest
 from pyquery import PyQuery as pq
 
+from django.contrib.auth.models import Permission
 from waffle.models import Flag, Switch
 
 from kuma.core.tests import eq_, ok_
@@ -8,8 +11,9 @@ from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
-from kuma.users.tests import UserTestCase
+from kuma.users.tests import create_document, SampleRevisionsMixin, UserTestCase
 from kuma.users.models import User, UserBan
+from kuma.wiki.models import DocumentSpamAttempt, RevisionAkismetSubmission
 
 
 @pytest.mark.dashboards
@@ -227,3 +231,316 @@ class RevisionsDashTest(UserTestCase):
         revisions = page.find('.dashboard-row')
 
         eq_(5, revisions.length)
+
+
+class SpamDashTest(SampleRevisionsMixin, UserTestCase):
+    fixtures = UserTestCase.fixtures + ['wiki/documents.json']
+
+    def test_not_logged_in(self):
+        """A user who is not logged in is not able to see the dashboard."""
+        response = self.client.get(reverse('dashboards.spam',
+                                           locale='en-US'))
+        eq_(302, response.status_code)
+
+    def test_permissions(self):
+        """A user with correct permissions is able to see the dashboard."""
+        self.client.login(username='testuser', password='testpass')
+        # Attempt to see spam dashboard as a logged-in user without permissions
+        response = self.client.get(reverse('dashboards.spam',
+                                           locale='en-US'))
+        eq_(403, response.status_code)
+
+        # Give testuser wiki.add_revisionakismetsubmission permission
+        perm_akismet = Permission.objects.get(codename='add_revisionakismetsubmission')
+        self.testuser.user_permissions.add(perm_akismet)
+        response = self.client.get(reverse('dashboards.spam',
+                                           locale='en-US'))
+        eq_(403, response.status_code)
+
+        # Give testuser wiki.add_documentspamattempt permission
+        perm_spam = Permission.objects.get(codename='add_documentspamattempt')
+        self.testuser.user_permissions.add(perm_spam)
+        response = self.client.get(reverse('dashboards.spam',
+                                           locale='en-US'))
+        eq_(403, response.status_code)
+
+        # Give testuser wiki.add_userban permission
+        perm_ban = Permission.objects.get(codename='add_userban')
+        self.testuser.user_permissions.add(perm_ban)
+        response = self.client.get(reverse('dashboards.spam',
+                                           locale='en-US'))
+        # With all correct permissions testuser is able to see the dashboard
+        eq_(200, response.status_code)
+        ok_('text/html' in response['Content-Type'])
+        ok_('dashboards/spam.html' in
+            [template.name for template in response.templates])
+
+    @mock.patch('kuma.dashboards.utils.analytics_upageviews')
+    def test_recent_spam_revisions_show(self, mock_analytics_upageviews):
+        """The correct spam revisions should show up."""
+        doc1 = create_document(save=True)
+        doc2 = create_document(save=True)
+        # Create some revisions by self.testuser
+        rev_doc0 = self.create_revisions(
+            num=1,
+            creator=self.testuser,
+            document=self.document
+        )
+        rev_doc1 = self.create_revisions(num=1, creator=self.testuser, document=doc1)
+        rev_doc2 = self.create_revisions(num=1, creator=self.testuser, document=doc2)
+        created_revisions = rev_doc0 + rev_doc1 + rev_doc2
+        # Mark each revision as created yesterday
+        for rev in created_revisions:
+            rev.created = datetime.datetime.today() - datetime.timedelta(days=1)
+            rev.save()
+        # Mark each of self.testuser's revisions as spam
+        for revision in created_revisions:
+            revision.akismet_submissions.add(RevisionAkismetSubmission(
+                sender=self.admin, type="spam")
+            )
+        # self.admin creates some revisions on a different document
+        self.create_revisions(num=3, creator=self.admin)
+
+        mock_analytics_upageviews.return_value = {
+            rev_doc0[0].id: 0,
+            rev_doc1[0].id: 0,
+            rev_doc2[0].id: 0
+        }
+
+        self.client.login(username='admin', password='testpass')
+        # The first response will say that the report is being processed
+        response = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        eq_(200, response.status_code)
+
+        response2 = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        page = pq(response2.content)
+        table_rows = page.find('#recent-spam-table tbody tr')
+        table_row_text = ''
+        for table_row in table_rows:
+            table_row_text += table_row.text_content()
+
+        eq_(len(table_rows), len(created_revisions))
+        for revision in created_revisions:
+            document_url = reverse(
+                'wiki.document',
+                kwargs={'document_path': revision.document.slug}
+            )
+            ok_(document_url in table_row_text)
+
+    def test_spam_trends_show(self):
+        """The spam trends table shows up."""
+        self.client.login(username='admin', password='testpass')
+        # The first response will say that the report is being processed
+        response = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        eq_(200, response.status_code)
+
+        response2 = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        page = pq(response2.content)
+        spam_trends_table = page.find('.spam-trends-table')
+        eq_(len(spam_trends_table), 1)
+
+    @mock.patch('kuma.dashboards.utils.analytics_upageviews')
+    def test_spam_trends_stats(self, mock_analytics_upageviews):
+        """Test that the correct stats show up on the spam trends dashboard."""
+        # Period length
+        days_in_week = 7
+        days_in_month = 28
+        days_in_quarter = 91
+        # Dates
+        today = datetime.datetime.today()
+        yesterday = today - datetime.timedelta(days=1)
+        three_days_ago = today - datetime.timedelta(days=3)
+        weekly_start_date = today - datetime.timedelta(days=days_in_week)
+        ten_days_ago = today - datetime.timedelta(days=10)
+        monthly_start_date = today - datetime.timedelta(days=days_in_month)
+        thirtyfive_days_ago = today - datetime.timedelta(days=35)
+        quarterly_start_date = today - datetime.timedelta(days=days_in_quarter)
+        hundred_days_ago = today - datetime.timedelta(days=100)
+        a_year_ago = datetime.datetime.now() - datetime.timedelta(days=365)
+
+        # Revisions made by self.testuser: 3 made today, 3 made 3 days ago,
+        # 3 made 10 days ago, 3 made 35 days ago, 3 made 100 days ago
+        revs = self.create_revisions(num=15, creator=self.testuser, document=self.document)
+        for i in range(0, 3):
+            revs[i].created = today
+        for i in range(3, 6):
+            revs[i].created = three_days_ago
+        for i in range(6, 9):
+            revs[i].created = ten_days_ago
+        for i in range(9, 12):
+            revs[i].created = thirtyfive_days_ago
+        for i in range(12, 15):
+            revs[i].created = hundred_days_ago
+        for rev in revs:
+            rev.save()
+
+        # Published spam by self.testuser
+        spam_rev_today = revs[2]
+        spam_rev_3_days_ago = revs[5]
+        spam_rev_10_days_ago = revs[8]
+        spam_rev_35_days_ago = revs[11]
+        spam_rev_100_days_ago = revs[14]
+        spam_revs = [spam_rev_today, spam_rev_3_days_ago, spam_rev_10_days_ago,
+                     spam_rev_35_days_ago, spam_rev_100_days_ago]
+        # Summary of spam submissions
+        spam_weekly = [spam_rev_3_days_ago]
+        spam_monthly = [spam_rev_3_days_ago, spam_rev_10_days_ago]
+        spam_quarterly = [spam_rev_3_days_ago, spam_rev_10_days_ago,
+                          spam_rev_35_days_ago]
+        # All of the spam_revs were published and then marked as spam
+        for rev in spam_revs:
+            rev.save()
+            rev.akismet_submissions.add(RevisionAkismetSubmission(
+                sender=self.admin, type="spam")
+            )
+
+        # Summary of self.testuser's ham submissions
+        ham_weekly = revs[3:5]
+        ham_monthly = revs[3:5] + revs[6:8]
+        ham_quarterly = revs[3:5] + revs[6:8] + revs[9:11]
+
+        # There were 2 correctly blocked spam attempts 3 days ago (within past week)
+        true_blocked_spam_num = 2
+        for i in range(0, true_blocked_spam_num):
+            document_spam_rev_3_days_ago = DocumentSpamAttempt(
+                user=self.testuser,
+                title='A spam revision',
+                slug='spam-revision-slug',
+                document=self.document,
+                review=DocumentSpamAttempt.SPAM
+            )
+            document_spam_rev_3_days_ago.save()
+            document_spam_rev_3_days_ago.created = three_days_ago
+            document_spam_rev_3_days_ago.save()
+
+        # There was 1 incorrectly blocked spam attempt 3 days ago
+        false_blocked_spam_num = 1
+        for i in range(0, false_blocked_spam_num):
+            document_ham_rev_3_days_ago = DocumentSpamAttempt(
+                user=self.testuser,
+                title='Not a spam revision',
+                slug='ham-revision-slug',
+                document=self.document,
+                review=DocumentSpamAttempt.HAM
+            )
+            document_ham_rev_3_days_ago.save()
+            document_ham_rev_3_days_ago.created = three_days_ago
+            document_ham_rev_3_days_ago.save()
+
+        page_views = {}
+        # The spam from 3 days ago was seen 3 times, from 10 days ago see 10 times,
+        # and from 35 days ago seen 35 times
+        page_views[spam_rev_3_days_ago.id] = 3
+        page_views[spam_rev_10_days_ago.id] = 10
+        page_views[spam_rev_35_days_ago.id] = 35
+        # The mock Google Analytics return values for page views
+        mock_analytics_upageviews.return_value = page_views
+
+        self.client.login(username='admin', password='testpass')
+        # The first response will say that the report is being processed
+        response = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        eq_(200, response.status_code)
+
+        response2 = self.client.get(reverse('dashboards.spam', locale='en-US'))
+        page = pq(response2.content)
+
+        row_daily = page.find('.spam-trends-table tbody tr')[0].text_content().replace(' ', '').strip('\n').split('\n')
+        row_weekly = page.find('.spam-trends-table tbody tr')[1].text_content().replace(' ', '').strip('\n').split('\n')
+        row_monthly = page.find('.spam-trends-table tbody tr')[2].text_content().replace(' ', '').strip('\n').split('\n')
+        row_quarterly = page.find('.spam-trends-table tbody tr')[3].text_content().replace(' ', '').strip('\n').split('\n')
+
+        # These are the columns in the spam dashboard spam trends table
+        period = 0
+        start_date = 1
+        spam_viewers_change_percent = 2
+        spam_viewers = 3
+        daily_average_viewers = 4
+        published_spam = 5
+        blocked_spam = 6
+        blocked_ham = 7
+        true_positive_rate = 8
+        true_negative_rate = 9
+
+        # The periods are identified as 'Daily', 'Weekly', 'Monthly', 'Quarterly'
+        eq_(row_daily[period], 'Daily')
+        eq_(row_weekly[period], 'Weekly')
+        eq_(row_monthly[period], 'Monthly')
+        eq_(row_quarterly[period], 'Quarterly')
+        # The start dates for each period are correct
+        eq_(row_daily[start_date], yesterday.strftime('%Y-%m-%d'))
+        eq_(row_weekly[start_date], weekly_start_date.strftime('%Y-%m-%d'))
+        eq_(row_monthly[start_date], monthly_start_date.strftime('%Y-%m-%d'))
+        eq_(row_quarterly[start_date], quarterly_start_date.strftime('%Y-%m-%d'))
+        # The page views during the week, month, quarter
+        spam_views_week = page_views[spam_rev_3_days_ago.id]
+        spam_views_month = spam_views_week + page_views[spam_rev_10_days_ago.id]
+        spam_views_month_exclude_week = page_views[spam_rev_10_days_ago.id]
+        spam_views_quarter = spam_views_month + page_views[spam_rev_35_days_ago.id]
+        spam_views_quarter_exclude_month = page_views[spam_rev_35_days_ago.id]
+        # The percentage change in spam viewers
+        weekly_spam_change_percent = '{:.1%}'.format(
+            float(spam_views_week - spam_views_month_exclude_week) / spam_views_month_exclude_week
+        )
+        monthly_spam_change_percent = '{:.1%}'.format(
+            float(spam_views_month - spam_views_quarter_exclude_month) / spam_views_quarter_exclude_month
+        )
+        eq_(row_daily[spam_viewers_change_percent], '0.0%')
+        eq_(row_weekly[spam_viewers_change_percent], weekly_spam_change_percent)
+        eq_(row_monthly[spam_viewers_change_percent], monthly_spam_change_percent)
+        eq_(row_quarterly[spam_viewers_change_percent], '0.0%')
+        # The spam viewers
+        eq_(int(row_daily[spam_viewers]), 0)
+        eq_(int(row_weekly[spam_viewers]), spam_views_week)
+        eq_(int(row_monthly[spam_viewers]), spam_views_month)
+        eq_(int(row_quarterly[spam_viewers]), spam_views_quarter)
+        # The daily average of spam viewers
+        eq_(float(row_daily[daily_average_viewers]), 0.0)
+        eq_(row_weekly[daily_average_viewers],
+            '{:.1f}'.format(float(spam_views_week) / days_in_week))
+        eq_(row_monthly[daily_average_viewers],
+            '{:.1f}'.format(float(spam_views_month) / days_in_month))
+        eq_(row_quarterly[daily_average_viewers],
+            '{:.1f}'.format(float(spam_views_quarter) / days_in_quarter))
+        # The published spam: 1 this week, 2 this month, 3 this quarter
+        eq_(int(row_daily[published_spam]), len([]))
+        eq_(int(row_weekly[published_spam]), len(spam_weekly))
+        eq_(int(row_monthly[published_spam]), len(spam_monthly))
+        eq_(int(row_quarterly[published_spam]), len(spam_quarterly))
+        # The blocked spam: there were 2 correctly blocked spam attempts 3 days ago
+        eq_(int(row_daily[blocked_spam]), 0)
+        eq_(int(row_weekly[blocked_spam]), true_blocked_spam_num)
+        eq_(int(row_monthly[blocked_spam]), true_blocked_spam_num)
+        eq_(int(row_quarterly[blocked_spam]), true_blocked_spam_num)
+        # The blocked ham: there was 1 incorrectly blocked spam attempt 3 days ago
+        eq_(int(row_daily[blocked_ham]), 0)
+        eq_(int(row_weekly[blocked_ham]), false_blocked_spam_num)
+        eq_(int(row_monthly[blocked_ham]), false_blocked_spam_num)
+        eq_(int(row_quarterly[blocked_ham]), false_blocked_spam_num)
+        # The true positive rate == blocked_spam / total spam
+        tpr_weekly = '{:.1%}'.format(
+            true_blocked_spam_num / float(true_blocked_spam_num + len(spam_weekly))
+        )
+        tpr_monthly = '{:.1%}'.format(
+            true_blocked_spam_num / float(true_blocked_spam_num + len(spam_monthly))
+        )
+        tpr_quarterly = '{:.1%}'.format(
+            true_blocked_spam_num / float(true_blocked_spam_num + len(spam_quarterly))
+        )
+        eq_(row_daily[true_positive_rate], '100.0%')
+        eq_(row_weekly[true_positive_rate], tpr_weekly)
+        eq_(row_monthly[true_positive_rate], tpr_monthly)
+        eq_(row_quarterly[true_positive_rate], tpr_quarterly)
+        # The true negative rate == published ham / total ham
+        tnr_weekly = '{:.1%}'.format(
+            len(ham_weekly) / float(false_blocked_spam_num + len(ham_weekly))
+        )
+        tnr_monthly = '{:.1%}'.format(
+            len(ham_monthly) / float(false_blocked_spam_num + len(ham_monthly))
+        )
+        tnr_quarterly = '{:.1%}'.format(
+            len(ham_quarterly) / float(false_blocked_spam_num + len(ham_quarterly))
+        )
+        eq_(row_daily[true_negative_rate], '100.0%')
+        eq_(row_weekly[true_negative_rate], tnr_weekly)
+        eq_(row_monthly[true_negative_rate], tnr_monthly)
+        eq_(row_quarterly[true_negative_rate], tnr_quarterly)

--- a/kuma/dashboards/urls.py
+++ b/kuma/dashboards/urls.py
@@ -19,4 +19,7 @@ urlpatterns = [
             url='/docs/MDN/Doc_status/Overview',
             permanent=True,
         )),
+    url(r'^dashboards/spam$',
+        views.spam,
+        name='dashboards.spam'),
 ]

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -22,6 +22,14 @@ def spam_dashboard_recent_events(start_date=None):
         'revision__document'
     ).order_by('-id')
 
+    # Document is new; document is a translation
+    change_types = {
+        (False, False): "New Page",
+        (True, False): "Page Edit",
+        (False, True): "New Translation",
+        (True, True): "Translation Update",
+    }
+
     for rs in recent_spam:
         revision = rs.revision
         document = revision.document
@@ -52,10 +60,7 @@ def spam_dashboard_recent_events(start_date=None):
             time_active_raw = next_rev.created - revision.created
             time_active = int(time_active_raw.total_seconds())
 
-        change_type = 'changetype_{}{}'.format(
-            'edit' if revision.previous else 'new',
-            'trans' if document.parent else ''
-        )
+        change_type = change_types[bool(revision.previous), bool(document.parent)]
 
         # Gather table data
         data['recent_spam'].append({

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -4,6 +4,7 @@ import datetime
 
 from dateutil import parser
 from django.utils import timezone
+from django.core.exceptions import ImproperlyConfigured
 
 from kuma.wiki.models import (DocumentDeletionLog, RevisionAkismetSubmission,
                               Revision, DocumentSpamAttempt)
@@ -268,7 +269,12 @@ def spam_dashboard_recent_events(start=None, end=None):
         start_date = min(item['date'] for item in chunk)
         revs = [item['revision_id'] for item in chunk]
 
-        views = analytics_upageviews(revs, start_date)
+        try:
+            views = analytics_upageviews(revs, start_date)
+        except ImproperlyConfigured as e:
+            data['improperly_configured'] = e.message
+            break
+
         for item in chunk:
             item['viewers'] = views[item['revision_id']]
 

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -1,0 +1,70 @@
+import datetime
+
+from django.utils import timezone
+
+from kuma.wiki.models import DocumentDeletionLog, RevisionAkismetSubmission
+
+
+def spam_dashboard_recent_events(start_date=None):
+    """Gather data for recent spam events."""
+    now = timezone.now()
+    data = {
+        'now': now,
+        'recent_spam': [],
+    }
+    if not start_date:
+        start_date = now - datetime.timedelta(days=181)
+
+    # Gather recent published spam
+    recent_spam = RevisionAkismetSubmission.objects.filter(
+        type='spam', revision__created__gt=start_date
+    ).select_related(
+        'revision__document'
+    ).order_by('-id')
+
+    for rs in recent_spam:
+        revision = rs.revision
+        document = revision.document
+
+        # We only care about the spam rev and the one immediately
+        # following, if there is one.
+        revisions = list(
+            document.revisions.filter(
+                id__gte=revision.id
+            ).only('id', 'created').order_by('id')[:2]
+        )
+
+        # How long was it active?
+        if len(revisions) == 1:
+            if document.deleted:
+                try:
+                    entry = DocumentDeletionLog.objects.filter(
+                        locale=document.locale, slug=document.slug
+                    ).latest('id')
+                    time_active_raw = entry.timestamp - revision.created
+                    time_active = int(time_active_raw.total_seconds())
+                except DocumentDeletionLog.DoesNotExist:
+                    time_active = 'Deleted'
+            else:
+                time_active = 'Current'
+        else:
+            next_rev = revisions[1]
+            time_active_raw = next_rev.created - revision.created
+            time_active = int(time_active_raw.total_seconds())
+
+        change_type = 'changetype_{}{}'.format(
+            'edit' if revision.previous else 'new',
+            'trans' if document.parent else ''
+        )
+
+        # Gather table data
+        data['recent_spam'].append({
+            'date': revision.created.date(),
+            'time_active': time_active,
+            'revision_id': revision.id,
+            'revision_path': revision.get_absolute_url(),
+            'change_type': change_type,
+            'document_path': revision.document.get_absolute_url(),
+        })
+
+    return data

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -156,9 +156,9 @@ def spam_dashboard_historical_stats(periods=None, end_date=None):
         period['spam_viewers_previous'] = 0
         for item in events_data.get('recent_spam', ()):
             if start <= item['date'] <= end:
-                period['spam_viewers'] += item['viewers']
+                period['spam_viewers'] += item.get('viewers', 0)
             elif previous_start <= item['date'] <= previous_end:
-                period['spam_viewers_previous'] += item['viewers']
+                period['spam_viewers_previous'] += item.get('viewers', 0)
 
         period['spam_viewers_daily_average'] = period['spam_viewers'] / length
         if period['spam_viewers_previous']:

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -3,7 +3,6 @@ from collections import defaultdict, Counter
 import datetime
 
 from dateutil import parser
-from django.utils import timezone
 from django.core.exceptions import ImproperlyConfigured
 
 from kuma.wiki.models import (DocumentDeletionLog, RevisionAkismetSubmission,
@@ -193,9 +192,9 @@ def spam_dashboard_historical_stats(periods=None, end_date=None):
 
 def spam_dashboard_recent_events(start=None, end=None):
     """Gather data for recent spam events."""
-    now = timezone.now()
+    now = datetime.datetime.now()
     data = {
-        'now': now,
+        'events_generated': now.isoformat(),
         'recent_spam': [],
     }
 

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -15,7 +15,7 @@ from kuma.core.utils import paginate
 from kuma.wiki.models import Document, Revision
 
 from .forms import RevisionDashboardForm
-from .jobs import SpamDashboardHistoricalStats, SpamDashboardRecentEvents
+from .jobs import SpamDashboardHistoricalStats
 from . import PAGE_SIZE
 
 
@@ -167,7 +167,5 @@ def spam(request):
 
     if not data:
         return render(request, 'dashboards/spam.html', {'processing': True})
-
-    data.update(SpamDashboardRecentEvents().get())
 
     return render(request, 'dashboards/spam.html', data)

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -2,6 +2,7 @@ import datetime
 import json
 
 from django.contrib.auth import get_user_model
+from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -9,6 +10,7 @@ from django.utils import timezone
 from django.views.decorators.http import require_GET
 import waffle
 
+from kuma.core.decorators import login_required
 from kuma.core.utils import paginate
 from kuma.wiki.models import Document, Revision
 
@@ -147,3 +149,14 @@ def topic_lookup(request):
     data = json.dumps(topiclist)
     return HttpResponse(data,
                         content_type='application/json; charset=utf-8')
+
+
+@require_GET
+@login_required
+@permission_required((
+    'wiki.add_revisionakismetsubmission',
+    'wiki.add_documentspamattempt',
+    'wiki.add_userban'), raise_exception=True)
+def spam(request):
+    """Dashboard for spam moderators."""
+    pass

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -15,7 +15,7 @@ from kuma.core.utils import paginate
 from kuma.wiki.models import Document, Revision
 
 from .forms import RevisionDashboardForm
-from .jobs import SpamDashboardRecentEvents
+from .jobs import SpamDashboardHistoricalStats, SpamDashboardRecentEvents
 from . import PAGE_SIZE
 
 
@@ -161,8 +161,13 @@ def topic_lookup(request):
 def spam(request):
     """Dashboard for spam moderators."""
 
-    data = SpamDashboardRecentEvents().get()
+    # Combine data sources
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    data = SpamDashboardHistoricalStats().get(yesterday)
+
     if not data:
         return render(request, 'dashboards/spam.html', {'processing': True})
+
+    data.update(SpamDashboardRecentEvents().get())
 
     return render(request, 'dashboards/spam.html', data)

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -157,7 +157,7 @@ def topic_lookup(request):
 @permission_required((
     'wiki.add_revisionakismetsubmission',
     'wiki.add_documentspamattempt',
-    'wiki.add_userban'), raise_exception=True)
+    'users.add_userban'), raise_exception=True)
 def spam(request):
     """Dashboard for spam moderators."""
 

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -15,6 +15,7 @@ from kuma.core.utils import paginate
 from kuma.wiki.models import Document, Revision
 
 from .forms import RevisionDashboardForm
+from .jobs import SpamDashboardRecentEvents
 from . import PAGE_SIZE
 
 
@@ -159,4 +160,9 @@ def topic_lookup(request):
     'wiki.add_userban'), raise_exception=True)
 def spam(request):
     """Dashboard for spam moderators."""
-    pass
+
+    data = SpamDashboardRecentEvents().get()
+    if not data:
+        return render(request, 'dashboards/spam.html', {'processing': True})
+
+    return render(request, 'dashboards/spam.html', data)

--- a/kuma/static/styles/dashboards.styl
+++ b/kuma/static/styles/dashboards.styl
@@ -114,6 +114,74 @@
     }
 }
 
+.spam-trends-table {
+    border: 0;
+    border-collapse: collapse;
+}
+
+.spam-trends-table caption {
+    text-align: center;
+}
+
+.spam-trends-table .data,
+.spam-trends-table .float,
+.spam-trends-table .rate {
+    text-align: right;
+    font-family: monospace;
+}
+
+.spam-trends-table .stat-header,
+.spam-trends-table .data,
+.spam-trends-table .float {
+    padding-left: 1em;
+    padding-right: 1em;
+}
+
+.spam-trends-table .rate {
+    padding-left: 1em;
+    padding-right: 0.5em;
+}
+
+.spam-events-table {
+    table-layout: fixed;
+    width: 100%;
+}
+
+.spam-events-table td {
+    word-break: keep-all;
+}
+
+.spam-events-table .data {
+    font-family: monospace;
+}
+
+.spam-events-table .name {
+    text-align: left;
+    padding-right: 5px;
+}
+
+.spam-events-table .path,
+.spam-events-table .name
+{
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.spam-events-table th {
+    vertical-align: bottom;
+}
+
+.spam-events-table .data,
+.spam-events-table .name {
+    /* 100% - (path %) / 5 columns */
+    width: 12%
+}
+
+.spam-events-table .path {
+    width: 40%
+}
+
 .dashboard-title {
     word-break: break-all;
 }


### PR DESCRIPTION
Adds a spam dashboard, displaying the trends of spam over time, and a list of the most recent spam revisions.

bug 1260264 (https://bugzilla.mozilla.org/show_bug.cgi?id=1260264)
Taiga user story 351 (https://tree.taiga.io/project/viya-mdn-durable-team/us/351)