### PR TITLE
[Bug 1218563] Run test in Docker environment with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,15 @@ language: python
 python:
     - "2.7"
 services:
+    - docker
     - memcached
-    - elasticsearch
 env:
     matrix:
         - TOXENV=py27
         - TOXENV=flake8
         - TOXENV=docs
         - TOXENV=dennis
+        - TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
     global:
         - DJANGO_SETTINGS_MODULE=kuma.settings.travis
         - DEBIAN_FRONTEND=noninteractive
@@ -26,6 +27,7 @@ env:
 matrix:
     allow_failures:
         - env: TOXENV=dennis
+        - env: TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
 before_install:
     - scripts/travis-install
     - pip install -U pip

--- a/scripts/docker-compose.travis.yml
+++ b/scripts/docker-compose.travis.yml
@@ -1,0 +1,10 @@
+worker: &worker
+  build: .
+  dockerfile: Dockerfile-base
+  environment:
+    - DJANGO_SETTINGS_MODULE
+    - DEBIAN_FRONTEND
+    - CFLAGS
+
+web:
+  <<: *worker

--- a/scripts/docker-compose.travis.yml
+++ b/scripts/docker-compose.travis.yml
@@ -8,3 +8,6 @@ worker: &worker
 
 web:
   <<: *worker
+
+api:
+  <<: *worker

--- a/scripts/docker-compose.travis.yml
+++ b/scripts/docker-compose.travis.yml
@@ -1,13 +1,17 @@
-worker: &worker
-  build: .
-  dockerfile: Dockerfile-base
-  environment:
-    - DJANGO_SETTINGS_MODULE
-    - DEBIAN_FRONTEND
-    - CFLAGS
+version: '2'
+services:
+  worker: &worker
+    build:
+      context: .
+      dockerfile: Dockerfile-base
+    environment:
+      - DJANGO_SETTINGS_MODULE
+      - DEBIAN_FRONTEND
+      - CFLAGS
 
-web:
-  <<: *worker
+  web:
+    <<: *worker
 
-api:
-  <<: *worker
+  api:
+    <<: *worker
+

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -31,6 +31,4 @@ then
     curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
     chmod +x docker-compose
     sudo mv docker-compose /usr/local/bin
-    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml pull
-    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml build
 fi

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -15,10 +15,22 @@ then
     sudo apt-get autoremove
     sudo apt-get autoclean
     sudo rm -rf /var/lib/mysql
-    sudo truncate -s 0 /var/log/mysql/error.log
 
+    # Install Elasticsearch
+    wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.2.deb
+    sudo dpkg -i elasticsearch-1.7.2.deb
+    
     # limit elasticsearch / java memory usage to avoid OOM Killer
     sudo service elasticsearch stop;
     echo "ES_HEAP_SIZE=256m" | sudo tee --append /etc/default/elasticsearch
     sudo service elasticsearch start;
+fi
+
+if [ "$TOXENV" == "docker" ]
+then
+    curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    chmod +x docker-compose
+    sudo mv docker-compose /usr/local/bin
+    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml pull
+    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml build
 fi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, flake8, docs, dennis
+envlist = py27, flake8, docs, dennis, docker
 skipsdist = True
 
 [testenv:py27]
@@ -30,6 +30,15 @@ basepython = python2.7
 # TODO: Update to released version of dennis when aca57f6d is released.
 deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
+
+[testenv:docker]
+commands = 
+    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml up -d
+    docker exec -it kuma_web_1 ./manage.py update_product_details -f
+    docker restart kuma_web_1
+    docker exec -it kuma_web_1 ./manage.py migrate
+    docker exec -i kuma_web_1 make compilejsi18n collectstatic
+    docker exec -i kuma_web_1 make test
 
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor

--- a/tox.ini
+++ b/tox.ini
@@ -34,10 +34,11 @@ commands = dennis-cmd lint --errorsonly locale/
 [testenv:docker]
 commands = 
     docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml up -d
-    # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
-    sleep 10
-    docker exec -it kuma_web_1 ./manage.py migrate
     docker exec -i kuma_web_1 make compilejsi18n collectstatic
+    # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
+    sleep 60
+    docker logs kuma_mysql_1
+    docker exec -it kuma_web_1 ./manage.py migrate
     docker exec -i kuma_web_1 make test
 
 [flake8]

--- a/tox.ini
+++ b/tox.ini
@@ -34,8 +34,8 @@ commands = dennis-cmd lint --errorsonly locale/
 [testenv:docker]
 commands = 
     docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml up -d
-    docker exec -it kuma_web_1 ./manage.py update_product_details -f
-    docker restart kuma_web_1
+    # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
+    sleep 10
     docker exec -it kuma_web_1 ./manage.py migrate
     docker exec -i kuma_web_1 make compilejsi18n collectstatic
     docker exec -i kuma_web_1 make test


### PR DESCRIPTION
All the test will pass after merging #3975 #3976 
I have tried and this is the [result](https://travis-ci.org/safwanrahman/kuma/jobs/160749971)

We must configure travis to build and run all the test in docker environment  so we can track if any of our patch make the docker environment broken.

Instead of pulling ``kuma_base`` image, I have configured to build the image locally so it will be possible to test against the ``Docker-base``. So in future we can avoid any regression and it will be easier to track.

Regarding travis CI, Docker is only supported in ``Ubuntu Trusty`` Environment and unfortunately, ``Elasticsearch`` service [is not available in the trusty environment](https://docs.travis-ci.com/user/trusty-ci-environment/#Data-Stores). So needed to configure the build script in order to download the ``elasticsearch`` and install it in the environment.

@jwhitlock @jgmize r?