### PR TITLE
Bug 1271509: Sample database and production scraper

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -139,7 +139,7 @@ initial link scrape, but that are passed on to the scraped documents:
 
 Create the Sample Database
 ==========================
-These scraping tools are used to crete a sample database of public
+These scraping tools are used to create a sample database of public
 information, which is used for development environments and functional
 testing without exposing any private production data.
 

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -137,3 +137,136 @@ initial link scrape, but that are passed on to the scraped documents:
 
 .. _`web crawler`: https://developer.mozilla.org/en-US/docs/Glossary/Crawler
 
+Create the Sample Database
+==========================
+These scraping tools are used to crete a sample database of public
+information, which is used for development environments and functional
+testing without exposing any private production data.
+
+When it is time to create a new sample database, an MDN staff person runs
+the commamd in the the container::
+
+    time scripts/create_sample_db.sh
+
+This takes 30 - 60 minutes with a good internet connection.  This is then
+uploaded to the ``mdn-downloads`` site:
+
+* https://mdn-downloads.s3-us-west-2.amazonaws.com/index.html
+* https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
+
+This uses the specification at ``etc/sample_db.json``, which includes the
+sources for scraping, as well as fixtures needed for a working development
+and testing environment.
+
+Load Custom Data
+================
+The ``sample_mdn`` command does the work of creating the sample database. It
+can also be used with a different specification to load custom fixtures and
+scrape additional data for your local environment.
+
+For example, loading a new sample database wipes out existing data, so you'll
+need to run the instructions in :ref:`enable-github-auth` again. Instead, you
+can create a specification for your development user and GitHub OAuth
+application::
+
+    {
+      "sources": [
+        ["user",
+         "my_username",
+         {
+           "social": true,
+           "email": "my_email@example.com"
+         }
+        ]
+      ],
+      "fixtures": {
+        "users.user": [
+          {
+            "username": "my_username",
+            "email": "my_email@example.com",
+            "is_staff": true,
+            "is_superuser": true
+          }
+        ],
+        "socialaccount.socialapp": [
+          {
+            "name": "GitHub",
+            "client_id": "client_id_from_github",
+            "secret": "secret_from_github",
+            "provider": "github",
+            "sites": [ [1] ]
+          }
+        ],
+        "socialaccount.socialaccount": [
+          {
+            "uid": "uid_from_github",
+            "user": ["my_username"],
+            "provider": "github"
+          }
+        ],
+        "account.emailaddress": [
+          {
+            "user": ["my_username"],
+            "email": "my_email@example.com",
+            "verified": true
+          }
+        ]
+      }
+    }
+
+To use this, you'll need to replace the placeholders:
+
+* ``my_username`` - your MDN username
+* ``my_email@example.com`` - your email address, verified on GitHub
+* ``client_id_from_github`` - from your GitHub OAuth app
+* ``secret_from_github`` - from your GitHub OAuth app
+* ``uid_from_github`` - from your MDN SocialAccount_
+
+Save it, for example as ``my_data.json``, and, after loading the sample
+database, load the extra data::
+
+    ./manage.py sample_mdn my_data.json
+
+This will allow you to quickly log in again using GitHub auth after loading the
+sample database.
+
+.. _SocialAccount: http://localhost:8000/admin/socialaccount/socialaccount/
+
+Anonymized Production Data
+==========================
+The production database contains confidential user information, such as email
+addresses and authentication tokens, and it is not distributed.  We try to make
+the sample database small but useful, and provide scripts to augment it for
+specific uses, reducing the need for production data.
+
+Production-scale data is occasionaly needed for development, such as testing
+the performance of data migrations and new algorithms, and for the
+`staging site`_.  In these cases, we generate an anonymized copy of production
+data, which deletes authentication keys and anonymizes user records.
+
+This is generated with the script ``scripts/clone_db.py`` on a recent backup of
+the production database. You can see a faster and less resource-intensive
+version of the process by running it against the sample database::
+
+    scripts/clone_db.py -H mysql -u root -p kuma -i mdn_sample_db.sql.gz anon_db
+
+This will generate a file ``anon_db-anon-20170606.sql.gz``, where the date is
+today's date.  To check that the anonymize script ran correctly, load the
+anonymized database dump and run the check script::
+
+    zcat anon_db-anon-20170606.sql.gz | ./manage.py dbshell
+    cat scripts/check_anonymize.sql | ./manage.py dbshell
+
+This runs a set of counting queries that should return 0 rows.
+
+A similar process is used to anonymize a recent production database dump.
+The development environment is not tuned for the I/O, memory, and disk
+requirements, and will fail with an error.  Instead, a host-installed version
+of MySQL is used, with the custom collation.  The entire process, from getting
+a backup to uploading a confirmed anonymized database, takes about half a day.
+
+We suspect that a clever user could de-anonymize the data in the full
+anonymized database, so we do not distribute it, and try to limit our own use
+of the database.
+
+.. _`staging site`: https://developer.allizom.org

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -105,3 +105,35 @@ Some useful options:
   Refresh an existing Document, instead of skipping
 
 For full options, see ``./manage.py scrape_document --help``
+
+Add Documents Linked from a Page
+================================
+If you need all the documents linked from a page in production or another Kuma
+instance, you can use the ``scrape_links`` command.  In the container (after
+``make bash`` or similar), run the following, using the desired URL::
+
+    ./manage.py scrape_links  # Scrape the homepage
+    ./manage.py scrape_links https://developer.mozilla.org/en-US/Web/CSS/display
+
+This treats a page a lot like a `web crawler`_ would, looking for wiki document
+links with the same locale from:
+
+- The header
+- The footer
+- The content
+- KumaScript-rendered sidebars and content
+
+This can result in a lot of traffic. There are options that don't affect the
+initial link scrape, but that are passed on to the scraped documents:
+
+``--revisions REVS``
+  Scrape more than one revision
+
+``--translations``
+  Scrape the translations of a page as well
+
+``--depth DEPTH``
+  Scrape one or more levels of child pages as well
+
+.. _`web crawler`: https://developer.mozilla.org/en-US/docs/Glossary/Crawler
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -210,6 +210,7 @@ management command. Replace ``YOUR_USERNAME`` with your username and
 With a password-enabled admin account, you can log into Django admin at
 http://localhost:8000/admin/login/
 
+.. _enable-github-auth:
 
 Enable GitHub Auth (optional)
 =============================

