### PR TITLE
bug 1267197: Change DocumentZoneMiddleware to deal with locale + zone redirects correctly

### DIFF
--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -45,8 +45,6 @@ class DocumentZoneMiddleware(object):
                 new_path = '/%s%s' % (request.LANGUAGE_CODE, new_path)
 
                 query = request.GET.copy()
-                if 'lang' in query:
-                    query.pop('lang')
                 new_path = urlparams(new_path, query_dict=query)
 
                 return HttpResponseRedirect(new_path)
@@ -56,8 +54,6 @@ class DocumentZoneMiddleware(object):
                 # in the url path between the language code and the zone's url_root?
                 new_path = u'/{}{}'.format(request.LANGUAGE_CODE, new_path)
                 query = request.GET.copy()
-                if 'lang' in query:
-                    query.pop('lang')
                 new_path = urlparams(new_path, query_dict=query)
 
                 return HttpResponsePermanentRedirect(new_path)

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,4 +1,4 @@
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import render
 
 from kuma.core.utils import urlparams
@@ -50,6 +50,17 @@ class DocumentZoneMiddleware(object):
                 new_path = urlparams(new_path, query_dict=query)
 
                 return HttpResponseRedirect(new_path)
+
+            elif request.path_info == u'/docs{}'.format(new_path):
+                # Is this a request for a DocumentZone, but with /docs/ wedged
+                # in the url path between the language code and the zone's url_root?
+                new_path = u'/{}{}'.format(request.LANGUAGE_CODE, new_path)
+                query = request.GET.copy()
+                if 'lang' in query:
+                    query.pop('lang')
+                new_path = urlparams(new_path, query_dict=query)
+
+                return HttpResponsePermanentRedirect(new_path)
 
             elif request.path_info.startswith(new_path):
                 # Is this a request for the relocated wiki path? If so, rewrite

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -226,6 +226,16 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         response = self.client.get(url, follow=False)
         self.assertRedirects(response, '/fr/Firefox', status_code=301)
 
+    def test_docs_zone_with_get_param_locale(self):
+        # A url with a get parameter locale should redirect to a
+        # version of the url with the locale at the head of the path,
+        # and then proceed from there as if we went to that url originally.
+        url = '/docs/Firefox'
+        response = self.client.get(url, {'lang': 'fr'}, follow=True)
+        self.assertEqual(response.redirect_chain,
+                         [('http://testserver/fr/docs/Firefox', 301),
+                          ('http://testserver/fr/Firefox', 301)])
+
     def test_zone_document_with_implied_default_locale(self):
         # This url will get two redirects: one to add the missing default
         # locale, and the other as a zone remap non-permanent redirect.

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -5,7 +5,7 @@ from kuma.core.cache import memcache
 from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
-from . import revision
+from . import revision, document
 from ..middleware import DocumentZoneMiddleware
 from ..models import DocumentZone
 
@@ -150,3 +150,101 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s' % non_zone_doc.slug
         response = self.client.get(url, follow=False)
         eq_(200, response.status_code)
+
+
+class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
+    """bug 1267197 -- Locales and DocumentZones do not always play nicely together,
+    particularly with the middleware that attempts to redirect requests to the
+    right location.
+
+    """
+
+    def setUp(self):
+        super(DocumentZoneWithLocaleTestCase, self).setUp()
+        memcache.clear()
+
+        root_rev = revision(title='Firefox', slug='Mozilla/Firefox',
+                            is_approved=True, save=True)
+        self.en_doc = root_rev.document
+        self.en_doc.locale = 'en-US'
+        self.en_doc.save()
+
+        self.en_root_zone = DocumentZone(document=self.en_doc, url_root='Firefox')
+        self.en_root_zone.save()
+
+        self.fr_doc = document(title='Firefox', slug='Mozilla/Firefox',
+                               parent=self.en_doc, locale='fr', save=True)
+        revision(document=self.fr_doc, is_approved=True, save=True)
+
+        self.fr_root_zone = DocumentZone(document=self.fr_doc, url_root='Firefox')
+        self.fr_root_zone.save()
+
+    def test_zone_with_implied_default_locale(self):
+        # This url lacks a locale, so the locale middleware will redirect to the
+        # canonical one for the default language.
+        url = '/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertRedirects(response, '/en-US/Firefox', status_code=301)
+
+    def test_zone_with_default_locale(self):
+        # This url is the canonical one for the English zone for this document,
+        # so just load it.
+        url = '/en-US/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertEqual(response.status_code, 200)
+
+    def test_zone_with_non_default_locale(self):
+        # This url is the canonical one for the French zone for this document,
+        # so just load it.
+        url = '/fr/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertEqual(response.status_code, 200)
+
+    def test_docs_zone_with_implied_default_locale(self):
+        # This url will get two redirects: one to add the missing default
+        # locale, and the other by triggering the new logic that will strip the
+        # /docs/ prefix from a DocumentZone url.
+        url = '/docs/Firefox'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.redirect_chain,
+                         [('http://testserver/en-US/docs/Firefox', 301),
+                          ('http://testserver/en-US/Firefox', 301)])
+
+    def test_docs_zone_with_default_locale(self):
+        # This url which mixes the Document url prefix /docs/ with a locale and
+        # a DocumentZone url will trigger the new logic, and will cause a
+        # permanent redirect to the canonical zone url.
+        url = '/en-US/docs/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertRedirects(response, '/en-US/Firefox', status_code=301)
+
+    def test_docs_zone_with_non_default_locale(self):
+        # This url which mixes the Document url prefix /docs/ with a locale and
+        # a DocumentZone url will trigger the new logic, and will cause a
+        # permanent redirect to the canonical zone url.
+        url = '/fr/docs/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertRedirects(response, '/fr/Firefox', status_code=301)
+
+    def test_zone_document_with_implied_default_locale(self):
+        # This url will get two redirects: one to add the missing default
+        # locale, and the other as a zone remap non-permanent redirect.
+        url = '/docs/Mozilla/Firefox'
+        response = self.client.get(url, follow=True)
+        self.assertEqual(response.redirect_chain,
+                         [('http://testserver/en-US/docs/Mozilla/Firefox', 301),
+                          ('http://testserver/en-US/Firefox', 302)])
+
+    def test_zone_document_with_default_locale(self):
+        # This url is the canonical one for our English document, so it should
+        # get a single, non-permanent redirect to the zone url.
+        url = '/en-US/docs/Mozilla/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertRedirects(response, '/en-US/Firefox', status_code=302)
+
+    def test_zone_document_with_non_default_locale(self):
+        # This url is the canonical one for our French document, so it should
+        # get a single, non-permanent redirect to the zone url.
+        url = '/fr/docs/Mozilla/Firefox'
+        response = self.client.get(url, follow=False)
+        self.assertRedirects(response, '/fr/Firefox', status_code=302)


### PR DESCRIPTION
~~by making use of the existing utility function `locale_and_slug_from_path`.~~

by checking to see if the requested url is '/docs/' + a zone root url and then dealing accordingly.
