### PR TITLE
Setuptools 26.1.1

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -11,7 +11,7 @@ EXPOSE 8000
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends python2.7 libpython2.7 python-dev \
-    python-pip python-setuptools gettext build-essential \
+    python-pip gettext build-essential \
     nodejs npm \
     libtidy-0.99-0 libtidy-dev \
     libxml2-dev libxslt1.1 libxslt1-dev \
@@ -20,6 +20,10 @@ RUN apt-get update && \
     libmagic-dev \
     libmysqlclient-dev \
     mysql-client  # Only for local dev.
+
+# bug 1301116
+RUN pip install setuptools==26.1.1
+
 RUN update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 RUN npm install -g \

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -29,11 +29,10 @@ pytz==2015.7 \
     --hash=sha256:99266ef30a37e43932deec2b7ca73e83c8dbc3b9ff703ec73eca6b1dae6befea \
     --hash=sha256:8b6ce1c993909783bc96e0b4f34ea223bff7a4df2c90bdb9c4e0f1ac928689e3
 # cryptography, django-honeypot
-# Force version from Ubuntu 16.04 LTS
-setuptools==20.7.0 \
-    --hash=sha256:8917a52aa3a389893221b173a89dae0471022d32bff3ebc31a1072988aa8039d \
-    --hash=sha256:505cdf282c5f6e3a056e79f0244b8945f3632257bba8469386c6b9b396400233 \
-    --hash=sha256:5704988be46145f68b3b04d599bb03d5b6aaeaf66de8f2896bb1d3ba8aebd7ba
+setuptools==26.1.1 \
+    --hash=sha256:226c9ce65e76c6069e805982b036f36dc4b227b37dd87fc219aef721ec8604ae \
+    --hash=sha256:475ce28993d7cb75335942525b9fac79f7431a7f6e8a0079c0f2680641379481 \
+    --hash=sha256:02a06e1a547b16c25143d2bb898008286a3cbd600a7dbe47234ce57dc51abbf6
 # bleach, django-appconf, django-cacheback, django-extensions, mock, etc.
 six==1.10.0 \
     --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1 \


### PR DESCRIPTION
This builds on #3960 but installs setuptools 26.1.1 without hash verification in `Dockerfile-base` as a workaround for the `AttributeError: 'Requirement' object has no attribute 'project_name'` error we get when attempting to use hash verification.