### PR TITLE
Bug 925460: Tweak mobile header logo placement

### DIFF
--- a/kuma/static/styles/components/structure/main-header.styl
+++ b/kuma/static/styles/components/structure/main-header.styl
@@ -34,7 +34,7 @@ Main header, wraps all components of logo, main, and secondary navigation
 
     #main-header {
         .logo {
-            margin-top: -33px;
+            margin-top: -27px;
         }
     }
 }


### PR DESCRIPTION
Slight tweak to logo placement at tablet (1024) size.

Before:
![screen shot 2016-11-04 at 14 50 53](https://cloud.githubusercontent.com/assets/854701/20023567/1ff09d88-a29e-11e6-8ec9-21498ae2e4c5.png)

After:
![screen shot 2016-11-04 at 14 51 01](https://cloud.githubusercontent.com/assets/854701/20023569/21cd5ab0-a29e-11e6-93ec-a1dc3258ceca.png)
