### PR TITLE
bug 1301102: Switch compressor to yuglify

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -937,9 +937,9 @@ PIPELINE = {
     'JAVASCRIPT': PIPELINE_JS,
     'DISABLE_WRAPPER': True,
     'CSS_COMPRESSOR': config('PIPELINE_CSS_COMPRESSOR',
-                             default='kuma.core.pipeline.cleancss.CleanCSSCompressor'),
+                             default='pipeline.compressors.yuglify.YuglifyCompressor'),
     'JS_COMPRESSOR': config('PIPELINE_JS_COMPRESSOR',
-                            default='pipeline.compressors.uglifyjs.UglifyJSCompressor'),
+                            default='pipeline.compressors.yuglify.YuglifyCompressor'),
     'PIPELINE_ENABLED': config('PIPELINE_ENABLED', not DEBUG, cast=bool),
     'PIPELINE_COLLECTOR_ENABLED': config('PIPELINE_COLLECTOR_ENABLED', not DEBUG, cast=bool),
 }

--- a/provisioning/roles/kuma/tasks/node.yml
+++ b/provisioning/roles/kuma/tasks/node.yml
@@ -3,12 +3,11 @@
   npm: name={{ item.name }} version={{ item.version }} global=yes
   with_items:
     - {name: 'fibers', version: '1.0.10'}
-    - {name: 'clean-css', version: '2.2.16'}
     - {name: 'csslint', version: '0.10.0'}
     - {name: 'jshint', version: '2.7.0'}
     - {name: 'stylus', version: '0.49.2'}
-    - {name: 'uglify-js', version: '2.4.13'}
     - {name: 'bower-installer', version: '1.2.0'}
+    - {name: 'yuglify', version: '0.1.4'}
 
 - name: Node binary symlinks
   file:
@@ -16,5 +15,4 @@
     path: "/usr/local/bin/{{ item }}"
     state: link
   with_items:
-    - cleancss
     - stylus


### PR DESCRIPTION
This switches the JS and CSS compressors to yuglify, as specified in [bug 1301102](https://bugzilla.mozilla.org/show_bug.cgi?id=1301102).  This does not work locally:

* ``vagrant provision`` does not install yuglify for me.  It is unclear if this is because I've done something to my Vagrant box, or because there is something wrong with ansible 1.9.2, or something else. I installed locally in my VM with ``sudo npm install yuglify --global``.
* I can't run ``./manage.py collectstatic`` It fails on compressing jQuery.

I'm opening a pull request to see if TravisCI has the same issues I have locally, and for further discussion on these changes.  **Do not merge**.