### PR TITLE
Hides the following links/buttons:

### DIFF
--- a/kuma/static/styles/maintenance-mode-global.scss
+++ b/kuma/static/styles/maintenance-mode-global.scss
@@ -8,10 +8,14 @@
     }
 }
 
-// hide login and edit buttons
+// hide links/buttons to disabled functions
 .maintenance-mode {
+    .activity-actions .edit,
+    .change-revisions,
     .login,
-    .page-buttons-edit {
+    .page-buttons-edit,
+    .revert-revision,
+    #translations-add {
         display: none;
     }
 }

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -26,7 +26,7 @@
 {% macro revision_diff(revision_from, revision_to, revision_from_header=None, revision_to_header=None, show_picker=False) -%}
   {% if revision_from and revision_to %}
     <section class="revision-diff">
-      <a href="{{ url('wiki.document_revisions', revision_from.document.slug)|urlparams(locale=revision_from.document.locale, origin='translate') }}">{{ _('Change Revisions') }}</a>
+      <a class="change-revisions" href="{{ url('wiki.document_revisions', revision_from.document.slug)|urlparams(locale=revision_from.document.locale, origin='translate') }}">{{ _('Change Revisions') }}</a>
       <header>
         <div class="rev-from">
             <h3>

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -67,7 +67,7 @@
               </div>
               {% if document.current_revision.id != rev.id and user_can_delete %}
               <div class="revision-list-cell">
-                <a href="{{ url('wiki.revert_document', document.slug, rev.id) }}" class="button" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
+                <a href="{{ url('wiki.revert_document', document.slug, rev.id) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
               </div>
               {% endif %}
             </li>

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -73,7 +73,7 @@
     </details>
 
     {% if document.allows_revision_by(request.user) %}
-    <a href="{{ url('wiki.revert_document', document.slug, revision.id) }}" class="button" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
+    <a href="{{ url('wiki.revert_document', document.slug, revision.id) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
     {% endif %}
   </article>
 {% endblock %}


### PR DESCRIPTION
- "Edit page" from /profiles/Profile
- "Revert to this revision" from /docs/path/to/doc$revision/123456
- "Change revisions" from /docs/path/to/doc$compare?locale=whtvr&to=12345&from=67890
- "Add a translation" from most/all /docs pages (inside the "Languages" drop down)