### PR TITLE
bug 1218563: Use py.test --reuse-db for speed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ env:
         - DEBIAN_FRONTEND=noninteractive
         - DATABASE_URL=mysql://root:kuma@localhost:3306/kuma
         - CFLAGS=-O0
+        - PYTEST_ADDOPTS=--create-db
 matrix:
     allow_failures:
         - env: TOXENV=locales DOCKER_COMPOSE_VERSION=1.9.0

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node {
           sh 'make compose-test TEST=noext' // "smoke" tests with no external deps
           sh 'make compose-test TEST="noext make build-static"' // required for many tests
           sh 'docker-compose build'
-          sh 'make compose-test'
+          sh 'make compose-test PYTEST_ADDOPTS=--create-db'
         }
 
         stage('Build & push kuma image') {

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -124,6 +124,13 @@ Apps are migrated using Django's migration system. To run the migrations::
 If your changes include schema modifications, see the Django documentation for
 the `migration workflow`_.
 
+To improve the speed of the test suite, the ``py.test`` option ``--reuse-db``
+is used, which does not delete the test database after use. If you change
+migrations yourself or switch to a branch with different migrations, you will
+need to recreate your test database by running::
+
+    py.test --create-db kuma/core
+
 .. _migration workflow: https://docs.djangoproject.com/en/1.8/topics/migrations/#workflow
 
 Coding conventions

--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -37,7 +37,8 @@ Some helpful command line arguments to py.test (won't work on ``make test``):
   Drop into pdb on test failure.
 
 ``--create-db``:
-  Create a new test database.
+  Create a new test database. This is required to apply a new schema or to
+  apply migrations to the test database.
 
 ``--showlocals``:
   Shows local variables in tracebacks on errors.
@@ -97,6 +98,18 @@ The test database
 The test suite will create a new database named ``test_%s`` where ``%s`` is
 whatever value you have for ``settings.DATABASES['default']['NAME']``. Make
 sure the user has ``ALL`` on the test database as well.
+
+The first time the test database is created, the migrations are applied. This
+includes the migration needed to apply the custom collation to the tag name
+index, so the ``py.test`` option ``--no-migrations`` will cause one or more
+tag tests to fail. On later runs, the same test database is used without being
+recreated from scratch, which speeds up tests considerably.
+
+When the schema and migrations change, the database will need to be recreated.
+This command will appear to pause for one or two minutes as it recreates the
+test database::
+
+    py.test --create-db kuma/core
 
 
 Markers

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -23,7 +23,8 @@ retaining the database::
   git submodule sync --recursive && git submodule update --init --recursive
   docker-compose pull
   docker-compose build --pull
-  docker-compose up
+  docker-compose up -d
+  docker-compose exec web bash -c "py.test --create-db kuma/core"
 
 
 Reset a corrupt database

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -rsxX --tb=native
+addopts = -rsxX --tb=native --reuse-db
 testpaths = kuma
 python_files = test*.py
 DJANGO_SETTINGS_MODULE = kuma.settings.testing

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ setenv =
     CFLAGS = -O0
     # TODO: remove once http://bugzil.la/1127798 is fixed
     PYTHONHASHSEED = 0
-passenv=DJANGO_SETTINGS_MODULE DEBIAN_FRONTEND CFLAGS
+passenv=DJANGO_SETTINGS_MODULE DEBIAN_FRONTEND CFLAGS PYTEST_ADDOPTS
 
 [testenv:flake8]
 basepython = python2.7
@@ -43,14 +43,14 @@ whitelist_externals = docker-compose
 setenv =
     COMPOSE_FILE = docker-compose.yml:scripts/docker-compose.travis.yml
     COMPOSE_PROJECT_NAME = kumatox
-passenv = UID
+passenv = UID PYTEST_ADDOPTS
 commands =
     docker-compose up -d --build mysql  # Build, init DB (can be slow)
     docker-compose build web    # Rebuild w/ new reqs, Dockerfile-base
     docker-compose up -d        # Startup remaining services
     docker-compose exec -T web make compilejsi18n collectstatic
     docker-compose exec web ./manage.py migrate
-    docker-compose exec -T web make test
+    docker-compose exec -T web make test PYTEST_ADDOPTS={env:PYTEST_ADDOPTS:}
     docker-compose stop         # Useful for local development
 
 [flake8]


### PR DESCRIPTION
Use ``--reuse-db`` by default, which does not destroy the test database at the end of testing, and re-uses it on the next test run without running the long database migrations.  Update the documentation with instructions for recreating the test database on schema changes.