### PR TITLE
Bug 1314708: Add testing login credentials, add dashboard tests

### DIFF
--- a/docs/tests-ui.rst
+++ b/docs/tests-ui.rst
@@ -140,7 +140,8 @@ Marks
 * ``login``
 
   These tests require the testing accounts to exist on the target site. For
-  security reasons these accounts will not be on production.
+  security reasons these accounts will not be on production. Exclude these tests
+  with ```-m 'not login'``
 
 Guidelines for writing tests
 ============================

--- a/tests/functional/test_article.py
+++ b/tests/functional/test_article.py
@@ -48,6 +48,17 @@ def test_header_displays(base_url, selenium):
 
 
 @pytest.mark.smoke
+@pytest.mark.nodata
+@pytest.mark.nondestructive
+def test_header_signin(base_url, selenium):
+    page = ArticlePage(selenium, base_url).open()
+    # click on sign in widget
+    page.header.trigger_signin()
+    # assert it's fowarded to github
+    assert 'https://github.com' in str(selenium.current_url)
+
+
+@pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_header_platform_submenu(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -1,0 +1,67 @@
+import pytest
+
+from pages.dashboard import DashboardPage
+from pages.admin import AdminLogin
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_dashboard(base_url, selenium):
+    page = DashboardPage(selenium, base_url).open()
+    first_row = page.first_row
+    # ip toggle not present
+    assert not page.is_ip_toggle_present
+    # ip ban not present
+    assert not first_row.is_ip_ban_present
+    # spam ham button not present
+    assert not first_row.is_spam_ham_button_present
+    # no dashboard-details
+    assert page.details_items_length is 0
+    # click first cell
+    page.open_first_details()
+    # dashboard-details exist and are visible
+    assert page.details_items_length is 1
+    assert page.is_first_details_displayed
+    # contains a diff
+    assert page.is_first_details_diff_displayed
+    # does not overflow page
+    assert page.dashboard_not_overflowing
+    # save id of first revision on page one
+    first_row_id = page.first_row_id
+    # click on page two link
+    page.click_page_two()
+    # save id of first revision on page tw0
+    new_first_row_id = page.first_row_id
+    # check first revison on page one is not on page two
+    assert first_row_id is not new_first_row_id
+
+
+@pytest.mark.smoke
+@pytest.mark.login
+@pytest.mark.nondestructive
+def test_dashboard_moderator(base_url, selenium):
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_moderator_user()
+    page = DashboardPage(selenium, base_url).open()
+    first_row = page.first_row
+    # ip toggle not present
+    assert not page.is_ip_toggle_present
+    # ip ban not present
+    assert not first_row.is_ip_ban_present
+    # spam ham button present
+    assert first_row.is_spam_ham_button_present
+
+
+@pytest.mark.smoke
+@pytest.mark.login
+@pytest.mark.nondestructive
+def test_dashboard_super(base_url, selenium):
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_super_user()
+    page = DashboardPage(selenium, base_url).open()
+    first_row = page.first_row
+    # ip toggle present
+    assert page.is_ip_toggle_present
+    # ip ban present
+    assert first_row.is_ip_ban_present
+    # spam ham button present
+    assert first_row.is_spam_ham_button_present

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -34,6 +34,17 @@ def test_header_platform_submenu(base_url, selenium):
     assert page.header.is_platform_submenu_displayed
 
 
+@pytest.mark.smoke
+@pytest.mark.nodata
+@pytest.mark.nondestructive
+def test_header_signin(base_url, selenium):
+    page = HomePage(selenium, base_url).open()
+    # click on sign in widget
+    page.header.trigger_signin()
+    # assert it's fowarded to github
+    assert 'https://github.com' in str(selenium.current_url)
+
+
 # footer tests
 @pytest.mark.smoke
 @pytest.mark.nodata

--- a/tests/pages/admin.py
+++ b/tests/pages/admin.py
@@ -1,0 +1,46 @@
+from pypom import Page, Region
+from selenium.webdriver.common.by import By
+
+
+class AdminLogin(Page):
+
+    URL_TEMPLATE = '/admin/'
+
+    SUPER_USER = "test-super"
+    MODERATOR_USER = "test-moderator"
+    NEW_USER = "test-new"
+    BANNED_USER = "test-banned"
+    SPAM_USER = "viagra-test-123"
+    PASSWORD = "test-password"
+
+    _username_field_locator = (By.ID, 'id_username')
+    _password_field_locator = (By.ID, 'id_password')
+    _login_button_locator = (By.CSS_SELECTOR, '[type="submit"]')
+
+    def login_user(self, username):
+        # username
+        username_field = self.find_element(*self._username_field_locator)
+        username_field.send_keys(username)
+        # password
+        password_field = self.find_element(*self._password_field_locator)
+        password_field.send_keys(self.PASSWORD)
+        # click login
+        login_button = self.find_element(*self._login_button_locator)
+        login_button.click()
+        # wait for dashboard to load
+        self.wait.until(lambda s: 'dashboard' in self.find_element(By.CSS_SELECTOR, 'body').get_attribute('class'))
+
+    def login_super_user(self):
+        self.login_user(self.SUPER_USER)
+
+    def login_moderator_user(self):
+        self.login_user(self.MODERATOR_USER)
+
+    def login_new_user(self):
+        self.login_user(self.NEW_USER)
+
+    def login_banned_user(self):
+        self.login_user(self.BANNED_USER)
+
+    def login_spam_user(self):
+        self.login_user(self.SPAM_USER)

--- a/tests/pages/admin.py
+++ b/tests/pages/admin.py
@@ -27,7 +27,7 @@ class AdminLogin(Page):
         # click login
         login_button = self.find_element(*self._login_button_locator)
         login_button.click()
-        # wait for dashboard to load
+        # wait for admin dashboard to load
         self.wait.until(lambda s: 'dashboard' in self.find_element(By.CSS_SELECTOR, 'body').get_attribute('class'))
 
     def login_super_user(self):

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -34,6 +34,7 @@ class BasePage(Page):
         # locators
         _root_locator = (By.ID, 'main-header')
         _menu_locator = (By.ID, 'nav-main-menu')
+        _signin_locator = (By.CSS_SELECTOR, '#nav-sec .login-link')
         _menu_top_links = (By.CSS_SELECTOR, '#main-nav > ul > li > a[href]')
         _platform_submenu_trigger_locator = (By.XPATH,
                                              'id(\'nav-platform-submenu\')/..')
@@ -54,6 +55,10 @@ class BasePage(Page):
         @property
         def is_displayed(self):
             return self.root.is_displayed()
+
+        def trigger_signin(self):
+            signin_link = self.find_element(*self._signin_locator)
+            signin_link.click()
 
         # nav is displayed?
         @property

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -1,0 +1,122 @@
+from pypom import Region
+from selenium.webdriver.common.by import By
+
+from pages.base import BasePage
+from pages.regions.notification import NotificationTray, Notification
+
+
+class DashboardPage(BasePage):
+
+    URL_TEMPLATE = '/{locale}/dashboards/revisions'
+
+    _revision_filter_form_locator = (By.ID, 'revision-filter')
+    _revision_page_input = (By.ID, 'revision-page')
+    _notification_tray_locator = (By.CSS_SELECTOR, '.notification-tray')
+    _first_notification_locator = (By.CSS_SELECTOR, '.notification-tray .notification:first-child')
+    _parent_locator = (By.ID, 'revision-replace-block')
+    _pagination_locator = (By.CSS_SELECTOR, '.pagination')
+    _page_two_link = (By.CSS_SELECTOR, '.pagination > li:first-child + li a')
+    _ip_toggle_locator = (By.ID, 'show_ips_btn')
+    _first_row_locator = (By.CSS_SELECTOR,
+                             '.dashboard-table tbody .dashboard-row:first-child')
+    _first_details_locator = (By.CSS_SELECTOR,
+                             '.dashboard-table tbody .dashboard-row:first-child + .dashboard-detail')
+    _first_details_diff_locator = (By.CSS_SELECTOR,
+                                  '.dashboard-table tbody .dashboard-row:first-child + .dashboard-detail .diff')
+    _details_locator = (By.CSS_SELECTOR, '.dashboard-detail')
+
+    @property
+    def is_ip_toggle_present(self):
+        try:
+            ip_toggle = self.find_element(*self._ip_toggle_locator)
+            return True
+        except:
+            return False
+
+    @property
+    def first_row(self):
+        first_row = self.find_element(*self._first_row_locator)
+        return DashboardRow(self, root=first_row)
+
+    @property
+    def first_row_id(self):
+        return self.find_element(*self._first_row_locator).get_attribute('data-revision-id')
+
+    @property
+    def details_items_length(self):
+        details_items = self.find_elements(*self._details_locator)
+        return len(details_items)
+
+    def open_first_details(self):
+        first_row = self.find_element(*self._first_row_locator)
+        first_row.click()
+        self.wait.until(lambda s: len(self.find_elements(*self._details_locator)) > 0)
+
+    @property
+    def is_first_details_displayed(self):
+        first_details = self.find_element(*self._first_details_locator)
+        return first_details.is_displayed()
+
+    @property
+    def is_first_details_diff_displayed(self):
+        first_details_diff = self.find_element(*self._first_details_diff_locator)
+        return first_details_diff.is_displayed()
+
+    def click_page_two(self):
+        revsion_filter_form = self.find_element(*self._revision_filter_form_locator)
+        page_two_link = self.find_element(*self._page_two_link)
+        page_two_link.click()
+        # revsion-page updates to not 1
+        self.wait.until(lambda s: int(self.find_element(*self._revision_page_input).get_attribute('value')) is not 1)
+        # form is disabled when ajax request made
+        self.wait.until(lambda s: 'disabled' in revsion_filter_form.get_attribute('class'))
+        # wait for tray to be added
+        self.wait.until(lambda s: len(self.find_elements(*self._notification_tray_locator)) > 0)
+        # wait for notification in tray
+        self.wait.until(lambda s: len(self.find_elements(*self._first_notification_locator)) > 0)
+        # form editable when ajax response arrives
+        self.wait.until(lambda s: 'disabled' not in revsion_filter_form.get_attribute('class'))
+        # wait for notification to close
+        self.wait.until(lambda s: 'closed' in self.find_element(*self._first_notification_locator).get_attribute('class'))
+        # revsion-page-value updates to 1
+        self.wait.until(lambda s: int(self.find_element(*self._revision_page_input).get_attribute('value')) == 1)
+        # opacity maniulation finishes
+        self.wait.until(lambda s: 'opacity' not in self.find_element(*self._parent_locator).get_attribute('style'))
+
+    @property
+    def dashboard_not_overflowing(self):
+        crawlBar = self.selenium.execute_script("return document.documentElement.scrollWidth>document.documentElement.clientWidth;")
+        return not crawlBar
+
+class DashboardRow(Region):
+
+    _root_locator = (By.CSS_SELECTOR, '.dashboard-row')
+    _ban_ip_locator = (By.CSS_SELECTOR, '.dashboard-ban-ip-link')
+    _spam_ham_button_locator = (By.CSS_SELECTOR, '.spam-ham-button')
+
+    @property
+    def revision_id(self):
+        return self.root.get_attribute('data-revision-id')
+
+    @property
+    def is_ip_ban_present(self):
+        try:
+            ip_toggle = self.find_element(*self._ban_ip_locator)
+            return True
+        except:
+            return False
+
+    @property
+    def is_spam_ham_button_present(self):
+        try:
+            ip_toggle = self.find_element(*self._spam_ham_button_locator)
+            return True
+        except:
+            return False
+
+class DashboardDetail(Region):
+
+    _root_locator = (By.CSS_SELECTOR, '.dashboard-detail')
+    _page_buttons_locator = (By.CSS_SELECTOR, '.page-buttons li a')
+    _diff_locator = (By.CSS_SELECTOR, '.diff')
+    _diff_rows_locator = (By.CSS_SELECTOR, '.diff tbody tr')

--- a/tests/pages/regions/notification.py
+++ b/tests/pages/regions/notification.py
@@ -1,0 +1,11 @@
+from pypom import Region
+from selenium.webdriver.common.by import By
+
+
+class NotificationTray(Region):
+
+    _root_locator = (By.CSS_SELECTOR, '.notification-tray')
+
+class Notification(Region):
+
+    _root_locator = (By.CSS_SELECTOR, '.notification')


### PR DESCRIPTION
- testing usernames and passwords
- page object for logging into admin
- test "sign in" forwards to github
- tests for revision dashboard

Testing usernames will be part of sample database or can be configured manually on dev machines. They will not be on staging or production.

Use `-m "not login"` to exclude tests requiring a login.

Not all login tests are destructive.