### PR TITLE
bug 1218563: Add basic install docs for Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ uploads/
 webroot/.htaccess
 wheelhouse
 xfers/*
+product_details_json/


### PR DESCRIPTION
Update the Docker installation documents for the new Docker environment, and get them to the "view the homepage" step in the Vagrant documentation.

The double-installation of product details is not ideal (once in the image, once again with the ``git clone`` checkout), but documenting what it looks like now, while I work on a PR to change it ([bug 1302459](https://bugzilla.mozilla.org/show_bug.cgi?id=1302459))

@stephaniehobson can you try the instructions to make sure they are clear?  The empty database path is sufficient for the homepage test.

@jgmize can you do a sanity check?