### PR TITLE
Bug 1265891: Add Bulgarian to candidate languages, display in some environments

### DIFF
--- a/jinja2/includes/translate_locales.html
+++ b/jinja2/includes/translate_locales.html
@@ -7,6 +7,7 @@ Background: https://bugzil.la/859499#c11
 {{ _('Bambara') }}
 {{ _('Bengali (Bangladesh)') }}
 {{ _('Bengali (India)') }}
+{{ _('Bulgarian') }}
 {{ _('Burmese') }}
 {{ _('Catalan') }}
 {{ _('Chinese (Simplified)') }}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -258,6 +258,20 @@ def _get_locales():
 LOCALES = _get_locales()
 LANGUAGES = [(locale, LOCALES[locale].native) for locale in MDN_LANGUAGES]
 
+
+def enable_candidate_languages():
+    # Enable candidate languages for display and translation
+    for locale in CANDIDATE_LANGUAGES:
+        LANGUAGE_URL_MAP[locale.lower()] = locale
+        LANGUAGES.append((locale, LOCALES[locale].native))
+
+
+ENABLE_CANDIDATE_LANGUAGES = config('ENABLE_CANDIDATE_LANGUAGES',
+                                    default=DEBUG,
+                                    cast=bool)
+if ENABLE_CANDIDATE_LANGUAGES:
+    enable_candidate_languages()
+
 # List of MindTouch locales mapped to Kuma locales.
 #
 # Language in MindTouch pages are first determined from the locale in the page

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -191,7 +191,9 @@ MDN_LANGUAGES = (
 # Locales being considered for MDN. This makes the UI strings available for
 # localization in Pontoon, but pages can not be translated into this language.
 # https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize/Starting_a_localization
-CANDIDATE_LANGUAGES = ()
+CANDIDATE_LANGUAGES = [
+    'bg',       # Bulgarian
+]
 
 RTL_LANGUAGES = (
     'ar',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -125,67 +125,67 @@ LANGUAGE_CODE = 'en-US'
 
 # Accepted locales
 MDN_LANGUAGES = (
-    'en-US',
-    'af',
-    'ar',
-    'az',
-    'bm',
-    'bn-BD',
-    'bn-IN',
-    'ca',
-    'cs',
-    'de',
-    'ee',
-    'el',
-    'es',
-    'fa',
-    'ff',
-    'fi',
-    'fr',
-    'fy-NL',
-    'ga-IE',
-    'ha',
-    'he',
-    'hi-IN',
-    'hr',
-    'hu',
-    'id',
-    'ig',
-    'it',
-    'ja',
-    'ka',
-    'kab',
-    'ko',
-    'ln',
-    'mg',
-    'ml',
-    'ms',
-    'my',
-    'nl',
-    'pl',
-    'pt-BR',
-    'pt-PT',
-    'ro',
-    'ru',
-    'son',
-    'sq',
-    'sr',
-    'sr-Latn',
-    'sv-SE',
-    'sw',
-    'ta',
-    'th',
-    'tl',
-    'tn',
-    'tr',
-    'uk',
-    'vi',
-    'wo',
-    'xh',
-    'yo',
-    'zh-CN',
-    'zh-TW',
-    'zu',
+    'en-US',    # English
+    'af',       # Akrikaans
+    'ar',       # Arabic
+    'az',       # Azerbaijani
+    'bm',       # Bambara
+    'bn-BD',    # Bengali (Bangladesh)
+    'bn-IN',    # Bengali (India)
+    'ca',       # Catalan
+    'cs',       # Czech
+    'de',       # German
+    'ee',       # Ewe
+    'el',       # Greek
+    'es',       # Spanish
+    'fa',       # Persian
+    'ff',       # Fulah
+    'fi',       # Finnish
+    'fr',       # French
+    'fy-NL',    # Frisian (Netherlands)
+    'ga-IE',    # Irish (Ireland)
+    'ha',       # Hausa
+    'he',       # Hebrew
+    'hi-IN',    # Hindi (India)
+    'hr',       # Croatian *** not in Pontoon
+    'hu',       # Hungarian
+    'id',       # Indonesian
+    'ig',       # Igbo
+    'it',       # Italian
+    'ja',       # Japanese
+    'ka',       # Georgian
+    'kab',      # Kabyle
+    'ko',       # Korean
+    'ln',       # Lingala
+    'mg',       # Malagasy
+    'ml',       # Malayalam
+    'ms',       # Malay
+    'my',       # Burmese
+    'nl',       # Dutch
+    'pl',       # Polish
+    'pt-BR',    # Portuguese (Brazil)
+    'pt-PT',    # Portuguese (Portugal)
+    'ro',       # Romanian
+    'ru',       # Russian
+    'son',      # Songhay
+    'sq',       # Albanian
+    'sr',       # Serbian
+    'sr-Latn',  # Serbian (Latin)
+    'sv-SE',    # Swedish (Sweden)
+    'sw',       # Swahili
+    'ta',       # Tamil
+    'th',       # Thai
+    'tl',       # Tagalog
+    'tn',       # Tswana *** not in Pontoon
+    'tr',       # Turkish
+    'uk',       # Ukranian
+    'vi',       # Vietnamese
+    'wo',       # Wolof
+    'xh',       # Xhosa
+    'yo',       # Yoruba
+    'zh-CN',    # Chinese (China)
+    'zh-TW',    # Chinese (Taiwan, Province of China)
+    'zu',       # Zulu
 )
 
 # Locales being considered for MDN. This makes the UI strings available for

--- a/kuma/settings/stage.py
+++ b/kuma/settings/stage.py
@@ -16,3 +16,5 @@ CELERYD_MAX_TASKS_PER_CHILD = 3000
 
 ES_INDEX_PREFIX = 'mdnstage'
 ES_LIVE_INDEX = True
+
+enable_candidate_languages()


### PR DESCRIPTION
* Add Bulgarian (bg) to the list of candidate languages for MDN.  This makes the string "Bulgarian" available for translation (next time we extract strings).
* Enable candidate languages in development and staging, so translators can see strings in context.
* Annotate languages list, so it is easier to identify locales