### PR TITLE
bug 1330838: Raise exceptions on pipeline errors

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -951,6 +951,7 @@ PIPELINE = {
     'STYLESHEETS': PIPELINE_CSS,
     'JAVASCRIPT': PIPELINE_JS,
     'DISABLE_WRAPPER': True,
+    'SHOW_ERRORS_INLINE': False,  # django-pipeline issue #614
     'COMPILERS': (
         'pipeline.compilers.sass.SASSCompiler',
     ),


### PR DESCRIPTION
The Jinja2 PipelineExtension can't render error CSS. This is tracked upstream in https://github.com/jazzband/django-pipeline/issues/614

Use the ``PIPELINE`` setting that raises an exception instead.