### PR TITLE
Bug 1310322: Add Newsletter Sign-Up

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -30,6 +30,10 @@ Switches
 * ``wiki_force_immediate_rendering`` - force wiki pages to render immediately
   in the same http request in which they are saved (not in a background
   process)
+* ``newsletter`` - show newsletter sign-up site wide
+* ``newsletter_article`` - show newsletter sign-up in article footer (must be
+  used in combination with ``newsletter``)
+
 
 Flags
 -----

--- a/jinja2/includes/newsletter.html
+++ b/jinja2/includes/newsletter.html
@@ -1,0 +1,40 @@
+<div class="newsletter">
+    <form id="newsletterForm" name="newsletter-form" class="nodisable" action="https://www.mozilla.org/en-US/newsletter/" method="post">
+        <h2 class="newsletter-teaser">{{ _('Learn the best of web development') }}</h2>
+        <p class="newsletter-description">{{ _('Sign up for our newsletter:') }}</p>
+        <input type="hidden" id="fmt" name="fmt" value="H">
+        <input type="hidden" id="newsletterNewslettersInput" name="newsletters" value="app-dev" />
+
+        <div id="newsletterErrors" class="newsletter-errors"></div>
+
+        <div id="newsletterEmail" class="form-group">
+            <label for="newsletterEmailInput" class="form-label offscreen">{{ _('E-mail') }}</label>
+            <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="you@example.com" size="30">
+        </div>
+
+        <div id="newsletterPrivacy" class="form-group form-group-agree hidden">
+            <input type="checkbox" id="newsletterPrivacyInput" name="privacy" required>
+            <label for="newsletterPrivacyInput">
+            {% trans policy_url="https://www.mozilla.org/privacy/" %}
+                I'm okay with Mozilla handling my info as explained in this <a href="{{ policy_url }}">Privacy Policy</a>.
+            {% endtrans %}
+            </label>
+        </div>
+        <div id="newsletterSubmit">
+            <button id="newsletter-submit" type="submit" class="button positive">{{ _('Sign up now') }}</button>
+        </div>
+        {% if request.LANGUAGE_CODE != 'en-US' %}
+        <p class="newsletter-lang">{{ _('The newsletter is offered in English only at the moment.') }}</p>
+        {% endif %}
+    </form>
+    <div id="newsletterThanks" class="newsletter-thanks hidden">
+        <h2>{{ _('Thanks! Please check your inbox to confirm your subscription.') }}</h2>
+        <p>{% trans %}
+           If you haven’t previously confirmed a subscription to a
+           Mozilla-related newsletter you may have to do so. Please check your
+           inbox or your spam filter for an email from us.
+           {% endtrans %}
+        </p>
+    </div>
+    <button id="newsletterHide" type="button" class="only-icon newsletter-hide hidden"><span>{{ _('Hide Newsletter Sign-up') }}</span><i aria-hidden="true" class="icon-times"></i></button>
+</div>

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -65,10 +65,10 @@
         </form>
     {% endif %}
 
-  <div class="home-features">
+  <div class="home-features {% if waffle.switch('newsletter') %}home-features-newsletter{% endif %}">
     <h2 class="offscreen">{{ _('Web Technologies') }}</h2>
     <div class="column-container">
-      <div class="column-home-features">
+      <div class="column-feature">
         <h3><i aria-hidden="true" class="icon-file-text"></i><span>{{ _('Web<br />Technologies') }}</span></h3>
         <ul>
           <li><a href="{{ wiki_url('Web/Reference/API') }}">{{ _('Web APIs &amp; DOM') }}</a></li>
@@ -78,7 +78,7 @@
           <li><a href="{{ wiki_url('Web') }}">{{ _('more...') }}</a></li>
         </ul>
       </div>
-      <div class="column-home-features">
+      <div class="column-feature">
         <h3><i aria-hidden="true" class="icon-graduation-cap"></i><span>{{ _('Learning') }}</span></h3>
         <ul>
           <li><a href="{{ wiki_url('Learn') }}">{{ _('Learning web development') }}</a></li>
@@ -88,17 +88,22 @@
           <li><a href="{{ wiki_url('Learn/JavaScript/') }}">{{ _('Learn JavaScript') }}</a></li>
         </ul>
       </div>
-      <div class="column-home-features">
+      <div class="column-feature">
         <h3><i aria-hidden="true" class="icon-wrench"></i><span>{{ _('Developer<br />Tools') }}</span></h3>
         <ul>
