### PR TITLE
bug 930102: Add "Hidden When Reading" style

### DIFF
--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -34,6 +34,7 @@
 .hidden {
     display: none;
 
+    html.cke_panel_container &,
     body[contenteditable] & {
         position: relative;
         display: block;

--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -113,7 +113,8 @@
         { name: 'Three Columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },
         { name: 'Syntax Box', element: 'pre', attributes: { 'class': 'syntaxbox' } },
-        { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } }
+        { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } },
+        { name: 'Hidden When Reading', element: 'div', attributes: { 'class': 'hidden' }, type: 'wrap' }
       ]);
     }
 


### PR DESCRIPTION
Add "Hidden When Reading" option to style dropdown in editor. In the menu, it has a similar appearance to when hidden content is displayed in the editor (that is, with a dotted outline around it). The small black area at the top-left is where the "hidden" tab is in the edit box; @stephaniehobson says this is not something we can easily fix and it isn't a significant issue anyway, so it should be fine as it is.

This is a rebase of PR #4057 after the Stylus → Sass change.