### PR TITLE
Bug 1260487: Remove obsolete items from nav & homepage.

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -129,7 +129,7 @@
         {% endif %}
     </div>
 
-    <nav id="main-nav" role="navigation"><ul><li><a href="{{ wiki_url('Web') }}">{{ _('Web Platform') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
+    <nav id="main-nav" role="navigation"><ul><li><a href="{{ wiki_url('Web') }}">{{ _('Web Technologies') }}<i aria-hidden="true" class="icon-caret-down"></i></a>
 
         <div class="submenu submenu-cols-2 js-submenu" id="nav-platform-submenu">
           <div class="submenu-column">
@@ -141,13 +141,13 @@
               <li><a href="{{ wiki_url('Web/Guide/Graphics') }}">{{ _('Graphics') }}</a></li>
               <li><a href="{{ wiki_url('Web/HTTP') }}">{{ _('HTTP') }}</a></li>
               <li><a href="{{ wiki_url('Web/API') }}">{{ _('APIs / DOM') }}</a></li>
-              <li><a href="{{ wiki_url('Web/Apps') }}">{{ _('Apps') }}</a></li>
+              <li><a href="{{ wiki_url('Mozilla/Add-ons/WebExtensions') }}">{{ _('WebExtensions') }}</a></li>
               <li><a href="{{ wiki_url('Web/MathML') }}">{{ _('MathML') }}</a></li>
             </ul>
           </div><div class="submenu-column last">
             <div class="title">{{ _('References & Guides') }}</div>
             <ul>
-              <li><a href="{{ wiki_url('Learn') }}">{{ _('Learn the Web') }}</a></li>
+              <li><a href="{{ wiki_url('Learn') }}">{{ _('Learning web development') }}</a></li>
               <li><a href="{{ wiki_url('Web/Tutorials') }}">{{ _('Tutorials') }}</a></li>
               <li><a href="{{ wiki_url('Web/Reference') }}">{{ _('References') }}</a></li>
               <li><a href="{{ wiki_url('Web/Guide') }}">{{ _('Developer Guides') }}</a></li>
@@ -164,7 +164,6 @@
             <ul>
               <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
               <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
-              <li><a href="{{ wiki_url('Mozilla/Add-ons/WebExtensions') }}">{{ _('WebExtensions') }}</a></li>
             </ul>
           </div>
         </div>

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -69,21 +69,23 @@
     <h2 class="offscreen">{{ _('Web Technologies') }}</h2>
     <div class="column-container">
       <div class="column-home-features">
-        <h3><i aria-hidden="true" class="icon-file-text"></i><span>{{ _('Web<br />Platform') }}</span></h3>
+        <h3><i aria-hidden="true" class="icon-file-text"></i><span>{{ _('Web<br />Technologies') }}</span></h3>
         <ul>
           <li><a href="{{ wiki_url('Web/Reference/API') }}">{{ _('Web APIs &amp; DOM') }}</a></li>
-          <li><a href="{{ wiki_url('Web/HTML') }}">{{ _('HTML') }}</a> &amp; <a href="{{ wiki_url('Web/Guide/HTML/HTML5') }}">{{ _('HTML5') }}</a></li>
-          <li><a href="{{ wiki_url('Web/CSS') }}">{{ _('CSS') }}</a> &amp; <a href="{{ wiki_url('Web/CSS/CSS3') }}">{{ _('CSS3') }}</a></li>
+          <li><a href="{{ wiki_url('Web/HTML') }}">{{ _('HTML') }}</a></li>
+          <li><a href="{{ wiki_url('Web/CSS') }}">{{ _('CSS') }}</a></li>
           <li><a href="{{ wiki_url('Web/JavaScript') }}">{{ _('JavaScript') }}</a></li>
           <li><a href="{{ wiki_url('Web') }}">{{ _('more...') }}</a></li>
         </ul>
       </div>
       <div class="column-home-features">
-        <h3 class="zones"><i aria-hidden="true" class="icon-suitcase"></i><span>{{ _('Mozilla<br> Docs') }}</span></h3>
+        <h3><i aria-hidden="true" class="icon-graduation-cap"></i><span>{{ _('Learning') }}</span></h3>
         <ul>
-          <li><a href="{{ wiki_url('Mozilla/Firefox') }}">{{ _('Firefox') }}</a></li>
-          <li><a href="{{ wiki_url('Mozilla/Add-ons') }}">{{ _('Add-ons') }}</a></li>
-          <li><a href="{{ wiki_url('Mozilla/Add-ons/WebExtensions') }}">{{ _('WebExtensions') }}</a></li>
+          <li><a href="{{ wiki_url('Learn') }}">{{ _('Learning web development') }}</a></li>
+          <li><a href="{{ wiki_url('Learn/Getting_started_with_the_web') }}">{{ _('Getting started with the Web') }}</a></li>
+          <li><a href="{{ wiki_url('Learn/HTML/') }}">{{ _('Learn HTML') }}</a></li>
+          <li><a href="{{ wiki_url('Learn/CSS/') }}">{{ _('Learn CSS') }}</a></li>
+          <li><a href="{{ wiki_url('Learn/JavaScript/') }}">{{ _('Learn JavaScript') }}</a></li>
         </ul>
       </div>
       <div class="column-home-features">
@@ -95,11 +97,6 @@
         <li><a href="{{ wiki_url('Tools/Performance') }}">{{ _('Performance Tools') }}</a></li>
         <li><a href="{{ wiki_url('Tools') }}">{{ _('more...') }}</a></li>
         </ul>
-      </div>
-      <div class="column-home-features">
-        <h3 class="connect"><i aria-hidden="true" class="icon-certificate"></i><span>{{ _('Connect') }}</span></h3>
-        <p>{{ _('Get Web technology news from Mozilla, get help from other developers, and more!') }}</p>
-        <p><a href="{{ wiki_url('Mozilla/Connect') }}">{{ _('Learn more and sign up!') }}</a></p>
       </div>
     </div>
   </div>

--- a/kuma/static/styles/components/home/base.styl
+++ b/kuma/static/styles/components/home/base.styl
@@ -63,38 +63,6 @@ Override MDN standard styles
         }
     }
 
