### PR TITLE
bug 1218563: remove deprecated docker tag -f

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,8 +110,8 @@ push-kuma:
 push: push-base push-kuma
 
 tag-latest:
-	docker tag -f ${BASE_IMAGE} ${BASE_IMAGE_LATEST}
-	docker tag -f ${KUMA_IMAGE} ${KUMA_IMAGE_LATEST}
+	docker tag ${BASE_IMAGE} ${BASE_IMAGE_LATEST}
+	docker tag ${KUMA_IMAGE} ${KUMA_IMAGE_LATEST}
 
 push-latest: push tag-latest
 	docker push ${BASE_IMAGE_LATEST}


### PR DESCRIPTION
This is necessary due to the recent docker upgrade on our CI.

https://docs.docker.com/engine/deprecated/#/f-flag-on-docker-tag

@jwhitlock r?