### PR TITLE
bug 1031910: Fix language detection for zones

### DIFF
--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -101,7 +101,11 @@
     // Multiple language support
     config.scayt_multiLanguageMode = true;
     config.scayt_disableOptionsStorage = 'all';
-    var lang = document.location.toString().match(/\/\/.+\/(.+)\/docs/)[1];
+    var lang = 'en-US';
+    var pathname = document.location.pathname;
+    if (pathname && pathname.split('/').length >= 2) {
+        lang = pathname.split('/')[1];
+    }
 
     // SCAYT expects underscores rather than dashes
     lang = lang.replace(/-/g, "_");


### PR DESCRIPTION
The language detection regex worked for regular URLs, but not zone URLs (URLs that omit /docs/). The new code works on both kinds:

https://developer.mozilla.org/en-US/docs/Web/HTML
https://developer.mozilla.org/en-US/Add-ons/Themes