### PR TITLE
bug 1340003: More changes for candidate languages

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -404,10 +404,9 @@ def build_index_sitemap(results):
 def build_sitemaps():
     """
     Build and save sitemap files for every MDN language and as a
-    callback save the sitempa index file as well.
+    callback save the sitemap index file as well.
     """
-    tasks = [build_locale_sitemap.si(locale)
-             for locale in settings.MDN_LANGUAGES]
+    tasks = [build_locale_sitemap.si(lang[0]) for lang in settings.LANGUAGES]
     post_task = build_index_sitemap.s()
     # we retry the chord unlock 300 times, so 5 mins with an interval of 1s
     chord(header=tasks, body=post_task).apply_async(max_retries=300, interval=1)

--- a/kuma/wiki/utils.py
+++ b/kuma/wiki/utils.py
@@ -18,8 +18,7 @@ def locale_and_slug_from_path(path, request=None, path_locale=None):
     redirect to a more canonical path. In any case, produce a locale and
     slug derived from the given path."""
     locale, slug, needs_redirect = '', path, False
-    mdn_languages_lower = dict((x.lower(), x)
-                               for x in settings.MDN_LANGUAGES)
+    mdn_locales = {lang[0].lower(): lang[0] for lang in settings.LANGUAGES}
 
     # If there's a slash in the path, then the first segment could be a
     # locale. And, that locale could even be a legacy MindTouch locale.
@@ -33,10 +32,10 @@ def locale_and_slug_from_path(path, request=None, path_locale=None):
             locale = settings.MT_TO_KUMA_LOCALE_MAP[l_locale]
             slug = maybe_slug
 
-        elif l_locale in mdn_languages_lower:
+        elif l_locale in mdn_locales:
             # The first segment looks like an MDN locale, redirect.
             needs_redirect = True
-            locale = mdn_languages_lower[l_locale]
+            locale = mdn_locales[l_locale]
             slug = maybe_slug
 
     # No locale yet? Try the locale detected by the request or in path


### PR DESCRIPTION
Use ``settings.LANGUAGES``, which includes ``CANDIDATE_LANGUAGES`` when enabled, instead of ``MDN_LANGUAGES``, which does not.  Two changes:

* ``kuma.wiki.utils.locale_and_slug_from_path`` - KumaScript requests raw pages in a interesting way, like [/en-US/docs/fr/Web/CSS?raw](https://developer.mozilla.org/en-US/docs/fr/Web/CSS?raw) instead of the expected [/fr/docs/Web/CSS?raw](https://developer.mozilla.org/fr/docs/Web/CSS?raw). Without this change, pages in candidate languages can't be rendered when enabled.
* ``kuma.wiki.tasks.build_sitemaps`` - Allow building candidate language sitemaps, found at http://localhost:8000/media/sitemaps/bg/sitemap.xml