### PR TITLE
bug 1314613: Drop dennis from TravisCI tasks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
         - TOXENV=py27
         - TOXENV=flake8
         - TOXENV=docs
-        - TOXENV=dennis
         - TOXENV=locales DOCKER_COMPOSE_VERSION=1.8.0
         - TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
     global:
@@ -27,7 +26,6 @@ env:
         - CFLAGS=-O0
 matrix:
     allow_failures:
-        - env: TOXENV=dennis
         - env: TOXENV=locales DOCKER_COMPOSE_VERSION=1.8.0
         - env: TOXENV=docker DOCKER_COMPOSE_VERSION=1.8.0
 before_install:

--- a/tox.ini
+++ b/tox.ini
@@ -25,12 +25,6 @@ basepython = python2.7
 deps = -rrequirements/docs.txt
 commands = sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
-[testenv:dennis]
-basepython = python2.7
-# TODO: Update to released version of dennis when aca57f6d is released.
-deps = https://github.com/willkg/dennis/archive/aca57f6d.zip
-commands = dennis-cmd lint --errorsonly locale/
-
 [testenv:locales]
 whitelist_externals =
     cat


### PR DESCRIPTION
The new locales task includes running ``dennis`` to lint the locales, so it is no longer needed as a separate ``tox`` / TravisCI task.