### PR TITLE
Escaping placeholder in template for bug 1315078

### DIFF
--- a/jinja2/includes/newsletter.html
+++ b/jinja2/includes/newsletter.html
@@ -9,7 +9,7 @@
 
         <div id="newsletterEmail" class="form-group">
             <label for="newsletterEmailInput" class="form-label offscreen">{{ _('E-mail') }}</label>
-            <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="you@example.com" size="30">
+            <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="{{ _('you@example.com') }}" size="30">
         </div>
 
         <div id="newsletterPrivacy" class="form-group form-group-agree hidden">


### PR DESCRIPTION
I just surrounded the string with the usual pattern and checked that HTML attributes were also dealt the same way on https://github.com/mozilla/kuma/blob/752bfb9ec0e803655c88a5391bba92b86ef33bdc/jinja2/includes/login.html#L19. Hoping it's ok for such a minor matter.