### PR TITLE
[Bug 1308222] move page fails with multiple profile same email

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -141,15 +141,14 @@ def build_json_data_for_document(pk, stale):
 
 
 @task
-def move_page(locale, slug, new_slug, email):
+def move_page(locale, slug, new_slug, user_id):
     transaction.set_autocommit(False)
     User = get_user_model()
     try:
-        user = User.objects.get(email=email)
+        user = User.objects.get(id=user_id)
     except User.DoesNotExist:
         transaction.rollback()
-        logging.error('Page move failed: no user with email address %s' %
-                      email)
+        logging.error('Page move failed: no user with id %s' % user_id)
         return
 
     try:

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -302,7 +302,7 @@ def move(request, document_slug, document_locale):
                 })
             move_page.delay(document_locale, document_slug,
                             form.cleaned_data['slug'],
-                            request.user.email)
+                            request.user.id)
             return render(request, 'wiki/move_requested.html', {
                 'form': form,
                 'document': doc


### PR DESCRIPTION
Use ``id`` instead of ``email``
@jwhitlock Small fix. r?