### PR TITLE
Fix Bug 1329743: Compat bugs.

### DIFF
--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -141,6 +141,7 @@ a {
 
 abbr[title] {
     cursor: help;
+    text-decoration: dotted underline;
 }
 
 sup {

--- a/kuma/static/styles/components/syntax/syntaxbox.scss
+++ b/kuma/static/styles/components/syntax/syntaxbox.scss
@@ -11,7 +11,6 @@ pre.twopartsyntaxbox {
     @extend %code-block;
     background: $code-block-background-alt-color;
     white-space: pre-wrap;
-    text-overflow: ellipsis ellipsis;
 }
 
 pre.twopartsyntaxbox {

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -133,8 +133,11 @@ icons for both types of indicators
 .experimentalBadge,
 /* es7 and harmony macros  */
 .overheadIndicator[style='background: #9CF49C;'],
-.overheadIndicator[style='background: rgb(156, 244, 156);'] // IE10 {
-    indicator-icon('\f0c3'); /* flask */
+/*
+IE 11 converts hex to rgb, so target that as well.
+*/
+.overheadIndicator[style='background: rgb(156, 244, 156);'] {
+    @include indicator-icon('\f0c3'); /* flask */
 }
 
 .warning:not(.notification) {

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -132,8 +132,9 @@ icons for both types of indicators
 .experimental,
 .experimentalBadge,
 /* es7 and harmony macros  */
-.overheadIndicator[style='background: #9CF49C;'] {
-    @include indicator-icon('\f0c3'); /* flask */
+.overheadIndicator[style='background: #9CF49C;'],
+.overheadIndicator[style='background: rgb(156, 244, 156);'] // IE10 {
+    indicator-icon('\f0c3'); /* flask */
 }
 
 .warning:not(.notification) {


### PR DESCRIPTION
Can't fix the Safari problem. Filed a bug, https://bugs.webkit.org/show_bug.cgi?id=166870

The IE problem is with an indicator that was a bit of a hack to begin with - we're styling based on inline styling. IE is changing the inline style from a hex to an rgb colour. So now we have a selector for the rgb value as well.

Text styling difference has to do with differing support for text-overflow: ellipsis. I don't think we want ellipsis here, since it could hide important information, so I removed it.

IE also has no default saying for abbr, so added that.