### PR TITLE
fix bug 1306087 - Update stackoverflow profile with regional domain

### DIFF
--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -115,7 +115,7 @@ class User(AbstractUser):
             'invalid',
         ),
         'stackoverflow': validators.RegexValidator(
-            r'^https?://stackoverflow\.com/users/',
+            r'^https?://([a-z]{2}\.)?stackoverflow\.com/users/',
             _('Enter a valid Stack Overflow URL.'),
             'invalid',
         ),


### PR DESCRIPTION
Fix bug 1306087: if you have a stack overflow profile in another country/language such as `es.stackoverflow.com` the validation fails. 

I'm restricting anything before `stackoverflow.com` to two lowercase letters so any `meta.stackoverflow.com` type url fails. I didn't extend the regex to  handle usernames as suggested in the [comments on bugzilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1306087#c5) - it's unnecessary for now and should be added for all profile urls or none.