### PR TITLE
bug 1218563: Disable pipeline in Vagrant development

### DIFF
--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -1,6 +1,9 @@
 import logging
 from .common import *  # noqa
 
+# Settings for Vagrant Development
+# TODO: Use environment to override, not settings picker
+
 DEFAULT_FILE_STORAGE = 'kuma.core.storage.KumaHttpStorage'
 LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN = PRODUCTION_URL + '/media/'
 
@@ -8,13 +11,17 @@ ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
 
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1')
 
+# Default DEBUG to True, and recompute derived settings
 DEBUG = config('DEBUG', default=True, cast=bool)
 DEBUG_TOOLBAR = config('DEBUG_TOOLBAR', default=False, cast=bool)
 SERVE_MEDIA = DEBUG
 DEBUG_PROPAGATE_EXCEPTIONS = DEBUG
+PIPELINE['PIPELINE_ENABLED'] = config('PIPELINE_ENABLED', not DEBUG, cast=bool)
+PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = config('PIPELINE_COLLECTOR_ENABLED',
+                                                not DEBUG, cast=bool)
+TEMPLATES[1]['OPTIONS']['debug'] = DEBUG
 
 LOG_LEVEL = logging.ERROR
-
 PROTOCOL = 'https://'
 DOMAIN = 'developer-local.allizom.org'
 SITE_URL = PROTOCOL + DOMAIN


### PR DESCRIPTION
Previously, the django-pipeline settings [PIPELINE_ENABLED](https://django-pipeline.readthedocs.io/en/latest/configuration.html#pipeline-enabled) and [PIPELINE_COLLECTOR_ENABLED](https://django-pipeline.readthedocs.io/en/latest/configuration.html#pipeline-collector-enabled) were unset, and were set to default values at runtime (Off for ``DEBUG=True``, on for ``DEBUG=False`` in production).

The Docker configuration sets them explictly, either from environment variables or the documented defaults.

The Vagrant dev environment starts with ``DEBUG=False``, and then resets it to ``DEBUG=True`` in ``settings/local.py``, but not until the pipeline is enabled for production, breaking static assets.

This code updates the Vagrant settings that get set to production defaults, and adds a note that ``local.py`` has a short life remaining.