### PR TITLE
bug 957802: Show locale diff only on string change

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,9 +34,11 @@ setenv =
     COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
     COMPOSE_PROJECT_NAME = localetox
     GIT_PAGER = cat
+# Test that locales are refreshed w/o error,
+# then display diff only if messages changed
 commands =
     docker-compose run noext make localerefresh
-    git diff locale/templates/LC_MESSAGES
+    git diff -G "^msgid " locale/templates/LC_MESSAGES
 
 [testenv:docker]
 whitelist_externals = docker-compose


### PR DESCRIPTION
In TravisCI, show the locale diff only if the localizable string changes. This makes it clearer when a string update is needed.