### PR TITLE
Fix bug 1325097: Make multi-column divs easier to see

### DIFF
--- a/kuma/static/styles/components/content.styl
+++ b/kuma/static/styles/components/content.styl
@@ -276,9 +276,19 @@ p.footnote {
 /* Classes created by the WYSIWYG */
 .twocolumns {
     vendorize(column-count, 2);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
 }
 .threecolumns {
     vendorize(column-count, 3);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
 }
 
 @media $media-query-small-mobile {

--- a/kuma/static/styles/includes/vars.styl
+++ b/kuma/static/styles/includes/vars.styl
@@ -232,3 +232,8 @@ $column-12, $column-all {
     margin: 0;
     float: none;
 }
+
+/*
+edit-mode customizations - applied to blocks only in edit mode
+====================================================================== */
+$editor-box-border = 2px dotted #ADF;


### PR DESCRIPTION
Updated the twocolumns and threecolumns classes so they draw with a pale blue border around the columns when in the editor, for ease of layout work. I used a variable, $editor-box-border-style to contain the style information to apply to these column boxes, so it can be easily changed in one place, and potentially reused elsewhere for other "draw borders in the editor" situations that may arise.