### PR TITLE
Update CKEditor doc to be more complete

### DIFF
--- a/docs/ckeditor.rst
+++ b/docs/ckeditor.rst
@@ -13,6 +13,11 @@ To rebuild CKEditor, run this on the host system::
 
     cd kuma/static/js/libs/ckeditor/
     ./docker-build.sh  # Creates a Java container, builds CKEditor
+    docker-compose exec web make build-static
+
+This builds CKEditor within a Docker VM, using the Java ``ckbuilder`` tool
+from CKSource, then builds static resources so that the updated editor
+is installed where it belongs.
 
 To rebuild CKEditor from a ``vagrant ssh`` shell (or locally if you have Java
 installed)::
@@ -37,3 +42,9 @@ to the tag or commit number specified in ``build.sh``:
 * `descriptionlist <https://github.com/Reinmar/ckeditor-plugin-descriptionlist>`_
 * `scayt <https://github.com/WebSpellChecker/ckeditor-plugin-scayt>`_
 * `wsc <https://github.com/WebSpellChecker/ckeditor-plugin-wsc>`_
+
+Change to CKEditor plugins which are bundled into Kuma should be made in the
+directory `/kuma/static/js/libs/ckeditor/source/ckeditor/plugins/ <https://github.com/mozilla/kuma/tree/master/kuma/static/js/libs/ckeditor/source/plugins>`_.
+
+Once you've made changes to a plugin, be sure to build the editor and the static
+resources again, as described in `Building CKEditor`_.


### PR DESCRIPTION
Added that you need to build-static after building the editor to pick up the new version. Also added info about where to find the source for plugins and how to do a build to test changes to them.