### PR TITLE
bug 1301116: Upgrade setuptools

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -29,11 +29,10 @@ pytz==2015.7 \
     --hash=sha256:99266ef30a37e43932deec2b7ca73e83c8dbc3b9ff703ec73eca6b1dae6befea \
     --hash=sha256:8b6ce1c993909783bc96e0b4f34ea223bff7a4df2c90bdb9c4e0f1ac928689e3
 # cryptography, django-honeypot
-# Force version from Ubuntu 16.04 LTS
-setuptools==20.7.0 \
-    --hash=sha256:8917a52aa3a389893221b173a89dae0471022d32bff3ebc31a1072988aa8039d \
-    --hash=sha256:505cdf282c5f6e3a056e79f0244b8945f3632257bba8469386c6b9b396400233 \
-    --hash=sha256:5704988be46145f68b3b04d599bb03d5b6aaeaf66de8f2896bb1d3ba8aebd7ba
+setuptools==26.1.1 \
+    --hash=sha256:226c9ce65e76c6069e805982b036f36dc4b227b37dd87fc219aef721ec8604ae \
+    --hash=sha256:475ce28993d7cb75335942525b9fac79f7431a7f6e8a0079c0f2680641379481 \
+    --hash=sha256:02a06e1a547b16c25143d2bb898008286a3cbd600a7dbe47234ce57dc51abbf6
 # bleach, django-appconf, django-cacheback, django-extensions, mock, etc.
 six==1.10.0 \
     --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1 \


### PR DESCRIPTION
setuptools 20.7.0 -> 26.1.1: Many fixes

The necessary fix is from 20.8.1:

https://github.com/pypa/setuptools/issues/544

The latest version has been active for a month, which seems like a long time for [setuptools releases](https://setuptools.readthedocs.io/en/latest/history.html).

This will break the Docker development environment, because it can't replace the system-installed setuptools 20.7.0.