### PR TITLE
bug 1269143: escape sample name

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -4,6 +4,7 @@ import urllib
 from collections import defaultdict
 from urllib import urlencode
 from urlparse import urlparse
+from xml.sax.saxutils import quoteattr
 
 import html5lib
 import newrelic.agent
@@ -140,7 +141,7 @@ class Extractor(object):
             sample = pq('<section>%s</section>' % section)
         else:
             # If no section, fall back to plain old ID lookup
-            sample = pq(src).find('[id="%s"]' % name)
+            sample = pq(src).find('[id=%s]' % quoteattr(name))
 
         selector_templates = (
             '.%s',

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1137,6 +1137,21 @@ class ExtractorTests(UserTestCase):
         result = rev.document.extract.code_sample('sample')
         eq_(expected, result)
 
+    @mock.patch('kuma.wiki.constants.CODE_SAMPLE_MACROS', ['LinkCodeSample'])
+    def test_code_samples_with_problematic_sample_name(self):
+        rev = revision(is_approved=True, save=True, content="""
+            <div id="sample" class="code-sample">
+                <pre class="brush: html">Some HTML</pre>
+                <pre class="brush: css">.some-css { color: red; }</pre>
+                <pre class="brush: js">window.alert("HI THERE")</pre>
+            </div>
+            {{ LinkCodeSample('sample1') }}
+        """)
+        # The real test here is to ensure that no exception is raised, but
+        # might as well also check that the sample section was not found.
+        result = rev.document.extract.code_sample("""sam<'&">ple""")
+        eq_(dict(html=None, css=None, js=None), result)
+
 
 class GetSEODescriptionTests(KumaTestCase):
 


### PR DESCRIPTION
* In wiki.content::Extractor.code_sample, escape the name of
the code sample when falling-back to the pyquery find.
* Add test for this case.