### PR TITLE
Bug 950945: Fix and improve MDN Sphinx template

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,10 +13,12 @@ Kuma
 .. image:: https://requires.io/github/mozilla/kuma/requirements.svg?branch=master
    :target: https://requires.io/github/mozilla/kuma/requirements/?branch=master
    :alt: Requirements Status
-   
+
 .. image:: http://img.shields.io/badge/license-MPL2-blue.svg
    :target: https://raw.githubusercontent.com/mozilla/kuma/master/LICENSE
    :alt: License
+
+.. Omit badges from docs
 
 Kuma is the platform that powers `MDN (developer.mozilla.org)
 <https://developer.mozilla.org>`_
@@ -25,21 +27,19 @@ Development
 ===========
 
 :Code:          https://github.com/mozilla/kuma
-
 :Issues:        http://mzl.la/mdn_backlog (Product)
+
                 https://prs.paas.allizom.org/mozilla:kuma,kuma-lib,kumascript,mozhacks (PR Queue)
-
 :Dev Docs:      https://kuma.readthedocs.io/en/latest/installation.html
-
 :CI Server:     https://travis-ci.org/mozilla/kuma
-
 :Mailing list:  https://lists.mozilla.org/listinfo/dev-mdn
-
 :IRC:           irc://irc.mozilla.org/mdndev
-                http://logs.glob.uno/?c=mozilla%23mdndev (logs)
 
+                http://logs.glob.uno/?c=mozilla%23mdndev (logs)
 :Servers:       http://mzl.la/whats-deployed (What's Deployed)
+
                 https://developer.allizom.org/ (stage)
+
                 https://developer.mozilla.org/ (prod)
 
 Getting Started

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -7,7 +7,9 @@ Generating Documentation
 This documentation is generated and published at
 `Read the Docs`_ whenever the master branch is updated.
 
-To generate locally, install the packages in ``requirements/docs.txt``, and run::
+To generate locally, install the packages in ``requirements/docs.txt``
+(inside the development VM or in a new `virtualenv`_ on the host system),
+and run::
 
     cd docs
     make html
@@ -41,3 +43,4 @@ To use the new theme in the public documentation,
 
 .. _`Read the Docs`: https://kuma.readthedocs.io/en/latest/
 .. _PyPI: https://pypi.python.org/pypi/mdn-sphinx-theme
+.. _virtualenv: https://virtualenv.pypa.io/en/stable/

--- a/docs/documentation.rst
+++ b/docs/documentation.rst
@@ -1,0 +1,43 @@
+=============
+Documentation
+=============
+
+Generating Documentation
+------------------------
+This documentation is generated and published at
+`Read the Docs`_ whenever the master branch is updated.
+
+To generate locally, install the packages in ``requirements/docs.txt``, and run::
+
+    cd docs
+    make html
+
+This will generate the documents with the index at
+``docs/_build/html/index.html``.
+
+
+Updating the MDN Sphinx Theme
+-----------------------------
+The documentation uses a Sphinx theme generated from the MDN templates:
+
+https://github.com/mdn/sphinx-theme
+
+If this theme is checked out, the in-development theme can be used to generate
+the local documentation::
+
+    pip install -e /path/to/sphinx-theme
+    cd docs
+    make html
+
+The theme's template can be regenerated with::
+
+    ./manage.py generate_sphinx_template > /path/to/sphinx-theme/mdn_theme/mdn/layout.html
+
+To use the new theme in the public documentation,
+
+1. Commit and merge the new template to ``sphinx-theme``
+2. Tag and publish a new version of ``mdn-sphinx-theme`` to PyPI_
+3. Update ``requirements/docs.txt`` in ``kuma``, merge to master
+
+.. _`Read the Docs`: https://kuma.readthedocs.io/en/latest/
+.. _PyPI: https://pypi.python.org/pypi/mdn-sphinx-theme

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,3 +24,4 @@ Contents:
    elasticsearch
    localization
    ckeditor
+   documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,4 +1,10 @@
+
+====
+Kuma
+====
+
 .. include:: ../README.rst
