### PR TITLE
bug 1325125: Detect leading spaces in the data protocol

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1185,7 +1185,7 @@ CONSTANCE_CONFIG = dict(
         "are removed from the file storage"
     ),
     KUMA_WIKI_HREF_BLOCKED_PROTOCOLS=(
-        '(?i)^(data\:?)',
+        '(?i)^\s*(data\:?)',
         'Regex for protocols that are blocked for A HREFs'
     ),
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS=(

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -70,15 +70,15 @@
             $(target).on('click', 'a', function (e) {
                 var $this = $(this);
 
-                // If we explicitly say not to track something, don't
-                if($this.hasClass('no-track')) {
-                    return;
-                }
-
                 // bug 1222864 - prevent links to data: uris
                 if (this.href.toLowerCase().indexOf('data') === 0) {
                     e.preventDefault();
                     analytics.trackError('XSS Attempt', 'data href');
+                    return;
+                }
+
+                // If we explicitly say not to track something, don't
+                if($this.hasClass('no-track')) {
                     return;
                 }
 


### PR DESCRIPTION
This builds on and replaces PR #4081 

* When edits are saved, detect the use of the ``data:`` protocol with leading spaces and remove from the content.
* When running ``trackOutboundLinks``, check for links using``data:`` protocol before the check for the ``no-track`` class.

The new detection pattern has been applied to stage and production.