### PR TITLE
bug 1330838: Generate hashed static assets with DEBUG=False

### DIFF
--- a/kuma/core/pipeline/storage.py
+++ b/kuma/core/pipeline/storage.py
@@ -1,7 +1,8 @@
+from django.conf import settings
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
 
 from pipeline.storage import PipelineMixin
 
 
 class ManifestPipelineStorage(PipelineMixin, ManifestStaticFilesStorage):
-    pass
+    packing = not settings.DEBUG

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -951,6 +951,7 @@ PIPELINE = {
     'STYLESHEETS': PIPELINE_CSS,
     'JAVASCRIPT': PIPELINE_JS,
     'DISABLE_WRAPPER': True,
+    'SHOW_ERRORS_INLINE': False,  # django-pipeline issue #614
     'COMPILERS': (
         'pipeline.compilers.sass.SASSCompiler',
     ),


### PR DESCRIPTION
Borrow the [Bedrock solution](https://github.com/mozilla/bedrock/blob/2fb16c05fbb847b57e0fbbea8a5b51d51d554e43/bedrock/base/storage.py#L15) for generating hashed static assets.