### PR TITLE
bug 957802: Update TravisCI cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ sudo: required
 branches:
     only:
         - master
-cache:
-    apt: true
-    directories:
-        - $HOME/.cache/pip
+cache: pip
 language: python
 python:
     - "2.7"


### PR DESCRIPTION
Current cache documentation (https://docs.travis-ci.com/user/caching/) says:

* Use "cache: pip" instead of caching the directory
* Don't cache Debian packages