### PR TITLE
bug 1218563: Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 # From kuma .gitignore
-!static/fonts/.htaccess
-!build/assets/css/README.md
 *.pyc
 *.pyo
 *.sw?

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+# From kuma .gitignore
 !static/fonts/.htaccess
 !build/assets/css/README.md
 *.pyc
@@ -41,3 +42,33 @@ uploads/
 webroot/.htaccess
 wheelhouse
 xfers/*
+
+# From kumascript .gitignore
+kumascript/*.swp
+kumascript/*.swo
+kumascript/tmp
+kumascript/logs
+kumascript/docs
+kumascript/.monitor
+kumascript/.nodemonignore
+kumascript/*.node
+kumascript/*.dSYM
+kumascript/*.o
+kumascript/*.a
+kumascript/*.dylib
+kumascript/*.un~
+kumascript/node_modules/fibers
+kumascript/node_modules/underscore/raw
+kumascript/npm-debug.log
+
+# Additional ignores
+.git
+.gitignore
+kumascript/.git
+kumascript/.gitignore
+provisioning
+k8s
+docker
+docker-compose*
+Dockerfile
+Dockerfile*


### PR DESCRIPTION
Add a .dockerignore that includes:
- Everything in .gitignore
- Everything in kumascript/.gitignore
- .git folders and others not needed in containers

This reduces my build context from 2 GB to about 50 MB.