### PR TITLE
bug 1218563: Tune MySQL for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,10 +69,6 @@ services:
 
   mysql:
     build: ./docker/images/mysql
-    entrypoint:
-      - docker-entrypoint.sh
-      - --character-set-server=utf8
-      - --collation-server=utf8_general_ci
     environment:
       - MYSQL_USER=kuma
       - MYSQL_PASSWORD=kuma

--- a/docker/images/mysql/Dockerfile
+++ b/docker/images/mysql/Dockerfile
@@ -2,6 +2,6 @@ FROM mysql:5.6
 
 MAINTAINER MDN Developer <dev-mdn@lists.mozilla.org>
 ENV MYSQL_ROOT_PASSWORD kuma
-RUN sed -Ei 's/\[mysqld\]/[mysqld]\nmax_allowed_packet=100M\ninnodb_log_file_size=1G/' /etc/mysql/my.cnf
+COPY kuma.cnf /etc/mysql/conf.d/
 COPY Index.xml /usr/share/mysql/charsets/
 EXPOSE 3306:3306

--- a/docker/images/mysql/kuma.cnf
+++ b/docker/images/mysql/kuma.cnf
@@ -1,0 +1,17 @@
+# Settings for local kuma development
+[mysqld]
+    # Ensure taggit gets production collation
+    character_set_server = utf8
+    collation_server     = utf8_general_ci
+
+    # Data and index cache, small perf increase
+    innodb_buffer_pool_size = 1G
+
+    # Size of redo logs, small perf increase
+    innodb_log_file_size    = 1G
+
+    # Write to disk once a second, 20% speed-up for osxfs
+    innodb_flush_log_at_trx_commit = 0
+
+    # Required to load production database
+    max_allowed_packet=100M


### PR DESCRIPTION
Move settings from `my.cnf` and `docker-compose.yml` to `/etc/mysql/conf.d/kuma.cnf`, and add some additional params to speed up test runs.

The big one is `innodb_flush_log_at_trx_commit=0`, which changes from writing to disk with each commit (`default of 1`) to writing once per second.  This was a 24% speed boost on Docker for Mac, from 1047 seconds to 745.
