### PR TITLE
fix bug 1307121: Add placeholder to Czech (cs) translation 

### DIFF
--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -1613,7 +1613,7 @@ msgstr "Zobrazení výsledků od %(start)s do %(end)s."
 #: kuma/search/jinja2/search/results.html:127
 #, python-format
 msgid "Search again in %(default_locale_native)s only"
-msgstr "Hledat znovu pouze v jazyce % (default_locale_native)"
+msgstr "Hledat znovu pouze v jazyce %(default_locale_native)s"
 
 #: kuma/search/jinja2/search/results.html:141
 msgid "Docs"


### PR DESCRIPTION
Add the placeholder string to the Czech (cs) translation of the search string.

The Czech translation team is active, so I want to give them some time to fix this the "right" way (via [Pontoon](https://pontoon.mozilla.org/cs/mdn/LC_MESSAGES/django.po/?search=Search+again&string=67765)), and to see if this needs a fix in Pontoon itself.  I'm opening the PR to avoid someone else opening a PR, hopefully I can close without merging in a bit.