### PR TITLE
[Bug 1308168] non-translated page should have English link to button, banner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
       - CSRF_COOKIE_SECURE=False
-      - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
+      - DATABASE_URL=mysql://kuma:kuma@mysql:3306/developer_mozilla_org
       - DEBUG=True
       - DEBUG_TOOLBAR=True
       - DOMAIN=localhost

--- a/docker/images/mysql/kuma.cnf
+++ b/docker/images/mysql/kuma.cnf
@@ -15,3 +15,6 @@
 
     # Required to load production database
     max_allowed_packet=100M
+    
+    general_log_file        = /var/log/mysql/mysql.log
+    general_log             = 1

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -305,7 +305,7 @@
                   <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
                     Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.
                     <a href="{{ help_link }}">Join us and help get the job done!</a><br>
-                    You can also read the article in <a href="{{ doc_abs_url }}"> {{ parent_language }}.</a>
+                    You can also read the article in <a href="{{ doc_abs_url }}">{{ parent_language }}</a>.
                   {% endtrans %}</bdi></p>
                 </div>
               {% endif %}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -300,11 +300,12 @@
                   {% endif %}
                 {% endif %}
               {% endif %}
-              {% if fallback_reason %}
+              {% if fallback_reason=='no_translation' %}
                 <div id="doc-pending-fallback" class="warning">
-                  <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native %}
+                  <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
                     Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.
-                    <a href="{{ help_link }}">Join us and help get the job done!</a>
+                    <a href="{{ help_link }}">Join us and help get the job done!</a><br>
+                    You can also read the article in <a href="{{ doc_abs_url }}"> {{ parent_language }}.</a>
                   {% endtrans %}</bdi></p>
                 </div>
               {% endif %}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -300,7 +300,7 @@
                   {% endif %}
                 {% endif %}
               {% endif %}
-              {% if fallback_reason=='no_translation' %}
+              {% if fallback_reason %}
                 <div id="doc-pending-fallback" class="warning">
                   <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
                     Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -21,7 +21,11 @@
         <div class="submenu js-submenu" id="languages-menu-submenu">
           <div class="submenu-column">
             <ul id="translations">
-              {% if document.other_translations %}
+              {% if document.other_translations or fallback_reason %}
+                {# show the parent locale in choices if fall back to parent for any reason #}
+                {% if fallback_reason %}
+                  <li><bdi><a rel="internal" href="{{ document.get_absolute_url() }}" title="{{ get_locale_localized(document.locale) }}">{{ document.language }} ({{ document.locale }})</a></bdi></li>
+                {% endif %}
                 {% for translation in document.other_translations %}
                   <li><bdi><a rel="internal" href="{{ url('wiki.document', translation.slug, locale=translation.locale) }}" title="{{ get_locale_localized(translation.locale) }}">{{ translation.language }} ({{ translation.locale }})</a></bdi></li>
                 {% endfor %}

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -23,7 +23,7 @@
             <ul id="translations">
               {% if document.other_translations or fallback_reason %}
                 {# show the parent locale in choices if fall back to parent for any reason #}
-                {% if fallback_reason %}
+                {% if fallback_reason=='no_translation' %}
                   <li><bdi><a rel="internal" href="{{ document.get_absolute_url() }}" title="{{ get_locale_localized(document.locale) }}">{{ document.language }} ({{ document.locale }})</a></bdi></li>
                 {% endif %}
                 {% for translation in document.other_translations %}

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import time
 
 from django.contrib.auth.models import Permission
 from django.core import mail
@@ -251,6 +252,7 @@ class RevisionFormViewTests(UserTransactionTestCase):
     # Keys for a page edit (English or translation)
     akismet_keys_edit = sorted(akismet_keys + ['permalink'])
 
+    #@profile
     def setUp(self):
         super(RevisionFormViewTests, self).setUp()
         self.testuser = self.user_model.objects.get(username='testuser')
@@ -716,6 +718,7 @@ class RevisionFormCreateTests(RevisionFormViewTests):
 
 
 class RevisionFormNewTranslationTests(RevisionFormViewTests):
+    t1 = time.time()
     """Test RevisionForm as used to create a page in translate view."""
 
     original = {  # Default attributes of original English page
@@ -748,6 +751,7 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
         'toc_depth': Revision.TOC_DEPTH_ALL,
     }
 
+    #@profile
     def setup_form(self, mock_requests):
         """
         Setup a RevisionForm for a POST to create a new translation.
@@ -797,10 +801,14 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
         rev_form.instance.document = fr_html_doc
         return rev_form
 
-    @pytest.mark.spam
     @requests_mock.mock()
+    #@profile
     def test_new_translation(self, mock_requests):
         """Test Akismet dual locale setting for new translations."""
+        from django.conf import settings
+        print settings.DATABASES
+        t = time.time()
+        print t - self.t1
         rev_form = self.setup_form(mock_requests)
         assert rev_form.is_valid()
         parameters = rev_form.akismet_parameters()
@@ -814,6 +822,7 @@ class RevisionFormNewTranslationTests(RevisionFormViewTests):
             u'Traduction initiale'
         )
         assert parameters['comment_content'] == expected_content
+        print time.time() - t
 
 
 class RevisionFormEditTranslationTests(RevisionFormViewTests):
@@ -913,7 +922,6 @@ class RevisionFormEditTranslationTests(RevisionFormViewTests):
 
         return rev_form1, rev_form2
 
-    @pytest.mark.spam
     @requests_mock.mock()
     def test_edit_translation(self, mock_requests):
         rev_form1, rev_form2 = self.setup_forms(mock_requests)


### PR DESCRIPTION
So if there are ``fallback_reason``, we should show the ``parent document`` locale as choice also. As the ``document`` is replaced by ``parent_document`` from view, we can only use the ``document`` attributes.
@jwhitlock r?