### PR TITLE
Bug 1218563: Enable page rendering in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ worker: &worker
     - mysql
     - elasticsearch
     - redis
+    - kumascript
   environment:
     # Django settings overrides:
     - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
@@ -21,6 +22,7 @@ worker: &worker
     - DEBUG=True
     - DOMAIN=localhost
     - ES_URLS=elasticsearch:9200
+    - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
     - MEMCACHE_SERVERS=memcached:11211
     - PROD_DETAILS_DIR=/app/product_details_json
     - PROTOCOL=http://
@@ -37,6 +39,19 @@ web:
   command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
   ports:
     - "8000:8000"
+
+# API is used by KumaScript for content and metadata
+api:
+  <<: *worker
+  command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
+  links:
+    - memcached
+    - mysql
+    - elasticsearch
+    - redis
+    # Drop kumascript link
+  ports:
+    - "8001:8000"
 
 #nginx:
 #  build: ./docker/images/nginx
@@ -79,6 +94,23 @@ kumascript:
   image: quay.io/mozmar/kumascript
   command: node run.js
   links:
-    - web
+    - api
+    - memcached
+  environment:
+    - log__console=true
+    - log__file=
+    - server__document_url_template=http://api:8000/en-US/docs/{path}?raw=1
+    - server__template_url_template=http://api:8000/en-US/docs/Template:{name}?raw=1
+    - server__memcache__server=memcached:11211
+    - server__template_class=EJSTemplate
+    - server__autorequire__mdn=MDN:Common
+    - server__autorequire__Date=DekiScript:Date
+    - server__autorequire__Page=DekiScript:Page
+    - server__autorequire__String=DekiScript:String
+    - server__autorequire__Uri=DekiScript:Uri
+    - server__autorequire__Web=DekiScript:Web
+    - server__autorequire__Wiki=DekiScript:Wiki
   ports:
     - "9080:9080"
+  volumes:
+    - ./kumascript:/app

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1276,7 +1276,8 @@ CONSTANCE_CONFIG = dict(
     ),
 )
 
-KUMASCRIPT_URL_TEMPLATE = 'http://localhost:9080/docs/{path}'
+KUMASCRIPT_URL_TEMPLATE = config('KUMASCRIPT_URL_TEMPLATE',
+                                 default='http://localhost:9080/docs/{path}')
 
 # Elasticsearch related settings.
 ES_DEFAULT_NUM_REPLICAS = 1


### PR DESCRIPTION
* Update KumaScript to current master, which includes setting the configuration from the command like.
* Add a new api service to handle KumaScript requests, allowing the docker-compose v1 linking to work correctly
* Allow environment override of the setting ``KUMASCRIPT_URL_TEMPLATE``
* Configure kumascript service for rendering pages and caching responses

r? @jgmize