### PR TITLE
Fix Bug 1332013: Allow syntax highlighting without line numbers

### DIFF
--- a/kuma/static/js/syntax-prism.js
+++ b/kuma/static/js/syntax-prism.js
@@ -28,11 +28,7 @@
             brush = $.trim(brushSearch[1].replace(';', ' ').split(' ')[0].toLowerCase());
         }
 
-        // Some boxes shouldn't be numbered
-        if($pre.hasClass('syntaxbox') || $pre.hasClass('twopartsyntaxbox') || $pre.hasClass('no-line-numbers')) {
-          $pre.attr('data-prism-prevent-line-number', 1);
-        }
-        else {
+        if (!$pre.hasClass('no-line-numbers')) {
             // Prism upgrade requires adding a class to use line numbering
             $pre.addClass('line-numbers');
         }

--- a/kuma/static/js/syntax-prism.js
+++ b/kuma/static/js/syntax-prism.js
@@ -29,7 +29,7 @@
         }
 
         // Some boxes shouldn't be numbered
-        if($pre.hasClass('syntaxbox') || $pre.hasClass('twopartsyntaxbox')) {
+        if($pre.hasClass('syntaxbox') || $pre.hasClass('twopartsyntaxbox') || $pre.hasClass('no-line-numbers')) {
           $pre.attr('data-prism-prevent-line-number', 1);
         }
         else {

--- a/kuma/static/styles/libs/prism/prism-line-numbers.css
+++ b/kuma/static/styles/libs/prism/prism-line-numbers.css
@@ -38,3 +38,7 @@ pre.line-numbers > code {
 			padding-right: 0.8em;
 			text-align: right;
 		}
+
+.no-line-numbers .line-numbers-rows {
+    display:none;
+}

--- a/kuma/static/styles/libs/prism/prism-line-numbers.css
+++ b/kuma/static/styles/libs/prism/prism-line-numbers.css
@@ -8,7 +8,12 @@ pre.line-numbers > code {
 	position: relative;
 }
 
+.line-numbers-rows {
+	display: none;
+}
+
 .line-numbers .line-numbers-rows {
+	display: block;
 	position: absolute;
 	pointer-events: none;
 	top: 0;
@@ -38,7 +43,3 @@ pre.line-numbers > code {
 			padding-right: 0.8em;
 			text-align: right;
 		}
-
-.no-line-numbers .line-numbers-rows {
-    display:none;
-}


### PR DESCRIPTION
This let's you do:

```
<pre class="brush: js no-line-numbers">
console.log("foo");
</pre>
```
Rendering with and without "no-line-numbers":
![no-line-numbers](https://cloud.githubusercontent.com/assets/349114/22076494/97d328b4-ddb0-11e6-92f7-cefebad8ab20.png)
