### PR TITLE
bug 1332828: Remove DekiWiki:Date from autoload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,7 +94,6 @@ services:
       - server__memcache__server=memcached:11211
       - server__template_class=EJSTemplate
       - server__autorequire__mdn=MDN:Common
-      - server__autorequire__Date=DekiScript:Date
       - server__autorequire__Page=DekiScript:Page
       - server__autorequire__String=DekiScript:String
       - server__autorequire__Uri=DekiScript:Uri


### PR DESCRIPTION
It is a lesser wrapper on the native Date type, and is shadowing the native Date type after the node 6.x update.