### PR TITLE
bug 1332777: git ignore static directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,9 @@
 .tox
 .vagrant
 bower_components
-static/*/*
+static/
 build.py
-build/assets/css/*
-build/locale/
+build/
 celeryev.pid
 coverage.xml
 docs/_build/


### PR DESCRIPTION
More robust git ignore for build and static directories within kuma repo.