### PR TITLE
bug 1325097: Make columns more visible in editor

### DIFF
--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -277,10 +277,20 @@ p.footnote {
 
 /* Classes created by the WYSIWYG */
 .twocolumns {
-   @include vendorize(column-count, 2);
+    @include vendorize(column-count, 2);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
 }
 .threecolumns {
-   @include vendorize(column-count, 3);
+    @include vendorize(column-count, 3);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
 }
 
 @media #{$media-query-small-mobile} {

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -185,3 +185,9 @@ $path-to-images : $path-to-assets + 'img/';
 $path-to-embedded-images : $path-to-images + 'embed/';
 $path-to-fonts : $path-to-assets + 'fonts/';
 $logo-sprite-url : $path-to-images + 'logo_sprite.svg';
+
+
+/*
+edit-mode customizations - applied to blocks only in edit mode
+====================================================================== */
+$editor-box-border : 2px dotted #ADF;


### PR DESCRIPTION
Updated the ``twocolumns`` and ``threecolumns`` classes so they draw with a pale blue dotted border around the columns when in the editor, for ease of layout work. The format is in a variable (``$editor-box-border``) so it can be reused in other similar cases if needed.

This is a rebase of PR #4080 after the Stylus → Sass update.