### PR TITLE
bug 1308322: Add wheel hash for click 6.6

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -70,6 +70,7 @@ anyjson==0.3.3 \
 
 # dennis
 click==6.6 \
+    --hash=sha256:fcf697e1fd4b567d817c69dab10a4035937fe6af175c05fd6806b69f74cbc6c4 \
     --hash=sha256:cc6a19da8ebff6e7074f731447ef7e112bd23adf3de5c597cf9989f2fd8defe9
 
 # django-allauth


### PR DESCRIPTION
The click maintainers uploaded a new wheel for [6.6](https://pypi.python.org/pypi/click/6.6) (see https://github.com/pallets/click/issues/671), and pip is failing to install based on the new hash.  This PR adds the wheel's new hash.