### PR TITLE
Add rel="nofollow" to non-indexable links.

### DIFF
--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -48,9 +48,9 @@
                   <th scope="row">
                       <h3><a href="{{ revision.document.get_absolute_url() }}">{{ revision.document.title }}</a></h3>
                       <ul class="activity-actions">
-                          <li><a href="{{ revision.document.get_edit_url() }}" class="edit">{{ _("Edit page") }}</a></li>
+                          <li><a href="{{ revision.document.get_edit_url() }}" class="edit" rel="nofollow, noindex">{{ _("Edit page") }}</a></li>
                           <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" rel="nofollow, noindex" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
-                          <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history">{{ _("View page history") }}</a></li>
+                          <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history" rel="nofollow, noindex">{{ _("View page history") }}</a></li>
                       </ul>
                   </th>
                   <td>{{ datetimeformat(revision.created, format='date') }}<br />

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -304,7 +304,7 @@
                 <div id="doc-pending-fallback" class="warning">
                   <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
                     Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.
-                    <a href="{{ help_link }}">Join us and help get the job done!</a><br>
+                    <a href="{{ help_link }}" rel="nofollow, noindex">Join us and help get the job done!</a><br>
                     You can also read the article in <a href="{{ doc_abs_url }}">{{ parent_language }}</a>.
                   {% endtrans %}</bdi></p>
                 </div>
@@ -412,7 +412,8 @@
 
                 $('<a>').attr({
                     href: href,
-                    'class': 'button section-edit only-icon'
+                    'class': 'button section-edit only-icon',
+                    'rel': 'nofollow, noindex'
                 })
                 .append($('<i aria-hidden="true" class="icon-pencil"></i>'))
                 .append($('<span>'))

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -42,7 +42,7 @@
       </li>{% endif %}
 
       {% if (not document.is_template) or (user.has_perm('wiki.change_template_document')) %}
-      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button" data-optimizely-hook="button-edit-doc" id="edit-button">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
+      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button" data-optimizely-hook="button-edit-doc" id="edit-button" rel="nofollow, noindex">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
       {% endif %}
 
         {% if user.is_authenticated() and document %}

--- a/kuma/wiki/jinja2/wiki/includes/document_tag.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_tag.html
@@ -4,7 +4,7 @@
     <strong>{{_('Tags:')}}</strong>&nbsp;
     <ul class="tags tags-small">
       {% for tag in tags %}
-        <li><a href="{{ url('wiki.tag', tag) }}">{{ tag }}</a></li>
+        <li><a href="{{ url('wiki.tag', tag) }}" rel="nofollow, noindex">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   </div>

--- a/kuma/wiki/jinja2/wiki/list/tags.html
+++ b/kuma/wiki/jinja2/wiki/list/tags.html
@@ -9,7 +9,7 @@
         <ul class="documents-list cols-3">
           {% for tag in tags.object_list %}
             <li>
-              <a href="{{url('wiki.tag', tag.name)}}">{{ tag.name }}</a>
+              <a href="{{url('wiki.tag', tag.name)}}" rel="nofollow, noindex">{{ tag.name }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -124,7 +124,7 @@
                         <ul class="tags">
                           {% for parent_tag in parent_tags %}
                           <li>
-                              <a href="{{url('wiki.tag', parent_tag.name)}}">{{ parent_tag.name }}</a>
+                              <a href="{{url('wiki.tag', parent_tag.name)}}" rel="nofollow, noindex">{{ parent_tag.name }}</a>
                           </li>
                           {% endfor %}
                         </ul>


### PR DESCRIPTION
Based on the [Google search results](https://www.google.de/search?biw=1280&bih=1237&q=site:developer.mozilla.org#q=site:developer.mozilla.org&start=553&filter=0) posted in the [parent bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1316610), I *think* I've found all the links missing `rel="nofollow, noindex"`.