### PR TITLE
[Bug 1218563] Configure Docker nginx container to serve through https

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,18 @@ localerefresh: localeextract localetest localecompile compilejsi18n collectstati
 	@echo Commit the new files with:
 	@echo git add --all locale\; git commit -m \"MDN string update $(shell date +%Y-%m-%d)\"
 
+generate-cert:
+	@mkdir -p ssl && \
+	openssl req \
+	    -x509 \
+			-sha256 \
+			-nodes \
+			-newkey rsa\:2048 \
+			-days 365 \
+	    -keyout ssl/server.key \
+			-out ssl/server.crt \
+			-subj '/CN=localhost'
+
 pull-base:
 	docker pull ${BASE_IMAGE}
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 --access-logfile=- kuma.wsgi:application
+    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
     ports:
       - "8000:8000"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,7 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
+    command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 --access-logfile=- kuma.wsgi:application
     ports:
       - "8000:8000"
 
@@ -55,14 +55,15 @@ services:
     ports:
       - "8001:8000"
 
-  #nginx:
-  #  build: ./docker/images/nginx
-  #  volumes:
-  #    - ./static:/app/static
-  #  ports:
-  #    - "80:80"
-  #  depends_on:
-  #    - web
+  nginx:
+    build: ./docker/images/nginx
+    volumes:
+      - ./static:/app/static
+    ports:
+      - "80:80"
+      - "443:443"
+    depends_on:
+      - web
 
   memcached:
     image: memcached

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,6 +59,7 @@ services:
     build: ./docker/images/nginx
     volumes:
       - ./static:/app/static
+      - ./ssl:/etc/nginx/ssl
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,20 +15,19 @@ services:
       - kumascript
     environment:
       # Django settings overrides:
-      - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
+      - ACCOUNT_DEFAULT_HTTP_PROTOCOL=https
       - ALLOWED_HOSTS=localhost,localhost:8000
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
-      - CSRF_COOKIE_SECURE=False
+      - CSRF_COOKIE_SECURE=True
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
       - DEBUG=True
       - DOMAIN=localhost
       - ES_URLS=elasticsearch:9200
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
       - MEMCACHE_SERVERS=memcached:11211
-      - PROD_DETAILS_DIR=/app/product_details_json
-      - PROTOCOL=http://
-      - SESSION_COOKIE_SECURE=False
+      - PROTOCOL=https://
+      - SESSION_COOKIE_SECURE=True
       - SITE_URL=https://localhost:8000
       # Celery environment overrides:
       - C_FORCE_ROOT=1  # TODO: switch to non-root user

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
+    cpu_shares: 700
     command: gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application
     ports:
       - "8000:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - PROD_DETAILS_DIR=/app/product_details_json
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
-      - SITE_URL=http://localhost:8000
+      - SITE_URL=https://localhost:8000
       # Celery environment overrides:
       - C_FORCE_ROOT=1  # TODO: switch to non-root user
       # Other environment overrides

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=https
-      - ALLOWED_HOSTS=localhost,localhost:8000
+      - ALLOWED_HOSTS=localhost
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
       - CSRF_COOKIE_SECURE=True
@@ -28,7 +28,7 @@ services:
       - MEMCACHE_SERVERS=memcached:11211
       - PROTOCOL=https://
       - SESSION_COOKIE_SECURE=True
-      - SITE_URL=https://localhost:8000
+      - SITE_URL=https://localhost
       # Celery environment overrides:
       - C_FORCE_ROOT=1  # TODO: switch to non-root user
       # Other environment overrides

--- a/docker/images/nginx/Dockerfile
+++ b/docker/images/nginx/Dockerfile
@@ -1,16 +1,2 @@
 FROM nginx
-
-# Creating self signed certificate for localhost
-RUN mkdir /etc/nginx/ssl
-
-RUN openssl req \
-        -x509 \
-        -nodes \
-        -newkey rsa:2048 \
-        -keyout /etc/nginx/ssl/server.key \
-        -out /etc/nginx/ssl/server.crt \
-        -days 1000 \
-        -subj "/CN=127.0.0.1"
-
-ADD nginx.conf /etc/nginx/nginx.conf
-EXPOSE 80 443
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/docker/images/nginx/Dockerfile
+++ b/docker/images/nginx/Dockerfile
@@ -1,3 +1,16 @@
 FROM nginx
