### PR TITLE
bug 1314613: Fix "locales" job in TravisCI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ localeextract:
 	python manage.py merge
 
 localecompile:
-	cd locale; ./compile-mo.sh . ; cd --
+	cd locale; ./compile-mo.sh .
 
 localerefresh: localeextract localetest localecompile compilejsi18n collectstatic
 	@echo

--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,13 @@ commands = dennis-cmd lint --errorsonly locale/
 
 [testenv:locales]
 whitelist_externals =
+    cat
     docker-compose
     git
 setenv =
     COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
     COMPOSE_PROJECT_NAME = localetox
+    GIT_PAGER = cat
 commands =
     docker-compose run noext make localerefresh
     git diff locale/templates/LC_MESSAGES


### PR DESCRIPTION
``cd --`` does the wrong thing inside the Docker container, and is also unnecessary, since each line of a Makefile is run in a separate process.

Also, ``less``, the default pager for ``git diff``, is interactive and does poorly in a TravisCI job, waiting for input that never happens. Instead, use ``cat`` as the git pager.