### PR TITLE
bug 1339375: Handle new params in GitHub emails

### DIFF
--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -134,7 +134,9 @@ class SocialTestMixin(object):
         {
             'email': 'octocat-private@example.com',
             'verified': True,
-            'primary': True
+            'primary': True,
+            # Added Feb 2017, bug 1339375
+            'visibility': 'private'
         }
     ]
 


### PR DESCRIPTION
GitHub added a new parameter "[visibility](https://developer.github.com/v3/users/emails/#toggle-primary-email-visibility)" to reflect if a GitHub user's primary email address is visible on their profile.  Update the signup form to only load the expected variables.