+    :start-after: .. Omit badges from docs
 
 Contents:
 

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -2,7 +2,7 @@
 
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="redesign no-js" {{ get_webfont_attributes(request) }} >
-<head prefix="og: http://ogp.me/ns#">
+<head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
@@ -13,8 +13,10 @@
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="{% block robots_value%}index, follow{% endblock %}">
-  <link rel="home" href="{{ url('home') }}">
-  <link rel="copyright" href="#copyright">
+  {%- if not is_sphinx %}
+    <link rel="home" href="{{ url('home') }}">
+    <link rel="copyright" href="#copyright">
+  {% endif %}
 
   {% block site_css %}
     {% stylesheet 'mdn' %}
@@ -24,17 +26,18 @@
     {% endfor %}
   {% endblock %}
 
-  <!-- common social tags -->
-  {% set social_logo = request.build_absolute_uri(static('img/opengraph-logo.png')) %}
-  <meta property="og:type" content="website">
-  <meta property="og:image" content="{{ social_logo }}">
-  <meta property="og:site_name" content="{{ _('Mozilla Developer Network') }}">
-  <meta name="twitter:card" content="summary">
-  <meta name="twitter:image" content="{{ social_logo }}">
-  <meta name="twitter:site" content="@MozDevNet">
-  <meta name="twitter:creator" content="@MozDevNet">
-
-  <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.LANGUAGE_CODE }}/search/xml" title="{{ _('Mozilla Developer Network') }}">
+  {%- if not is_sphinx %}
+    <!-- common social tags -->
+    {% set social_logo = request.build_absolute_uri(static('img/opengraph-logo.png')) %}
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="{{ social_logo }}">
+    <meta property="og:site_name" content="{{ _('Mozilla Developer Network') }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="{{ social_logo }}">
+    <meta name="twitter:site" content="@MozDevNet">
+    <meta name="twitter:creator" content="@MozDevNet">
+    <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.LANGUAGE_CODE }}/search/xml" title="{{ _('Mozilla Developer Network') }}">
+  {% endif %}
 
   <!-- third-generation iPad with high-resolution Retina display: -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ static('img/favicon144.png') }}">
@@ -81,10 +84,10 @@
 
   <ul id="nav-access">
     <li><a href="#{% block main_content_id %}content{% endblock %}" id="skip-main">{{ _('Skip to main content') }}</a></li>
+    {%- if not is_sphinx %}
     <li><a id="skip-language" href="#language">{{ _('Select language') }}</a></li>
-    {% if not is_sphinx %}
-      <li><a href="#q" id="skip-search">{{ _('Skip to search') }}</a></li>
-    {% endif %}
+    <li><a href="#q" id="skip-search">{{ _('Skip to search') }}</a></li>
+    {%- endif %}
   </ul>
 
   <!-- Header -->
@@ -233,11 +236,11 @@
 
     {{ providers_media_js() }}
     {% javascript 'main' %}
