### PR TITLE
bug 1271552: Config case-insenstive tags

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1424,3 +1424,6 @@ if SENTRY_DSN:
 # Tell django-recaptcha we want to use "No CAPTCHA".
 # Note: The API keys are located in Django constance.
 NOCAPTCHA = True  # Note: Using No Captcha implies SSL.
+
+# Prevent adding a tag like 'javascript' if 'JavaScript' exists
+TAGGIT_CASE_INSENSITIVE = True


### PR DESCRIPTION
django-taggit 0.16.0 added config item ``TAGGIT_CASE_INSENSITIVE``.  When ``True``, an existing tag 'JavaScript' will prevent a new tag 'javascript' from being added. When ``False`` (the default), 'javascript' will be added as well.  This doesn't prevent problems if you try to add 'TAG' and 'tag' at the same time.

This does not fix the bad data already in production, but may prevent new duplicate tags from being added.