--- a/etc/sample_db.json
+++ b/etc/sample_db.json
@@ -1,0 +1,703 @@
+{
+  "sources": [
+    ["links", "/", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/Mozilla/Firefox", {"revisions": 15}],
+    ["document", "/en-US/docs/Web/Apps", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/MDN_at_ten/History_of_MDN", {}],
+    ["document", "/en-US/docs/Archive/JXON", {}],
+    ["document", "/en-US/docs/User:anonymous:uitest", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/User:teoli/In_content", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/Experiment:FrameworkTest/Comparison_Operators", {"translations": true, "revisions": 3}],
+    ["document", "/en-US/docs/Mozilla/Projects/Midas/Security_preferences", {}],
+    ["document", "/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach", {}],
+    ["document", "/en-US/docs/Web/Guide/CSS/Media_queries", {}],
+    ["document", "/en-US/docs/Learn/Getting_started_with_the_web/JavaScript_basics", {}],
+    ["user", "Sheppy", {"social": true, "email": "sheppy@mozilla.com"}],
+    ["user", "jwhitlock", {"social": true, "email": "jwhitlock@mozilla.com"}]
+  ],
+  "fixtures": {
+    "database.constance": [
+      {
+        "key": "KUMASCRIPT_TIMEOUT",
+        "value": 30
+      }, {
+        "key": "KUMASCRIPT_MAX_AGE",
+        "value": 30
+      }
+    ],
+    "auth.group": [
+      {
+        "name": "Attachment Moderators",
+        "permissions": [
+          ["add_documentdeletionlog"],
+          ["add_logentry"],
+          ["add_trashedattachment"],
+          ["change_attachment"],
+          ["change_attachmentrevision"],
+          ["change_documentdeletionlog"],
+          ["change_trashedattachment"],
+          ["delete_attachment"],
+          ["delete_attachmentrevision"],
+          ["delete_documentattachment"],
+          ["delete_trashedattachment"]
+        ]
+      }, {
+        "name": "Beta Testers"
+      }, {
+        "name": "Known Authors"
+      }, {
+        "name": "Localization leaders",
+        "permissions": [
+          ["add_attachment"],
+          ["add_attachmentrevision"],
+          ["add_documentattachment"],
+          ["add_userban"],
+          ["change_attachment"],
+          ["change_attachmentrevision"],
+          ["change_documentattachment"],
+          ["change_userban"],
+          ["delete_userban"],
+          ["move_tree"]
+        ]
+      }, {
+        "name": "Page Creators"
+      }, {
+        "name": "Spam Admins",
+        "permissions": [
+          ["add_revisionakismetsubmission"],
+          ["add_userban"],
+          ["change_documentspamattempt"],
+          ["change_revisionakismetsubmission"],
+          ["change_revisionip"],
+          ["change_userban"]
+        ]
+      }, {
+        "name": "Topic drivers",
+        "permissions": [
+          ["add_attachment"],
+          ["add_documentattachment"],
+          ["change_attachment"],
+          ["change_documentattachment"],
+          ["move_tree"]
+        ]
+      }, {
+        "name": "Trusted writers",
+        "permissions": [
+          ["add_documentspamattempt"],
+          ["add_revisionakismetsubmission"],
+          ["change_documentspamattempt"],
+          ["change_revisionakismetsubmission"],
+          ["delete_documentspamattempt"],
+          ["delete_revisionakismetsubmission"]
+        ]
+      }, {
+        "name": "Uploaders",
+        "permissions": [
+          ["add_attachment"],
+          ["add_attachmentrevision"],
+          ["add_documentattachment"],
+          ["add_trashedattachment"],
+          ["change_attachment"],
+          ["change_attachmentrevision"],
+          ["change_documentattachment"]
+        ]
+      }, {
+        "name": "redesign_testers"
+      }
+    ],
+    "auth.permission": [
+      {
+        "codename": "add_attachment",
+        "name": "Can add attachment",
+        "content_type": ["attachments", "attachment"]
+      }, {
+        "codename": "add_attachmentrevision",
+        "name": "Can add attachment revision",
+        "content_type": ["attachments", "attachmentrevision"]
+      }, {
+        "codename": "add_document",
+        "name": "Can add document",
+        "content_type": ["wiki", "document"]
+      }, {
+        "codename": "add_documentattachment",
+        "name": "Can add document attachment",
+        "content_type": ["wiki", "documentattachment"]
+      }, {
+        "codename": "add_documentdeletionlog",
+        "name": "Can add document deletion log",
+        "content_type": ["wiki", "documentdeletionlog"]
+      }, {
+        "codename": "add_documentspamattempt",
+        "name": "Can add document spam attempt",
+        "content_type": ["wiki", "documentspamattempt"]
+      }, {
+        "codename": "add_logentry",
+        "name": "Can add log entry",
+        "content_type": ["admin", "logentry"]
+      }, {
+        "codename": "add_revisionakismetsubmission",
+        "name": "Can add Akismet submission",
+        "content_type": ["wiki", "revisionakismetsubmission"]
+      }, {
+        "codename": "add_trashedattachment",
+        "name": "Can add Trashed attachment",
+        "content_type": ["attachments", "trashedattachment"]
+      }, {
+        "codename": "add_userban",
+        "name": "Can add user ban",
+        "content_type": ["users", "userban"]
+      }, {
+        "codename": "change_attachment",
+        "name": "Can change attachment",
+        "content_type": ["attachments", "attachment"]
+      }, {
+        "codename": "change_attachmentrevision",
+        "name": "Can change attachment revision",
+        "content_type": ["attachments", "attachmentrevision"]
+      }, {
+        "codename": "change_documentattachment",
+        "name": "Can change document attachment",
+        "content_type": ["wiki", "documentattachment"]
+      }, {
+        "codename": "change_documentdeletionlog",
+        "name": "Can change document deletion log",
+        "content_type": ["wiki", "documentdeletionlog"]
+      }, {
+        "codename": "change_documentspamattempt",
+        "name": "Can change document spam attempt",
+        "content_type": ["wiki", "documentspamattempt"]
+      }, {
+        "codename": "change_revisionakismetsubmission",
+        "name": "Can change Akismet submission",
+        "content_type": ["wiki", "revisionakismetsubmission"]
+      }, {
+        "codename": "change_revisionip",
+        "name": "Can change revision ip",
+        "content_type": ["wiki", "revisionip"]
+      }, {
+        "codename": "change_trashedattachment",
+        "name": "Can change Trashed attachment",
+        "content_type": ["attachments", "trashedattachment"]
+      }, {
+        "codename": "change_userban",
+        "name": "Can change user ban",
+        "content_type": ["users", "userban"]
+      }, {
+        "codename": "delete_attachment",
+        "name": "Can delete attachment",
+        "content_type": ["attachments", "attachment"]
+      }, {
+        "codename": "delete_attachmentrevision",
+        "name": "Can delete attachment revision",
+        "content_type": ["attachments", "attachmentrevision"]
+      }, {
+        "codename": "delete_documentattachment",
+        "name": "Can delete document attachment",
+        "content_type": ["wiki", "documentattachment"]
+      }, {
+        "codename": "delete_documentspamattempt",
+        "name": "Can delete document spam attempt",
+        "content_type": ["wiki", "documentspamattempt"]
+      }, {
+        "codename": "delete_revisionakismetsubmission",
+        "name": "Can delete Akismet submission",
+        "content_type": ["wiki", "revisionakismetsubmission"]
+      }, {
+        "codename": "delete_trashedattachment",
+        "name": "Can delete Trashed attachment",
+        "content_type": ["attachments", "trashedattachment"]
+      }, {
+        "codename": "delete_userban",
+        "name": "Can delete user ban",
+        "content_type": ["users", "userban"]
+      }, {
+        "codename": "move_tree",
+        "name": "Can move a tree of documents",
+        "content_type": ["wiki", "document"]
+      }
+    ],
+    "contenttypes.contenttype": [
+      {
+        "app_label": "admin",
+        "model": "logentry"
+      }, {
+        "app_label": "attachments",
+        "model": "attachment"
+      }, {
+        "app_label": "attachments",
+        "model": "attachmentrevision"
+      }, {
+        "app_label": "attachments",
+        "model": "trashedattachment"
+      }, {
+        "app_label": "users",
+        "model": "userban"
+      }, {
+        "app_label": "wiki",
+        "model": "document"
+      }, {
+        "app_label": "wiki",
+        "model": "documentattachment"
+      }, {
+        "app_label": "wiki",
+        "model": "documentdeletionlog"
+      }, {
+        "app_label": "wiki",
+        "model": "documentspamattempt"
+      }, {
+        "app_label": "wiki",
+        "model": "revisionakismetsubmission"
+      }, {
+        "app_label": "wiki",
+        "model": "revisionip"
+      }
+    ],
+    "sites.site": [
+      {
+        "id": 1,
+        "name": "localhost:8000",
+        "domain": "localhost:8000"
+      }
+    ],
+    "users.user": [
+      {
+        "username": "test-super",
+        "email": "test-super@example.com",
+        "password": "test-password",
+        "is_staff": true,
+        "is_superuser": true
+      }, {
+        "username": "test-moderator",
+        "email": "test-moderator@example.com",
+        "password": "test-password",
+        "is_staff": true,
+        "groups": [
+          ["Attachment Moderators"],
+          ["Page Creators"],
+          ["Trusted writers"],
+          ["Spam Admins"],
+          ["Uploaders"]
+        ]
+      }, {
+        "username": "test-new",
+        "email": "test-new@example.com",
+        "password": "test-password",
+        "is_staff": true
+      }, {
+        "username": "test-banned",
+        "email": "test-banned@example.com",
+        "password": "test-password",
+        "is_staff": true
+      }, {
+        "username": "viagra-test-123",
+        "email": "test-spammer@example.com",
+        "password": "test-password",
+        "is_staff": true
+      }
+    ],
+    "users.userban": [
+      {
+        "user": ["test-banned"],
+        "by": ["test-super"],
+        "reason": "Spam"
+      }],
+    "waffle.flag": [
+      {
+        "name": "kumaediting",
+        "superusers": false,
+        "authenticated": true,
+        "note": "Use this to put the wiki into read-only mode.",
+        "created": "2014-01-14"
+      }, {
+        "name": "page_move",
+        "everyone": false,
+        "staff": true,
+        "created": "2014-01-14"
+      }, {
+        "name": "search_suggestions",
+        "superusers": false,
+        "created": "2014-10-14"
+      }, {
+        "name": "registration_disabled",
+        "everyone": false,
+        "superusers": false,
+        "created": "2015-02-25"
+      }, {
+        "name": "wiki_samples",
+        "note": "Add a button to open wiki doc samples in Codepen and/or jsFiddle",
+        "everyone": true,
+        "staff": true,
+        "created": "2015-07-20"
+      }, {
+        "name": "compat_api",
+        "created": "2015-10-01"
+      }, {
+        "name": "section_edit",
+        "note": "Show section edit buttons to signed-in users when mousing over section headers",
+        "created": "2015-10-07"
+      }, {
+        "name": "wiki_spam_exempted",
+        "note": "Exempted from spam checks (deprecated)",
+        "superusers": false,
+        "created": "2015-10-28",
+        "FORCE": true
+      }, {
+        "name": "spam_checks_enabled",
+        "note": "Decides whether spam checks are enabled site-wide.",
+        "everyone": true,
+        "superusers": false,
+        "created": "2015-10-28",
+        "FORCE": true
+      }, {
+        "name": "spam_submisions_enabled",
+        "note": "Decides whether ham and spam submissions are allowed to be done.",
+        "created": "2016-01-11"
+      }, {
+        "name": "spam_admin_override",
+        "note": "User's content should be trusted by Akismet",
+        "superusers": false,
+        "created": "2016-04-20"
+      }, {
+        "name": "spam_spammer_override",
+        "note": "User's content is always spam",
+        "superusers": false,
+        "created": "2016-04-20"
+      }, {
+        "name": "spam_testing_mode",
+        "note": "Edits are test content and should not train Akismet",
+        "superusers": false,
+        "created": "2016-04-20"
+      }, {
+        "name": "wiki_spam_training",
+        "note": "Do not block page changes when detected as spam",
+        "everyone": false,
+        "superusers": false,
+        "created": "2016-04-20"
+      }, {
+        "name": "iperceptions",
+        "note": "Enable the iPerceptions pop-up survey",
+        "everyone": false,
+        "superusers": false,
+        "created": "2016-08-03"
+      }, {
+        "name": "sg_task_completion",
+        "note": "Show Survey Gizmo link to task completion survey.",
+        "superusers": false,
+        "created": "2016-08-12"
+      }
+    ],
+    "waffle.switch": [
+      {
+        "name": "wiki_error_on_delete",
+        "active": false,
+        "note": "",
+        "created": "2014-01-14"
+      }, {
+        "name": "wiki_force_immediate_rendering",
+        "active": false,
+        "note": "",
+        "created": "2014-01-14"
+      }, {
+        "name": "enable_optimizely",
+        "active": false,
+        "note": "Enable this switch to include the Optimizely JavaScript.\n\nThis switch needs to be enabled to create or run experiments. The switch can be disabled to improve performance if experiments are not being run and no new experiments need to be created right now.",
+        "created": "2014-07-15"
+      }, {
+        "name": "welcome_email",
+        "active": true,
+        "note": "",
+        "created": "2014-08-07"
+      }, {
+        "name": "application_ACAO",
+        "active": true,
+        "note": "",
+        "created": "2014-12-23"
+      }, {
+        "name": "store_revision_ips",
+        "active": true,
+        "note": "",
+        "created": "2014-12-26"
+      }, {
+        "name": "dumb_doc_urls",
+        "active": true,
+        "note": "See https://github.com/mozilla/kuma/pull/3331",
+        "created": "2015-07-09"
+      }, {
+        "name": "newsletter",
+        "active": true,
+        "note": "Show newsletter signup.",
+        "created": "2016-11-02"
+      }, {
+        "name": "newsletter_article",
+        "active": true,
+        "note": "Show newsletter sign-up in article footers, also requires `newsletter` to be active.",
+        "created": "2016-11-02"
+      }
+    ],
+    "search.filtergroup": [
+      {
+        "name": "Topics",
+        "slug": "topic"
+      }
+    ],
+    "search.filter": [
+      {
+        "name": "APIs and DOM",
+        "slug": "api",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["API"]
+        ]
+      }, {
+        "name": "Add-ons & Extensions",
+        "slug": "addons",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Add-ons"],
+          ["Extensions"],
+          ["Plugins"],
+          ["Themes"]
+        ]
+      }, {
+        "name": "CSS",
+        "slug": "css",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["CSS"]
+        ]
+      }, {
+        "name": "Canvas",
+        "slug": "canvas",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Canvas"]
+        ]
+      }, {
+        "name": "Firefox OS",
+        "slug": "firefox-os",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Firefox OS"]
+        ]
+      }, {
+        "name": "Firefox for Android",
+        "slug": "firefox-mobile",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Firefox Mobile"]
+        ]
+      }, {
+        "name": "Firefox for Desktop",
+        "slug": "firefox-desktop",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Firefox Desktop"]
+        ]
+      }, {
+        "name": "Firefox",
+        "slug": "firefox",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Firefox"]
+        ]
+      }, {
+        "name": "Games",
+        "slug": "games",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Games"]
+        ]
+      }, {
+        "name": "HTML",
+        "slug": "html",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["HTML"]
+        ]
+      }, {
+        "name": "HTTP",
+        "slug": "http",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["HTTP"]
+        ]
+      }, {
+        "name": "JavaScript",
+        "slug": "js",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["JavaScript"]
+        ]
+      }, {
+        "name": "Marketplace",
+        "slug": "marketplace",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Marketplace"]
+        ]
+      }, {
+        "name": "MathML",
+        "slug": "mathml",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["MathML"]
+        ]
+      }, {
+        "name": "Mobile",
+        "slug": "mobile",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Mobile"]
+        ]
+      }, {
+        "name": "Open Web Apps",
+        "slug": "apps",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Apps"]
+        ]
+      }, {
+        "name": "SVG",
+        "slug": "svg",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["SVG"]
+        ]
+      }, {
+        "name": "Web Development",
+        "slug": "webdev",
+        "enabled": true,
+        "default": true,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["Web Development"]
+        ]
+      }, {
+        "name": "WebGL",
+        "slug": "webgl",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["WebGL"]
+        ]
+      }, {
+        "name": "Writing Documentation",
+        "slug": "docs",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["MDC_Project"],
+          ["MDC Project"],
+          ["Documentation"],
+          ["MDN Meta"],
+          ["MDN"]
+        ]
+      }, {
+        "name": "XPCOM",
+        "slug": "xpcom",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["XPCOM"]
+        ]
+      }, {
+        "name": "XUL",
+        "slug": "xul",
+        "enabled": true,
+        "default": false,
+        "group": ["Topics", "topic"],
+        "tags": [
+          ["XUL"]
+        ]
+      }
+    ],
+    "taggit.tag": [
+      {"name": "API"},
+      {"name": "Add-ons"},
+      {"name": "Apps"},
+      {"name": "CSS"},
+      {"name": "Canvas"},
+      {"name": "Documentation"},
+      {"name": "Extensions"},
+      {"name": "Firefox Desktop"},
+      {"name": "Firefox Mobile"},
+      {"name": "Firefox OS"},
+      {"name": "Firefox"},
+      {"name": "Games"},
+      {"name": "HTML"},
+      {"name": "HTTP"},
+      {"name": "JavaScript"},
+      {"name": "MDC Project"},
+      {"name": "MDC_Project"},
+      {"name": "MDN Meta"},
+      {"name": "MDN"},
+      {"name": "Marketplace"},
+      {"name": "MathML"},
+      {"name": "Mobile"},
+      {"name": "Plugins"},
+      {"name": "SVG"},
+      {"name": "Themes"},
+      {"name": "Web Development"},
+      {"name": "WebGL"},
+      {"name": "XPCOM"},
+      {"name": "XUL"}
+    ],
+    "feeder.feed": [
+      {
+        "shortname": "moz-hacks",
+        "title": "Mozilla Hacks - the Web developer blog",
+        "url": "https://hacks.mozilla.org/feed/",
+        "etag": "stale",
+        "last_modified": "2017-01-01",
+        "enabled": true,
+        "keep": 10
+      }
+    ],
+    "feeder.bundle": [
+      {
+        "shortname": "updates-moz-hacks",
+        "feeds": [
+          ["moz-hacks"]
+        ]
+      }
+    ]
+  }
+}

