### PR TITLE
bug 1342474: remove wiki.move_requested endpoint

### DIFF
--- a/kuma/wiki/urls.py
+++ b/kuma/wiki/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import include, url
-from django.views.generic import TemplateView
 
 from kuma.attachments.feeds import AttachmentsFeed
 from kuma.attachments.views import edit_attachment
@@ -101,9 +100,6 @@ urlpatterns = [
     url(r'^/preview-wiki-content$',
         views.revision.preview,
         name='wiki.preview'),
-    url(r'^/move-requested$',
-        TemplateView.as_view(template_name='wiki/move_requested.html'),
-        name='wiki.move_requested'),
     url(r'^/get-documents$',
         views.misc.autosuggest_documents,
         name='wiki.autosuggest_documents'),


### PR DESCRIPTION
This PR simply removes the "wiki.move_requested" endpoint (https://developer.mozilla.org/en-US/docs/move-requested) as it is a broken URL (always raises an ISE). It's view is a generic TemplateView, and it's template expects a context containing a document, but there's no way to inject a document into the context, either for example via GET params (they are not extracted even if provided) or POST data (POST's are not handled).

This endpoint was originally added via this commit https://github.com/mozilla/kuma/commit/b71558845015a11deab36a370a317bf4cc75fbff in 2013, and was originally used as a target for redirects from the "wiki.move" endpoint (as @jwhitlock suspected - amazing memory!). This is no longer the case. The endpoint is no longer used, and can be safely removed.