-        <li><a href="{{ wiki_url('Tools/Page_Inspector') }}">{{ _('Page Inspector') }}</a></li>
-        <li><a href="{{ wiki_url('Tools/Web_Console') }}">{{ _('Web Console') }}</a></li>
-        <li><a href="{{ wiki_url('Tools/Debugger') }}">{{ _('JavaScript Debugger') }}</a></li>
-        <li><a href="{{ wiki_url('Tools/Performance') }}">{{ _('Performance Tools') }}</a></li>
-        <li><a href="{{ wiki_url('Tools') }}">{{ _('more...') }}</a></li>
+          <li><a href="{{ wiki_url('Tools/Page_Inspector') }}">{{ _('Page Inspector') }}</a></li>
+          <li><a href="{{ wiki_url('Tools/Web_Console') }}">{{ _('Web Console') }}</a></li>
+          <li><a href="{{ wiki_url('Tools/Debugger') }}">{{ _('JavaScript Debugger') }}</a></li>
+          <li><a href="{{ wiki_url('Tools/Performance') }}">{{ _('Performance Tools') }}</a></li>
+          <li><a href="{{ wiki_url('Tools') }}">{{ _('more...') }}</a></li>
         </ul>
       </div>
     </div>
+    {% if waffle.switch('newsletter') %}
+      <div class="feature-newsletter">
+        {% include "includes/newsletter.html" %}
+      </div>
+    {% endif %}
   </div>
 
 </div></div>
@@ -188,5 +193,8 @@
     <script>
         jQuery('#home-search-form').searchSuggestions();
     </script>
+  {% endif %}
+  {% if waffle.switch('newsletter') %}
+    {% javascript 'newsletter' %}
   {% endif %}
 {% endblock %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -860,6 +860,15 @@ PIPELINE_JS = {
             'async': True,
         },
     },
