### PR TITLE
[Bug 1218563] Adding a user without root privillage in docker

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -41,5 +41,8 @@ ENV PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor \
 COPY ./requirements /app/requirements
 RUN pip install --no-cache-dir -r requirements/dev.txt
 
+RUN useradd kuma
+USER kuma
+
 ENV WEB_CONCURRENCY=4
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--timeout=120", "kuma.wsgi:application"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,8 +30,6 @@ services:
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=http://localhost:8000
-      # Celery environment overrides:
-      - C_FORCE_ROOT=1  # TODO: switch to non-root user
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
 


### PR DESCRIPTION
It will add a without root privilege user named ``kumadev`` and adding ``USER`` parameters in docker file so all the shell access will be done with ``kumadev`` user. As per mentioned in [doc](https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices/#/user)

If anyone needs root access to the container, they can add ``--user root`` parameter to either ``docker exec`` or ``docker-compose run``.
like
``docker-compose run --rm --user root web bash``
@jwhitlock r?