### PR TITLE
Adjust settings to improve debugging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - C_FORCE_ROOT=1  # TODO: switch to non-root user
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
+      - PYTHONUNBUFFERED=True
 
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - CSRF_COOKIE_SECURE=False
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
       - DEBUG=True
+      - DEBUG_TOOLBAR=True
       - DOMAIN=localhost
       - ES_URLS=elasticsearch:9200
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
@@ -38,14 +39,14 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
+    command: gunicorn -w 4 --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
     ports:
       - "8000:8000"
 
   # API is used by KumaScript for content and metadata
   api:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
+    command: gunicorn -w 4 --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
     depends_on:
       - memcached
       - mysql

--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -9,7 +9,7 @@ LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN = PRODUCTION_URL + '/media/'
 
 ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
 
-INTERNAL_IPS = ('127.0.0.1', '192.168.10.1')
+INTERNAL_IPS = ('127.0.0.1', '192.168.10.1', '172.18.0.1')
 
 # Default DEBUG to True, and recompute derived settings
 DEBUG = config('DEBUG', default=True, cast=bool)


### PR DESCRIPTION
- enable Django Debug Toolbar by adding in the container's IP address
- log gunicorn accesses to stdout, so that the docker logs catch them
