### PR TITLE
bug 1314290: Fix ALLOWED_HOSTS for api in Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     environment:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
-      - ALLOWED_HOSTS=localhost,localhost:8000
+      - ALLOWED_HOSTS=localhost,127.0.0.1,[::1],web,api
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
       - CSRF_COOKIE_SECURE=False


### PR DESCRIPTION
Django 1.8.16 checks [ALLOWED_HOSTS](https://docs.djangoproject.com/en/1.8/ref/settings/#std:setting-ALLOWED_HOSTS) even when ``DEBUG=True``. This prevented the api container from accepting connections from the kumascript container, even though it allowed direct access with http://localhost:8001.

Added 'api' and 'web' as expected hostnames, and the other local names you get with the default ``ALLOWED_HOSTS``.  Django strips the port number from the request host, so 'localhost:8000' is always checked as 'localhost', and does not need to appear in the settings.

To check that kumascript is talking to the api container:

1. Log in to your local MDN (only logged-in users can request a page re-render)
2. Set constance variable ``KUMASCRIPT_TIMEOUT`` to 30 (default 0, disables rendering)
3. Set constance variable ``KUMASCRIPT_MAX_AGE`` to 2 (default 600 seconds, which makes it less likely to see requests)
4. Load a wiki page, such as http://localhost:8000/en-US/docs/User:shobson, creating it from [production](https://developer.mozilla.org/en-US/docs/User:shobson?raw) if needed.
5. In a console, run ``docker-compose logs -f kumascript api`` to watch the logs
6. Force refresh the page to start a re-render.

Without this change, you should get a traceback that includes ``DisallowedHost: Invalid HTTP_HOST header: 'api:8000'. You may need to add u'api' to ALLOWED_HOSTS.``.

With this change (and a ``docker-compose up -d`` to apply it), you should see requests to the api container, such as:

```
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/en-US/User:shobson?raw=1 HTTP/1.1" 200 1830 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:anch?raw=1 HTTP/1.1" 200 528 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:bug?raw=1 HTTP/1.1" 200 2832 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:firefoxchannellink?raw=1 HTTP/1.1" 200 1601 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:irclink?raw=1 HTTP/1.1" 200 782 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:downloadbutton?raw=1 HTTP/1.1" 200 259 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:link?raw=1 HTTP/1.1" 200 305 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:linkitem?raw=1 HTTP/1.1" 200 561 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:linkitemdl?raw=1 HTTP/1.1" 200 479 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:dekiscript:string?raw=1 HTTP/1.1" 200 2979 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:57 +0000] "GET /en-US/docs/Template:insertfeedlinklist?raw=1 HTTP/1.1" 200 1746 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:dekiscript:date?raw=1 HTTP/1.1" 200 346 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:dekiscript:wiki?raw=1 HTTP/1.1" 200 13629 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:mdn:common?raw=1 HTTP/1.1" 200 15097 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:dekiscript:web?raw=1 HTTP/1.1" 200 1386 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:dekiscript:uri?raw=1 HTTP/1.1" 200 993 "-" "-"
api_1            | 172.18.0.7 - - [17/Nov/2016:20:51:58 +0000] "GET /en-US/docs/Template:dekiscript:page?raw=1 HTTP/1.1" 200 7662 "-" "-"
kumascript_1     | info: 172.18.0.8 - - [Thu, 17 Nov 2016 20:52:00 GMT] "GET /docs/en-US/User:shobson HTTP/1.1" 200 2978 "-" "python-requests/2.9.1" 2718 source=server, pid=1
```