### PR TITLE
bug 950945: Update mdn-sphinx-theme to 2016.0

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -5,7 +5,7 @@ Babel==2.2.0
 docutils==0.12
 Jinja2==2.7.3
 MarkupSafe==0.23
-mdn-sphinx-theme==2015.2
+mdn-sphinx-theme==2016.0
 Pygments==2.1.1
 pytz==2015.7
 six==1.10.0


### PR DESCRIPTION
Uses the [new theme](https://pypi.python.org/pypi/mdn-sphinx-theme) tagged from https://github.com/mdn/sphinx-theme/pull/10 and generated from #3954.

r? @stephaniehobson