### PR TITLE
bug 1308307: add locale to subject of email

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -302,8 +302,8 @@ def send_first_edit_email(revision_pk):
     """ Make an 'edited' notification email for first-time editors """
     revision = Revision.objects.get(pk=revision_pk)
     user, doc = revision.creator, revision.document
-    subject = (u"[MDN] %(user)s made their first edit, to: %(doc)s" %
-               {'user': user.username, 'doc': doc.title})
+    subject = (u"[MDN] [%(loc)s] %(user)s made their first edit, to: %(doc)s" %
+               {'loc': doc.locale, 'user': user.username, 'doc': doc.title})
     message = render_to_string('wiki/email/edited.ltxt',
                                context_dict(revision))
     doc_url = absolutify(doc.get_absolute_url())

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -504,7 +504,12 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         eq_(2, len(mail.outbox))
         first_edit_email = mail.outbox[0]
         expected_to = [config.EMAIL_LIST_SPAM_WATCH]
-        expected_subject = u'[MDN] %(username)s made their first edit, to: %(title)s' % ({'username': new_rev.creator.username, 'title': self.d.title})
+        expected_subject = (
+            u'[MDN] [%(loc)s] %(user)s made their first edit, to: %(title)s' %
+            {'loc': self.d.locale,
+             'user': new_rev.creator.username,
+             'title': self.d.title}
+        )
         eq_(expected_subject, first_edit_email.subject)
         eq_(expected_to, first_edit_email.to)
 


### PR DESCRIPTION
* update wiki.tasks.send_first_edit_email to add locale
  to subject of the "first-edit" email
* update test_new_revision_POST_document_with_current
  within wiki/tests/test_templates.py to reflect change