### PR TITLE
Bug 1341770: Add content experiments

### DIFF
--- a/Jenkinsfiles/content-exp.yml
+++ b/Jenkinsfiles/content-exp.yml
@@ -1,0 +1,3 @@
+pipeline:
+  enabled: true
+  script: demo

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -4,6 +4,9 @@
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="redesign no-js" data-ffo-opensans="false" data-ffo-opensanslight="false">
 <head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
+
+  {% block experiment_js %}{% endblock %}
+
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
   {% if not is_sphinx %}

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -4,9 +4,7 @@
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="redesign no-js" data-ffo-opensans="false" data-ffo-opensanslight="false">
 <head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
-
-  {% block experiment_js %}{% endblock %}
-
+  {%- block experiment_js %}{% endblock %}
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
   {% if not is_sphinx %}

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -30,6 +30,13 @@
         ga('set', 'dimension12', '{{ analytics_page_revision }}');
     {%- endif %}
 
+    {%- if content_experiment and content_experiment.selection_is_valid %}
+        // dimension15 == “a/b test variation”, user scope
+        ga('set', 'dimension15', '{{ content_experiment.ga_name }}:{{ content_experiment.selected }}');
+        // dimension16 == "Original Path", hit scope
+        ga('set', 'dimension16', '{{ content_experiment.original_path }}');
+    {%- endif %}
+
     (function() {
         // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
         var win = window;

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -30,7 +30,9 @@
         ga('set', 'dimension12', '{{ analytics_page_revision }}');
     {%- endif %}
 
-    {%- if content_experiment and content_experiment.selection_is_valid %}
+    {%- if not request.user.is_authenticated() and
+           content_experiment and
+           content_experiment.selection_is_valid %}
         // dimension15 == “a/b test variation”, user scope
         ga('set', 'dimension15', '{{ content_experiment.ga_name }}:{{ content_experiment.selected }}');
         // dimension16 == "Original Path", hit scope

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -953,6 +953,15 @@ PIPELINE_JS = {
         ),
         'output_filename': 'build/js/ace.js',
     },
+    'experiment-wiki-content': {
+        'source_filenames': (
+            'js/libs/mozilla.dnthelper.js',
+            'js/libs/mozilla.cookiehelper.js',
+            'js/libs/mozilla.trafficcop.js',
+            'js/experiment-wiki-content.js',
+        ),
+        'output_filename': 'build/js/experiment-wiki-content',
+    },
 }
 
 PIPELINE = {

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -960,7 +960,16 @@ PIPELINE_JS = {
             'js/libs/mozilla.trafficcop.js',
             'js/experiment-wiki-content.js',
         ),
-        'output_filename': 'build/js/experiment-wiki-content',
+        'output_filename': 'build/js/experiment-wiki-content.js',
+    },
+    'experiment-framework-test': {
+        'source_filenames': (
+            'js/libs/mozilla.dnthelper.js',
+            'js/libs/mozilla.cookiehelper.js',
+            'js/libs/mozilla.trafficcop.js',
+            'js/experiment-framework-test.js',
+        ),
+        'output_filename': 'build/js/experiment-framework-test.js',
     },
 }
 
@@ -1463,6 +1472,11 @@ NOCAPTCHA = True  # Note: Using No Captcha implies SSL.
 TAGGIT_CASE_INSENSITIVE = True
 
 # Content Experiments
+# Must be kept up to date with PIPELINE_JS setting and the JS client-side
+#  configuration. The 'id' should be a key in PIPELINE_JS, that loads
+#  Traffic Cop and a client-side configuration like
+#  kuma/static/js/experiment-wiki-content.js
+#
 CONTENT_EXPERIMENTS = [{
     'id': 'experiment-framework-test',
     'ga_name': 'framework-test',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1452,3 +1452,18 @@ NOCAPTCHA = True  # Note: Using No Captcha implies SSL.
 
 # Tell django-taggit to use case-insensitive search for existing tags
 TAGGIT_CASE_INSENSITIVE = True
+
+# Content Experiments
+CONTENT_EXPERIMENTS = [{
+    'id': 'experiment-framework-test',
+    'ga_name': 'framework-test',
+    'param': 'v',
+    'pages': [{
+        'locale': 'en-US',
+        'slug': 'Web/JavaScript/Reference/Operators/Comparison_Operators',
+        'variants': [
+            ['control', 50, 'Web/JavaScript/Reference/Operators/Comparison_Operators'],
+            ['test', 50, 'Experiment:FrameworkTest/Comparison_Operators'],
+        ]
+    }]
+}]

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1486,8 +1486,8 @@ CONTENT_EXPERIMENTS = [{
         'locale': 'en-US',
         'slug': 'Web/JavaScript/Reference/Operators/Comparison_Operators',
         'variants': [
-            ['control', 50, 'Web/JavaScript/Reference/Operators/Comparison_Operators'],
-            ['test', 50, 'Experiment:FrameworkTest/Comparison_Operators'],
+            ['control', 'Web/JavaScript/Reference/Operators/Comparison_Operators'],
+            ['test', 'Experiment:FrameworkTest/Comparison_Operators'],
         ]
     }]
 }]

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1476,6 +1476,7 @@ TAGGIT_CASE_INSENSITIVE = True
 #  configuration. The 'id' should be a key in PIPELINE_JS, that loads
 #  Traffic Cop and a client-side configuration like
 #  kuma/static/js/experiment-wiki-content.js
