### PR TITLE
bug 957802 - Update node provisioning

### DIFF
--- a/provisioning/roles/nodesource.node/Dockerfile
+++ b/provisioning/roles/nodesource.node/Dockerfile
@@ -1,15 +1,16 @@
 FROM ubuntu:trusty
 MAINTAINER Mark Wolfe <mark@wolfe.id.au>
 
+# http://docs.ansible.com/ansible/intro_installation.html#latest-releases-via-apt-ubuntu
+RUN apt-get install software-properties-common -y --force-yes
+RUN apt-add-repository ppa:ansible/ansible
 RUN apt-get update
-RUN apt-get install -y --force-yes \
-	python-pycurl \
-	python-apt \
-	ansible \
-	lsb-release
+RUN apt-get install ansible -y --force-yes
+
 
 ENV WORKDIR /build/ansible-nodejs
 ADD . /build/ansible-nodejs
+ADD . /etc/ansible/roles/ansible-nodejs-role
 ADD ./tests/localhosts /etc/ansible/hosts
 
 RUN ansible-playbook $WORKDIR/role.yml -c local

--- a/provisioning/roles/nodesource.node/README.md
+++ b/provisioning/roles/nodesource.node/README.md
@@ -1,7 +1,5 @@
 # ansible-nodejs-role
 
-<a href="https://nodesource.com"><img src="https://nodesource.com/assets/logo.svg" height="10%" width="10%"></a>
-
 This is an Ansible role which adds the the NodeSource APT repository and installs Node.js.
 
 Currently this role supports the following operating systems and releases.
@@ -28,6 +26,7 @@ Then configure it as follows:
 ## Role Variables
 
 - `nodejs_nodesource_pin_priority`: Pin-Priority of the NodeSource repository (default: `500`).
+- `nodejs_version`: Set Node version (options: `0.10` or `0.12` or `4.4`, default: `4.4`)
 
 ## Testing
 
@@ -43,4 +42,4 @@ Mark Wolfe <mark@wolfe.id.au>
 
 ## License
 
-This code is Copyright (c) 2014 NodeSource and Mark Wolfe and licenced under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.
+This code is Copyright (c) 2014 NodeSource and Mark Wolfe and licenced under the MIT licence. All rights not explicitly granted in the MIT license are reserved. See the included [LICENSE.md](./LICENSE.md) file for more details.

--- a/provisioning/roles/nodesource.node/defaults/main.yml
+++ b/provisioning/roles/nodesource.node/defaults/main.yml
@@ -1,3 +1,6 @@
 ---
 # Pin-Priority of NodeSource repository
 nodejs_nodesource_pin_priority: 500
+
+# 0.10 or 0.12 or 4.x
+nodejs_version: "4.4"

--- a/provisioning/roles/nodesource.node/meta/.galaxy_install_info
+++ b/provisioning/roles/nodesource.node/meta/.galaxy_install_info
@@ -1,1 +1,1 @@
-{install_date: 'Tue May 19 13:09:02 2015', version: master}
+{install_date: 'Thu Sep  8 22:11:33 2016', version: master}

--- a/provisioning/roles/nodesource.node/role.yml
+++ b/provisioning/roles/nodesource.node/role.yml
@@ -2,5 +2,5 @@
 - name: Test the Node.js role
   hosts: all
   sudo: yes
-  tasks:
-    - include: "tasks/main.yml"
+  roles:
+    - role: "ansible-nodejs-role"

--- a/provisioning/roles/nodesource.node/tasks/main.yml
+++ b/provisioning/roles/nodesource.node/tasks/main.yml
@@ -1,21 +1,30 @@
 # Install Node.js using packages crafted by NodeSource
 ---
 - name: Ensure the system can use the HTTPS transport for APT
-  stat: path=/usr/lib/apt/methods/https
+  stat:
+    path: /usr/lib/apt/methods/https
   register: apt_https_transport
 
 - name: Install HTTPS transport for APT
-  apt: pkg=apt-transport-https state=installed
+  apt:
+    pkg: apt-transport-https
+    state: installed
   when: not apt_https_transport.stat.exists
 
 - name: Import the NodeSource GPG key into apt
-  apt_key: url=https://deb.nodesource.com/gpgkey/nodesource.gpg.key state=present
+  apt_key:
+    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    state: present
 
 - name: Add NodeSource deb repository
-  apt_repository: repo='deb https://deb.nodesource.com/node {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource deb-src repository
-  apt_repository: repo='deb-src https://deb.nodesource.com/node {{ ansible_distribution_release }} main' state=present
+  apt_repository:
+    repo: 'deb-src https://deb.nodesource.com/node_{{ debian_repo_version }} {{ ansible_distribution_release }} main'
+    state: present
 
 - name: Add NodeSource repository preferences
   template:
@@ -23,4 +32,8 @@
     dest: /etc/apt/preferences.d/deb_nodesource_com_node.pref
 
 - name: Install Node.js
-  apt: pkg=nodejs state=installed update_cache=yes
+  apt:
+    pkg:
+      - nodejs={{ nodejs_version }}*
+    state: installed
+    update_cache: yes

--- a/provisioning/roles/nodesource.node/tasks/main.yml
+++ b/provisioning/roles/nodesource.node/tasks/main.yml
@@ -13,7 +13,8 @@
 
 - name: Import the NodeSource GPG key into apt
   apt_key:
-    url: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
+    id: "68576280"
+    url: https://keyserver.ubuntu.com/pks/lookup?op=get&fingerprint=on&search=0x1655A0AB68576280
     state: present
 
 - name: Add NodeSource deb repository

--- a/provisioning/roles/nodesource.node/vars/main.yml
+++ b/provisioning/roles/nodesource.node/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for nodejs
+debian_repo_version: "{{ nodejs_version if '4' not in nodejs_version else '4.x' }}"

--- a/provisioning/travis.yml
+++ b/provisioning/travis.yml
@@ -3,6 +3,7 @@
   sudo: true
   vars_files:
     - vars/mysql.yml
+    - vars/node.yml
   pre_tasks:
     - name: Get MySQL GPG key
       apt_key:

--- a/provisioning/vagrant.yml
+++ b/provisioning/vagrant.yml
@@ -29,6 +29,7 @@
     - vars/elasticsearch.yml
     - vars/mysql.yml
     - vars/rabbitmq.yml
+    - vars/node.yml
   roles:
     - geerlingguy.memcached
     - geerlingguy.mysql

--- a/provisioning/vars/node.yml
+++ b/provisioning/vars/node.yml
@@ -1,0 +1,1 @@
+nodejs_version: "0.10"


### PR DESCRIPTION
Update to the latest version of the ansible-galaxy role ``nodesource.node``, and then patch it to install the NodeSource apt GPG key from keyserver.ubuntu.com, since they switch to CloudFront and SNI for the old file server, and the old version of Python in Ubuntu 14.04 can't handle it.