### PR TITLE
Add Gulp to front-end workflow.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,10 +14,9 @@
 .tox
 .vagrant
 bower_components
-static/*/*
+static/
 build.py
-build/assets/css/*
-build/locale/
+build/
 celeryev.pid
 coverage.xml
 docs/_build/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,20 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* global __dirname, require */
+
+const gulp = require('gulp');
+const watch = require('gulp-watch');
+
+gulp.task('media:watch', () => {
+    return gulp.src('./kuma/static/**/*')
+        .pipe(watch('./kuma/static/**/*', {
+            'verbose': true
+        }))
+        .pipe(gulp.dest('./static'));
+});
+
+gulp.task('default', () => {
+    gulp.start('media:watch');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "kuma",
+  "version": "0.1.0",
+  "description": "The project that powers MDN.",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mozilla/kuma.git"
+  },
+  "author": "Mozilla",
+  "license": "MPL",
+  "bugs": {
+    "url": "https://bugzilla.mozilla.org/"
+  },
+  "devDependencies": {
+    "gulp": "^3.9.1",
+    "gulp-watch": "^4.3.6"
+  }
+}


### PR DESCRIPTION
After merging, need to run `npm install`, then `gulp`. With `gulp` running, any change to a file in `/kuma/kuma/static` should be logged to the console and copied to `/static`.

Page loads are a bit slower (~3.5s), but I'm guessing that's due to the pipeline recompiling assets each time. Still a workable delay, IMO.