### PR TITLE
bug 1269143: fix for null/ctl chars in sample name

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -141,7 +141,10 @@ class Extractor(object):
             sample = pq('<section>%s</section>' % section)
         else:
             # If no section, fall back to plain old ID lookup
-            sample = pq(src).find('[id=%s]' % quoteattr(name))
+            try:
+                sample = pq(src).find('[id=%s]' % quoteattr(name))
+            except ValueError:
+                return data
 
         selector_templates = (
             '.%s',


### PR DESCRIPTION
* fix case when sample name contains null or control
  characters (in general whenever a ValueError is
  raised within the PyQuery.find method).
* add test case