### PR TITLE
Update travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: required
 branches:
     only:
         - master


### PR DESCRIPTION
According to Travis CI documentation, in the newly added repository, by default ``sudo`` is false. Therefore I could not run Travis Ci build from my fork. adding ``sudo: required`` will make the build run in my fork. more information can be found [here](https://docs.travis-ci.com/user/ci-environment/)