### PR TITLE
Bug 1286541: Task completion longer between prompts

### DIFF
--- a/kuma/static/js/task-completion.js
+++ b/kuma/static/js/task-completion.js
@@ -32,8 +32,8 @@
         // open notification
         var notification = mdn.Notifier.growl(ask, {closable: true, duration: 0}).question();
 
-        // don't ask task completion again for 30 days
-        localStorage.setItem('taskTracker', Date.now() + (1000*60*60*24)*30);
+        // don't ask task completion again for 32 days (waffle flags last 31)
+        localStorage.setItem('taskTracker', Date.now() + (1000*60*60*24)*32);
 
         // get ga to append the clientId once it has initialized
         ga(function(tracker) {


### PR DESCRIPTION
Increased the wait before prompting again to 32 days. The django waffle flag sorting lasts 31 days. This means people will be re-sorted randomly by waffle before the survey code can prompt them with the survey again.