### PR TITLE
[Bug 1218563] Remove TransactionTestCase in order to make test faster

### DIFF
--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.cache import cache
-from django.test import TestCase, TransactionTestCase
+from django.test import TestCase
 from django.test.client import Client
 from django.utils.translation import trans_real
 
@@ -143,8 +143,4 @@ class KumaTestMixin(object):
 
 
 class KumaTestCase(KumaTestMixin, TestCase):
-    pass
-
-
-class KumaTransactionTestCase(KumaTestMixin, TransactionTestCase):
     pass

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -9,7 +9,7 @@ from django.contrib.sites.models import Site
 from django.utils.crypto import get_random_string
 from django.utils.six.moves.urllib_parse import urlparse, parse_qs
 
-from kuma.core.tests import KumaTestCase, KumaTransactionTestCase
+from kuma.core.tests import KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.tests import revision as create_revision, document as create_document
 from ..providers.github.provider import KumaGitHubProvider
@@ -25,10 +25,6 @@ class UserTestMixin(object):
 
 
 class UserTestCase(UserTestMixin, KumaTestCase):
-    pass
-
-
-class UserTransactionTestCase(UserTestMixin, KumaTransactionTestCase):
     pass
 
 

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -14,7 +14,7 @@ from kuma.core.urlresolvers import reverse
 from kuma.spam.constants import (CHECK_URL, SPAM_ADMIN_FLAG,
                                  SPAM_SPAMMER_FLAG, SPAM_TESTING_FLAG,
                                  SPAM_CHECKS_FLAG, VERIFY_URL)
-from kuma.users.tests import UserTestCase, UserTransactionTestCase
+from kuma.users.tests import UserTestCase
 
 from ..constants import SPAM_EXEMPTED_FLAG, SPAM_TRAINING_FLAG
 from ..forms import AkismetHistoricalData, RevisionForm, TreeMoveForm
@@ -92,7 +92,7 @@ class AkismetHistoricalDataTests(UserTestCase):
         assert params == {'content': 'spammy'}
 
 
-class RevisionFormTests(UserTransactionTestCase):
+class RevisionFormTests(UserTestCase):
     """
     Generic tests for RevisionForm.
 
@@ -232,7 +232,7 @@ class RevisionFormTests(UserTransactionTestCase):
 
 
 @override_config(AKISMET_KEY='forms')
-class RevisionFormViewTests(UserTransactionTestCase):
+class RevisionFormViewTests(UserTestCase):
     """Setup tests for RevisionForm as used in views."""
     rf = RequestFactory()
     akismet_keys = [  # Keys for a new English page or new translation


### PR DESCRIPTION
Remove ``TransactionTestCase`` in order to run the test faster in OS X. @davedash [blogged it ](http://davedash.com/2010/03/16/making-our-tests-run-thrice-as-fast/) many years ago while working in ``zamboni`` and I think it is still valid today.

I believe this test was living there from the ``zamboni`` era as ``kitsune`` and ``zamboni`` shared code among each other.