### PR TITLE
bug 1332886: Fix deployment

### DIFF
--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -67,14 +67,18 @@ def checkin_changes(ctx):
     ctx.local(settings.DEPLOY_SCRIPT)
 
 
-@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+@hostgroups(settings.KUMA_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def deploy_app(ctx):
     ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+
+
+@hostgroups(settings.KUMA_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
+def restart_web(ctx):
     ctx.remote("service httpd restart")
 
 
 @hostgroups(settings.KUMA_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
-def deploy_kumascript(ctx):
+def restart_kumascript(ctx):
     ctx.remote("/usr/bin/supervisorctl stop all; /usr/bin/killall nodejs; /usr/bin/supervisorctl start all")
 
 
@@ -85,8 +89,7 @@ def prime_app(ctx):
 
 
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
-def update_celery(ctx):
-    ctx.remote(settings.REMOTE_UPDATE_SCRIPT)
+def restart_celery(ctx):
     ctx.remote('/usr/bin/supervisorctl mrestart celery\*')
 
 
@@ -165,10 +168,11 @@ def update(ctx):
 def deploy(ctx):
     checkin_changes()
     deploy_app()
-    deploy_kumascript()
+    restart_web()
+    restart_kumascript()
+    restart_celery()
     ping_newrelic()
 #    prime_app()
-    update_celery()
 
 
 @task


### PR DESCRIPTION
The celery nodes run kumascript, and are used for force-refresh document rendering.  Previously, celery's kumascript was restarted before the code was updated, so they always ran last deployment's code.  This didn't matter much over the last 5 years, when kumascript engine changes were rare.

Change deployment from:
* Update code on web machines
* Restart Apache on web machines
* Restart KumaScript on all machines
* Ping New Relic
* Update code on celery machines
* Restart Celery on celery machines

to:
* Update code on all machines
* Restart Apache on all machines
* Restart KumaScript on all machines
* Restart Celery on the celery machines
* Ping New Relic