+    'newsletter': {
+        'source_filenames': (
+            'js/newsletter.js',
+        ),
+        'output_filename': 'build/js/newsletter.js',
+        'extra_context': {
+            'async': True,
+        },
+    },
     'fellowship': {
         'source_filenames': (
             'js/fellowship.js',

--- a/kuma/static/js/newsletter.js
+++ b/kuma/static/js/newsletter.js
@@ -1,0 +1,213 @@
+;(function(doc) {
+    'use strict';
+
+    // !! this file assumes only one signup form per page !!
+
+    var newsletterForm = doc.getElementById('newsletterForm');
+    var isHidden = false;
+    var isArticle = false;
+
+    if(!newsletterForm) {
+        return;
+    } else {
+        // check for local storage
+        if(mdn.features.localStorage) {
+            // if hidden by local storage
+            isHidden = localStorage.getItem('newsletterHide') === 'true' ? true : false;
+        }
+
+        // check for article
+        if(doc.querySelector('.wiki-block-newsletter')) {
+            isArticle = true;
+        }
+
+        if(!mdn.features.localStorage || !isArticle) {
+            newsletter();
+        } else if(isArticle && !isHidden) {
+            newsletter();
+            newsletterAddHideButton();
+        } else if (isArticle && isHidden) {
+            newsletterHide();
+        }
+    }
+
+    function newsletter() {
+        var newsletterEmailInput = doc.getElementById('newsletterEmailInput');
+        var newsletterPrivacy = doc.getElementById('newsletterPrivacy');
+
+        // handle errors
+        var errorArray = [];
+        var newsletterErrors = doc.getElementById('newsletterErrors');
+
+        function newsletterError() {
+            if(errorArray.length) {
+                showFormErrors(errorArray);
+            } else {
+                // no error messages, forward to server for better troubleshooting
+                newsletterForm.setAttribute('data-skip-xhr', true);
+                newsletterForm.submit();
+            }
+        }
+
+        function showFormErrors(errorArray) {
+            var errorList = doc.createElement('ul');
+            errorList.className = 'errorlist';
+
+            for (var i = 0, l = errorArray.length; i < l; i++) {
+                var item = doc.createElement('li');
+                item.appendChild(doc.createTextNode(errorArray[i]));
+                errorList.appendChild(item);
+            }
+            newsletterErrors.appendChild(errorList);
+            $(newsletterErrors).removeClass('hidden');
+            // track an error happened
+            mdn.analytics.trackEvent({
+                'category': 'newsletter',
+                'action': 'progression',
+                'label': 'error'
+            });
+        }
+
+        // show success message
+        function newsletterThanks() {
+            var thanks = doc.getElementById('newsletterThanks');
+
+            // show thanks message
+            $(thanks).removeClass('hidden');
+
+            // track success
+            mdn.analytics.trackEvent({
+                'category': 'newsletter',
+                'action': 'progression',
+                'label': 'complete'
+            });
+
+            // don't show signup form on article pages anymore
+            newsletterSaveHide();
+        }
+
+        // XHR subscribe; handle errors; display thanks message on success.
+        function newsletterSubscribe(event) {
+            var skipXHR = newsletterForm.getAttribute('data-skip-xhr');
+            if (skipXHR) {
+                // track this
+                mdn.analytics.trackEvent({
+                    'category': 'newsletter',
+                    'action': 'progression',
+                    'label': 'error-forward'
+                });
+
+                return true;
+            }
+            event.preventDefault();
+            event.stopPropagation();
+
+            // track this submission
+            mdn.analytics.trackEvent({
+                'category': 'newsletter',
+                'action': 'progression',
+                'label': 'submission'
+            });
+
+            // new submission, clear old errors
+            errorArray = [];
+            $(newsletterErrors).addClass('hidden');
+            while (newsletterErrors.firstChild) {
+                newsletterErrors.removeChild(newsletterErrors.firstChild);
+            }
+
+            var fmt = doc.getElementById('fmt').value;
+            var email = newsletterEmailInput.value;
+            var newsletter = doc.getElementById('newsletterNewslettersInput').value;
+            var privacy = doc.querySelector('input[name="privacy"]:checked') ? '&privacy=true' : '';
+            var params = 'email=' + encodeURIComponent(email) +
+                         '&newsletters=' + newsletter +
+                         privacy +
+                         '&fmt=' + fmt +
+                         '&source_url=' + encodeURIComponent(doc.location.href);
+
+            var xhr = new XMLHttpRequest();
+
+            xhr.onload = function(r) {
+                if (r.target.status >= 200 && r.target.status < 300) {
+                    // response is null if handled by service worker
+                    if(response === null) {
+                        newsletterError(new Error());
+                        return;
+                    }
+                    var response = r.target.response;
+                    if (response.success === true) {
+                        $(newsletterForm).addClass('hidden');
+                        newsletterThanks();
+                    } else {
+                        if(response.errors) {
+                            for (var i = 0, l = response.errors.length; i < l; i++) {
+                                errorArray.push(response.errors[i]);
+                            }
+                        }
+                        newsletterError(new Error());
+                    }
+                }
+                else {
+                    newsletterError(new Error());
+                }
+            };
+
+            xhr.onerror = function(event) {
+                newsletterError(event);
+            };
+
+            var url = newsletterForm.getAttribute('action');
+
+            xhr.open('POST', url, true);
+            xhr.setRequestHeader('Content-type', 'application/x-www-form-urlencoded');
+            xhr.setRequestHeader('X-Requested-With','XMLHttpRequest');
+            xhr.timeout = 5000;
+            xhr.ontimeout = newsletterError;
+            xhr.responseType = 'json';
+            xhr.send(params);
+
+            return false;
+        }
+
+        newsletterForm.addEventListener('submit', newsletterSubscribe, false);
+
+        newsletterEmailInput.addEventListener('focus', function() {
+            $(newsletterPrivacy).removeClass('hidden');
+            mdn.analytics.trackEvent({
+                'category': 'newsletter',
+                'action': 'prompt',
+                'label': 'focus'
+            });
+        }, false);
+    }
+
+    function newsletterAddHideButton() {
+        var $hideButton = $('#newsletterHide');
+        // show button
+        $hideButton.removeClass('hidden');
+        // add listener
+        $hideButton.on('click', newsletterHandleHideClick);
+    }
+
+    function newsletterHide() {
+        // remove newsletter parent wiki-block
+        var $wikiBlock = $('.wiki-block-newsletter');
+        $wikiBlock.addClass('hidden');
+    }
+
+    function newsletterSaveHide() {
+        localStorage.setItem('newsletterHide', true);
+    }
+
+    function newsletterHandleHideClick() {
+        newsletterHide();
+        newsletterSaveHide();
+        mdn.analytics.trackEvent({
+            'category': 'newsletter',
+            'action': 'prompt',
+            'label': 'hide'
+        });
+    }
+
+})(document);

--- a/kuma/static/styles/components/form.styl
+++ b/kuma/static/styles/components/form.styl
@@ -1,0 +1,7 @@
+.form-group {
+    margin-bottom: $grid-spacing;
+}
+
+.form-input {
+    border-radius: 3px
+}

--- a/kuma/static/styles/components/home/home-features.styl
+++ b/kuma/static/styles/components/home/home-features.styl
@@ -13,6 +13,7 @@
         display: flex;
         flex-direction: row;
         align-items: center
+        min-height: 39px;
         set-larger-font-size();
         font-weight: bold;
         font-family: 'Open Sans Extra Bold', sans-serif;
@@ -46,23 +47,68 @@
     }
 }
 
