### PR TITLE
[Bug 1292624] Suggest moving translated pages after moving an English page

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -220,14 +220,21 @@ def move_page(locale, slug, new_slug, email):
 
     full_url = settings.SITE_URL + '/' + locale + '/docs/' + new_slug
 
+    other_locale_urls = [settings.SITE_URL + translation.get_absolute_url()
+                         for translation in doc.translations.all().order_by('locale')]
+
     message = """
         Page move completed.
 
         The move requested for the document with slug %(slug)s in locale
         %(locale)s, and all its children, has been completed.
 
+        But following localized articles should be moved also:
+        %(locale_urls)s
+
         You can now view this document at its new location: %(full_url)s.
-    """ % {'slug': slug, 'locale': locale, 'full_url': full_url}
+    """ % {'slug': slug, 'locale': locale, 'full_url': full_url,
+           'locale_urls': '\n'.join(other_locale_urls)}
 
     send_mail(subject,
               textwrap.dedent(message),

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -220,8 +220,16 @@ def move_page(locale, slug, new_slug, email):
 
     full_url = settings.SITE_URL + '/' + locale + '/docs/' + new_slug
 
+    # Get the parent document, if parent doc is None, it means its the parent document
+    parent_doc = doc.parent or doc
+
     other_locale_urls = [settings.SITE_URL + translation.get_absolute_url()
-                         for translation in doc.translations.all().order_by('locale')]
+                         for translation in parent_doc.translations.exclude(locale=doc.locale)
+                                                                   .order_by('locale')]
+
+    # If the document is a translation we should include the parent document url to the list
+    if doc.parent:
+        other_locale_urls = [settings.SITE_URL + doc.parent.get_absolute_url()] + other_locale_urls
 
     message = """
         Page move completed.
@@ -229,7 +237,7 @@ def move_page(locale, slug, new_slug, email):
         The move requested for the document with slug %(slug)s in locale
         %(locale)s, and all its children, has been completed.
 
-        But following localized articles should be moved also:
+        But following localized articles may need to be moved also:
         %(locale_urls)s
 
         You can now view this document at its new location: %(full_url)s.

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -231,21 +231,21 @@ def move_page(locale, slug, new_slug, email):
     if doc.parent:
         other_locale_urls = [settings.SITE_URL + doc.parent.get_absolute_url()] + other_locale_urls
 
-    message = """
+    message = textwrap.dedent("""
         Page move completed.
 
         The move requested for the document with slug %(slug)s in locale
         %(locale)s, and all its children, has been completed.
 
-        But following localized articles may need to be moved also:
+        The following localized articles may need to be moved also:
         %(locale_urls)s
 
         You can now view this document at its new location: %(full_url)s.
-    """ % {'slug': slug, 'locale': locale, 'full_url': full_url,
-           'locale_urls': '\n'.join(other_locale_urls)}
+    """) % {'slug': slug, 'locale': locale, 'full_url': full_url,
+            'locale_urls': '\n'.join(other_locale_urls)}
 
     send_mail(subject,
-              textwrap.dedent(message),
+              message,
               settings.DEFAULT_FROM_EMAIL,
               [user.email])
 


### PR DESCRIPTION
[Bug 1292624 comment 2](https://bugzilla.mozilla.org/show_bug.cgi?id=1292624#c2) describes to reproduce the issue and check the feature. Unfortunately, due to [Bug 1301867](https://bugzilla.mozilla.org/show_bug.cgi?id=1301867), the page move does not work and the email is not generated if ``CELERY_ALWAYS_EAGER`` is ``True``. So you should add ``CELERY_ALWAYS_EAGER = False`` in the ``.env`` file in order to get the test email in ``/tmp/kuma-messages``

@jwhitlock r?