+
+# Creating self signed certificate for localhost
+RUN mkdir /etc/nginx/ssl
+
+RUN openssl req \
+        -x509 \
+        -nodes \
+        -newkey rsa:2048 \
+        -keyout /etc/nginx/ssl/server.key \
+        -out /etc/nginx/ssl/server.crt \
+        -days 1000 \
+        -subj "/CN=127.0.0.1"
+
 ADD nginx.conf /etc/nginx/nginx.conf
-EXPOSE 80
+EXPOSE 80 443

--- a/docker/images/nginx/nginx.conf
+++ b/docker/images/nginx/nginx.conf
@@ -14,11 +14,16 @@ http {
     }
 
     server {
-        listen 80 default;
-        listen 443 ssl;
+        listen 80;
+        charset utf-8;
+        return 301 https://$host$request_uri;
+        }
+
+    server {
+        listen 443 ssl default;
         charset utf-8;
 
-        #ssl on;
+        ssl on;
         ssl_certificate /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;
 

--- a/docker/images/nginx/nginx.conf
+++ b/docker/images/nginx/nginx.conf
@@ -1,13 +1,32 @@
+user  nginx;
+
 worker_processes 1;
+
+# This log file is mapped to stderr in the nginx base image.
+error_log  /var/log/nginx/error.log warn;
+
+pid /var/run/nginx.pid;
 
 events {
     worker_connections 1024;
-    accept_mutex off;
 }
 
 http {
-    include mime.types;
+    include /etc/nginx/mime.types;
     default_type application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] '
+        '"$request" $status $body_bytes_sent '
+        '"$http_referer" "$http_user_agent" "$http_x_forwarded_for" '
+        '$request_time $upstream_response_time';
+
+    # This log file is mapped to stdout in the nginx base image.
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+    keepalive_timeout 65;
 
     upstream django {
         server web:8000;
@@ -17,15 +36,21 @@ http {
         listen 80;
         charset utf-8;
         return 301 https://$host$request_uri;
-        }
+    }
 
     server {
         listen 443 ssl default;
         charset utf-8;
 
         ssl on;
-        ssl_certificate /etc/nginx/ssl/server.crt;
+        ssl_certificate     /etc/nginx/ssl/server.crt;
         ssl_certificate_key /etc/nginx/ssl/server.key;
+
+        location /static/ {
+            gzip on;
+            expires -1; # no-cache
+            alias /app/static/;
+        }
 
         location / {
             proxy_pass http://django;

--- a/docker/images/nginx/nginx.conf
+++ b/docker/images/nginx/nginx.conf
@@ -15,7 +15,12 @@ http {
 
     server {
         listen 80 default;
+        listen 443 ssl;
         charset utf-8;
+
+        #ssl on;
+        ssl_certificate /etc/nginx/ssl/server.crt;
+        ssl_certificate_key /etc/nginx/ssl/server.key;
 
         location / {
             proxy_pass http://django;

--- a/docker/images/nginx/nginx.conf
+++ b/docker/images/nginx/nginx.conf
@@ -47,9 +47,35 @@ http {
         ssl_certificate_key /etc/nginx/ssl/server.key;
 
         location /static/ {
-            gzip on;
-            expires -1; # no-cache
             alias /app/static/;
+            gzip on;
+            gzip_vary on;
+            gzip_comp_level     5;
+            gzip_min_length  1000;
+            gzip_types
+                text/css
+                text/html
+                text/javascript
+                text/plain
+                text/xml
+                application/json
+                application/javascript
+                application/x-javascript
+                application/vnd.ms-fontobject
+                application/x-font-opentype
+                application/x-font-truetype
+                application/x-font-ttf
+                application/xml
+                font/eot
+                font/opentype
+                font/otf
+                image/svg+xml
+                image/vnd.microsoft.icon;
+            add_header Access-Control-Allow-Origin *;
+            # For development purposes, do not allow static
+            # assets to be cached and keep max-age low for HSTS.
+            add_header Cache-Control no-store;
+            add_header Strict-Transport-Security "max-age=60" always;
         }
 
         location / {


### PR DESCRIPTION
This patch setups a Docker nginx container which makes the site serve through ssl with a self signed certificate. So the site can be accessed through `https://127.0.0.1`.
I have made a redirect rule in nginx so that all request coming from `http` will be redirected to `https`.

I think, some documentation change is needed. I will find out and fix them.

@jwhitlock r?
