### PR TITLE
bug 1330838: Add node-sass to base image

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -38,6 +38,7 @@ RUN npm install -g \
     csslint@0.10.0 \
     jshint@2.7.0 \
     stylus@0.49.2 \
+    node-sass@4.3.0 \
     uglify-js@2.4.13 \
     clean-css@3.4.23
 ENV PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor \


### PR DESCRIPTION
Get node-sass into the base image, so the quick tests (locales in TravisCI, tests in Jenkins) will pass for PR #4109.