### PR TITLE
bug 1314613: Add locale refresh as TravisCI task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
         - TOXENV=flake8
         - TOXENV=docs
         - TOXENV=dennis
+        - TOXENV=locales DOCKER_COMPOSE_VERSION=1.8.0
         - TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
     global:
         - DJANGO_SETTINGS_MODULE=kuma.settings.travis
@@ -27,6 +28,7 @@ env:
 matrix:
     allow_failures:
         - env: TOXENV=dennis
+        - env: TOXENV=locales DOCKER_COMPOSE_VERSION=1.8.0
         - env: TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
 before_install:
     - scripts/travis-install

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -19,14 +19,14 @@ then
     # Install Elasticsearch
     wget https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.2.deb
     sudo dpkg -i elasticsearch-1.7.2.deb
-    
+
     # limit elasticsearch / java memory usage to avoid OOM Killer
     sudo service elasticsearch stop;
     echo "ES_HEAP_SIZE=256m" | sudo tee --append /etc/default/elasticsearch
     sudo service elasticsearch start;
 fi
 
-if [ "$TOXENV" == "docker" ]
+if [ "$TOXENV" == "docker" -o "$TOXENV" == "locales" ]
 then
     curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
     chmod +x docker-compose

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,17 @@ basepython = python2.7
 deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
 commands = dennis-cmd lint --errorsonly locale/
 
+[testenv:locales]
+whitelist_externals =
+    docker-compose
+    git
+setenv =
+    COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
+    COMPOSE_PROJECT_NAME = localetox
+commands =
+    docker-compose run noext make localerefresh
+    git diff locale/templates/LC_MESSAGES
+
 [testenv:docker]
 whitelist_externals = docker-compose
 setenv =
@@ -39,7 +50,7 @@ setenv =
 commands =
     docker-compose up -d --build mysql  # Build, init DB (can be slow)
     docker-compose build web    # Rebuild w/ new reqs, Dockerfile-base
-    docker-compose up -d        # Startup remainin services
+    docker-compose up -d        # Startup remaining services
     docker-compose exec -T web make compilejsi18n collectstatic
     docker-compose exec web ./manage.py migrate
     docker-compose exec -T web make test


### PR DESCRIPTION
Refresh the locales in TravisCI, to detect issues in templates and translations during the PR process. Run a diff of the changed strings, to make it easier to determine when to release a new string pack.