### PR TITLE
[Bug 1269104] Compare a new translation to the English document

### DIFF
--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -63,6 +63,9 @@
                 <a href="{{ rev.creator.get_absolute_url() }}">{{ rev.creator }}</a>
               </div>
               <div class="revision-list-cell revision-list-comment">
+                {% if rev.document.locale != document.locale %}
+                  <em>{{ get_locale_localized(rev.document.locale) }}</em>
+                {% endif %}
                 {{ format_comment(rev) }}
               </div>
               {% if document.current_revision.id != rev.id and user_can_delete %}

--- a/kuma/wiki/queries.py
+++ b/kuma/wiki/queries.py
@@ -1,50 +1,6 @@
 from django.db import models
 
 
-class MultiQuerySet(object):
-    def __init__(self, *args, **kwargs):
-        self.querysets = args
-        self._count = None
-
-    def _clone(self):
-        querysets = [qs._clone() for qs in self.querysets]
-        return MultiQuerySet(*querysets)
-
-    def __repr__(self):
-        return repr(list(self.querysets))
-
-    def count(self):
-        if not self._count:
-            self._count = sum([qs.count() for qs in self.querysets])
-        return self._count
-
-    def __len__(self):
-        return self.count()
-
-    def exists(self):
-        return self.count() > 0
-
-    def __iter__(self):
-        for qs in self.querysets:
-            for item in qs.all():
-                yield item
-
-    def __getitem__(self, item):
-        offset, stop, step = item.indices(self.count())
-        items = []
-        total_len = stop - offset
-        for qs in self.querysets:
-            if len(qs) < offset:
-                offset -= len(qs)
-            else:
-                items += list(qs[offset:offset + total_len - len(items)])
-                if len(items) >= total_len:
-                    return items
-                else:
-                    offset = 0
-                    continue
-
-
 class TransformQuerySet(models.query.QuerySet):
     def __init__(self, *args, **kwargs):
         super(TransformQuerySet, self).__init__(*args, **kwargs)

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -215,6 +215,24 @@ class ViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(all_url)
         eq_(200, resp.status_code)
 
+    def test_translation_history_has_based_on_revision_to_compare(self):
+        """In the history of a translation, there should be based on revision
+           So that its possible to compare a new translation with its based on"""
+
+        eng_rev = revision(is_approved=True, save=True)
+        trans_doc = document(locale='bn-BD', parent=eng_rev.document, save=True)
+        revision(document=trans_doc, based_on=eng_rev, save=True)
+
+        url = reverse('wiki.document_revisions', args=(trans_doc.slug,), locale=trans_doc.locale)
+        resp = self.client.get(url)
+        eq_(200, resp.status_code)
+        data = pq(resp.content)
+        list_content = data('.revision-list-contain').find('li')
+        # Check there are 2 revision in the list
+        eq_(2, len(list_content))
+        # Check parent_revision id is below to compare from
+        eq_(str(eng_rev.id), list_content.find('input[name=from]')[1].attrib['value'])
+
     def test_toc_view(self):
         slug = 'toc_test_doc'
         html = '<h2>Head 2</h2><h3>Head 3</h3>'

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -190,14 +190,14 @@ def revisions(request, document_slug, document_locale):
     # Grab revisions, but defer summary and content because they can lead to
     # attempts to cache more than memcached allows.
     all_revisions = (document.revisions.defer('summary', 'content').order_by('created', 'id')
-                                                                   .reverse().transform(get_previous))
+                     .select_related('creator').reverse().transform(get_previous))
 
     if not all_revisions.exists():
         raise Http404
 
     if per_page == 'all':
         page = None
-        revisions = list(all_revisions)
+        all_revisions = list(all_revisions)
     else:
         try:
             per_page = int(per_page)
@@ -205,19 +205,19 @@ def revisions(request, document_slug, document_locale):
             per_page = DOCUMENTS_PER_PAGE
 
         page = paginate(request, all_revisions, per_page)
