### PR TITLE
Fix Bug 1281855: Indicators shouldn't clear:both

### DIFF
--- a/kuma/static/styles/includes/mixins_indicators.styl
+++ b/kuma/static/styles/includes/mixins_indicators.styl
@@ -11,6 +11,7 @@ block indicators aka banners
 $indicator-block {
     set-message-base(true);
     clearfix();
+    clear: none; // over-rides default value assigned in clearfix
 
     background-color: $light-background-color;
     font-size: $smaller-font-size;


### PR DESCRIPTION
Over-rides the clear:both value assigned by using the clearfix() mixin.