### PR TITLE
Bug 1218563: Improve TravisCI docker build and test (version 2)

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -32,8 +32,10 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
-commands = 
-    docker-compose -f docker-compose.yml -f scripts/docker-compose.travis.yml up -d
+setenv =
+    COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
+commands =
+    docker-compose up -d
     docker exec -i kuma_web_1 make compilejsi18n collectstatic
     # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
     sleep 60

--- a/tox.ini
+++ b/tox.ini
@@ -32,21 +32,24 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
-whitelist_externals =
-    docker-compose
-    sleep
+whitelist_externals = docker-compose
 setenv =
     COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
     COMPOSE_PROJECT_NAME = kumatox
 commands =
-    docker-compose up -d
+    # Build MySQL and start first, to give it time to initialize the DB
+    docker-compose up --build -d mysql
+    # Build the Kuma containers with new requirements and Dockerfile-base
+    # Start the rest of the services
+    docker-compose up --build -d
+    # Initialize assets
     docker-compose exec -T web make compilejsi18n collectstatic
-    # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
-    sleep 60
-    docker-compose logs mysql
+    # Setup the database
     docker-compose exec web ./manage.py migrate
+    # Run tests inside the web container
     docker-compose exec -T web make test
-    docker-compose stop         # Useful for local development
+    # Stop containers (useful for local development)
+    docker-compose stop
 
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor

--- a/tox.ini
+++ b/tox.ini
@@ -32,16 +32,21 @@ deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:docker]
+whitelist_externals =
+    docker-compose
+    sleep
 setenv =
     COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
+    COMPOSE_PROJECT_NAME = kumatox
 commands =
     docker-compose up -d
-    docker exec -i kuma_web_1 make compilejsi18n collectstatic
+    docker-compose exec -T web make compilejsi18n collectstatic
     # TODO: mysql needs some time to set up. find a way to eliminate the waiting time
     sleep 60
-    docker logs kuma_mysql_1
-    docker exec -it kuma_web_1 ./manage.py migrate
-    docker exec -i kuma_web_1 make test
+    docker-compose logs mysql
+    docker-compose exec web ./manage.py migrate
+    docker-compose exec -T web make test
+    docker-compose stop         # Useful for local development
 
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor


### PR DESCRIPTION
Improve on PR #3977 (test docker travis):

- Use environment variables to simplify ``docker-compose`` calls
- Eliminate some warnings by adding build steps, configuring ``tox``
- Start the ``mysql`` container while the ``web`` image is building, to eliminate ``sleep 60``

This is a variant of PR #4007 that uses ``docker-compose up --build -d`` instead of ``docker-compose build web; docker-compose up -d``. Both avoid a warning about implicit builds, but I want to compare the output from the two methods.