### PR TITLE
fix bug 1254630: Open new browsing context when reporting a problem

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -175,8 +175,8 @@
             </ul>
             <ul>
               <li><a href="{{ wiki_url('MDN/Community') }}">{{ _('Join the MDN community') }}</a></li>
-              <li><a href="https://bugzilla.mozilla.org/form.doc?bug_file_loc={{ request.build_absolute_uri()|urlencode }}">{{ _('Report a content problem') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
-              <li><a href="https://bugzilla.mozilla.org/form.mdn">{{ _('Report a bug') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
+              <li><a target="_blank" href="https://bugzilla.mozilla.org/form.doc?bug_file_loc={{ request.build_absolute_uri()|urlencode }}">{{ _('Report a content problem') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
+              <li><a target="_blank" href="https://bugzilla.mozilla.org/form.mdn">{{ _('Report a bug') }}<i aria-hidden="true" class="icon-external-link"></i></a></li>
             </ul>
           </div>
         </div>


### PR DESCRIPTION
The options to "Report a bug" / "Report a content problem" open in a new browsing context because the content of the page you're currently on is very frequently needed in order to accomplish your goal.