### PR TITLE
Bug 1332882 Fix capitalization for Articles in need of review page

### DIFF
--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -9,9 +9,9 @@
   {% endif %}
 {% endblock %}
 {% if tag %}
-  {% set title = _('Articles in Need of Review Tagged: %(tag)s', tag=tag) %}
+  {% set title = _('Articles in need of review: %(tag)s', tag=tag) %}
 {% else %}
-  {% set title = _('All Articles in Need of Review') %}
+  {% set title = _('All articles in need of review') %}
 {% endif %}
 {% block title %}{{ page_title(title) }}{% endblock %}
 {% set crumbs = [(None, title)] %}


### PR DESCRIPTION
Fixed the capitalization of the Articles in need page title as specified by the styleguide here https://developer.mozilla.org/en-US/docs/MDN/Contribute/Guidelines/Writing_style_guide#Title_and_heading_capitalization