### PR TITLE
Bug 1218563: Update Development docs for Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,5 +117,14 @@ push-latest: push tag-latest
 	docker push ${BASE_IMAGE_LATEST}
 	docker push ${KUMA_IMAGE_LATEST}
 
+up:
+	docker-compose up -d
+
+bash: up
+	docker exec -it kuma_web_1 bash
+
+shell_plus: up
+	docker exec -it kuma_web_1 ./manage.py shell_plus
+
 # Those tasks don't have file targets
 .PHONY: test coveragetest intern locust clean locale install compilecss compilejsi18n collectstatic localetest localeextract localecompile localerefresh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ worker: &worker
   links:
     - memcached
     - mysql
-    #- elasticsearch
+    - elasticsearch
     - redis
   environment:
     # Django settings overrides:
@@ -20,7 +20,7 @@ worker: &worker
     - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
     - DEBUG=True
     - DOMAIN=localhost
-    #- ES_URLS=elasticsearch:9200
+    - ES_URLS=elasticsearch:9200
     - MEMCACHE_SERVERS=memcached:11211
     - PROD_DETAILS_DIR=/app/product_details_json
     - PROTOCOL=http://
@@ -69,8 +69,8 @@ mysql:
   volumes_from:
     - mysql-data
 
-#elasticsearch:
-#  image: elasticsearch:1.7
+elasticsearch:
+  image: elasticsearch:1.7
 
 redis:
   image: redis

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -299,18 +299,10 @@ Kuma will automatically run in debug mode, with the ``DEBUG`` setting
 turned to ``True``. That will make it serve images and have the pages
 formatted with CSS automatically.
 
-Vagrant requires additional settings in a ``.env`` file, until
-`PR 3972`_ is merged::
-
-    PIPELINE_ENABLED=false
-    PIPELINE_COLLECTOR_ENABLED=false
-
 Setting ``DEBUG=false`` file will put the installation in production mode and
 ask for minified assets.  This only works in the Vagrant environment, which
 uses Apache to serve the static files.  In Docker, static files will not be
 served and the site will be unstyled.
-
-.. _PR 3972: https://github.com/mozilla/kuma/pull/3972
 
 Production assets
 *****************

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -50,8 +50,13 @@ other containers. Useful docker sub-commands::
     docker-compose up -d             # Start the containers
     docker-compose rm                # Destroy the containers
 
-Run all commands in this doc in the ``kuma_web_1`` container after ``docker
-exec -it kuma_web_1 bash``.
+There are ``make`` shortcuts on the host for frequent commands, such as::
+
+    make up         # docker-compose up -d
+    make bash       # docker exec -it kuma_web_1 bash
+    make shell_plus # docker exec -it kuma_web_1 ./manage.py shell_plus
+
+Run all commands in this doc in the ``kuma_web_1`` container after ``make bash``
 
 Running Kuma
 ============
@@ -64,9 +69,9 @@ There are additional Kuma-specific services that are configured in
 
 The development instance is then available at https://developer-local.allizom.org.
 
-When the Docker container environment is started with ``docker-compose up``,
-all of the services (backend and Kuma-specific) are started. The development
-instance is available at http://localhost:8000.
+When the Docker container environment is started (``make up`` or similar), all
+of the services are also started. The development instance is available at
+http://localhost:8000.
 
 Running the Tests
 =================

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -84,9 +84,6 @@ Run the Django test suite::
 
     make test
 
-In the Vagrant VM, all the tests should pass.  In the Docker container, search
-tests will fail, because ElasticSearch is not installed.
-
 For more information, see the :doc:`test documentation <tests>`.
 
 Front-end tests

--- a/docs/installation-docker.rst
+++ b/docs/installation-docker.rst
@@ -51,6 +51,14 @@ Docker setup
 
         docker-compose up -d
 
+The following instructions assume that you are running from a folder named
+``kuma``, so that the containers created are named ``kuma_web_1``,
+``kuma_worker_1``, etc.  If you run from another folder, like ``mdn``, the
+containers will be named ``mdn_web_1``, ``mdn_worker_1``, etc. Adjust the
+command accordingly, or force the ``kuma`` name with::
+
+        docker-compose up -d -p kuma
+
 Install Product Details
 =======================
 The `product details JSON`_ includes common data for Mozilla products,

--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -1,6 +1,9 @@
 import logging
 from .common import *  # noqa
 
+# Settings for Vagrant Development
+# TODO: Use environment to override, not settings picker
+
 DEFAULT_FILE_STORAGE = 'kuma.core.storage.KumaHttpStorage'
 LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN = PRODUCTION_URL + '/media/'
 
@@ -8,13 +11,17 @@ ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
 
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1')
 
+# Default DEBUG to True, and recompute derived settings
 DEBUG = config('DEBUG', default=True, cast=bool)
 DEBUG_TOOLBAR = config('DEBUG_TOOLBAR', default=False, cast=bool)
 SERVE_MEDIA = DEBUG
 DEBUG_PROPAGATE_EXCEPTIONS = DEBUG
+PIPELINE['PIPELINE_ENABLED'] = config('PIPELINE_ENABLED', not DEBUG, cast=bool)
+PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = config('PIPELINE_COLLECTOR_ENABLED',
+                                                not DEBUG, cast=bool)
+TEMPLATES[1]['OPTIONS']['debug'] = DEBUG
 
 LOG_LEVEL = logging.ERROR
-
 PROTOCOL = 'https://'
 DOMAIN = 'developer-local.allizom.org'
 SITE_URL = PROTOCOL + DOMAIN


### PR DESCRIPTION
Update the [Development](https://kuma.readthedocs.io/en/latest/development.html) docs to run in either Vagrant or Docker.  It may be easier to review by letting GitHub [render the document](https://github.com/mozilla/kuma/blob/d5d7875b812a0225b34eb64f840f2b0efef90381/docs/development.rst).

This integrates some changes from other branches and PRs:

* Add ``make bash``, ``make up``, etc. from @jgmize jgmize's branch
* Add ElasticSearch from @safwanrahman PR #3976 
* Fix ``PIPELINE_ENABLED`` in Vagrant from PR #3972 

I'm trying to err on the side of an incremental change instead of a perfect fix. I'm omitting these tasks, documented in the [triage doc](https://docs.google.com/document/d/1cnuw2F25gtUPeHCXuu8zYf5H9v_UPdgmanJ7oVM6uoc/edit#):

* Nice to Have
  - Method for using ``fswatch`` in host system that call ``stylus`` in Docker container, for targeted update on saving ``*.styl`` files
  - Speed up tests in Docker (880 seconds vs 160 in Vagrant)
  - Serve production-like compressed static assets (Apache in Vagrant) 
  - Configure SSL / HTTPS for local Docker development
* Future Work
  - Rewrite document to have a narrative, "Here's how you develop a PR for Kuma", rather than being a grab bag of tips and tricks.
  - Add documentation for migration warning “Your models have changes that are not yet reflected in a migration” (``pytz`` is a big offender)
  - Add documentation for safe migration strategy  (migrate so database runs with n-1 and n deployed code bases)
  - Move / pull ``requirements/README.rst`` into docs ( 👍 all docs together, 👎 less discoverable while working with requirements)

Feel free to argue if you disagree with my prioritization.

r? @jgmize