### PR TITLE
Automatically import sample MDN db upon k8s demo instance creation

### DIFF
--- a/Jenkinsfiles/demo.groovy
+++ b/Jenkinsfiles/demo.groovy
@@ -14,5 +14,6 @@ stage('Deploy') {
   sh "KUBECONFIG=${env.KUBECONFIG} kubectl --namespace=${env.DEIS_APP} apply -f k8s/"
   sh 'make deis-pull'
   sh 'make deis-migrate'
+  sh 'make demo-db-import'
   sh 'make deis-scale-worker'
 }

--- a/Jenkinsfiles/dynamicmysql.yml
+++ b/Jenkinsfiles/dynamicmysql.yml
@@ -1,0 +1,3 @@
+pipeline:
+  enabled: true
+  script: demo

--- a/Jenkinsfiles/import-demo-db.sh
+++ b/Jenkinsfiles/import-demo-db.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -x
+
+# DEIS_APP contains the mdn-demo- branch prefix
+KUBE_NAMESPACE="${DEIS_APP}"
+
+# relatively static vars
+MYSQL_PORT=3306
+MDN_SAMPLE_DB_URL=https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
+MYSQL_DATABASE=developer_mozilla_org
+DOCKER_IMAGE="quay.io/mozmar/mdn-myql-demo-import-helper:latest"
+POD_NAME="mdn-db-import"
+
+cleanup_old_pods() {
+    echo -n "Clearing out old pods..."
+    kubectl -n "${KUBE_NAMESPACE}" delete pod "${POD_NAME}" > /dev/null 2>&1 || true
+    echo "Finished"
+}
+
+fetch_pod_ip() {
+    echo "Fetching MySQL pod IP"
+    MYSQL_IP=$(kubectl get service mysql -n "${KUBE_NAMESPACE}" -o json | jq -r '.spec.clusterIP')
+    echo "MySQL IP = ${MYSQL_IP}"
+}
+
+run_db_import() {
+    echo "Starting db import pod ${POD_NAME} in namespace ${KUBE_NAMESPACE}"
+    kubectl run mdn-db-import \
+        --image ${DOCKER_IMAGE} \
+        -n "${KUBE_NAMESPACE}" \
+        --restart=Never \
+        --env="MYSQL_ROOT_PASSWORD=kuma" \
+        --env="MYSQL_USER=root" \
+        --env="MYSQL_PASSWORD=kuma" \
+        --env="MYSQL_DATABASE=$MYSQL_DATABASE" \
+        --env="MYSQL_IP=$MYSQL_IP" \
+        --env="MYSQL_PORT=$MYSQL_PORT" \
+        --env="MDN_SAMPLE_DB_URL=$MDN_SAMPLE_DB_URL"
+    echo "DB import pod started"
+}
+
+cleanup_old_pods
+fetch_pod_ip
+run_db_import
+echo "DB import script complete"

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,9 @@ deis-pull:
 deis-scale-worker:
 	DEIS_PROFILE=${DEIS_PROFILE} ${DEIS_BIN} ps:scale worker=${WORKERS} -a ${DEIS_APP}
 
+demo-db-import:
+	Jenkinsfiles/import-demo-db.sh
+
 k8s-migrate:
 	kubectl --namespace ${DEIS_APP} exec \
 	$(shell kubectl --namespace ${DEIS_APP} get pods | grep ${DEIS_APP}-cmd | awk '{print $$1}') \

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -364,6 +364,22 @@ You can deploy a hosted demo instance of Kuma by following these steps:
 
 #. Mozilla SRE's will periodically remove old instances
 
+#. Connecting to the demo database instance
+
+If you have access to Kubernetes, you can run the following command to connect 
+to the MySQL instance::
+
+    MY_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    DEMO_MYSQL_POD=$(kubectl -n "mdn-demo-${MY_GIT_BRANCH}" get pods | grep "^mysql" | awk '{ print $1 }')
+    kubectl -n "mdn-demo-${MY_GIT_BRANCH}" exec -it ${DEMO_MYSQL_POD} bash
+
+    mysql -p developer_mozilla_org
+
+**Note**: if you copy and paste the code above into a bash terminal and are
+wondering why the commands don't appear in your bash history, it's because there's
+whitespace at the beginning of the line.
+
+
 
 .. _maintenance-mode:
 


### PR DESCRIPTION
following the docs [here](https://kuma.readthedocs.io/en/latest/development.html#deis-workflow-demo-instances), the MySQL database should now be populated with sample data upon demo instance creation. 

Note: demo branch names must follow Deis naming conventions, hence the sad branch name so I could test an actual demo instance.