### PR TITLE
bug 1218563: Improve TravisCI docker build and test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,10 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
-commands = 
-    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml up -d
+setenv =
+    COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
+commands =
+    docker-compose up -d
     docker exec -i kuma_web_1 make compilejsi18n collectstatic
     # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
     sleep 60

--- a/tox.ini
+++ b/tox.ini
@@ -32,18 +32,15 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
-whitelist_externals =
-    docker-compose
-    sleep
+whitelist_externals = docker-compose
 setenv =
     COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
     COMPOSE_PROJECT_NAME = kumatox
 commands =
-    docker-compose up -d
+    docker-compose up -d --build mysql  # Build, init DB (can be slow)
+    docker-compose build web    # Rebuild w/ new reqs, Dockerfile-base
+    docker-compose up -d        # Startup remainin services
     docker-compose exec -T web make compilejsi18n collectstatic
-    # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
-    sleep 60
-    docker-compose logs mysql
     docker-compose exec web ./manage.py migrate
     docker-compose exec -T web make test
     docker-compose stop         # Useful for local development

--- a/tox.ini
+++ b/tox.ini
@@ -32,16 +32,21 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
+whitelist_externals =
+    docker-compose
+    sleep
 setenv =
     COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
+    COMPOSE_PROJECT_NAME = kumatox
 commands =
     docker-compose up -d
-    docker exec -i kuma_web_1 make compilejsi18n collectstatic
+    docker-compose exec -T web make compilejsi18n collectstatic
     # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
     sleep 60
-    docker logs kuma_mysql_1
-    docker exec -it kuma_web_1 ./manage.py migrate
-    docker exec -i kuma_web_1 make test
+    docker-compose logs mysql
+    docker-compose exec web ./manage.py migrate
+    docker-compose exec -T web make test
+    docker-compose stop         # Useful for local development
 
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor


### PR DESCRIPTION
Improve on PR #3977 (test docker travis):

- Use environment variables to simplify ``docker-compose`` calls
- Eliminate some warnings by adding build steps, configuring ``tox``
- Start the ``mysql`` container while the ``web`` image is building, to eliminate ``sleep 60``
- _Formerly included "build and test the base image", but PR #3977 already does that_

See #4011 for an alternate implementation with less commands.