### PR TITLE
Bug 1318821 - Fix syntaxbox to use <pre>

### DIFF
--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -107,12 +107,12 @@
     if(!CKEDITOR.stylesSet.registered['default']) {
       CKEDITOR.stylesSet.add('default', [
         { name: 'None', element: 'p' },
-        { name: 'Note box', element: 'div', attributes: { 'class': 'note' }, type: 'wrap' },
-        { name: 'Warning box', element: 'div', attributes: { 'class': 'warning' }, type: 'wrap' },
-        { name: 'Two columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
-        { name: 'Three columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
+        { name: 'Note Box', element: 'div', attributes: { 'class': 'note' }, type: 'wrap' },
+        { name: 'Warning Box', element: 'div', attributes: { 'class': 'warning' }, type: 'wrap' },
+        { name: 'Two Columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
+        { name: 'Three Columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },
-        { name: 'Syntax Box', element: 'div', attributes: { 'class': 'syntaxbox' } },
+        { name: 'Syntax Box', element: 'pre', attributes: { 'class': 'syntaxbox' } },
         { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } }
       ]);
     }


### PR DESCRIPTION
Fix bug 1318821 — Change CKEditor config so the toolbar option to create a Syntax Box creates a ``<pre class=“syntaxbox”>`` instead of a ``<div class=“syntaxbox”>``. This makes it actually work right. While at it, I normalized the capitalization of the titles of options in the styles menu.