+# Only one experiment should be active for a given locale and slug.
 #
 CONTENT_EXPERIMENTS = [{
     'id': 'experiment-framework-test',

--- a/kuma/static/js/experiment-framework-test.js
+++ b/kuma/static/js/experiment-framework-test.js
@@ -1,0 +1,14 @@
+(function() {
+    'use strict';
+
+    var lou = new Mozilla.TrafficCop({
+        id: 'experiment-framework-test',
+        cookieExpires: 24 * 365, // 1 year
+        variations: {
+            'v=control': 50, // original
+            'v=test': 50     // content from Experiment:FrameworkTest
+        }
+    });
+    lou.init();
+
+})(window.Mozilla);

--- a/kuma/static/js/experiment-wiki-content.js
+++ b/kuma/static/js/experiment-wiki-content.js
@@ -1,0 +1,16 @@
+(function() {
+    'use strict';
+
+    // cookie will expire in 24 hours
+    var lou = new Mozilla.TrafficCop({
+        id: 'experiment-wiki-content',
+        // assumes all content experiments live at ?v=2
+        variations: {
+            'v=1': 50, // double control
+            'v=2': 50 // variation w/new content
+        }
+    });
+
+    // TODO: uncomment below to enable traffic redirection
+    //lou.init();
+})(window.Mozilla);

--- a/kuma/static/js/libs/mozilla.cookiehelper.js
+++ b/kuma/static/js/libs/mozilla.cookiehelper.js
@@ -1,0 +1,99 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/*\
+|*|
+|*|  :: cookies.js ::
+|*|
+|*|  A complete cookies reader/writer framework with full unicode support.
+|*|
+|*|  Revision #1 - September 4, 2014
+|*|
+|*|  https://developer.mozilla.org/en-US/docs/Web/API/document.cookie
+|*|  https://developer.mozilla.org/User:fusionchess
+|*|
+|*|  This framework is released under the GNU Public License, version 3 or later.
+|*|  http://www.gnu.org/licenses/gpl-3.0-standalone.html
+|*|
+|*|  Syntaxes:
+|*|
+|*|  * Mozilla.Cookies.setItem(name, value[, end[, path[, domain[, secure]]]])
+|*|  * Mozilla.Cookies.getItem(name)
+|*|  * Mozilla.Cookies.removeItem(name[, path[, domain]])
+|*|  * Mozilla.Cookies.hasItem(name)
+|*|  * Mozilla.Cookies.keys()
+|*|
+\*/
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+Mozilla.Cookies = {
+    getItem: function (sKey) {
+        if (!sKey) { return null; }
+        return decodeURIComponent(document.cookie.replace(new RegExp('(?:(?:^|.*;)\\s*' + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=\\s*([^;]*).*$)|^.*$'), '$1')) || null;
+    },
+    setItem: function (sKey, sValue, vEnd, sPath, sDomain, bSecure) {
+        if (!sKey || /^(?:expires|max\-age|path|domain|secure)$/i.test(sKey)) { return false; }
+        var sExpires = '';
+        if (vEnd) {
+            switch (vEnd.constructor) {
+            case Number:
+                sExpires = vEnd === Infinity ? '; expires=Fri, 31 Dec 9999 23:59:59 GMT' : '; max-age=' + vEnd;
+                break;
+            case String:
+                sExpires = '; expires=' + vEnd;
+                break;
+            case Date:
+                sExpires = '; expires=' + vEnd.toUTCString();
+                break;
+            }
+        }
+        document.cookie = encodeURIComponent(sKey) + '=' + encodeURIComponent(sValue) + sExpires + (sDomain ? '; domain=' + sDomain : '') + (sPath ? '; path=' + sPath : '') + (bSecure ? '; secure' : '');
+        return true;
+    },
+    removeItem: function (sKey, sPath, sDomain) {
+        if (!this.hasItem(sKey)) { return false; }
+        document.cookie = encodeURIComponent(sKey) + '=; expires=Thu, 01 Jan 1970 00:00:00 GMT' + (sDomain ? '; domain=' + sDomain : '') + (sPath ? '; path=' + sPath : '');
+        return true;
+    },
+    hasItem: function (sKey) {
+        if (!sKey) { return false; }
+        return (new RegExp('(?:^|;\\s*)' + encodeURIComponent(sKey).replace(/[\-\.\+\*]/g, '\\$&') + '\\s*\\=')).test(document.cookie);
+    },
+    keys: function () {
+        var aKeys = document.cookie.replace(/((?:^|\s*;)[^\=]+)(?=;|$)|^\s*|\s*(?:\=[^;]*)?(?:\1|$)/g, '').split(/\s*(?:\=[^;]*)?;\s*/);
+        for (var nLen = aKeys.length, nIdx = 0; nIdx < nLen; nIdx++) { aKeys[nIdx] = decodeURIComponent(aKeys[nIdx]); }
+        return aKeys;
+    },
+    enabled: function() {
+        /**
+         * Cookies feature detect lifted from Modernizr
+         * https://github.com/Modernizr/Modernizr/blob/master/feature-detects/cookies.js
+         *
+         * navigator.cookieEnabled cannot detect custom or nuanced cookie blocking
+         * configurations. For example, when blocking cookies via the Advanced
+         * Privacy Settings in IE9, it always returns true. And there have been
+         * issues in the past with site-specific exceptions.
+         * Don't rely on it.
+
+         * try..catch because in some situations `document.cookie` is exposed but throws a
+         * SecurityError if you try to access it; e.g. documents created from data URIs
+         * or in sandboxed iframes (depending on flags/context)
+         */
+        try {
+            // Create cookie
+            document.cookie = 'cookietest=1';
+            var ret = document.cookie.indexOf('cookietest=') !== -1;
+            // Delete cookie
+            document.cookie = 'cookietest=1; expires=Thu, 01-Jan-1970 00:00:01 GMT';
+            return ret;
+        }
+        catch (e) {
+            return false;
+        }
+    }
+};

--- a/kuma/static/js/libs/mozilla.dnthelper.js
+++ b/kuma/static/js/libs/mozilla.dnthelper.js
@@ -1,0 +1,54 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+/**
+ * Returns true or false based on whether doNotTack is enabled. It also takes into account the
+ * anomalies, such as !bugzilla 887703, which effect versions of Fx 31 and lower. It also handles
+ * IE versions on Windows 7, 8 and 8.1, where the DNT implementation does not honor the spec.
+ * @see https://bugzilla.mozilla.org/show_bug.cgi?id=1217896 for more details
+ * @params {string} [dnt] - An optional mock doNotTrack string to ease unit testing.
+ * @params {string} [ua] - An optional mock userAgent string to ease unit testing.
+ * @returns {boolean} true if enabled else false
+ */
+Mozilla.dntEnabled = function(dnt, ua) {
+    'use strict';
+
+    // for old version of IE we need to use the msDoNotTrack property of navigator
+    // on newer versions, and newer platforms, this is doNotTrack but, on the window object
+    // Safari also exposes the property on the window object.
+    var dntStatus = dnt || navigator.doNotTrack || window.doNotTrack || navigator.msDoNotTrack;
+    var userAgent = ua || navigator.userAgent;
+
+    // List of Windows versions known to not implement DNT according to the standard.
+    var anomalousWinVersions = ['Windows NT 6.1', 'Windows NT 6.2', 'Windows NT 6.3'];
+
+    var fxMatch = userAgent.match(/Firefox\/(\d+)/);
+    var ieRegEx = /MSIE|Trident/i;
+    var isIE = ieRegEx.test(userAgent);
+    // Matches from Windows up to the first occurance of ; un-greedily
+    // http://www.regexr.com/3c2el
+    var platform = userAgent.match(/Windows.+?(?=;)/g);
+
+    // With old versions of IE, DNT did not exist so we simply return false;
+    if (isIE && typeof Array.prototype.indexOf !== 'function') {
+        return false;
+    } else if (fxMatch && parseInt(fxMatch[1], 10) < 32) {
+        // Can't say for sure if it is 1 or 0, due to Fx bug 887703
+        dntStatus = 'Unspecified';
+    } else if (isIE && platform && anomalousWinVersions.indexOf(platform.toString()) !== -1) {
+        // default is on, which does not honor the specification
+        dntStatus = 'Unspecified';
+    } else {
+        // sets dntStatus to Disabled or Enabled based on the value returned by the browser.
+        // If dntStatus is undefined, it will be set to Unspecified
+        dntStatus = { '0': 'Disabled', '1': 'Enabled' }[dntStatus] || 'Unspecified';
+    }
+
+    return dntStatus === 'Enabled' ? true : false;
+};

--- a/kuma/static/js/libs/mozilla.trafficcop.js
+++ b/kuma/static/js/libs/mozilla.trafficcop.js
@@ -1,0 +1,236 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+* License, v. 2.0. If a copy of the MPL was not distributed with this
+* file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// create namespace
+if (typeof Mozilla === 'undefined') {
+    var Mozilla = {};
+}
+
+/**
+ * Traffic Cop traffic redirector for A/B/x testing
+ *
+ * Example usage:
+ *
+ * var cop = new Mozilla.TrafficCop({
+ *     id: 'exp_firefox_new_all_link',
+ *     cookieExpires: 48,
+ *     variations: {
+ *         'v=1': 25,
+ *         'v=2': 25,
+ *         'v=3': 25
+ *     }
+ * });
+ *
+ * cop.init();
+ *
+ *
+ * @param Object config: Object literal containing the following:
+ *      String id (required): Unique-ish string for cookie identification.
+ *          Only needs to be unique to other currently running tests.
+ *      Number cookieExpires (optional): Number of hours browser should remember
+ *          the variation chosen for the user. Defaults to 24 (hours). A value
+ *          of 0 will result in a session-length cookie.
+ *      Object variations (required): Object holding key/value pairs of
+ *          variations and their respective traffic percentages. Example:
+ *
+ *          variations: {
+ *              'v=1': 20,
+ *              'v=2': 20,
+ *              'v=3': 20
+ *          }
+ */
+Mozilla.TrafficCop = function(config) {
+    'use strict';
+
+    // make sure config is an object
+    config = (typeof config === 'object') ? config : {};
+
+    // store id
+    this.id = config.id;
+
+    // store variations
+    this.variations = config.variations;
+
+    // store total percentage of users targeted
+    this.totalPercentage = 0;
+
+    // store experiment cookie expiry (defaults to 24 hours)
+    this.cookieExpires = (config.cookieExpires !== undefined) ? config.cookieExpires : 24;
+
+    this.redirectVariation = null;
+
+    // calculate and store total percentage of variations
+    for (var v in this.variations) {
+        if (this.variations.hasOwnProperty(v) && typeof this.variations[v] === 'number') {
+            this.totalPercentage += this.variations[v];
+        }
+    }
+
+    return this;
+};
+
+Mozilla.TrafficCop.noVariationCookieValue = 'novariation';
+
+/*
+ * Initialize the traffic cop. Validates variations, ensures user is not
+ * currently viewing a variation, and (possibly) redirects to a variation
+ */
+Mozilla.TrafficCop.prototype.init = function() {
+    var redirectUrl;
+
+    // respect the DNT
+    if (typeof Mozilla.dntEnabled === 'function' && Mozilla.dntEnabled()) {
+        return;
+    }
+
+    // If cookie helper is not defined or cookies are not enabled, do nothing.
+    if (typeof Mozilla.Cookies === 'undefined' || !Mozilla.Cookies.enabled()) {
+        return;
+    }
+
+    // make sure config is valid (id & variations present)
+    if (this.verifyConfig()) {
+        // make sure current page doesn't match a variation
+        // (to avoid infinite redirects)
+        if (!this.isVariation()) {
+            // roll the dice to see if user should be send to a variation
+            redirectUrl = this.generateRedirectUrl();
+
+            if (redirectUrl) {
+                // if we get a variation, send the user and store a cookie
+                if (redirectUrl !== Mozilla.TrafficCop.noVariationCookieValue) {
+                    Mozilla.Cookies.setItem(this.id, this.redirectVariation, this.cookieExpiresDate());
+                    window.location.href = redirectUrl;
+                }
+            } else {
+                // if no variation, set a cookie so user isn't re-entered into
+                // the dice roll on next page load
+                Mozilla.Cookies.setItem(this.id, Mozilla.TrafficCop.noVariationCookieValue, this.cookieExpiresDate());
+            }
+        }
+    }
+};
+
+/*
+ * Ensures variations were provided and in total capture between 1 and 99%
+ * of users.
+ */
+Mozilla.TrafficCop.prototype.verifyConfig = function() {
+    if (!this.id || typeof this.id !== 'string') {
+        return false;
+    }
+
+    // make sure totalPercent is between 0 and 100
+    if (this.totalPercentage === 0 || this.totalPercentage > 100) {
+        return false;
+    }
+
+    // make sure cookieExpires is null or a number
+    if (typeof this.cookieExpires !== 'number') {
+        return false;
+    }
+
+    return true;
+};
+
+/*
+ * Generates an expiration date for the visitor's cookie.
+ * 'date' param used only for unit testing.
+ */
+Mozilla.TrafficCop.prototype.cookieExpiresDate = function(date) {
+    // default to null, meaning a session-length cookie
+    var d = null;
+
+    if (this.cookieExpires > 0) {
+        d = date || new Date();
+        d.setHours(d.getHours() + this.cookieExpires);
+    }
+
+    return d;
+};
+
+/*
+ * Checks to see if user is currently viewing a variation.
+ */
+Mozilla.TrafficCop.prototype.isVariation = function(queryString) {
+    var isVariation = false;
+    queryString = queryString || window.location.search;
+
+    // check queryString for presence of variation
+    for (var v in this.variations) {
+        if (queryString.indexOf('?' + v) > -1 || queryString.indexOf('&' + v) > -1) {
+            isVariation = true;
+            break;
+        }
+    }
+
+    return isVariation;
+};
+
+/*
+ * Generates a random percentage (between 1 and 100, inclusive) and determines
+ * which (if any) variation should be matched.
+ */
+Mozilla.TrafficCop.prototype.generateRedirectUrl = function(url) {
+    var hash;
+    var rando;
+    var redirect;
+    var runningTotal;
+    var urlParts;
+
+    // url parameter only supplied for unit tests
+    url = url || window.location.href;
+
+    // strip hash from URL (if present)
+    if (url.indexOf('#') > -1) {
+        urlParts = url.split('#');
+        url = urlParts[0];
+        hash = urlParts[1];
+    }
+
+    // check to see if user has a cookie from a previously visited variation
+    // also make sure variation in cookie is still valid (you never know)
+    if (Mozilla.Cookies.hasItem(this.id)) {
+        // if the cookie is a variation, grab it and proceed
+        if (this.variations[Mozilla.Cookies.getItem(this.id)]) {
+            this.redirectVariation = Mozilla.Cookies.getItem(this.id);
+        // if the cookie is no variation, return the unset redirect to keep user
+        // in the same (no variation) cohort
+        } else if (Mozilla.Cookies.getItem(this.id) === Mozilla.TrafficCop.noVariationCookieValue) {
+            return Mozilla.TrafficCop.noVariationCookieValue;
+        }
+    } else {
+        // conjure a random number between 1 and 100 (inclusive)
+        rando = Math.floor(Math.random() * 100) + 1;
+
+        // make sure random number falls in the distribution range
+        if (rando <= this.totalPercentage) {
+            runningTotal = 0;
+
+            // loop through all variations
+            for (var v in this.variations) {
+                // check if random number falls within current variation range
+                if (rando <= (this.variations[v] + runningTotal)) {
+                    this.redirectVariation = v;
+                    break;
+                }
+
+                // tally variation percentages for the next loop iteration
+                runningTotal += this.variations[v];
+            }
+        }
+    }
+
+    // if a variation was chosen, construct a new URL
+    if (this.redirectVariation) {
+        redirect = url + (url.indexOf('?') > -1 ? '&' : '?') + this.redirectVariation;
+
+        // re-insert hash (if originally present)
+        if (hash) {
+            redirect += '#' + hash;
+        }
+    }
+
+    return redirect;
+};

--- a/kuma/wiki/jinja2/wiki/base.html
+++ b/kuma/wiki/jinja2/wiki/base.html
@@ -1,5 +1,11 @@
 {% extends "base.html" %}
 
+{% block experiment_js %}
+    {%- if content_experiment and content_experiment.selection_is_valid == False %}
+        {% javascript 'experiment-wiki-content' %}
+    {%- endif %}
+{% endblock %}
+
 {% block site_css %}
     {{ super() }}
     {% stylesheet 'wiki' %}

--- a/kuma/wiki/jinja2/wiki/base.html
+++ b/kuma/wiki/jinja2/wiki/base.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
 
 {% block experiment_js %}
-    {%- if content_experiment and content_experiment.selection_is_valid == False %}
-        {% javascript 'experiment-wiki-content' %}
+    {%- if not request.user.is_authenticated() and
+           content_experiment and
+           not content_experiment.selection_is_valid %}
+        {% javascript content_experiment.id %}
     {%- endif %}
 {% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -41,7 +41,13 @@
         </div>
       </li>{% endif %}
 
-      {% if (not document.is_template) or (user.has_perm('wiki.change_template_document')) %}
+      {%- set is_experiment = (
+            content_experiment and
+            content_experiment.selection_is_valid) %}
+      {%- set can_edit_template = (
+            (not document.is_template) or
+            user.has_perm('wiki.change_template_document')) %}
+      {% if (not is_experiment) and can_edit_template %}
       <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button" data-optimizely-hook="button-edit-doc" id="edit-button" rel="nofollow, noindex">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
       {% endif %}
 

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -334,6 +334,8 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
         assert self.expected_15 in response.content
         assert self.expected_16 in response.content
         assert self.script_src not in response.content
+        doc = pq(response.content)
+        assert not doc('#edit-button')
 
     def test_user_valid_variant_selected(self):
         """Users are not added to the Google Analytics cohort on the variant."""
@@ -350,6 +352,8 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
         assert self.expected_15 not in response.content
         assert self.expected_16 not in response.content
         assert self.script_src not in response.content
+        doc = pq(response.content)
+        assert not doc('#edit-button')
 
 
 class RevisionTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -277,8 +277,8 @@ _TEST_CONTENT_EXPERIMENTS = [{
         'locale': 'en-US',
         'slug': 'Original',
         'variants': [
-            ['control', 50, 'Original'],
-            ['test', 50, 'Experiment:Test/Variant'],
+            ['control', 'Original'],
+            ['test', 'Experiment:Test/Variant'],
         ]
     }]
 }]

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -1,0 +1,139 @@
+"""
+Tests for kuma/wiki/views/document.py
+
+Legacy tests are in test_views.py.
+"""
+
+import mock
+import pytest
+
+from kuma.wiki.models import Document
+from kuma.wiki.views.document import _apply_content_experiment
+
+
+@pytest.fixture
+def ce_settings(settings):
+    settings.CONTENT_EXPERIMENTS = [{
+        'id': 'experiment-test',
+        'ga_name': 'experiment-test',
+        'param': 'v',
+        'pages': [{
+            'locale': 'en-US',
+            'slug': 'Original',
+            'variants': [
+                ['control', 50, 'Original'],
+                ['test', 50, 'Experiment:Test/Variant'],
+            ]
+        }]
+    }]
+    return settings
+
+
+def test_apply_content_experiment_no_experiment(ce_settings, rf):
+    """If not under a content experiment, use the original Document."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = 'en-US'
+    doc.slug = 'Other'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug))
+
+    experiment_doc, params = _apply_content_experiment(request, doc)
+
+    assert experiment_doc == doc
+    assert params is None
+
+
+def test_apply_content_experiment_has_experiment(ce_settings, rf):
+    """If under a content experiment, return original Document and params."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = 'en-US'
+    doc.slug = 'Original'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug))
+
+    experiment_doc, params = _apply_content_experiment(request, doc)
+
+    assert experiment_doc == doc
+    assert params == {
+        'id': 'experiment-test',
+        'ga_name': 'experiment-test',
+        'param': 'v',
+        'original_path': '/en-US/docs/Original',
+        'variants': [
+            ['control', 50, 'Original'],
+            ['test', 50, 'Experiment:Test/Variant'],
+        ],
+        'selected': None,
+        'selection_is_valid': None,
+    }
+
+
+def test_apply_content_experiment_selected_original(ce_settings, rf):
+    """If the original is selected as the content experiment, return it."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    db_doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = db_doc.locale = 'en-US'
+    doc.slug = db_doc.slug = 'Original'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug), {'v': 'control'})
+
+    with mock.patch(
+            'kuma.wiki.views.document.Document.objects.get',
+            return_value=db_doc) as mock_get:
+        experiment_doc, params = _apply_content_experiment(request, doc)
+
+    mock_get.assert_called_once_with(locale='en-US', slug='Original')
+    assert experiment_doc == db_doc
+    assert params['selected'] == 'control'
+    assert params['selection_is_valid']
+
+
+def test_apply_content_experiment_selected_variant(ce_settings, rf):
+    """If the variant is selected as the content experiment, return it."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    db_doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = db_doc.locale = 'en-US'
+    doc.slug = 'Original'
+    db_doc.slug = 'Experiment:Test/Variant'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug), {'v': 'test'})
+
+    with mock.patch(
+            'kuma.wiki.views.document.Document.objects.get',
+            return_value=db_doc) as mock_get:
+        experiment_doc, params = _apply_content_experiment(request, doc)
+
+    mock_get.assert_called_once_with(locale='en-US',
+                                     slug='Experiment:Test/Variant')
+    assert experiment_doc == db_doc
+    assert params['selected'] == 'test'
+    assert params['selection_is_valid']
+
+
+def test_apply_content_experiment_bad_selection(ce_settings, rf):
+    """If the variant is selected as the content experiment, return it."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = 'en-US'
+    doc.slug = 'Original'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug), {'v': 'other'})
+
+    experiment_doc, params = _apply_content_experiment(request, doc)
+
+    assert experiment_doc == doc
+    assert params['selected'] is None
+    assert not params['selection_is_valid']
+
+
+def test_apply_content_experiment_valid_selection_no_doc(ce_settings, rf):
+    """If the Document for a variant doesn't exist, return the original."""
+    doc = mock.Mock(spec_set=['locale', 'slug'])
+    doc.locale = 'en-US'
+    doc.slug = 'Original'
+    request = rf.get('/%s/docs/%s' % (doc.locale, doc.slug), {'v': 'test'})
+
+    with mock.patch(
+            'kuma.wiki.views.document.Document.objects.get',
+            side_effect=Document.DoesNotExist) as mock_get:
+        experiment_doc, params = _apply_content_experiment(request, doc)
+
+    mock_get.assert_called_once_with(locale='en-US',
+                                     slug='Experiment:Test/Variant')
+    assert experiment_doc == doc
+    assert params['selected'] is None
+    assert not params['selection_is_valid']

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -21,8 +21,8 @@ def ce_settings(settings):
             'locale': 'en-US',
             'slug': 'Original',
             'variants': [
-                ['control', 50, 'Original'],
-                ['test', 50, 'Experiment:Test/Variant'],
+                ['control', 'Original'],
+                ['test', 'Experiment:Test/Variant'],
             ]
         }]
     }]
