### PR TITLE
Fix Bug 1305156: Code Samples are LTR

### DIFF
--- a/kuma/static/styles/components/syntax/base.styl
+++ b/kuma/static/styles/components/syntax/base.styl
@@ -30,7 +30,7 @@ pre[class*='language-'] {
 }
 
 /*
-Enhamcements!
+Enhancements!
 ====================================================================== */
 :not(pre):not(code)>code[class*='language-'],
 pre[class*='language-'] {

--- a/kuma/static/styles/includes/mixins.styl
+++ b/kuma/static/styles/includes/mixins.styl
@@ -442,6 +442,8 @@ $code-block {
     color: $text-color;
     font-family: $code-block-font-family;
     font-weight: normal;
+    direction: ltr;
+    text-align: left;
 
     vendorize(tab-size, 4);
     vendorize(hyphens, none);


### PR DESCRIPTION
Small code change to force LTR in code samples. Problem is most apparent in webkit browsers.

Useful testing pages:
https://developer.mozilla.org/en-US/docs/User:stephaniehobson:code
https://developer.mozilla.org/ar/docs/User:stephaniehobson:code (not actually translated but appears with RTL UI and styles.)