-        revisions = list(page.object_list)
+        all_revisions = list(page.object_list)
     # In order to compare the first revision of a translation, need to insert its parent revision to the list
     # The parent revision should stay at last page in order to compare. So insert only if there are no next page or
     # all revisions are showing
     if (not page or not page.has_next()) and document.parent:
         # *all_revisions are in descending order. so call last() in order to get first revision
-        first_rev_based_on = all_revisions.last().based_on
+        first_rev_based_on = all_revisions[-1].based_on
         # Translation can be orphan so that first revision does not have any english based on. So handle the situation.
         if first_rev_based_on:
-            revisions.append(first_rev_based_on)
+            all_revisions.append(first_rev_based_on)
 
     context = {
-        'revisions': revisions,
+        'revisions': all_revisions,
         'document': document,
         'page': page,
     }

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -210,7 +210,11 @@ def revisions(request, document_slug, document_locale):
     # The parent revision should stay at last page in order to compare. So insert only if there are no next page or
     # all revisions are showing
     if (not page or not page.has_next()) and document.parent:
-        revisions.append(all_revisions.last().based_on)
+        # *all_revisions are in descending order. so call last() in order to get first revision
+        first_rev_based_on = all_revisions.last().based_on
+        # Translation can be orphan so that first revision does not have any english based on. So handle the situation.
+        if first_rev_based_on:
+            revisions.append(first_rev_based_on)
 
     context = {
         'revisions': revisions,

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -8,9 +8,8 @@ from kuma.core.utils import paginate
 
 from ..constants import DOCUMENTS_PER_PAGE
 from ..decorators import process_document_path, prevent_indexing
-from ..models import (Document, DocumentTag, Revision, ReviewTag,
+from ..models import (Document, DocumentTag, ReviewTag,
                       LocalizationTag)
-from ..queries import MultiQuerySet
 
 
 @block_user_agents
@@ -190,30 +189,28 @@ def revisions(request, document_slug, document_locale):
 
     # Grab revisions, but defer summary and content because they can lead to
     # attempts to cache more than memcached allows.
-    revisions = MultiQuerySet(
-        (Revision.objects.filter(pk=document.current_revision.pk)
-                         .prefetch_related('creator', 'document')
-                         .transform(get_previous)),
-        (Revision.objects.filter(document=document)
-                         .order_by('-created', '-id')
-                         .exclude(pk=document.current_revision.pk)
-                         .prefetch_related('creator', 'document')
-                         .transform(get_previous))
-    )
+    all_revisions = (document.revisions.defer('summary', 'content').order_by('created', 'id')
+                                                                   .reverse().transform(get_previous))
 
-    if not revisions.exists():
+    if not all_revisions.exists():
         raise Http404
 
     if per_page == 'all':
         page = None
+        revisions = list(all_revisions)
     else:
         try:
             per_page = int(per_page)
         except ValueError:
             per_page = DOCUMENTS_PER_PAGE
 
-        page = paginate(request, revisions, per_page)
-        revisions = page.object_list
+        page = paginate(request, all_revisions, per_page)
+        revisions = list(page.object_list)
+    # In order to compare the first revision of a translation, need to insert its parent revision to the list
+    # The parent revision should stay at last page in order to compare. So insert only if there are no next page or
+    # all revisions are showing
+    if (not page or not page.has_next()) and document.parent:
+        revisions.append(all_revisions.last().based_on)
 
     context = {
         'revisions': revisions,

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -94,7 +94,12 @@ def compare(request, document_slug, document_locale):
     to_id = smart_int(request.GET.get('to'))
 
     revisions = Revision.objects.prefetch_related('document')
-    revision_from = get_object_or_404(revisions, id=from_id, document=doc)
+    # It should also be possible to compare from the parent document revision
+    try:
+        revision_from = revisions.get(id=from_id, document=doc)
+    except Revision.DoesNotExist:
+        revision_from = get_object_or_404(revisions, id=from_id, document=doc.parent)
+
     revision_to = get_object_or_404(revisions, id=to_id, document=doc)
 
     context = {


### PR DESCRIPTION
So its possible to compare with the english document. In order to compare, I have chosen the revision that the translation based on.
Also refactored the queryset because I think its overkilling and its possible to fetch the data with simple queryset.
@jwhitlock Should we add test for this change?
r?