@@ -58,8 +58,8 @@ def test_apply_content_experiment_has_experiment(ce_settings, rf):
         'param': 'v',
         'original_path': '/en-US/docs/Original',
         'variants': [
-            ['control', 50, 'Original'],
-            ['test', 50, 'Experiment:Test/Variant'],
+            ['control', 'Original'],
+            ['test', 'Experiment:Test/Variant'],
         ],
         'selected': None,
         'selection_is_valid': None,

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -274,7 +274,7 @@ def _apply_content_experiment(request, doc):
                 selected = request.GET.get(experiment['param'])
                 if selected:
                     exp_params['selection_is_valid'] = False
-                    for variant, percent, variant_slug in pages['variants']:
+                    for variant, variant_slug in pages['variants']:
                         if selected == variant:
                             try:
                                 content_doc = Document.objects.get(

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -243,6 +243,54 @@ def _get_doc_and_fallback_reason(document_locale, document_slug):
     return doc, fallback_reason
 
 
+def _apply_content_experiment(request, doc):
+    """
+    Get Document and rendering parameters changed by the content experiment.
+
+    If the page is under a content experiment and the selected variant is
+    valid, the return is (the variant Document, the experiment params).
+
+    If the page is under a content experiment but the variant is invalid or
+    not selected, the return is (original Document, the experiment params).
+
+    If the page is not under a content experiment, the return is
+    (original Document, None).
+    """
+    for experiment in settings.CONTENT_EXPERIMENTS:
+        for pages in experiment['pages']:
+            if (pages['locale'] == doc.locale and pages['slug'] == doc.slug):
+                # This page is under a content experiment
+                exp_params = {
+                    'id': experiment['id'],
+                    'ga_name': experiment['ga_name'],
+                    'param': experiment['param'],
+                    'original_path': request.path,
+                    'variants': pages['variants'],
+                    'selected': None,
+                    'selection_is_valid': None,
+                }
+
+                # Which variant was selected?
+                selected = request.GET.get(experiment['param'])
+                if selected:
+                    exp_params['selection_is_valid'] = False
+                    for variant, percent, variant_slug in pages['variants']:
+                        if selected == variant:
+                            try:
+                                content_doc = Document.objects.get(
+                                    locale=pages['locale'],
+                                    slug=variant_slug)
+                            except Document.DoesNotExist:
+                                pass
+                            else:
+                                # Valid variant selected
+                                exp_params['selected'] = selected
+                                exp_params['selection_is_valid'] = True
+                                return content_doc, exp_params
+                return doc, exp_params  # No (valid) variant selected
+    return doc, None  # Not a content experiment
+
+
 @block_user_agents
 @require_GET
 @allow_CORS_GET
@@ -615,9 +663,15 @@ def document(request, document_slug, document_locale):
         rendering_params[param] = request.GET.get(param, False) is not False
     rendering_params['section'] = request.GET.get('section', None)
     rendering_params['render_raw_fallback'] = False
-    rendering_params['use_rendered'] = kumascript.should_use_rendered(doc, request.GET)
+
+    # Are we in a content experiment?
+    original_doc = doc
+    doc, exp_params = _apply_content_experiment(request, doc)
+    rendering_params['experiment'] = exp_params
 
     # Get us some HTML to play with.
+    rendering_params['use_rendered'] = (
+        kumascript.should_use_rendered(doc, request.GET))
     doc_html, ks_errors, render_raw_fallback = _get_html_and_errors(
         request, doc, rendering_params)
     rendering_params['render_raw_fallback'] = render_raw_fallback
@@ -661,7 +715,7 @@ def document(request, document_slug, document_locale):
 
     # Bundle it all up and, finally, return.
     context = {
-        'document': doc,
+        'document': original_doc,
         'document_html': doc_html,
         'toc_html': toc_html,
         'quick_links_html': quick_links_html,
@@ -679,6 +733,7 @@ def document(request, document_slug, document_locale):
         'share_text': share_text,
         'search_url': get_search_url_from_referer(request) or '',
         'analytics_page_revision': doc.current_revision_id,
+        'content_experiment': rendering_params['experiment'],
     }
     response = render(request, 'wiki/document.html', context)
     return _set_common_headers(doc, rendering_params['section'], response)

--- a/media/robots.txt
+++ b/media/robots.txt
@@ -19,6 +19,7 @@ Disallow: /*docs/new
 Disallow: /*docs/get-documents
 Disallow: /*docs/submit_akismet_spam
 Disallow: /*docs/load*
+Disallow: /*docs/Experiment:*
 Disallow: /*$compare
 Disallow: /*$revision
 Disallow: /*$history


### PR DESCRIPTION
Content experiments are A/B tests where some visitors see the Document content from a different page, based on a URL parameter. See [A/B Testing of wiki page content](https://docs.google.com/document/d/1CUe6-EqNbpSkLMLxfd0RWW6-TbPZFRtLc0rMh2Uu3G0/edit#) for the full spec.

This PR doesn't include functional tests, but should.  I plan to add those in a future PR, after PR #4150 is merged.

The first experiment will test out the framework. Anonymous users visiting [Web/JavaScript/Reference/Operators/Comparison_Operators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Comparison_Operators) will have a 50% / 50% chance of viewing the content from [Experiment:FrameworkTest/Comparison_Operators](https://developer.mozilla.org/en-US/docs/Experiment:FrameworkTest/Comparison_Operators), which is currently the same.

The backend:
* Selects pages and variants for the experiment with the ``CONTENT_EXPERIMENTS`` setting
* Injects [Traffic Cop](https://mozilla.github.io/meao/2017/01/16/traffic-cop/) when a page in the experiment is requested by an anonymous user
* Switches to variant content when a variant is requested
* Add the Google Analytics custom dimensions and disables editing when an anon user requests a variant

The front-end:
* Picks a variant for the experiment, storing the choice in a cookie
* Redirects the user from the original to the variant with a query string parameter