### PR TITLE
bug 957802: Update contribute.json

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -7,26 +7,24 @@
         "tests": "https://travis-ci.org/mozilla/kuma"
     },
     "participate": {
-        "home": "https://wiki.mozilla.org/MDN/Development",
+        "home": "https://wiki.mozilla.org/MDN",
         "docs": "https://kuma.readthedocs.io/",
         "mailing-list": "https://www.mozilla.org/about/forums/#dev-mdn",
         "irc": "irc://irc.mozilla.org/#mdndev",
         "irc-contacts": [
-            "davidwalsh",
-            "groovecoder",
-            "hoosteeno",
-            "jezdez",
+            "jgmize",
+            "jpetto",
             "jwhitlock",
-            "openjck",
-            "robhudson",
+            "metadave",
+            "rjohnson",
             "shobson"
         ]
     },
     "bugs": {
         "list": "https://bugzilla.mozilla.org/buglist.cgi?list_id=11220394&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=REOPENED&product=Mozilla%20Developer%20Network",
         "report": "https://bugzilla.mozilla.org/form.mdn",
-        "mentored": "https://bugzilla.mozilla.org/buglist.cgi?list_id=11220418&o1=isnotempty&f1=bug_mentor&query_format=advanced&bug_status=UNCONFIRMED&bug_status=NEW&bug_status=REOPENED&product=Mozilla%20Developer%20Network",
-        "goodfirstbug": "https://bugzilla.mozilla.org/buglist.cgi?bug_status=UNCONFIRMED&bug_status=NEW&bug_status=ASSIGNED&bug_status=REOPENED&columnlist=short_desc%2Ccomponent%2Cchangeddate&product=Mozilla%20Developer%20Network&query_format=advanced&status_whiteboard=[good%20first%20bug]&status_whiteboard_type=allwordssubstr&list_id=11218458"
+        "mentored": "https://bugzilla.mozilla.org/buglist.cgi?o1=isnotempty&f1=bug_mentor&resolution=---&product=Mozilla%20Developer%20Network",
+        "goodfirstbug": "https://bugzilla.mozilla.org/buglist.cgi?resolution=---&product=Mozilla%20Developer%20Network&status_whiteboard=[good%20first%20bug]&status_whiteboard_type=allwordssubstr"
     },
     "urls": {
         "prod": "https://developer.mozilla.org/",
@@ -39,7 +37,7 @@
         "html5",
         "jquery",
         "ckeditor",
-        "vagrant",
+        "docker",
         "ansible",
         "mysql",
         "elasticsearch"


### PR DESCRIPTION
* Move ``home`` link from old Platform dev page to MDN Durable Team homepage
* Update IRC handle list
* Fix ``mentored`` and ``goodfirstbug`` links
* Swap keyword ``vagrant`` for ``docker``