--- a/kuma/scrape/__init__.py
+++ b/kuma/scrape/__init__.py
@@ -4,6 +4,5 @@ Scrape data from one Kuma instance to this one.
 This is useful for development, to test code against specific production data,
 and to create the basic sample database for development and testing.
 
-TODO: Sample DB code from sample_database_wip_1271509
 TODO: Extract attachment data from documents
 """

--- a/kuma/scrape/fixture.py
+++ b/kuma/scrape/fixture.py
@@ -12,8 +12,8 @@ class FixtureLoader(object):
 
     # Needed information about the supported Django models for fixtures
     # The key is the app_label.model_name, such as wiki.revision for Revision:
-    #  Revision._meta.app_label == wiki
-    #  Revision._meta.model_name == revision
+    #  Revision._meta.app_label == 'wiki'
+    #  Revision._meta.model_name == 'revision'
     # The value is a dictionary of:
     # - natural_key: Properties used to find existing database records
     # - relations: Details of properties that are foreign keys
@@ -155,8 +155,7 @@ class FixtureLoader(object):
             natural_key_spec = metadata['natural_key']
             relations = metadata.get('relations', {})
             filters = metadata.get('filters', {})
-            app_label, model_name = model_id.split('.')
-            assert apps.get_model(app_label, model_name)
+            assert apps.get_model(model_id)
 
             parsed.setdefault(model_id, [])
             for item_num, item in enumerate(items):
@@ -227,8 +226,7 @@ class FixtureLoader(object):
         existing, loaded, pending = 0, 0, 0
         for model_id, items in self.spec.items():
             metadata = self.model_metadata[model_id]
-            app_label, model_name = model_id.split('.')
-            Model = apps.get_model(app_label, model_name)
+            Model = apps.get_model(model_id)
 
             self.instances.setdefault(model_id, {})
             for item in items:

--- a/kuma/scrape/fixture.py
+++ b/kuma/scrape/fixture.py
@@ -19,6 +19,15 @@ class FixtureLoader(object):
     # - relations: Details of properties that are foreign keys
     # - filters: Methods to run on values before saving to the database
     model_metadata = {
+        'account.emailaddress': {
+            'natural_key': ('email',),
+            'relations': {
+                'user': {
+                    'link': 'to_one',
+                    'resource': 'users.user',
+                },
+            },
+        },
         'auth.group': {
             'natural_key': ('name',),
             'relations': {
@@ -70,6 +79,27 @@ class FixtureLoader(object):
         },
         'search.filtergroup': {
             'natural_key': ('name', 'slug'),
+        },
+        'sites.site': {
+            'natural_key': ('id',),
+        },
+        'socialaccount.socialaccount': {
+            'natural_key': ('uid', 'provider'),
+            'relations': {
+                'user': {
+                    'link': 'to_one',
+                    'resource': 'users.user',
+                }
+            }
+        },
+        'socialaccount.socialapp': {
+            'natural_key': ('name', ),
+            'relations': {
+                'sites': {
+                    'link': 'to_many',
+                    'resource': 'sites.site'
+                }
+            }
         },
         'taggit.tag': {
             'natural_key': ('name',),

--- a/kuma/scrape/fixture.py
+++ b/kuma/scrape/fixture.py
@@ -250,8 +250,8 @@ class FixtureLoader(object):
         """
         Attempt to create or update an item.
 
