### PR TITLE
Add simple in-line editorial comments feature

### DIFF
--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -56,6 +56,36 @@
     }
 }
 
+/* Editorial comments; don't display these unless in the editor. */
+
+.editorial-comment {
+  display: none;
+
+  html.cke_panel_container &,
+  body[contenteditable] & {
+    position: relative;
+    display: block;
+    border: 1px solid #3e3544;
+    padding: 6px 3px 3px;
+    background-color: #e9c0ff;
+    margin-bottom: 9px;
+
+    &:before {
+      @include set-font-size(16px);
+      content: "Editorial Note";
+      position: absolute;
+      top: -25px;
+      left: -1px;
+      z-index: 10;
+      display: block;
+      padding: 0 8px;
+      background-color: #3e3544;
+      color: #e9c0ff;
+    }
+
+  }
+}
+
 .title {
     @include title-header();
 }

--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -154,7 +154,8 @@
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },
         { name: 'Syntax Box', element: 'pre', attributes: { 'class': 'syntaxbox' } },
         { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } },
-        { name: 'Hidden When Reading', element: 'div', attributes: { 'class': 'hidden' }, type: 'wrap' }
+        { name: 'Hidden When Reading', element: 'div', attributes: { 'class': 'hidden' }, type: 'wrap' },
+        { name: 'Editorial Note', element: 'div', attributes: { 'class': 'editorial-comment' }, type: 'wrap' }
       ]);
     }
     config.keystrokes = [


### PR DESCRIPTION
Adds a new CSS class, editorial-comment, which makes a &lt;div&gt; that is presented
in a nice box but only when in the editor; this is meant to be used for leaving
notes to self and/or other writers, review comments, or to place information that will be useful
when it's time to make upcoming changes to the article without having the editorial notes displayed to most users.

The new style can be applied by selecting "Editorial Note" from the Style
drop-down in the editor's toolbar.