### PR TITLE
bug 1218563: Default to www-data user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   worker: &worker
     image: quay.io/mozmar/kuma_base
     command: ./manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
-    user: ${UID:-0}
+    user: ${UID:-33}
     volumes:
       - ./:/app
     depends_on:


### PR DESCRIPTION
On MacOS, ``UID`` is unset, and the root is used by default. This causes the worker container to fail, since ``C_FORCE_ROOT`` is no longer used.  Change the default to UID 33, which is the ``www-data`` user, when UID is unset.  I believe most Linux systems (including the Jenkins build?) set a ``UID`` in the environment.

Message printed in the logs:

```
Running a worker with superuser privileges when the
worker accepts messages serialized with pickle is a very bad idea!

If you really want to continue then you have to set the C_FORCE_ROOT
environment variable (but please think about this before you do).

User information: uid=0 euid=0 gid=0 egid=0
```