-    h3 {
-        clearfix();
-        text-transform: uppercase;
-
-        {$selector-icon} {
-            width: 42px;
-            height: 39px;
-            background-position: 0 -147px;
-            background-size: 134px auto;
-            color: #0095dd;
-            bidi-value(float, left, right);
-            bidi-value(margin-right, $icon-margin, 0);
-            bidi-value(margin-left, 0, $icon-margin);
-
-            &:before {
-                margin: 11px 0 0 0;
-                display: block;
-                text-align: center;
-            }
-        }
-
-        &.connect {
-            span {
-                padding-top: 10px;
-            }
-        }
-
-        span {
-            bidi-value(float, left, right);
-        }
-    }
-
     .entry-meta {
         set-smaller-font-size();
         font-style: italic;

--- a/kuma/static/styles/components/home/home-features.styl
+++ b/kuma/static/styles/components/home/home-features.styl
@@ -10,12 +10,34 @@
     }
 
     h3 {
+        display: flex;
+        flex-direction: row;
+        align-items: center
         set-larger-font-size();
         font-weight: bold;
         font-family: 'Open Sans Extra Bold', sans-serif;
+        text-transform: uppercase;
+        clearfix();
 
         {$selector-icon} {
-            bidi-style(margin-right, $icon-margin, margin-left, 0);
+            width: 42px;
+            height: 39px;
+            background-position: 0 -147px;
+            background-size: 134px auto;
+            color: #0095dd;
+            bidi-value(float, left, right);
+            bidi-value(margin-right, $icon-margin, 0);
+            bidi-value(margin-left, 0, $icon-margin);
+
+            &:before {
+                margin: 11px 0 0 0;
+                display: block;
+                text-align: center;
+            }
+        }
+
+        span {
+            bidi-value(float, left, right);
         }
     }
 
@@ -25,7 +47,7 @@
 }
 
 .column-home-features {
-    @extend $column-strip;
+    @extend $column-third;
 }
 
 


### PR DESCRIPTION
- Web Platform -> Web Technologies
- Move WebExtentions under Web Technologies
- Remove Mozilla Docs and Contact from homepage
- Add Learning Area to homepage
- Remove HTML5 and CSS3 from homepage
- Add styles to vertically center single line headings in supporting browsers