-.column-home-features {
+.column-feature {
     @extend $column-third;
 }
 
+.home-features-newsletter .column-container {
+    @extend $column-8;
+    bidi-value(float, left, right);
+    margin-right: $grid-margin;
+}
 
-@media $media-query-mobile {
+.feature-newsletter {
+    @extend $column-4;
+    bidi-value(float, left, right);
 
-    .column-home-features {
-        width: auto !important;
-        float: none;
-        margin-bottom: $grid-spacing;
+    h2 {
+        font-family: 'Open Sans Extra Bold', sans-serif;
+    }
+}
+
+@media $media-query-tablet {
+    .home-features-newsletter .column-container {
+        width: 48.5%;
     }
 
-    .column-home-features {
+    .home-features-newsletter .column-feature {
+        width: 100%;
+        margin: 0;
+
+        ul {
+            margin-bottom: $grid-spacing;
+        }
+
         li {
             display: inline-block;
             bidi-style(padding-right, $grid-spacing, padding-left, 0);
         }
+    }
+
+    .feature-newsletter {
+        width: 48.5%;
+    }
+}
+
+@media $media-query-mobile {
+
+    .column-feature {
+        ul {
+            margin-bottom: $grid-spacing;
+        }
+
+        li {
+            display: inline-block;
+            bidi-style(padding-right, $grid-spacing, padding-left, 0);
+        }
+    }
+
+    .home-features-newsletter .column-container {
+        width: 100%;
+        margin: 0;
+    }
+
+    .feature-newsletter {
+        width: 100%;
     }
 }

--- a/kuma/static/styles/components/home/home-masthead.styl
+++ b/kuma/static/styles/components/home/home-masthead.styl
@@ -2,6 +2,7 @@
 homepage masthead (search, feature callouts)
 ====================================================================== */
 .home-masthead {
+    clearfix();
     padding: $first-content-top-padding 0;
 
     h1 {
@@ -30,8 +31,8 @@ homepage masthead (search, feature callouts)
     }
 
     .search-icon {
-    		position: absolute;
-    		top: ($grid-spacing * 2 + 7);
+		position: absolute;
+		top: ($grid-spacing * 2 + 7);
     }
 
     input#home-q {
@@ -43,31 +44,31 @@ homepage masthead (search, feature callouts)
     }
 }
 
-
-
 @media $media-query-tablet {
 
     .home-masthead {
-        h1, input {
+        h1 {
             width: 90%;
+            text-align: center;
+
+            span {
+                display: inline;
+                bidi-style(padding-left, 0, padding-right, 0);
+            }
         }
     }
 }
 
 @media $media-query-mobile {
-
-    .home-masthead {
-        h1, input {
-            width: 90%;
-
-            span {
-                padding-left: 0;
-            }
-        }
+    h1 {
+        set-font-size(34px);
     }
+    .search-form {
+        width: 100%;
+        padding-top: $grid-spacing;
 
-    .home-masthead h1,
-    .home-search-form {
-        display: none;
+        .search-icon {
+           top: ($grid-spacing + 7);
+        }
     }
 }

--- a/kuma/static/styles/components/newsletter.styl
+++ b/kuma/static/styles/components/newsletter.styl
@@ -1,0 +1,42 @@
+.newsletter-box {
+    position: relative;
+    notification-theme($default);
+    margin-bottom: $grid-spacing;
+    border: none;
+    padding: $grid-spacing;
+}
+
+.newsletter-teaser {
+    margin-bottom: $grid-spacing;
+
+    .wiki-block-newsletter & {
+        bidi-style(padding-right, ($grid-spacing * 3), padding-left, 0); // leave space for close button
+    }
+}
+
+.newsletter-description {
+    margin-bottom: 0;
+}
+
+.newsletter-errors .errorlist {
+    bidi-style(padding-left, 0, padding-right, 0);
+    list-style-type: none;
+}
+
+.newsletter-lang {
+    margin-top: $grid-spacing;
+    margin-bottom: 0;
+    font-style: italic;
+}
+
+.newsletter-input-email {
+    box-sizing: border-box;
+    width: 100%;
+    max-width: 450px;
+}
+
+.newsletter-hide {
+    position: absolute;
+    top: $grid-spacing;
+    bidi-style(right, $grid-spacing, left, auto);
+}

--- a/kuma/static/styles/main.styl
+++ b/kuma/static/styles/main.styl
@@ -13,7 +13,9 @@
 @require 'components/components';
 @require 'components/content';
 @require 'components/structure';
+@require 'components/form';
 @require 'components/tags';
 @require 'components/doc-title';
 @require 'components/errorlist';
 @require 'components/compact';
+@require 'components/newsletter';

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -24,9 +24,6 @@
 {% endblock %}
 
 {% block content %}
-  <form class="submission" method="post" action="">
-    {% csrf_token %}
-
     <div class="column-container">
 
       <div class="column-2 smaller">
@@ -51,7 +48,8 @@
 
       <div id="user-edit" class="column-half">
         <h1 class="user-title">{% include 'socialaccount/snippets/login_service_icon.html' %}{{ edit_user.username }}</h1>
-
+            <form class="submission" method="post" action="">
+              {% csrf_token %}
               <fieldset class="section notitle" id="personal">
                 <ul>
                   <li id="field-beta" class="field">
@@ -132,25 +130,31 @@
 
                 </ul>
               </fieldset>
-
+              <p><button type="submit" class="positive">{{ _('Publish') }}<i aria-hidden="true" class="icon-check"></i></button></p>
+            </form>
       </div>
-
+      <div class="column-4">
+        {% if waffle.switch('newsletter') %}
+          <div class="newsletter-box">
+            {% include "includes/newsletter.html" %}
+          </div>
+          <h3>Unsubscribe</h3>
+          <p><a href="https://www.mozilla.org/en-US/newsletter/recovery/">{{ _('Manage your Mozilla Newsletter Subscriptions.') }}</a></p>
+        {% endif %}
+      </div>
     </div>
 
-    <div class="column-container">
-      <div class="column-2"></div>
-      <div class="column-half">
-        <p><button type="submit" class="positive">{{ _('Publish') }}<i aria-hidden="true" class="icon-check"></i></button></p>
-      </div>
-    </div>
-
-  </form>
 {% endblock %}
 
 {% block js %}
-<script type="text/javascript">
-// <![CDATA[
+  <script type="text/javascript">
+  // <![CDATA[
     var INTEREST_SUGGESTIONS = {{ INTEREST_SUGGESTIONS|jsonencode }};
-// ]]>
-</script>
+  // ]]>
+  </script>
+
+  {% if waffle.switch('newsletter') %}
+    {% javascript 'newsletter' %}
+  {% endif %}
+
 {% endblock %}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -356,6 +356,14 @@
                   {% endif %}
                 </div>
               {% endif %}
+
+              {% if waffle.switch('newsletter') and waffle.switch('newsletter_article') %}
+                <div class="wiki-block wiki-block-newsletter">
+                  <div class="newsletter-box">
+                    {% include "includes/newsletter.html" %}
+                  </div>
+                </div>
+              {% endif %}
             </div>
 
             {% if show_left %}
@@ -430,6 +438,10 @@
 
   {% if waffle.flag('sg_task_completion') %}
     {% javascript 'task-completion' %}
+  {% endif %}
+
+  {% if waffle.switch('newsletter') and waffle.switch('newsletter_article') %}
+    {% javascript 'newsletter' %}
   {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
Newsletter sign up form added behind waffle switch (``newsletter``) on homepage, article footers (+``newsletter_article``), and profile edit page. Plus associated styles and javascript. newsletter.js was copied from https://github.com/mozilla/basket-example and then modified.

Things to test:
- Use failure@example.com and success@example.com to test responses from the server on form submissions. An error message should display on screen.
- Google Analytics events should fire on: input focus, form submission, form success, form error, user clicking the close button on the form
- There's a close button on the form. It should only display on the article pages for browsers with local storage support. Clicking the close button should make the form go away and localStorage should prevent it from coming back.
- After a successful signup the form should no long appear in the article footer.
- All strings should be translated.
- The English only warning/apology should only show up on non en-US pages.
- I didn't break the profile edit page with the changes I made to to add the newsletter.
- Unsubscribe link is on profile page and works.
