### PR TITLE
[Bug 1294904] Language drop down menus should be sorted

### DIFF
--- a/jinja2/includes/lang_switcher.html
+++ b/jinja2/includes/lang_switcher.html
@@ -1,5 +1,5 @@
 {% set default_locale = settings.LANGUAGE_CODE %}
-{% set dafault_language = settings.LOCALES[default_locale].native %}
+{% set default_language = settings.LOCALES[default_locale].native %}
 <form class="languages go" method="get" action="#">
   <label for="language">{{ _('Other languages:') }}</label>
   {% for name, value in request.GET.iteritems() %}

--- a/jinja2/includes/lang_switcher.html
+++ b/jinja2/includes/lang_switcher.html
@@ -1,3 +1,5 @@
+{% set default_locale = settings.LANGUAGE_CODE %}
+{% set dafault_language = settings.LOCALES[default_locale].native %}
 <form class="languages go" method="get" action="#">
   <label for="language">{{ _('Other languages:') }}</label>
   {% for name, value in request.GET.iteritems() %}
@@ -6,10 +8,16 @@
     {% endif %}
   {% endfor %}
   <select id="language" class="autosubmit" name="lang">
+    {# The default locale should always be in the first choice -#}
+    <option title="{{ get_locale_localized(default_locale) }}" value="{{ default_locale }}">
+      {{ dafault_language }} ({{ default_locale }})
+    </option>
     {% for code, name in settings.LANGUAGES -%}
-      <option title="{{ get_locale_localized(code) }}" value="{{ code }}"{% if code == LANG %} selected{% endif %}>
-        {{ name }} ({{ code }})
-      </option>
+      {% if code != default_locale %}
+        <option title="{{ get_locale_localized(code) }}" value="{{ code }}"{% if code == LANG %} selected{% endif %}>
+          {{ name }} ({{ code }})
+        </option>
+      {% endif %}
     {%- endfor %}
   </select>
   <noscript><button type="submit">{{ _('Go') }}</button></noscript>

--- a/jinja2/includes/lang_switcher.html
+++ b/jinja2/includes/lang_switcher.html
@@ -10,7 +10,7 @@
   <select id="language" class="autosubmit" name="lang">
     {# The default locale should always be in the first choice -#}
     <option title="{{ get_locale_localized(default_locale) }}" value="{{ default_locale }}">
-      {{ dafault_language }} ({{ default_locale }})
+      {{ default_language }} ({{ default_locale }})
     </option>
     {% for code, name in settings.LANGUAGES -%}
       {% if code != default_locale %}

--- a/kuma/core/tests/test_templates.py
+++ b/kuma/core/tests/test_templates.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 from django.utils import translation
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase, eq_
+from kuma.core.tests import KumaTestCase, eq_, ok_
 
 
 class MockRequestTests(KumaTestCase):
@@ -42,6 +42,14 @@ class BaseTemplateTests(MockRequestTests):
         doc = pq(html)
         dir_attr = doc('html').attr['dir']
         eq_('rtl', dir_attr)
+
+    def test_lang_switcher(self):
+        translation.activate("bn-BD")
+        html = render_to_string(self.template, request=self.request)
+        doc = pq(html)
+        # Check default locale is in the first choice field
+        first_field = doc("#language.autosubmit option")[0].text_content()
+        ok_(settings.LANGUAGE_CODE in first_field)
 
 
 class ErrorListTests(MockRequestTests):

--- a/kuma/search/signals.py
+++ b/kuma/search/signals.py
@@ -22,7 +22,7 @@ def render_done_handler(**kwargs):
         if outdated:
             log.info('Found a newer index and scheduled '
                      'indexing it after promotion.')
-        doc_pks = set(doc.other_translations.values_list('pk', flat=True))
+        doc_pks = set([item.pk for item in doc.other_translations])
         doc_pks.add(doc.id)
         try:
             index_documents.delay(list(doc_pks), current_index.pk)

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1413,13 +1413,13 @@ Full traceback:
         Return a list of Documents - other translations of this Document
         """
         if self.parent is None:
-            return self.translations.all().order_by('locale')
+            return list(self.translations.all().order_by('locale'))
         else:
-            translations = (self.parent.translations.all()
+            translations = list(self.parent.translations
                                 .exclude(id=self.id)
                                 .order_by('locale'))
-            pks = list(translations.values_list('pk', flat=True))
-            return Document.objects.filter(pk__in=[self.parent.pk] + pks)
+            # The parent doc should be at first
+            return [self.parent] + translations
 
     @property
     def parents(self):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -204,11 +204,11 @@ class DocumentTests(UserTestCase):
                                     .order_by('locale')
                                     .values_list('pk', flat=True))
         eq_(list(children),
-            list(parent.other_translations.values_list('pk', flat=True)))
+            [trans.pk for trans in parent.other_translations])
 
-        enfant_translation_pks = (enfant.other_translations
-                                        .values_list('pk', flat=True))
-        ok_(parent.pk in enfant_translation_pks)
+        # Check the parent document is in the first index of the list
+        eq_(parent.pk, enfant.other_translations[0].pk)
+        enfant_translation_pks = [trans.pk for trans in enfant.other_translations]
         ok_(bambino.pk in enfant_translation_pks)
         eq_(False, enfant.pk in enfant_translation_pks)
 

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -203,6 +203,51 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         ok_('<div class="page-toc">' not in response.content)
 
+    def test_lang_switcher_footer(self):
+        """Test the language switcher footer"""
+        parent = document(locale=settings.WIKI_DEFAULT_LANGUAGE, save=True)
+        trans_bn_bd = document(parent=parent, locale="bn-BD", save=True)
+        trans_ar = document(parent=parent, locale="ar", save=True)
+        trans_pt_br = document(parent=parent, locale="pt-BR", save=True)
+        trans_fr = document(parent=parent, locale="fr", save=True)
+
+        response = self.client.get(trans_pt_br.get_absolute_url())
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        options = doc(".languages.go select.wiki-l10n option")
+
+        # The requeseted document language name should be at first
+        ok_(trans_pt_br.language in options[0].text)
+        ok_(parent.language not in options[0].text)
+        # The parent document language should be at at second
+        ok_(parent.language in options[1].text)
+        ok_(trans_ar.language not in options[1].text)
+        # Then should be ar, bn-BD, fr
+        ok_(trans_ar.language in options[2].text)
+        ok_(trans_bn_bd.language in options[3].text)
+        ok_(trans_fr.language in options[4].text)
+
+    def test_lang_switcher_button(self):
+        parent = document(locale=settings.WIKI_DEFAULT_LANGUAGE, save=True)
+        trans_bn_bd = document(parent=parent, locale="bn-BD", save=True)
+        trans_ar = document(parent=parent, locale="ar", save=True)
+        trans_pt_br = document(parent=parent, locale="pt-BR", save=True)
+        trans_fr = document(parent=parent, locale="fr", save=True)
+
+        response = self.client.get(trans_pt_br.get_absolute_url())
+        eq_(200, response.status_code)
+        doc = pq(response.content)
+        options = doc("#languages-menu-submenu ul#translations li a")
+
+        # The requeseted document language name should not be at button
+        ok_(trans_pt_br.language not in options[0].text)
+        # Parent document language name should be at first
+        ok_(parent.language in options[0].text)
+        # Then should be ar, bn-BD, fr
+        ok_(trans_ar.language in options[1].text)
+        ok_(trans_bn_bd.language in options[2].text)
+        ok_(trans_fr.language in options[3].text)
+
 
 class RevisionTests(UserTestCase, WikiTestCase):
     """Tests for the Revision template"""


### PR DESCRIPTION
So I have changed the way ``other_translations`` model function works. It should return a ``list``, but it was returning ``queryset``. It was done intentionally at #1953. Reading the conversation, got that it was changed because of hard to test. But, now I have seen some test for this function and I have changed the test to test the functionality with ``list`` instead of ``queryset``.

In order to change ``other_translations`` model function, I need to change the ``search/signals.py
`` so nothing will break.

Adding total 3 template tests so that we don't get regression in the future. I hope it works

Though the affect will be in the frontend, most of the changes are in the backend. so @jwhitlock r?