### PR TITLE
Fix Bug 1149205: Break long titles intelligently.

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -162,6 +162,24 @@
     });
 
     /*
+        Add intelligent break points to long article titles
+    */
+    $('#wiki-document-head h1').each(function() {
+        var $title = $(this);
+        var text = $title.text();
+        // split on . - : ( or capital letter, only if followed by 2 letters
+        var split = text.split(/(?=[\.:\-\(A-Z][\.:\-\(A-Z]{0,}[a-zA-Z]{3})/g);
+        // empty h1
+        $title.empty();
+        // put array back into h1 seperated by <wbr> tags
+        $.each(split, function(key, value) {
+            $title.append('<wbr>');
+            // add text back, make sure it goes back as text, not code to run
+            $title.append(doc.createTextNode(value));
+        });
+    });
+
+    /*
         Syntax highlighting scripts
     */
     if($('article pre').length && ('querySelectorAll' in doc)) (function() {

--- a/kuma/static/styles/base/elements/typography.styl
+++ b/kuma/static/styles/base/elements/typography.styl
@@ -12,8 +12,7 @@ Headings
 
 h1, h2, h3, h4 {
     margin-bottom: ($content-block-margin / 2);
-    word-wrap: break-word; /* keep for browsers & locales that don't support hyphens */
-    vendorize(hyphens, auto);
+    word-wrap: break-word;
 
     font-family: $heading-font-family;
     font-weight: $light-font-weight;


### PR DESCRIPTION
Previously we've used the CSS property hyphens to break up long titles on short screens but it's not cross browser and it breaks stuff that doesn't need to be broken, obscuring meaning.

This small script targets only long article titles and adds a <wbr> tag to give the browser more accurate direction for where to break titles.

Testing pages:
https://developer-local.allizom.org/en-US/docs/Web/API/MediaStreamAudioDestinationNode/stream

https://developer-local.allizom.org/en-US/Add-ons/Firefox_for_Android/API/window.NativeWindow/window.NativeWindow.contextmenus/window.NativeWindow.contextmenus.remove

https://developer-local.allizom.org/en-US/docs/Web/CSS/:-moz-system-metric%28scrollbar-thumb-proportional%29

(make sure code escaping is working properly)
https://developer-local.allizom.org/en-US/docs/Web/HTML/Element/blockquote