-
+    {% if not is_sphinx %}
       <script>
         if(window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
       </script>
-
+    {% endif %}
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,4 +1,4 @@
-{% from "includes/common_macros.html" import optimizely_script with context %}
+{% from "includes/common_macros.html" import optimizely_script with context -%}
 
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="redesign no-js" {{ get_webfont_attributes(request) }} >

--- a/kuma/wiki/jinja2/wiki/sphinx.html
+++ b/kuma/wiki/jinja2/wiki/sphinx.html
@@ -1,59 +1,51 @@
 {% extends "base.html" %}
 
-{% block title %}{{ '{{ docstitle|e }} &mdash; MDN' }}{% endblock %}
+{% block title %}{{ '{{ docstitle }} - MDN' }}{% endblock %}
 
 {% block content %}
-
-    <!-- left crumb navigation -->
-    <nav class="crumbs" role="navigation"><ol><li class="crumb"><a href="{{ '{{ pathto(master_doc) }}' }}">{{ '{{ docstitle }}' }}</a></li><li class="crumb">{{ '{{ title }}' }}</li></ol></nav>
-
-  <div id="wiki-column-container">
-    <div class="column-container column-container-reverse">
-      <div class="column-strip wiki-column" id="wiki-right">
-        <!-- table of contents -->
-        <div id="toc" class="toc toggleable">
-          <a href="#toc" class="title toggler">Table of Contents<i></i></a>
-          <ol class="toggle-container">
-            {{ '{{ toctree(collapse=False) }}' }}
-          </ol>
+  <!-- left crumb navigation -->
+  <nav class="crumbs" role="navigation">
+    <ol>
+      <li class="crumb"><a href="{{ '{{ pathto(master_doc) }}' }}">{{ '{{ docstitle }}' }}</a></li>
+      <li class="crumb">{{ '{{ title }}' }}</li>
+    </ol>
+  </nav>
+  <div class="page-buttons hidden"></div>{# Give wiki.js a button div to move #}
+  <div class="wiki-main-content"><div class="center">
+    <div id="wiki-column-container">
+      <div class="column-container column-container-reverse">
+        <div class="column-strip wiki-column" id="wiki-right">
+          <div id="toc" class="toc toggleable">{# table of contents #}
+            <a href="#toc" class="title toggler">Table of Contents<i></i></a>
+            <ol class="toggle-container">
+              {{ '{{ toctree(collapse=False) }}' }}
+            </ol>
+          </div>
+        </div>
+        <div id="wiki-content" class="column-main wiki-column text-content">
+          {{ '{% block body %}{% endblock %}' }}
         </div>
       </div>
-      <div id="wiki-content" class="column-main wiki-column">
-        {# <h1 class="page-title">{{ title }}</h1> #}
-        {{ '{% block body %}{% endblock %}' }}
-      </div>
     </div>
-  </div>
-
-{% endblock %}
-
-{% block footer_copyright %}
-    <p>
-      {% trans copyright_url=wiki_url('Project:Copyrights'), about_url=wiki_url('Project:About') %}
-      Content is available under a license specific to this project.
-      &middot; <a href="{{ about_url }}">About MDN</a>
-      &middot; <a href="//github.com/mozilla/kuma">Contribute to the code</a>
-      &middot; <a href="//www.mozilla.org/en-US/privacy">Privacy policy</a>
-      {% endtrans %}
-    </p>
+  </div></div>
 {% endblock %}
 
 {% block footer_copyright_redesign %}
-    <p>
-      {% trans copyright_url=wiki_url('Project:Copyrights'), about_url=wiki_url('Project:About') %}
-      &copy; 2005-2015 Mozilla Developer Network and individual contributors<br />
+  <p>
+    {% trans this_year=this_year, about_url=wiki_url('Project:About') %}
+      &copy; 2005-{{ this_year }} Mozilla Developer Network and individual contributors<br />
       Content is available under a license specific to this project.
       &middot; <a href="{{ about_url }}">About MDN</a>
       &middot; <a href="//github.com/mozilla/kuma">Contribute to the code</a>
       &middot; <a href="//www.mozilla.org/en-US/privacy">Privacy policy</a>
-      {% endtrans %}
-    </p>
+    {% endtrans %}
+  </p>
 {% endblock %}
 
 {% block js %}
-    {% javascript 'wiki' %}
+  {%- javascript 'wiki' %}
 {% endblock %}
 
 {% block extrahead %}
-  {% stylesheet 'sphinx' %}
+  {%- stylesheet 'sphinx' %}
 {% endblock %}

--- a/kuma/wiki/management/commands/generate_sphinx_template.py
+++ b/kuma/wiki/management/commands/generate_sphinx_template.py
@@ -58,5 +58,9 @@ class Command(NoArgsCommand):
         content = content.replace('src="/static/',
                                   'src="%s/static/' % settings.PRODUCTION_URL)
 
+        # Fix missing DOCTYPE
+        assert content.startswith("<html")
+        content = u"<!DOCTYPE html>\n" + content
+
         # Output the response
         print content.encode('utf8')

--- a/kuma/wiki/management/commands/generate_sphinx_template.py
+++ b/kuma/wiki/management/commands/generate_sphinx_template.py
@@ -1,8 +1,10 @@
+import datetime
+
 from django.conf import settings
 from django.core.management.base import NoArgsCommand
 from django.shortcuts import render
-from django.test import RequestFactory
-from django.utils.translation import ugettext
+from django.test import RequestFactory, override_settings
+
 from html5lib import constants as html5lib_constants
 
 from kuma.wiki.content import parse
@@ -25,11 +27,18 @@ class Command(NoArgsCommand):
         # Create a mock request for the sake of rendering the template
         request = RequestFactory().get('/')
         request.LANGUAGE_CODE = settings.LANGUAGE_CODE
-        request.META['SERVER_NAME'] = 'developer.mozilla.org'
-
+        host = 'developer.mozilla.org'
+        request.META['SERVER_NAME'] = host
+        this_year = datetime.date.today().year
         # Load the page with sphinx template
-        content = render(request, 'wiki/sphinx.html',
-                         {'is_sphinx': True, 'gettext': ugettext}).content
+        with override_settings(
+                ALLOWED_HOSTS=[host],
+                SITE_URL=settings.PRODUCTION_URL,
+                DEBUG=False):
+            content = render(request, 'wiki/sphinx.html',
+                             {'is_sphinx': True,
+                              'LANG': settings.LANGUAGE_CODE,
+                              'this_year': this_year}).content
 
         # Use a filter to make links absolute
         tool = parse(content, is_full_document=True)
@@ -42,6 +51,10 @@ class Command(NoArgsCommand):
                 'link': 'href',
                 'script': 'src'
             }).serialize()
+
+        # Make in-comment script src absolute for IE
+        content = content.replace('src="/static/',
+                                  'src="%s/static/' % settings.PRODUCTION_URL)
 
         # Output the response
         print content.encode('utf8')

--- a/kuma/wiki/management/commands/generate_sphinx_template.py
+++ b/kuma/wiki/management/commands/generate_sphinx_template.py
@@ -4,6 +4,7 @@ from django.conf import settings
 from django.core.management.base import NoArgsCommand
 from django.shortcuts import render
 from django.test import RequestFactory, override_settings
+from django.utils import translation
 
 from html5lib import constants as html5lib_constants
 
@@ -14,7 +15,7 @@ class Command(NoArgsCommand):
 
     def handle(self, *args, **options):
 
-        # Not ideal, but we need to temporarily remove inline elemnents as a
+        # Not ideal, but we need to temporarily remove inline elements as a
         # void/ignored element
         # TO DO:  Can this clone code be shortened?
         new_void_set = set()
@@ -26,7 +27,8 @@ class Command(NoArgsCommand):
 
         # Create a mock request for the sake of rendering the template
         request = RequestFactory().get('/')
-        request.LANGUAGE_CODE = settings.LANGUAGE_CODE
+        request.LANGUAGE_CODE = settings.LANGUAGE_CODE  # for Jinja2
+        translation.activate(settings.LANGUAGE_CODE)  # for context var LANG
         host = 'developer.mozilla.org'
         request.META['SERVER_NAME'] = host
         this_year = datetime.date.today().year
@@ -35,10 +37,10 @@ class Command(NoArgsCommand):
                 ALLOWED_HOSTS=[host],
                 SITE_URL=settings.PRODUCTION_URL,
                 DEBUG=False):
-            content = render(request, 'wiki/sphinx.html',
-                             {'is_sphinx': True,
-                              'LANG': settings.LANGUAGE_CODE,
-                              'this_year': this_year}).content
+            response = render(request, 'wiki/sphinx.html',
+                              {'is_sphinx': True,
+                               'this_year': this_year})
+        content = response.content
 
         # Use a filter to make links absolute
         tool = parse(content, is_full_document=True)

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,7 +3,7 @@
 alabaster==0.7.7
 Babel==2.2.0
 docutils==0.12
-Jinja2==2.8
+Jinja2==2.7.3
 MarkupSafe==0.23
 mdn-sphinx-theme==2015.2
 Pygments==2.1.1


### PR DESCRIPTION
* Fix the ``./manage.py generate_sphinx_template`` command
* Update the template to match the current MDN JS and CSS
* Omit some more items from the Sphinx template, such as social graph and Google Analytics
* Add generating the documentation to the documentation
* Update the docs to use the new version of the theme.

This PR is used to generate the changes in https://github.com/mdn/sphinx-theme/pull/10, which is necessary to release ``mdn-sphinx-theme`` version 2016.0 and fix some issues with the [current documentation](https://kuma.readthedocs.io/en/latest/).

@stephaniehobson I'd appreciate a code review, especially of ``base.html`` but I don't expect you to generate the docs locally unless you are looking to level up in backend development.