-        Returns the instance if attempt suceeded, or None if related items are
-        needed.
+        Returns the instance if attempt suceeded.
+        Raises NeedsDependency if a dependency must be created first.
         """
         natural_key_spec = metadata['natural_key']
         relations = metadata.get('relations', {})

--- a/kuma/scrape/fixture.py
+++ b/kuma/scrape/fixture.py
@@ -1,0 +1,297 @@
+"""Load test fixtures from a specification."""
+
+from django.apps import apps
+from django.contrib.auth.hashers import make_password
+
+import logging
+logger = logging.getLogger('kuma.scraper')
+
+
+class FixtureLoader(object):
+    """Load fixtures into the current database."""
+
+    # Needed information about the supported Django models for fixtures
+    # The key is the app_label.model_name, such as wiki.revision for Revision:
+    #  Revision._meta.app_label == wiki
+    #  Revision._meta.model_name == revision
+    # The value is a dictionary of:
+    # - natural_key: Properties used to find existing database records
+    # - relations: Details of properties that are foreign keys
+    # - filters: Methods to run on values before saving to the database
+    model_metadata = {
+        'auth.group': {
+            'natural_key': ('name',),
+            'relations': {
+                'permissions': {
+                    'link': 'to_many',
+                    'resource': 'auth.permission'
+                },
+            },
+        },
+        'auth.permission': {
+            'natural_key': ('codename',),
+            'relations': {
+                'content_type': {
+                    'link': 'to_one',
+                    'resource': 'contenttypes.contenttype'
+                },
+            },
+        },
+        'contenttypes.contenttype': {
+            'natural_key': ('app_label', 'model'),
+        },
+        'database.constance': {
+            'natural_key': ('key', ),
+        },
+        'feeder.bundle': {
+            'natural_key': ('shortname',),
+            'relations': {
+                'feeds': {
+                    'link': 'to_many',
+                    'resource': 'feeder.feed',
+                },
+            },
+        },
+        'feeder.feed': {
+            'natural_key': ('shortname',),
+        },
+        'search.filter': {
+            'natural_key': ('name', 'slug'),
+            'relations': {
+                'group': {
+                    'link': 'to_one',
+                    'resource': 'search.filtergroup'
+                },
+                'tags': {
+                    'link': 'to_many',
+                    'resource': 'taggit.tag'
+                },
+            },
+        },
+        'search.filtergroup': {
+            'natural_key': ('name', 'slug'),
+        },
+        'taggit.tag': {
+            'natural_key': ('name',),
+        },
+        'users.user': {
+            'natural_key': ('username',),
+            'relations': {
+                'groups': {
+                    'link': 'to_many',
+                    'resource': 'auth.group',
+                },
+            },
+            'filters': {
+                'password': 'make_password',
+            },
+        },
+        'users.userban': {
+            'natural_key': ('user', 'by'),
+            'relations': {
+                'user': {
+                    'link': 'to_one',
+                    'resource': 'users.user',
+                },
+                'by': {
+                    'link': 'to_one',
+                    'resource': 'users.user',
+                },
+            },
+        },
+        'waffle.flag': {
+            'natural_key': ('name',),
+        },
+        'waffle.switch': {
+            'natural_key': ('name',),
+        },
+    }
+
+    class NeedsDependency(Exception):
+        """A fixture has an un-resolved dependency."""
+        pass
+
+    def __init__(self, specification):
+        """Intialize with a specification dictionary."""
+        self.instances = {}
+        self.spec = self.parse_specification(specification)
+
+    def parse_specification(self, specification):
+        """Parse and validate the specification."""
+        parsed = {}
+        for model_id, items in specification.items():
+            # Parse and validate the model
+            metadata = self.model_metadata[model_id]
+            natural_key_spec = metadata['natural_key']
+            relations = metadata.get('relations', {})
+            filters = metadata.get('filters', {})
+            app_label, model_name = model_id.split('.')
+            assert apps.get_model(app_label, model_name)
+
+            parsed.setdefault(model_id, [])
+            for item_num, item in enumerate(items):
+                # Parse and validate the natural key
+                key = []
+                for name in natural_key_spec:
+                    relation = relations.get(name, {})
+                    try:
+                        value = item.pop(name)
+                    except KeyError:
+                        raise ValueError('%s %d: Needs key "%s"' %
+                                         (model_id, item_num, name))
+                    else:
+                        if relation:
+                            assert relation['link'] == 'to_one'
+                            key.append(tuple(value))
+                        else:
+                            key.append(value)
+
+                data = {
+                    'key': tuple(key),
+                    'fields': {},
+                    'relations': {},
+                }
+
+                # Parse and validate the remaining properties
+                for name, value in item.items():
+                    relation = relations.get(name, {})
+                    if relation:
+                        if relation['link'] == 'to_one':
+                            data['relations'][name] = tuple(value)
+                        else:
+                            assert relation['link'] == 'to_many'
+                            data['relations'][name] = [tuple(val) for val in value]
+                    elif name in filters:
+                        value_filter = getattr(self, filters[name])
+                        data['fields'][name] = value_filter(value)
+                    else:
+                        data['fields'][name] = value
+
+                parsed[model_id].append(data)
+        return parsed
+
+    def load(self):
+        """Load items until complete or progress stops."""
+        if not self.spec:
+            return
+        existing, loaded, pending = (0, 0, 0)
+        cycle = 0
+        while cycle == 0 or pending:
+            cycle += 1
+            last_counts = (existing, loaded, pending)
+            existing, loaded, pending = self.load_cycle()
+            logger.info("Fixtures cycle %d: %d existing, %d loaded,"
+                        " %d pending.", cycle, existing, loaded, pending)
+            if (existing, loaded, pending) == last_counts:
+                raise RuntimeError("Dependency block detected.")
+
+    def load_cycle(self):
+        """
+        Load as many items as we can this cycle.
+
+        Returns a tuple of counts:
+        * Existing items from previous cycles
+        * Items loaded this cycle
+        * Items that were unable to be loaded this cycle
+        """
+        existing, loaded, pending = 0, 0, 0
+        for model_id, items in self.spec.items():
+            metadata = self.model_metadata[model_id]
+            app_label, model_name = model_id.split('.')
+            Model = apps.get_model(app_label, model_name)
+
+            self.instances.setdefault(model_id, {})
+            for item in items:
+                if item['key'] in self.instances[model_id]:
+                    existing += 1
+                else:
+                    try:
+                        instance = self.load_item(item, Model, metadata)
+                    except self.NeedsDependency as nd:
+                        relation, key = nd.args
+                        logger.debug("%s %s requires %s %s",
+                                     model_id, item['key'],
+                                     relation['resource'], key)
+                        pending += 1
+                    else:
+                        self.instances[model_id][item['key']] = instance
+                        loaded += 1
+        return existing, loaded, pending
+
+    def load_item(self, item, Model, metadata):
+        """
+        Attempt to create or update an item.
+
+        Returns the instance if attempt suceeded, or None if related items are
+        needed.
+        """
+        natural_key_spec = metadata['natural_key']
+        relations = metadata.get('relations', {})
+
+        # Check for required relations in the natural key
+        for name, key in zip(natural_key_spec, item['key']):
+            relation = relations.get(name, {})
+            if relation:
+                instances = self.instances.get(relation['resource'], {})
+                if key not in instances:
+                    raise self.NeedsDependency(relation, key)
+
+        # Check for required relations in other properties
+        for name, value in item['relations'].items():
+            relation = relations[name]
+            if relation['link'] == 'to_one':
+                required = [value]
+            else:
+                required = value
+            instances = self.instances.get(relation['resource'], {})
+            for key in required:
+                if key not in instances:
+                    raise self.NeedsDependency(relation, key)
+
+        # Prepare the items in the key
+        key_dict = {}
+        for name, key in zip(natural_key_spec, item['key']):
+            relation = relations.get(name, {})
+            if relation:
+                rel = self.instances[relation['resource']][key]
+                key_dict[name] = rel
+            else:
+                key_dict[name] = key
+
+        # Prepare the other properties
+        defaults = item['fields'].copy()
+        for name, value in item['relations'].items():
+            relation = relations[name]
+            if relation['link'] == 'to_one':
+                rel = self.instances[relation['resource']][value]
+                defaults[name] = rel
+
+        # Get or create the new instance. Set the non-relation properties
+        # when creating an instance.
+        instance, created = Model.objects.get_or_create(
+            defaults=defaults, **key_dict)
+
+        # For existing instances, set the properties
+        if not created:
+            for name, value in item['fields'].items():
+                setattr(instance, name, value)
+            for name, value in item['relations'].items():
+                relation = relations[name]
+                if relation['link'] == 'to_one':
+                    rel = self.instances[relation['resource']][value]
+                    setattr(instance, name, rel)
+            instance.save()
+
+        # Set the relations for new and existing instances
+        for name, values in item['relations'].items():
+            relation = relations[name]
+            if relation['link'] == 'to_many':
+                for value in values:
+                    rel = self.instances[relation['resource']][value]
+                    getattr(instance, name).add(rel)
+
+        return instance
+
+    def make_password(self, password):
+        """Create a database hash for a password."""
+        return make_password(password)

--- a/kuma/scrape/management/commands/sample_mdn.py
+++ b/kuma/scrape/management/commands/sample_mdn.py
@@ -12,7 +12,7 @@ class Command(ScrapeCommand):
     def add_arguments(self, parser):
         parser.add_argument('spec',
                             metavar='specification.json',
-                            help=('Sample specification file'))
+                            help='Sample specification file')
         parser.add_argument('--host',
                             help=('Where to sample MDN from (default'
                                   ' "developer.mozilla.org")'),
@@ -24,12 +24,12 @@ class Command(ScrapeCommand):
                             dest='ssl')
 
     def handle(self, *arg, **options):
-        self.setup_logging(options.get('verbosity'))
+        self.setup_logging(options['verbosity'])
         host = options['host']
         ssl = options['ssl']
         scraper = self.make_scraper(host=host, ssl=ssl)
-        spec_file = open(options['spec'])
-        data = json.load(spec_file)
+        with open(options['spec']) as spec_file:
+            data = json.load(spec_file)
 
         # Load fixtures, which may include flags and settings
         fl = FixtureLoader(data.get('fixtures', {}))
@@ -51,4 +51,4 @@ class Command(ScrapeCommand):
                 incomplete += 1
         if incomplete:
             raise CommandError("%d source%s incomplete." %
-                               (incomplete, 's' if incomplete != 0 else ''))
+                               (incomplete, '' if incomplete == 1 else 's'))

--- a/kuma/scrape/management/commands/sample_mdn.py
+++ b/kuma/scrape/management/commands/sample_mdn.py
@@ -43,7 +43,11 @@ class Command(ScrapeCommand):
         incomplete = 0
         for name, source in sources.items():
             if source.state != source.STATE_DONE:
-                self.stderr.write("%s: %s\n" % (name, source.state))
+                if hasattr(source, 'error'):
+                    err = ' "%s"' % source.error
+                else:
+                    err = ''
+                self.stderr.write("%s: %s%s\n" % (name, source.state, err))
                 incomplete += 1
         if incomplete:
             raise CommandError("%d source%s incomplete." %

--- a/kuma/scrape/management/commands/scrape_document.py
+++ b/kuma/scrape/management/commands/scrape_document.py
@@ -1,5 +1,7 @@
 """Scrape a wiki document from a Kuma website."""
 
+from django.core.management.base import CommandError
+
 from . import ScrapeCommand
 
 
@@ -42,7 +44,7 @@ class Command(ScrapeCommand):
         scraper.scrape()
         source = scraper.sources['document:' + path]
         if source.state == source.STATE_ERROR:
-            raise Exception('Unable to scrape document "%s".' % path)
+            raise CommandError('Unable to scrape document "%s".' % path)
 
         elif source.freshness == source.FRESH_NO and not options['force']:
             self.stderr.write('Document "%s" already exists. Use --force to update.' % path)

--- a/kuma/scrape/management/commands/scrape_links.py
+++ b/kuma/scrape/management/commands/scrape_links.py
@@ -1,0 +1,40 @@
+"""Scrape all the data from the homepage, so that all the links will work."""
+from . import ScrapeCommand
+
+
+class Command(ScrapeCommand):
+    help = 'Scrape the pages linked from a page (default homepage).'
+
+    def add_arguments(self, parser):
+        """Add common arguments for scraping MDN."""
+        parser.add_argument('url',
+                            metavar='URL_OR_PATH',
+                            nargs='?',
+                            default='https://developer.mozilla.org/en-US/',
+                            help='URL or path to a wiki page')
+        parser.add_argument('--revisions',
+                            dest='revisions',
+                            metavar='REVS', type=int, default=1,
+                            help='Depth in revision history to scrape')
+        parser.add_argument('--translations',
+                            help='Include translations',
+                            action='store_true',
+                            dest='translations')
+        parser.add_argument('--depth',
+                            dest='depth',
+                            metavar='DEPTH', type=self.int_all_type, default=0,
+                            help=('Depth in the topic tree to scrape'
+                                  ' ("all" for all)'))
+
+    def handle(self, *arg, **options):
+        self.setup_logging(options['verbosity'])
+        host, ssl, path = self.parse_url_or_path(options['url'])
+        scraper = self.make_scraper(host=host, ssl=ssl)
+
+        params = {}
+        for param in ('translations', 'revisions', 'depth'):
+            if options[param]:
+                params[param] = options[param]
+        scraper.add_source("links", path, **params)
+
+        scraper.scrape()

--- a/kuma/scrape/management/commands/scrape_links.py
+++ b/kuma/scrape/management/commands/scrape_links.py
@@ -1,4 +1,6 @@
-"""Scrape all the data from the homepage, so that all the links will work."""
+"""Scrape document links found on a MDN page, so that all the links will work."""
+from django.core.management.base import CommandError
+
 from . import ScrapeCommand
 
 
@@ -38,3 +40,6 @@ class Command(ScrapeCommand):
         scraper.add_source("links", path, **params)
 
         scraper.scrape()
+        source = scraper.sources['links:' + path]
+        if source.state == source.STATE_ERROR:
+            raise CommandError('Unable to scrape links on "%s".' % path)

--- a/kuma/scrape/management/commands/scrape_user.py
+++ b/kuma/scrape/management/commands/scrape_user.py
@@ -1,5 +1,5 @@
 """Scrape a user profile from a Kuma website."""
-
+from django.core.management.base import CommandError
 
 from . import ScrapeCommand
 
@@ -46,6 +46,6 @@ class Command(ScrapeCommand):
         scraper.scrape()
         source = scraper.sources['user:' + profile]
         if source.state == source.STATE_ERROR:
-            raise Exception('Unable to scrape user "%s".' % profile)
+            raise CommandError('Unable to scrape user "%s".' % profile)
         elif source.freshness == source.FRESH_NO and not options['force']:
             self.stderr.write('User "%s" already exists. Use --force to update.' % profile)

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -114,7 +114,8 @@ class Scraper(object):
                     'complete, freshness=%(freshness)s, with %(dep_count)s'
                     ' dependant source%(dep_s)s.')
     _report_error = (_report_prefix +
-                     'errored, with %(dep_count)s dependant source%(dep_s)s.')
+                     'errored %(err_msg)s, with %(dep_count)s dependant'
+                     ' source%(dep_s)s.')
     _report_progress = (_report_prefix +
                         'in state "%(state)s" with %(dep_count)s dependant'
                         ' source%(dep_s)s.')
@@ -161,17 +162,22 @@ class Scraper(object):
                                     source_key)
 
                 # Detect unfinished work and report on changed state (in debug)
+                log_func = logger.debug
+                err_msg = ""
                 if source.state == Source.STATE_DONE:
-                    msg = self._report_done
+                    log_fmt = self._report_done
                 elif source.state == Source.STATE_ERROR:
-                    msg = self._report_error
+                    log_func = logger.warn
+                    err_msg = '"%s"' % source.error
+                    log_fmt = self._report_error
                 else:
                     repeat = True
-                    msg = self._report_progress
-                logger.debug(msg, {'cycle': cycle,
+                    log_fmt = self._report_progress
+                log_func(log_fmt, {'cycle': cycle,
                                    'source_num': source_num,
                                    'source_total': source_total,
                                    'source_key': source_key,
+                                   'err_msg': err_msg,
                                    'state': source.state,
                                    'freshness': source.freshness,
                                    'dep_count': dep_count,

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -8,9 +8,9 @@ import time
 import requests
 
 from .sources import (
-    DocumentChildrenSource, DocumentHistorySource, DocumentMetaSource,
-    DocumentRenderedSource, DocumentSource, LinksSource, RevisionSource,
-    Source, UserSource, ZoneRootSource)
+    DocumentChildrenSource, DocumentCurrentSource, DocumentHistorySource,
+    DocumentMetaSource, DocumentRenderedSource, DocumentSource, LinksSource,
+    RevisionSource, Source, UserSource, ZoneRootSource)
 from .storage import Storage
 
 logger = logging.getLogger('kuma.scraper')
@@ -67,6 +67,7 @@ class Scraper(object):
     source_types = {
         'document': DocumentSource,
         'document_children': DocumentChildrenSource,
+        'document_current': DocumentCurrentSource,
         'document_history': DocumentHistorySource,
         'document_meta': DocumentMetaSource,
         'document_rendered': DocumentRenderedSource,

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -113,12 +113,12 @@ class Scraper(object):
                       ' Source %(source_key)s ')
     _report_done = (_report_prefix +
                     'complete, freshness=%(freshness)s, with %(dep_count)s'
-                    ' dependant source%(dep_s)s.')
+                    ' dependent source%(dep_s)s.')
     _report_error = (_report_prefix +
-                     'errored %(err_msg)s, with %(dep_count)s dependant'
+                     'errored %(err_msg)s, with %(dep_count)s dependent'
                      ' source%(dep_s)s.')
     _report_progress = (_report_prefix +
-                        'in state "%(state)s" with %(dep_count)s dependant'
+                        'in state "%(state)s" with %(dep_count)s dependent'
                         ' source%(dep_s)s.')
 
     def scrape(self):

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -9,8 +9,8 @@ import requests
 
 from .sources import (
     DocumentChildrenSource, DocumentHistorySource, DocumentMetaSource,
-    DocumentRenderedSource, DocumentSource, RevisionSource, Source, UserSource,
-    ZoneRootSource)
+    DocumentRenderedSource, DocumentSource, LinksSource, RevisionSource,
+    Source, UserSource, ZoneRootSource)
 from .storage import Storage
 
 logger = logging.getLogger('kuma.scraper')
@@ -70,6 +70,7 @@ class Scraper(object):
         'document_history': DocumentHistorySource,
         'document_meta': DocumentMetaSource,
         'document_rendered': DocumentRenderedSource,
+        'links': LinksSource,
         'revision': RevisionSource,
         'user': UserSource,
         'zone_root': ZoneRootSource,

--- a/kuma/scrape/sources/__init__.py
+++ b/kuma/scrape/sources/__init__.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 from .base import DocumentBaseSource, Source
 from .document import DocumentSource
 from .document_children import DocumentChildrenSource
+from .document_current import DocumentCurrentSource
 from .document_history import DocumentHistorySource
 from .document_meta import DocumentMetaSource
 from .document_rendered import DocumentRenderedSource
@@ -15,6 +16,7 @@ from .zone_root import ZoneRootSource
 __all__ = [
     DocumentBaseSource,
     DocumentChildrenSource,
+    DocumentCurrentSource,
     DocumentHistorySource,
     DocumentMetaSource,
     DocumentRenderedSource,

--- a/kuma/scrape/sources/__init__.py
+++ b/kuma/scrape/sources/__init__.py
@@ -7,6 +7,7 @@ from .document_children import DocumentChildrenSource
 from .document_history import DocumentHistorySource
 from .document_meta import DocumentMetaSource
 from .document_rendered import DocumentRenderedSource
+from .links import LinksSource
 from .revision import RevisionSource
 from .user import UserSource
 from .zone_root import ZoneRootSource
@@ -18,6 +19,7 @@ __all__ = [
     DocumentMetaSource,
     DocumentRenderedSource,
     DocumentSource,
+    LinksSource,
     RevisionSource,
     Source,
     UserSource,

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -1,12 +1,9 @@
 """Shared interface for data sources."""
 from __future__ import absolute_import, unicode_literals
-import logging
 import re
 
 from django.utils.six import binary_type, text_type, python_2_unicode_compatible
 from django.utils.six.moves.urllib.parse import unquote
-
-logger = logging.getLogger('kuma.scraper')
 
 
 class Source(object):
@@ -162,7 +159,7 @@ class Source(object):
             try:
                 load_return = self.load_and_validate_existing(storage)
             except self.SourceError as error:
-                logger.warn(error.format, *error.format_args)
+                self.error = error
                 self.state = self.STATE_ERROR
             else:
                 has_existing, next_sources = load_return
@@ -177,7 +174,7 @@ class Source(object):
             try:
                 has_prereqs, data = self.load_prereqs(requester, storage)
             except self.SourceError as error:
-                logger.warn(error.format, *error.format_args)
+                self.error = error
                 self.state = self.STATE_ERROR
             else:
                 if has_prereqs:
@@ -186,7 +183,7 @@ class Source(object):
                     try:
                         next_sources = self.save_data(storage, data)
                     except self.SourceError as error:
-                        logger.warn(error.format, *error.format_args)
+                        self.error = error
                         self.state = self.STATE_ERROR
                     else:
                         self.state = self.STATE_DONE

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -234,4 +234,5 @@ class DocumentSource(DocumentBaseSource):
                     doc_data['locale'], self.path)
                 doc_data['locale'] = self.locale
         storage.save_document(doc_data)
-        return []
+        return [('document_current', self.normalized_path,
+                 {'revisions': self.revisions})]

--- a/kuma/scrape/sources/document_current.py
+++ b/kuma/scrape/sources/document_current.py
@@ -1,0 +1,63 @@
+"""DocumentCurrent checks that the current revision is scraped."""
+from __future__ import absolute_import, unicode_literals
+import logging
+
+from .base import DocumentBaseSource
+from .revision import RevisionSource
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class DocumentCurrentSource(DocumentBaseSource):
+    """
+    Ensure the current revision is scraped.
+
+    For some documents, such as page moves, the latest revision is not the
+    current revision. Usually the second-to-latest is.
+    """
+
+    OPTIONS = {
+        'revisions': ('int', 1),  # Scrape this many past revisions
+    }
+
+    def load_prereqs(self, requester, storage):
+        """Check if current revision is in loaded revisions."""
+        doc = storage.get_document(self.locale, self.slug)
+        if doc and doc.current_revision:
+            return True, []  # Document has a current revision, we're done
+
+        # Are all the requested revisions loaded?
+        data = storage.get_document_history(self.locale, self.slug)
+        if not data:
+            return False, {'needs': [('document_history', self.path,
+                                      {'revisions': self.revisions})]}
+        needed = []
+        for src_type, href, params in data['revisions'][:self.revisions]:
+            locale, slug, rev_id = RevisionSource.split_path(href)
+            rev = storage.get_revision(rev_id)
+            if rev is None:
+                needed.append((src_type, href, params))
+        if needed:
+            return False, {'needs': needed}  # Wait for revisions to load
+        if data['is_all']:
+            raise self.SourceError('No current_revision found for document.')
+
+        # Ask for one more revision for the document
+        # The common case is that the second-to-most-recent revision is the
+        # current revision (just before a page move)
+        next_srcs = [
+            ('document', self.path, {'revisions': self.revisions + 1})]
+
+        if len(data['revisions']) > self.revisions:
+            # Pre-request the next revision, to help avoid dependency block
+            next_srcs.append(data['revisions'][self.revisions])
+        else:
+            # Pre-request 2x revisions, to avoid dependency block detection
+            # and avoid Shlemiel the painter's algorithm.
+            next_srcs.append(('document_history', self.path,
+                              {'revisions': len(data['revisions']) * 2}))
+        return False, {'needs': next_srcs}
+
+    def save_data(self, storage, data):
+        """Nothing to save for this source, no next sources."""
+        return []

--- a/kuma/scrape/sources/document_history.py
+++ b/kuma/scrape/sources/document_history.py
@@ -25,9 +25,9 @@ class DocumentHistorySource(DocumentBaseSource):
 
     def load_and_validate_existing(self, storage):
         """Load history data from a previous operation."""
-        revs = storage.get_document_history(self.locale, self.slug)
-        if revs and len(revs) >= self.revisions:
-            requested_revisions = revs[:self.revisions]
+        data = storage.get_document_history(self.locale, self.slug)
+        if data and len(data['revisions']) >= self.revisions:
+            requested_revisions = data['revisions'][:self.revisions]
             requested_revisions.reverse()
             return True, requested_revisions
         else:
@@ -45,7 +45,9 @@ class DocumentHistorySource(DocumentBaseSource):
     def save_data(self, storage, data):
         """Extract revisions and save for next call."""
         revs = self.extract_data(data)
-        storage.save_document_history(self.locale, self.slug, revs)
+        is_all = len(revs) < self.revisions
+        data = {'revisions': revs, 'is_all': is_all}
+        storage.save_document_history(self.locale, self.slug, data)
         requested_revisions = revs[:self.revisions]
         requested_revisions.reverse()
         return requested_revisions

--- a/kuma/scrape/sources/document_rendered.py
+++ b/kuma/scrape/sources/document_rendered.py
@@ -29,7 +29,10 @@ class DocumentRenderedSource(DocumentBaseSource):
 
     def load_prereqs(self, requester, storage):
         """Request the document, and process the redirects and response."""
-        response = requester.request(self.source_path())
+        response = requester.request(self.source_path(),
+                                     raise_for_status=False)
+        if response.status_code not in (200, 301, 302):
+            raise self.SourceError('status_code %s', response.status_code)
         data = {}
 
         # Is this a redirect?

--- a/kuma/scrape/sources/links.py
+++ b/kuma/scrape/sources/links.py
@@ -1,0 +1,98 @@
+"""LinksSource gathers wiki document links from a rendered page."""
+
+from __future__ import absolute_import, unicode_literals
+import logging
+
+from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlparse
+from pyquery import PyQuery as pq
+
+from .base import Source
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class LinksSource(Source):
+    """Gather document links from a rendered page for scraping.
+
+    Links are scraped from the header, footer, and content. Links that look
+    like documents are queued for download. This will not include the current
+    page, which should be requested with a DocumentSource if applicable.
+    """
+
+    OPTIONS = {
+        'depth': ('int_all', 0),          # Scrape the topic tree to this depth
+        'revisions': ('int', 1),          # Scrape this many past revisions
+        'translations': ('bool', False),  # Scrape the alternate translations
+    }
+
+    PARAM_NAME = 'path'
+
+    ignored_slugs = set((
+        'dashboards',
+        'search',
+        'users/signin',
+    ))
+
+    def __init__(self, path=None, **options):
+        """Process and validate the initial path."""
+        if (not path) or (path == '/'):
+            path = '/en-US/'  # Default to English homepage
+        path = urlparse(path).path
+        assert path.startswith('/')
+        self.locale = urlparse(path).path.split('/')[1]
+        assert self.locale in settings.MDN_LANGUAGES
+        super(LinksSource, self).__init__(path, **options)
+
+    def load_prereqs(self, requester, storage):
+        """Request the page and gather document links."""
+        response = requester.request(self.path)
+        parsed = pq(response.content)
+        options = self.current_options()
+        requirements = []
+        seen_paths = set()
+
+        for link in parsed('a'):
+            doc_path = self.doc_path_for_href(link.attrib.get('href', ''))
+            if doc_path and doc_path not in seen_paths:
+                seen_paths.add(doc_path)
+                requirements.append(('document', doc_path, options))
+
+        return True, requirements
+
+    def doc_path_for_href(self, href):
+        """
+        Return a Document path for the given <a href="url">.
+
+        If the href doesn't look like a wiki document, then return None.
+        """
+        href = self.decode_href(href)
+        path = urlparse(href).path
+
+        # Strip trailing slashes
+        if path.endswith('/'):
+            path = path[:-1]
+
+        # Skip anchors and non-absolute links
+        # The URLAbsolutionFilter should convert to absolute links
+        if not path.startswith('/'):
+            return
+
+        # Skip API endpoints
+        if '$' in path:
+            return
+
+        # Skip other locales, non-translated pages, and the homepage
+        if not path.startswith('/' + self.locale + '/'):
+            return
+
+        # Skip known non-wiki documents
+        slug = path.split('/', 2)[2]
+        if any([slug.startswith(ignore) for ignore in self.ignored_slugs]):
+            return
+
+        return path
+
+    def save_data(self, storage, data):
+        """Return the links on the page as post-sources."""
+        return data

--- a/kuma/scrape/sources/links.py
+++ b/kuma/scrape/sources/links.py
@@ -41,7 +41,7 @@ class LinksSource(Source):
             path = '/en-US/'  # Default to English homepage
         path = urlparse(path).path
         assert path.startswith('/')
-        self.locale = urlparse(path).path.split('/')[1]
+        self.locale = path.split('/')[1]
         assert self.locale in settings.MDN_LANGUAGES
         super(LinksSource, self).__init__(path, **options)
 

--- a/kuma/scrape/sources/links.py
+++ b/kuma/scrape/sources/links.py
@@ -30,6 +30,7 @@ class LinksSource(Source):
 
     ignored_slugs = set((
         'dashboards',
+        'profiles',
         'search',
         'users/signin',
     ))

--- a/kuma/scrape/sources/revision.py
+++ b/kuma/scrape/sources/revision.py
@@ -36,9 +36,10 @@ class RevisionSource(Source):
             logger.warn(exception)
             self.state = self.STATE_ERROR
 
-    def split_path(self, path):
+    @classmethod
+    def split_path(cls, path):
         """Extract a revision parameters from a path."""
-        match = self.re_path.match(path)
+        match = cls.re_path.match(path)
         if match:
             locale, slug, raw_rev_id = match.groups()
             return locale, slug, int(raw_rev_id)

--- a/kuma/scrape/storage.py
+++ b/kuma/scrape/storage.py
@@ -164,7 +164,10 @@ class Storage(object):
         localization_tags = data.pop('localization_tags', [])
         revision, created = Revision.objects.get_or_create(
             id=revision_id,
-            defaults={'creator': creator, 'document': document})
+            defaults={'creator': creator,
+                      'document': document,
+                      'is_approved': False,  # Don't make current rev
+                      })
         for name, value in data.items():
             setattr(revision, name, value)
         revision.content = revision.content or ""

--- a/kuma/scrape/tests/conftest.py
+++ b/kuma/scrape/tests/conftest.py
@@ -33,12 +33,12 @@ def root_doc(simple_doc, simple_user):
         content='<p>Getting started...</p>',
         title='Root Document',
         created=datetime(2016, 1, 1))
-    simple_doc.current_revision = Revision.objects.create(
+    current_rev = Revision.objects.create(
         document=simple_doc,
         creator=simple_user,
         content='<p>The root document.</p>',
         created=datetime(2016, 2, 1))
-    simple_doc.save()
+    assert simple_doc.current_revision == current_rev
     return simple_doc
 
 
@@ -50,7 +50,7 @@ def translated_doc(root_doc):
         slug='Racine',
         locale='fr',
         title='Document Racine')
-    revision = Revision.objects.create(
+    current_rev = Revision.objects.create(
         document=translated_doc,
         content='<p>Commencer...</p>',
         title='Document Racine',
@@ -58,6 +58,5 @@ def translated_doc(root_doc):
         based_on=root_doc.current_revision,
         creator=root_doc.current_revision.creator,
         created=datetime(2017, 6, 1, 15, 28))
-    translated_doc.current_revision = revision
-    translated_doc.save()
+    assert translated_doc.current_revision == current_rev
     return translated_doc

--- a/kuma/scrape/tests/test_fixture.py
+++ b/kuma/scrape/tests/test_fixture.py
@@ -1,0 +1,161 @@
+import pytest
+
+from django.contrib.auth.models import Group, Permission
+from django.contrib.contenttypes.models import ContentType
+
+from kuma.scrape.fixture import FixtureLoader
+from kuma.users.models import User, UserBan
+from constance import config
+
+
+def test_empty_fixtures():
+    """A empty specification is OK, does nothing."""
+    FixtureLoader({}).load()
+
+
+@pytest.mark.django_db
+def test_load_constance():
+    """A fixture without dependencies is loaded."""
+    spec = {
+        'database.constance': [{
+            'key': 'KUMASCRIPT_MAX_AGE', 'value': 321
+        }]}
+    FixtureLoader(spec).load()
+    config._backend._cache = None  # Avoid cached config value
+    assert config.KUMASCRIPT_MAX_AGE == 321
+
+
+@pytest.mark.django_db
+def test_load_group():
+    """A fixture with existing to-many dependencies is loaded."""
+    spec = {
+        'auth.group': [{
+            'name': 'Attachment Moderators',
+            'permissions': [
+                ['change_attachment']
+            ]
+        }],
+        'auth.permission': [{
+            'codename': 'change_attachment',
+            'name': 'Can change attachment',
+            'content_type': ['attachments', 'attachment']
+        }],
+        'contenttypes.contenttype': [{
+            'app_label': 'attachments',
+            'model': 'attachment',
+        }]
+    }
+    ct_attachment = ContentType.objects.get(
+        app_label='attachments', model='attachment')
+    perm_attachment = Permission.objects.get(
+        content_type=ct_attachment, codename='change_attachment')
+    group_query = Group.objects.filter(name='Attachment Moderators')
+    assert not group_query.exists()
+
+    FixtureLoader(spec).load()
+
+    group = group_query.get()
+    assert list(group.permissions.all()) == [perm_attachment]
+
+
+def test_underspecified_key_is_error():
+    """A fixture must define all the natural key items."""
+    spec = {
+        'users.user': [{
+            'email': 'email@example.com',
+            'password': 'password',
+        }]
+    }
+    with pytest.raises(ValueError) as error:
+        FixtureLoader(spec)
+    assert str(error.value) == 'users.user 0: Needs key "username"'
+
+
+@pytest.mark.django_db
+def test_relation_as_key():
+    """A fixture with a relation as a key can be loaded."""
+    spec = {
+        'users.user': [{
+            'username': 'admin',
+            'is_staff': True
+        }, {
+            'username': 'spammer',
+        }],
+        'users.userban': [{
+            'user': ['spammer'],
+            'by': ['admin'],
+            'reason': 'Spam'
+        }]
+    }
+    FixtureLoader(spec).load()
+    ban = UserBan.objects.get()
+    assert ban.user.username == 'spammer'
+    assert ban.by.username == 'admin'
+
+
+@pytest.mark.django_db
+def test_update_m2m_of_existing_instance():
+    """Many-to-many relations of existing instances are updated."""
+    user = User.objects.create(username='ironman')
+    assert not user.groups.exists()
+    spec = {
+        'auth.group': [{
+            'name': 'Avengers',
+        }, {
+            'name': 'Illuminati',
+        }],
+        'users.user': [{
+            'username': 'ironman',
+            'is_staff': True,
+            'groups': [['Avengers'], ['Illuminati']]
+        }]
+    }
+    FixtureLoader(spec).load()
+    user.refresh_from_db()
+    new_groups = list(sorted(user.groups.values_list('name', flat=True)))
+    assert new_groups == ['Avengers', 'Illuminati']
+
+
+def test_missing_relation_is_error():
+    """An unspecified relation is detected, raises exception."""
+    spec = {
+        'users.user': [{
+            'username': 'captain_america',
+            'groups': [['SHIELD']]
+        }]
+    }
+    with pytest.raises(RuntimeError) as error:
+        FixtureLoader(spec).load()
+    assert str(error.value) == 'Dependency block detected.'
+
+
+@pytest.mark.django_db
+def test_missing_key_relation_is_error():
+    """An unspecified relation is detected, raises exception."""
+    spec = {
+        'users.user': [{
+            'username': 'odin',
+        }],
+        'users.userban': [{
+            'user': ['loki'],
+            'by': ['odin'],
+            'reason': 'Treason'
+        }]
+    }
+    with pytest.raises(RuntimeError) as error:
+        FixtureLoader(spec).load()
+    assert str(error.value) == 'Dependency block detected.'
+
+
+@pytest.mark.django_db
+def test_user_password():
+    """A user.password is hashed."""
+    spec = {
+        'users.user': [{
+            'username': 'wagstaff',
+            'password': 'swordfish'
+        }]
+    }
+    FixtureLoader(spec).load()
+    user = User.objects.get(username='wagstaff')
+    assert user.check_password('swordfish')

--- a/kuma/scrape/tests/test_source_document.py
+++ b/kuma/scrape/tests/test_source_document.py
@@ -138,7 +138,7 @@ def test_gather_standard_doc_all_prereqs():
     storage.get_document_history.return_value = [
         ('revisions', path + '$revision/2016', {})]
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     storage.save_document.assert_called_once_with(doc_data)
 
@@ -158,7 +158,7 @@ def test_gather_standard_doc_metdata_loses():
     storage.get_document_history.return_value = [
         ('revisions', path + '$revision/2016', {})]
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     storage.save_document.assert_called_once_with(doc_data)
 
@@ -195,7 +195,7 @@ def test_gather_standard_doc_no_uuid():
         ('revisions', path + '$revision/2016', {})]
 
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     expected = doc_data.copy()
     del expected['uuid']
@@ -266,7 +266,8 @@ def test_gather_normalized_path_moved_page_followed():
         'redirect_to': '/en-US/docs/NewLocation'}
     storage.get_document.return_value = "Redirect Document"
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', '/en-US/docs/Origin',
+                          {'revisions': 1})]
     assert source.state == source.STATE_DONE
     expected_data = {
         'locale': 'en-US',
@@ -329,7 +330,7 @@ def test_gather_redirect_to_zone_page_complete():
     storage.get_document_history.return_value = [
         ('revisions', path + '$revision/2017', {})]
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     expected = doc_data.copy()
     expected['slug'] = 'Root/Zone'
@@ -382,7 +383,7 @@ def test_gather_redirect_to_zone_subpage_complete():
     storage.get_document_history.return_value = [
         ('revisions', path + '$revision/2018', {})]
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     expected = doc_data.copy()
     expected['slug'] = 'Root/Zone/Child'
@@ -475,7 +476,7 @@ def test_gather_localized_doc_sets_parent():
     storage.get_document_history.return_value = [
         ('revisions', path + '$revision/2020', {})]
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     expected = doc_data.copy()
     expected['locale'] = 'fr'
@@ -517,6 +518,6 @@ def test_gather_document_children_loaded():
         ('revisions', doc_path + '$revision/2016', {})]
     storage.get_document_children.return_value = []
     resources = source.gather(None, storage)
-    assert resources == []
+    assert resources == [('document_current', doc_path, {'revisions': 1})]
     assert source.state == source.STATE_DONE
     assert source.freshness == source.FRESH_YES

--- a/kuma/scrape/tests/test_source_document_current.py
+++ b/kuma/scrape/tests/test_source_document_current.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentCurrentSource class (document.current_revision)."""
+from __future__ import unicode_literals
+
+import mock
+
+from kuma.scrape.sources import DocumentCurrentSource
+from . import mock_storage
+
+
+def test_gather_has_current(root_doc):
+    """If document.current_revision is set, we're done."""
+    storage = mock_storage(spec=['get_document'])
+    storage.get_document.return_value = root_doc
+    source = DocumentCurrentSource(root_doc.get_absolute_url())
+
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+
+
+def test_gather_needs_to_scrape_history(root_doc):
+    """If the document history is unavailable, wait."""
+    root_doc.current_revision = None
+    root_doc.save()
+    root_url = root_doc.get_absolute_url()
+    storage = mock_storage(spec=['get_document', 'get_document_history'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_history.return_value = None
+    source = DocumentCurrentSource(root_url)
+
+    resources = source.gather(None, storage)
+    assert resources == [('document_history', root_url, {'revisions': 1})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    storage.get_document_history.assert_called_once_with(root_doc.locale,
+                                                         root_doc.slug)
+
+
+def test_gather_needs_to_scrape_revision(root_doc):
+    """If a revision was requested but not scraped, wait."""
+    root_doc.current_revision = None
+    root_doc.save()
+    rev1, rev2 = root_doc.revisions.all()
+    storage = mock_storage(spec=['get_document', 'get_document_history',
+                                 'get_revision'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_history.return_value = {
+        'is_all': False,
+        'revisions': [
+            ('revision', rev1.get_absolute_url(), {}),
+            ('revision', rev2.get_absolute_url(), {})]}
+    storage.get_revision.return_value = None
+    source = DocumentCurrentSource(root_doc.get_absolute_url())
+
+    resources = source.gather(None, storage)
+    assert resources == [('revision', rev1.get_absolute_url(), {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    storage.get_revision.assert_called_once_with(rev1.id)
+
+
+def test_gather_needs_to_scrape_more_revisions(root_doc):
+    """If a revision was included in history but not scraped, request it."""
+    root_doc.current_revision = None
+    root_doc.save()
+    rev1, rev2 = root_doc.revisions.all()
+    storage = mock_storage(spec=['get_document', 'get_document_history',
+                                 'get_revision'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_history.return_value = {
+        'is_all': False,
+        'revisions': [
+            ('revision', rev1.get_absolute_url(), {}),
+            ('revision', rev2.get_absolute_url(), {})]}
+    storage.get_revision.return_value = rev1
+    source = DocumentCurrentSource(root_doc.get_absolute_url())
+
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', '/en-US/docs/Root', {'revisions': 2}),
+        ('revision', rev2.get_absolute_url(), {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    storage.get_revision.assert_called_once_with(rev1.id)
+
+
+def test_gather_needs_to_scrape_more_history(root_doc):
+    """If we've scraped all the known revisions, request more history."""
+    root_doc.current_revision = None
+    root_doc.save()
+    root_url = root_doc.get_absolute_url()
+    rev1, rev2 = root_doc.revisions.all()
+    storage = mock_storage(spec=['get_document', 'get_document_history',
+                                 'get_revision'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_history.return_value = {
+        'is_all': False,
+        'revisions': [
+            ('revision', rev1.get_absolute_url(), {}),
+            ('revision', rev2.get_absolute_url(), {})]}
+    storage.get_revision.return_value = rev1
+    source = DocumentCurrentSource(root_url, revisions=2)
+
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', root_url, {'revisions': 3}),
+        ('document_history', root_url, {'revisions': 4})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    assert storage.get_revision.mock_calls == [
+        mock.call(rev1.id), mock.call(rev2.id)]
+
+
+def test_gather_no_more_history_to_scrape(root_doc):
+    """If a doc has no current rev, scrape all history and fail."""
+    root_doc.current_revision = None
+    root_doc.save()
+    root_url = root_doc.get_absolute_url()
+    rev1, rev2 = root_doc.revisions.all()
+    storage = mock_storage(spec=['get_document', 'get_document_history',
+                                 'get_revision'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_history.return_value = {
+        'is_all': True,
+        'revisions': [
+            ('revision', rev1.get_absolute_url(), {}),
+            ('revision', rev2.get_absolute_url(), {})]}
+    storage.get_revision.return_value = rev1
+    source = DocumentCurrentSource(root_url, revisions=2)
+
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_UNKNOWN

--- a/kuma/scrape/tests/test_source_document_history.py
+++ b/kuma/scrape/tests/test_source_document_history.py
@@ -24,10 +24,13 @@ def test_gather_revisions_default(root_doc, client):
         ('revision', revision_pattern % rev.id, {}) for rev in [rev2]]
     assert resources == expected_resources
     assert source.state == source.STATE_DONE
-    expected_stored = [
-        ('revision', revision_pattern % rev.id, {}) for rev in [rev2, rev1]]
+    expected_data = {
+        'is_all': False,
+        'revisions': [
+            ('revision', revision_pattern % rev2.id, {}),
+            ('revision', revision_pattern % rev1.id, {})]}
     storage.save_document_history.assert_called_once_with(
-        'en-US', 'Root', expected_stored)
+        'en-US', 'Root', expected_data)
 
 
 def test_gather_revisions_multiple(root_doc, client):
@@ -48,8 +51,36 @@ def test_gather_revisions_multiple(root_doc, client):
         ('revision', revision_pattern % rev.id, {}) for rev in [rev1, rev2]]
     assert resources == expected_resources
     assert source.state == source.STATE_DONE
+    expected_data = {
+        'is_all': False,
+        'revisions': expected_resources[::-1]}
     storage.save_document_history.assert_called_once_with(
-        'en-US', 'Root', expected_resources[::-1])
+        'en-US', 'Root', expected_data)
+
+
+def test_gather_revisions_more_than_available(root_doc, client):
+    """If a revision count is more than the revisions, take note."""
+    path = root_doc.get_absolute_url()
+    source = DocumentHistorySource(path, revisions=3)
+    html = client.get(path + '$history').content
+    requester = mock_requester(content=html, status_code=200)
+    storage = mock_storage(spec=[
+        'get_document_history', 'save_document_history'])
+    resources = source.gather(requester, storage)
+    history_path = path + '$history?limit=3'
+    requester.request.assert_called_once_with(history_path,
+                                              raise_for_status=False)
+    rev1, rev2 = root_doc.revisions.all()
+    revision_pattern = path + '$revision/%d'
+    expected_resources = [
+        ('revision', revision_pattern % rev.id, {}) for rev in [rev1, rev2]]
+    assert resources == expected_resources
+    assert source.state == source.STATE_DONE
+    expected_data = {
+        'is_all': True,
+        'revisions': expected_resources[::-1]}
+    storage.save_document_history.assert_called_once_with(
+        'en-US', 'Root', expected_data)
 
 
 def test_gather_error():
@@ -68,9 +99,11 @@ def test_gather_rev_existing():
     """If previously called, populate history from storage."""
     source = DocumentHistorySource('/en-US/docs/Root')
     storage = mock_storage(spec=['get_document_history'])
-    storage.get_document_history.return_value = [
-        ('revision', '/en-US/docs/Root$revision/%d' % num, {})
-        for num in range(10, 1, -1)]
+    storage.get_document_history.return_value = {
+        'is_all': False,
+        'revisions': [
+            ('revision', '/en-US/docs/Root$revision/%d' % num, {})
+            for num in range(10, 1, -1)]}
     resources = source.gather(None, storage)
     assert resources == [('revision', '/en-US/docs/Root$revision/10', {})]
     assert source.state == source.STATE_DONE
@@ -94,5 +127,8 @@ def test_gather_translated(translated_doc, client):
     expected_resources = [('revision', rev_path, {'based_on': based_on_path})]
     assert resources == expected_resources
     assert source.state == source.STATE_DONE
+    expected_data = {
+        'is_all': False,
+        'revisions': expected_resources}
     storage.save_document_history.assert_called_once_with(
-        'fr', 'Racine', expected_resources)
+        'fr', 'Racine', expected_data)

--- a/kuma/scrape/tests/test_source_document_rendered.py
+++ b/kuma/scrape/tests/test_source_document_rendered.py
@@ -58,6 +58,7 @@ def test_root_doc(root_doc, client):
     storage = mock_storage(spec=['save_document_rendered'])
     resources = source.gather(requester, storage)
     assert resources == []
+    assert source.state == source.STATE_DONE
     storage.save_document_rendered.assert_called_once_with(
         'en-US', 'Root', {})
 
@@ -73,13 +74,14 @@ def test_non_zone_redirect(root_doc, client):
     html = client.get(url).content
     source = DocumentRenderedSource(url)
     requester = mock_requester(
-        response_spec=['content', 'history', 'url'],
+        response_spec=['content', 'history', 'status_code', 'url'],
         history=[(301, url)],
         final_path=url,
         content=html)
     storage = mock_storage(spec=['save_document_rendered'])
     resources = source.gather(requester, storage)
     assert resources == []
+    assert source.state == source.STATE_DONE
     storage.save_document_rendered.assert_called_once_with(
         'en-US', 'Root', {})
 
@@ -90,13 +92,14 @@ def test_zone_root_doc(zone_root_doc, client):
     html = client.get(url, follow=True).content
     source = DocumentRenderedSource(url)
     requester = mock_requester(
-        response_spec=['content', 'history', 'url'],
+        response_spec=['content', 'history', 'status_code', 'url'],
         history=[(302, url)],
         final_path=zone_root_doc.zone.url_root,
         content=html)
     storage = mock_storage(spec=['save_document_rendered'])
     resources = source.gather(requester, storage)
     assert resources == []
+    assert source.state == source.STATE_DONE
     context = {
         'redirect_to': 'Zone',
         'is_zone_root': True,
@@ -111,13 +114,29 @@ def test_zone_child_doc(zone_root_doc, zone_child_doc, client):
     html = client.get(url, follow=True).content
     source = DocumentRenderedSource(url)
     requester = mock_requester(
-        response_spec=['content', 'history', 'url'],
+        response_spec=['content', 'history', 'status_code', 'url'],
         history=[(302, url)],
         final_path=zone_root_doc.zone.url_root,
         content=html)
     storage = mock_storage(spec=['save_document_rendered'])
     resources = source.gather(requester, storage)
     assert resources == []
+    assert source.state == source.STATE_DONE
     context = {'redirect_to': 'Zone'}
     storage.save_document_rendered.assert_called_once_with(
         'en-US', 'Root/Zone/Child', context)
+
+
+def test_missing_doc(client):
+    """
+    A missing document results in an error.
+
+    One cause: translations are requested, and a recently deleted
+    translation is in the metadata.
+    """
+    source = DocumentRenderedSource('/en-US/docs/missing')
+    requester = mock_requester(status_code=404)
+    storage = mock_storage()
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR

--- a/kuma/scrape/tests/test_source_document_rendered.py
+++ b/kuma/scrape/tests/test_source_document_rendered.py
@@ -23,11 +23,12 @@ def zone_root_doc(root_doc, settings):
         document=doc,
         url_root='Zone',
         css_slug='special')
-    doc.current_revision = Revision.objects.create(
+    revision = Revision.objects.create(
         document=doc,
         creator=root_doc.current_revision.creator,
         content='<p>This is the Zone.</p>',
         created=datetime(2016, 12, 14))
+    assert doc.current_revision == revision
     doc.rendered_html = doc.current_revision.content
     doc.save()
     return doc
@@ -41,11 +42,10 @@ def zone_child_doc(zone_root_doc):
         slug=zone_root_doc.slug + '/Child',
         parent_topic=zone_root_doc)
     creator = zone_root_doc.current_revision.creator
-    doc.current_revision = Revision.objects.create(
+    Revision.objects.create(
         content='<p>A zone subpage.</p>',
         creator=creator,
         document=doc)
-    doc.save()
     return doc
 
 

--- a/kuma/scrape/tests/test_source_links.py
+++ b/kuma/scrape/tests/test_source_links.py
@@ -61,14 +61,16 @@ def test_gather_homepage(client, db):
         assert spec not in resources
 
 
-def test_gather_ignore_anchors_relative_links(client, root_doc):
+def test_gather_ignores_links(client, root_doc, simple_user):
+    user_profile_url = simple_user.get_absolute_url()
     content = """
 <ul>
   <li><a href="/en-US/docs/Absolute/Link">Absolute Link</a></li>
   <li><a href="Relative/Link">Relative Link</a></li>
   <li><a href="#later">Later in this page.</a></li>
+  <li><a href="%s">Profile Link</a></li>
 </ul>
-"""
+""" % user_profile_url
     new_rev = Revision(
         document=root_doc,
         creator=root_doc.current_revision.creator,
@@ -92,3 +94,4 @@ def test_gather_ignore_anchors_relative_links(client, root_doc):
         assert base_path not in path
         assert "Relative/Link" not in path
         assert "#later" not in path
+        assert user_profile_url not in path

--- a/kuma/scrape/tests/test_source_links.py
+++ b/kuma/scrape/tests/test_source_links.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+"""Tests for the LinksSource class (Links from a page)."""
+from __future__ import unicode_literals
+from datetime import datetime
+
+from kuma.scrape.sources import LinksSource
+from kuma.wiki.models import Revision
+from . import mock_requester, mock_storage
+
+
+def test_init_blank():
+    source = LinksSource()
+    assert source.path == '/en-US/'
+    assert source.locale == 'en-US'
+
+
+def test_init_slash():
+    source = LinksSource('/')
+    assert source.path == '/en-US/'
+
+
+def test_init_full_url():
+    url = 'https://developer.mozilla.org/en-US/docs/Web/CSS'
+    source = LinksSource(url)
+    assert source.path == '/en-US/docs/Web/CSS'
+    assert source.locale == 'en-US'
+
+
+def test_init_non_english():
+    url = '/fr/docs/Web/CSS'
+    source = LinksSource(url)
+    assert source.path == '/fr/docs/Web/CSS'
+    assert source.locale == 'fr'
+
+
+def test_gather_homepage(client, db):
+    source = LinksSource('/')
+    html = client.get('/en-US/').content
+    requester = mock_requester(content=html)
+    storage = mock_storage()
+    resources = source.gather(requester, storage)
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+
+    # The exact list of resources will change as the homepage changes
+    expected_paths = [
+        '/en-US/docs/Learn',
+        '/en-US/docs/Mozilla/Firefox',
+        '/en-US/docs/Web/JavaScript',
+    ]
+    for path in expected_paths:
+        spec = ('document', path, {})
+        assert spec in resources
+
+    # These appear on the homepage, but shouldn't in the paths to scrape
+    unexpected_paths = [
+        '/en-US/search',
+    ]
+    for path in unexpected_paths:
+        spec = ('document', path, {})
+        assert spec not in resources
+
+
+def test_gather_ignore_anchors_relative_links(client, root_doc):
+    content = """
+<ul>
+  <li><a href="/en-US/docs/Absolute/Link">Absolute Link</a></li>
+  <li><a href="Relative/Link">Relative Link</a></li>
+  <li><a href="#later">Later in this page.</a></li>
+</ul>
+"""
+    new_rev = Revision(
+        document=root_doc,
+        creator=root_doc.current_revision.creator,
+        content=content,
+        created=datetime(2017, 6, 5))
+    new_rev.save()
+    base_path = root_doc.get_absolute_url()
+    html = client.get(base_path).content
+
+    source = LinksSource(base_path)
+    requester = mock_requester(content=html)
+    storage = mock_storage()
+    resources = source.gather(requester, storage)
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+
+    expected = ('document', '/en-US/docs/Absolute/Link', {})
+    assert expected in resources
+
+    for doc, path, options in resources:
+        assert base_path not in path
+        assert "Relative/Link" not in path
+        assert "#later" not in path

--- a/kuma/scrape/tests/test_source_revision.py
+++ b/kuma/scrape/tests/test_source_revision.py
@@ -26,8 +26,7 @@ def tagged_doc(db, django_user_model):
         title='Test Document',
         tags='"One" "Two" "Three"'
     )
-    document.current_revision = revision
-    document.save()
+    assert document.current_revision == revision
     return document
 
 

--- a/kuma/scrape/tests/test_storage.py
+++ b/kuma/scrape/tests/test_storage.py
@@ -262,6 +262,7 @@ def test_get_revision_missing():
 
 def test_save_revision_current(simple_doc, simple_user):
     """Creating the current revision updates the associated document."""
+    assert not simple_doc.html
     data = {
         'id': 1000,
         'creator': simple_user,
@@ -277,6 +278,7 @@ def test_save_revision_current(simple_doc, simple_user):
     Storage().save_revision(data)
     rev = Revision.objects.get(id=1000)
     assert rev.document == simple_doc
+    assert rev.document.html == rev.content
     assert rev.creator == simple_user
     assert rev.tags == '"One" "Two" "Three"'
     assert rev.content == '<p>My awesome content.</p>'
@@ -284,6 +286,8 @@ def test_save_revision_current(simple_doc, simple_user):
 
 def test_save_revision_not_current(root_doc, simple_user):
     """Creating an older revision does not update the associated document."""
+    old_content = root_doc.html
+    assert old_content
     data = {
         'id': 1000,
         'creator': simple_user,
@@ -299,6 +303,7 @@ def test_save_revision_not_current(root_doc, simple_user):
     Storage().save_revision(data)
     rev = Revision.objects.get(id=1000)
     assert rev.document == root_doc
+    assert rev.document.html == old_content
     assert rev.creator == simple_user
     assert rev.tags == ''
     assert rev.content == '<p>My awesome content.</p>'

--- a/scripts/create_sample_db.sh
+++ b/scripts/create_sample_db.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+set -e
+
+#################
+# Setup Variables
+#################
+
+# Directory of this script, default config
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+PARENT_DIR="$( dirname ${DIR} )"
+ETC_DIR="${PARENT_DIR}/etc"
+
+if [ -z "$DATABASE_URL" ]; then
+    echo "DATABASE_URL must be a valid connection URL. Are you in the docker environment?"
+    exit 1
+fi
+
+# Parse DATABASE_URL for database connection parts
+# DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
+DB_URL_BASE=${DATABASE_URL%/*}   # Remove database name from end
+DB_PORT=${DB_URL_BASE##*:}       # Capture port (3306)
+DB_TMP=${DB_URL_BASE%:*}         # Drop :3306 and...
+DB_TMP=${DB_TMP#*://}            # Drop mysql://
+DB_USER=${DB_TMP%:*}             # Capture user (root)
+DB_TMP=${DB_TMP#*:}              # Drop user
+DB_PASSWORD=${DB_TMP%@*}         # Capture password (kuma)
+DB_HOST=${DB_TMP#*@}             # Capture hostname (mysql)
+
+# Create a unique database with the current timestamp
+DB_NAME=sample_$(date +%s)
+
+# Setup parameters for sampling
+VERBOSITY=${VERBOSITY:-2}
+SAMPLE_HOST=${SAMPLE_HOST:-developer.mozilla.org}
+SAMPLE_SSL=${SAMPLE_SSL:-1}
+SAMPLE_DUMP="mdn_sample_db.sql"
+SAMPLE_SPEC=${1:-${ETC_DIR}/sample_db.json}
+SAMPLE_DEBUG=${SAMPLE_DEBUG:-0}
+if [ "$SAMPLE_DEBUG" == "0" ]; then
+    DEBUG_CMD=
+else
+    DEBUG_CMD="python -m pdb"
+fi
+
+SAMPLE_ARGS=""
+if [ "$SAMPLE_HOST" != "developer.mozilla.org" ]; then
+    SAMPLE_ARGS="$SAMPLE_ARGS --host=$SAMPLE_HOST"
+fi
+
+if [ "$SAMPLE_SSL" == "0" ]; then
+    SAMPLE_ARGS="$SAMPLE_ARGS --nossl"
+fi
+
+# Use the new database in Django management commands
+export DATABASE_URL=${DB_URL_BASE}/${DB_NAME}
+
+#############
+# Import data
+#############
+
+echo "*** Creating the sample database ${DB_NAME}"
+mysql --host=$DB_HOST --user=$DB_USER --password=$DB_PASSWORD \
+  -e "CREATE DATABASE ${DB_NAME} CHARACTER SET utf8;"
+
+echo "*** Initializing the database"
+$DIR/../manage.py migrate
+
+echo "*** Importing data from ${SAMPLE_HOST}"
+$DEBUG_CMD $DIR/../manage.py sample_mdn $SAMPLE_ARGS -v$VERBOSITY $SAMPLE_SPEC
+
+echo "*** Fetching Hacks Posts"
+$DIR/../manage.py update_feeds
+
+echo "*** Exporting to ${SAMPLE_DUMP}"
+# Export to SQL file
+mysqldump --host=$DB_HOST --user=$DB_USER --password=$DB_PASSWORD \
+  $DB_NAME > ${SAMPLE_DUMP}
+
+echo "*** Dropping sample database ${DB_NAME}"
+mysql --host=$DB_HOST --user=$DB_USER --database=${DB_NAME} \
+  --password=$DB_PASSWORD \
+  -e "DROP DATABASE ${DB_NAME};"


### PR DESCRIPTION
Now that PR #4245 and PR #4248 are merged, this PR is getting a little more sane:

* Adds a management command ``scrape_links`` to find document links on an MDN page. It is designed for the homepage, but can work on other pages as needed.
* Adds a management command ``sample_mdn`` that loads fixtures and scrapes production data from a JSON spec.
* Adds a script to create an empty but migrated database, load it with fixtures and scraped data, and export a SQL dump for development and testing. Since the data is scraped from public interfaces, avoids issues with exposing personally identifiable information.

A recent generated sample database is at http://mdn-downloads.s3-website-us-west-2.amazonaws.com/mdn_sample_db.sql.gz

To Do:
* [x] Remove unneeded stuff like ``./manage.py sample_templates`` and debug print statements that are now obvious once I've opened the PR.
* [x] Split up big files for sanity and better GitHub review
* [x] Split up long ``gather`` methods into sane methods
* [x] Update documentation to use sample database
* [x] Improve S3 download site
* [x] Set valid test account passwords for integration tests
* [x] Ensure [fr/docs/User:anonymous:uitest](https://developer.mozilla.org/fr/docs/User:anonymous:uitest) is in sample DB
* [x] Include Mozilla Hacks blog scrape
* [x] *Maybe* Add en-US/docs/Apps
* [x] Add documentation for sampling data, generating the database
* [x] Allow scraping a tree of documents, like /en-US/Web/HTML
* [x] Change management command ``scrape_homepage`` to a generic ``scrape_links``.
* [x] Add "less verbose" mode for cron-based sample DB generation
* [x] Set Site 1 to localhost:8000 from example.com
* [x] Add URLs in tests/performance/smoke.py to the sample DB

Not this PR:
* Extract attachment data from documents
* Render documents and set the render date of documents to avoid rebuild of sample DB on load