### PR TITLE
Bugs 924767, 924583, 1306286: Increase contrast on text and links

### DIFF
--- a/kuma/static/styles/base/elements/typography.styl
+++ b/kuma/static/styles/base/elements/typography.styl
@@ -17,6 +17,7 @@ h1, h2, h3, h4 {
     font-family: $heading-font-family;
     font-weight: $light-font-weight;
     line-height: 1;
+    color: $heading-color;
     {$selector-heading-font-fallback} {
         font-family: $heading-font-family-fallback;
         letter-spacing: -0.04em;
@@ -205,4 +206,3 @@ kbd {
 var {
     font-style: italic;
 }
-

--- a/kuma/static/styles/components/home/column-callout.styl
+++ b/kuma/static/styles/components/home/column-callout.styl
@@ -84,7 +84,7 @@ Media queries
 Colours and icons
 -------------------------------------------------------------- */
 .callout-learn {
-    background-color: #e14164;
+    background-color: #c43957;
 }
 
 .callout-deved {

--- a/kuma/static/styles/components/home/home-masthead.styl
+++ b/kuma/static/styles/components/home/home-masthead.styl
@@ -6,7 +6,6 @@ homepage masthead (search, feature callouts)
     padding: $first-content-top-padding 0;
 
     h1 {
-        color: $blue-background-text-color;
         margin: 0 auto;
         width: 60%;
 
@@ -14,6 +13,10 @@ homepage masthead (search, feature callouts)
             bidi-style(padding-left, 20%, padding-right, 0);
             display: block;
         }
+    }
+
+    h1, h2, h3 {
+        color: $blue-background-text-color;
     }
 }
 

--- a/kuma/static/styles/components/wiki/communitybox.styl
+++ b/kuma/static/styles/components/wiki/communitybox.styl
@@ -17,7 +17,7 @@ $communitybox-spacing = 13px;
     & a:hover,
     & a:focus,
     & a:visited {
-        color: #fff;
+        color: $blue-background-text-color;;
     }
 
     strong {
@@ -32,6 +32,11 @@ $communitybox-spacing = 13px;
 
     h2 {
         margin-bottom: 0;
+        color: $blue-background-text-color;
+    }
+
+    h3 {
+        color: $blue-background-text-color;
     }
 }
 

--- a/kuma/static/styles/includes/vars.styl
+++ b/kuma/static/styles/includes/vars.styl
@@ -16,8 +16,9 @@ VENDOR-PREFIXES = '-webkit-' '-moz-' '-ms-';
 /*
 colors
 ====================================================================== */
-$text-color = #4d4e53;
-$link-color = #0095dd;
+$text-color = #3b3c40;
+$heading-color = #4d4e53;
+$link-color = #217AC0;
 $menu-link-color = $text-color;
 $blue-background-text-color = #fff;
 $header-background-color = #eaeff2;


### PR DESCRIPTION
Fix Bug 924767 - text contrast
Bug 924583 - link contrast
Fix Bug 1306286 - homepage contrast

Subtle increase to contrast of body text since we were already meeting WCAG guidelines here.

Less subtle increase to link colour. Still don't met WCAG guidelines but significant improvement, especially on non-white backgrounds.

Homepage contrast issues should be fixed by combination of text contrast changes and changing colour of callout background.
