### PR TITLE
Bug 1259776: Display ban info on user profile

### DIFF
--- a/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
@@ -60,7 +60,7 @@
                             {% endif %}
                         </dl>
                         {% endif %}
-                        {% if request.user.is_superuser and revision.creator.active_ban %}
+                        {% if request.user.has_perm('users.add_userban') and revision.creator.active_ban %}
                             <div class="banned">
                             {{ _('banned %(ban_date)s by %(user)s',
                                  ban_date=datetimeformat(revision.creator.active_ban.date, format='date'),

--- a/kuma/static/styles/components/banned.styl
+++ b/kuma/static/styles/components/banned.styl
@@ -3,6 +3,7 @@
 */
 
 .banned {
-    color: #f00;
+    color: $negative;
     set-smaller-font-size();
+    font-style: italic;
 }

--- a/kuma/static/styles/users.styl
+++ b/kuma/static/styles/users.styl
@@ -13,6 +13,7 @@ Profile shared
 Profile view
 ====================================================================== */
 @require 'components/activity';
+@require 'components/banned';
 @require 'components/users/docs-activity';
 @require 'components/users/user-links';
 @require 'components/users/user-head';

--- a/kuma/users/jinja2/users/includes/user_title_info.html
+++ b/kuma/users/jinja2/users/includes/user_title_info.html
@@ -103,3 +103,10 @@
 </ul>
 
 <div class="user-since">{% trans date_joined=datetimeformat(detail_user.date_joined, format='date') %}Member since {{ date_joined }}{% endtrans %}</div>
+{% if not is_me and user.has_perm('users.add_userban') and detail_user.active_ban %}
+  <div class="banned">
+    {{ _('banned %(ban_date)s by %(user)s',
+    ban_date=datetimeformat(detail_user.active_ban.date, format='date'),
+    user=user_display(detail_user.active_ban.by)) }}
+  </div>
+{% endif %}

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -358,7 +358,7 @@ def user_detail(request, username):
     """
     detail_user = get_object_or_404(User, username=username)
 
-    if (detail_user.active_ban and not request.user.is_superuser):
+    if (detail_user.active_ban and not request.user.has_perm('users.add_userban')):
         return render(request, '403.html',
                       {'reason': 'bannedprofile'}, status=403)
 


### PR DESCRIPTION
Displays ban info to users with ban permissions instead of super user permissions.

Adds ban date and moderator to user profile page.
