### PR TITLE
Bug 1331643, 1330357: De-duplicate tags, allow mixed-case interests

### DIFF
--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -51,22 +51,9 @@ class _NamespacedTaggableManager(_TaggableManager):
 
         if namespace is not None:
             # Namespace requested, so generate filtered set
-            # TODO: Do this in the DB query? Might not be worth it.
-            #
-            # On databases with case-insensitive collation, we can end
-            # up with duplicate tags (the same tag, differing only by
-            # case, like 'javascript' and 'JavaScript') in some
-            # cases. The most common instance of this is user
-            # tags, which are coerced to lowercase on save to avoid
-            # the problem, but because there are a large number of
-            # these duplicates already existing, we do a quick filter
-            # here to ensure we don't return a bunch of dupes that
-            # differ only by case.
-            seen = []
             results = []
             for tag in tags:
-                if tag.name.startswith(namespace) and tag.name.lower() not in seen:
-                    seen.append(tag.name.lower())
+                if tag.name.startswith(namespace):
                     results.append(tag)
             return results
 

--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -118,11 +118,13 @@ class _NamespacedTaggableManager(_TaggableManager):
 
     def _ensure_ns(self, namespace, tags):
         """Ensure each tag name in the list starts with the given namespace"""
-        ns_tags = []
-        for t in tags:
-            if not t.startswith(namespace):
-                t = '%s%s' % (namespace, t)
-            ns_tags.append(t)
+        ns_tags = set()
+        tag_model = self.through.tag_model()
+        for name in tags:
+            if not name.startswith(namespace):
+                name = '%s%s' % (namespace, name)
+            tag, created = tag_model.objects.get_or_create(name=name)
+            ns_tags.add(tag)
         return ns_tags
 
 

--- a/kuma/core/tests/test_taggit_extras.py
+++ b/kuma/core/tests/test_taggit_extras.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 
+from taggit.models import Tag
+
 from .taggit_extras.models import Food
 
 
@@ -74,3 +76,19 @@ class NamespacedTaggableManagerTest(TestCase):
         apple.tags.add_ns('a:', *tags)
 
         self.assert_tags_equal(apple.tags.all(), ['a:%s' % t for t in tags])
+
+    def test_duplicate_names_to_create(self):
+        apple = self.food_model.objects.create(name="apple")
+        tags = ['tasty', 'Tasty']
+        apple.tags.add_ns('a:', *tags)
+        assert apple.tags.count() == 1
+        tag = apple.tags.get()
+        assert tag.name in ('a:tasty', 'a:Tasty')
+
+    def test_duplicate_names_existing(self):
+        apple = self.food_model.objects.create(name="apple")
+        Tag.objects.create(name='a:Red')
+        Tag.objects.create(name='a:Tasty')
+        tags = ['tasty', 'Tasty', 'Red', 'red']
+        apple.tags.add_ns('a:', *tags)
+        self.assert_tags_equal(apple.tags.all(), ['a:Tasty', 'a:Red'])

--- a/kuma/static/js/users.js
+++ b/kuma/static/js/users.js
@@ -87,8 +87,7 @@
     $(document).ready(function(){
 
         // Convert interests text field into a tag-it widget
-        // also lowercase to deal with database weirdness
-        var interests = $('#id_user-interests').val().toLowerCase();
+        var interests = $('#id_user-interests').val();
         $('#id_user-interests').hide()
             .val(interests)
             .after('<ul id="tagit-interests"></ul>')
@@ -108,9 +107,8 @@
         $('#tagit-interests .tagit-new input').attr('placeholder', gettext('New interest...'));
 
         // Convert the expertise text field into tag list
-        // lowercase to deal with database weirdness
         // checkboxes sync'd to interests
-        var expertise = $('#id_user-expertise').val().toLowerCase();
+        var expertise = $('#id_user-expertise').val();
         $('#id_user-expertise').hide()
         .val(expertise)
         .after('<ul id="tags-expertise" class="tags"></ul>');

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -429,7 +429,7 @@ def user_edit(request, username):
             # Update tags from form fields
             for field, tag_ns in field_to_tag_ns:
                 field_value = user_form.cleaned_data.get(field, '')
-                tags = [tag.lower() for tag in parse_tags(field_value)]
+                tags = parse_tags(field_value)
                 new_user.tags.set_ns(tag_ns, *tags)
 
             return redirect(edit_user)

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1727,8 +1727,13 @@ class Revision(models.Model):
         self.document.current_revision = self
 
         # Since Revision stores tags as a string, we need to parse them first
-        # before setting on the Document.
-        self.document.tags.set(*parse_tags(self.tags))
+        # before setting on the Document. And since taggit has issues adding
+        # duplicated names, convert to a unique set of DocumentTags
+        doc_tags = set()
+        for name in parse_tags(self.tags):
+            doc_tag, created = DocumentTag.objects.get_or_create(name=name)
+            doc_tags.add(doc_tag)
+        self.document.tags.set(*doc_tags)
 
         self.document.save()
 


### PR DESCRIPTION
With [bug 1293749](https://bugzilla.mozilla.org/show_bug.cgi?id=1293749) fixed (Add missing ``UNIQUE KEY`` indexes in production), some new issues have appeared:

* [bug 1330357](https://bugzilla.mozilla.org/show_bug.cgi?id=1330357) - ISE if profile interest tag is not lowercase in the database
* [bug 1331643](https://bugzilla.mozilla.org/show_bug.cgi?id=1331643) - ISE when adding two document tags that only differ in capitalization

Both appear to be caused by an issue with [django-taggit](https://github.com/alex/django-taggit) and MySQL with a case-insensitive collation and a unique index.  Adding two "case similar" tags, like "WEB" and "web", will result in attempting to add both, and raise an IntegrityError.

The issue is handled in this PR by querying the database for existing tags with "case similar" names, and creating new ones as needed, and then passing the unique set of Tag instances to taggit to create the many-to-many relations, rather than passing a list of names.

Additionally, user profile interests and expertise were restricted to lower-case tags to avoid triggering the creation of duplicate tags.  This removes the restriction and UI changes, so that non-lowercase interests, like "HTML" and "CSS", can be added.  This change allows mixed-case profile tags, but existing tags will need to be updated in the database as desired.
