### PR TITLE
bug 1341770: Add tests of content experiments

### DIFF
--- a/tests/functional/test_content_experiment.py
+++ b/tests/functional/test_content_experiment.py
@@ -1,0 +1,94 @@
+import pytest
+
+from pages.admin import AdminLogin
+from pages.article import ArticlePage
+from pages.content_experiment import VariantPage
+
+# Copied from kuma/settings/common.py, because we can't import directly
+CONTENT_EXPERIMENTS = [{
+    'id': 'experiment-framework-test',
+    'ga_name': 'framework-test',
+    'param': 'v',
+    'pages': [{
+        'locale': 'en-US',
+        'slug': 'Web/JavaScript/Reference/Operators/Comparison_Operators',
+        'variants': [
+            ['control',
+             'Web/JavaScript/Reference/Operators/Comparison_Operators'],
+            ['test', 'Experiment:FrameworkTest/Comparison_Operators'],
+        ]
+    }]
+}]
+
+EXPECTED_TITLES = {
+    ('en-US', 'Web/JavaScript/Reference/Operators/Comparison_Operators'):
+        'Comparison operators - JavaScript | MDN',
+}
+
+
+# Create nicer parameter lists for tests, verbose output
+CONTENT_PAGES, CONTENT_VARIANTS = [], []
+for exp in CONTENT_EXPERIMENTS:
+    for page in exp['pages']:
+        CONTENT_PAGES.append((exp['id'], page['locale'], page['slug']))
+        for variant in page['variants']:
+            CONTENT_VARIANTS.append((exp['id'], page['locale'], page['slug'],
+                                     variant[0]))
+
+
+def get_experiment_data(exp_id, locale, slug):
+    for exp in CONTENT_EXPERIMENTS:
+        if exp['id'] == exp_id:
+            for page in exp['pages']:
+                if page['locale'] == locale and page['slug'] == slug:
+                    return {
+                        'ga_name': exp['ga_name'],
+                        'param': exp['param'],
+                        'expected_title': EXPECTED_TITLES[(locale, slug)],
+                        'variants': [name for name, src in page['variants']],
+                    }
+    raise Exception("Invalid experiment")
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("exp_id,locale,slug", CONTENT_PAGES)
+def test_content_exp_redirect(base_url, selenium, exp_id, locale, slug):
+    data = get_experiment_data(exp_id, locale, slug)
+    page = ArticlePage(selenium, base_url, locale=locale, slug=slug).open()
+    assert selenium.title == data['expected_title']
+    seed_url = page.seed_url
+    expected_variant_urls = ["%s?%s=%s" % (seed_url, data['param'], variant)
+                             for variant in data['variants']]
+    assert selenium.current_url in expected_variant_urls
+    assert not page.has_edit_button
+
+
+@pytest.mark.login
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("exp_id,locale,slug", CONTENT_PAGES)
+def test_content_exp_logged_in(base_url, selenium, exp_id, locale, slug):
+    data = get_experiment_data(exp_id, locale, slug)
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_new_user()
+    page = ArticlePage(selenium, base_url, locale=locale, slug=slug).open()
+    assert selenium.title == data['expected_title']
+    assert selenium.current_url == page.seed_url
+    assert page.has_edit_button
+
+
+@pytest.mark.nondestructive
+@pytest.mark.parametrize("exp_id,locale,slug,variant", CONTENT_VARIANTS)
+def test_content_exp_variant(
+        base_url, selenium, exp_id, locale, slug, variant):
+    data = get_experiment_data(exp_id, locale, slug)
+    page = VariantPage(selenium, base_url, locale=locale, slug=slug,
+                       param=data['param'], variant=variant).open()
+    assert selenium.current_url == page.seed_url
+    assert selenium.title == data['expected_title']
+    expected_canonical = page.seed_url.split('?')[0]
+    assert page.canonical_url == expected_canonical
+    assert not page.has_edit_button
+    if page.has_google_analytics:
+        expected_dim15 = "%s:%s" % (data['ga_name'], variant)
+        assert page.ga_value('dimension15') == expected_dim15
+        assert page.ga_value('dimension16') == "/%s/docs/%s" % (locale, slug)

--- a/tests/pages/article.py
+++ b/tests/pages/article.py
@@ -6,8 +6,11 @@ from selenium.webdriver.common.action_chains import ActionChains
 
 
 class ArticlePage(BasePage):
+    """A non-zone MDN wiki page."""
 
-    URL_TEMPLATE = '/{locale}/docs/User:anonymous:uitest'
+    URL_TEMPLATE = '/{locale}/docs/{slug}'
+    DEFAULT_LOCALE = 'en-US'
+    DEFAULT_SLUG = 'User:anonymous:uitest'
 
     # article meta
     _language_add_link_locator = (By.ID, 'translations-add')
@@ -28,6 +31,12 @@ class ArticlePage(BasePage):
     _editorial_review_link_locator = (By.CSS_SELECTOR, 'a[href$=Do_an_editorial_review]')
     # table of contents
     _toc_locator = (By.ID, 'toc')
+
+    def __init__(self, *args, **kwargs):
+        locale = kwargs.pop('locale', self.DEFAULT_LOCALE)
+        slug = kwargs.pop('slug', self.DEFAULT_SLUG)
+        super(ArticlePage, self).__init__(locale=locale, slug=slug,
+                                          *args, **kwargs)
 
     # article title
     @property
@@ -64,6 +73,10 @@ class ArticlePage(BasePage):
     def is_add_translation_link_available(self):
         self.display_language_menu()
         self.add_translation_link.is_displayed()
+
+    @property
+    def has_edit_button(self):
+        return len(self.find_elements(*self._edit_button_locator)) > 0
 
     @property
     def is_edit_button_displayed(self):

--- a/tests/pages/content_experiment.py
+++ b/tests/pages/content_experiment.py
@@ -1,0 +1,34 @@
+from selenium.webdriver.common.by import By
+
+from pages.article import ArticlePage
+
+
+class VariantPage(ArticlePage):
+    """A variant page under a content experiment."""
+
+    URL_TEMPLATE = '/{locale}/docs/{slug}?{param}={variant}'
+    _canonical_locator = (By.CSS_SELECTOR, 'head link[rel=canonical]')
+
+    def __init__(self, *args, **kwargs):
+        """Default path is /en-US/docs/User:anonymous:uitest?v=control"""
+        param = kwargs.pop('param', 'v')
+        variant = kwargs.pop('variant', None)
+        assert variant is not None
+        super(VariantPage, self).__init__(param=param, variant=variant,
+                                          *args, **kwargs)
+
+    @property
+    def canonical_url(self):
+        canon_link = self.find_element(*self._canonical_locator)
+        return canon_link and canon_link.get_attribute('href')
+
+    @property
+    def has_google_analytics(self):
+        return self.selenium.execute_script(
+            'return ((typeof(ga) !== "undefined") &&'
+            '        (typeof(ga.getByName("t0")) !== "undefined"));')
+
+    def ga_value(self, name):
+        """Value of a Google Analytics variable."""
+        return self.selenium.execute_script(
+            'return ga.getByName("t0").get("%s");' % name)


### PR DESCRIPTION
* Allow slug change for ArticlePage
* Add ArticlePage.has_edit_button
* Add VariantPage for content experiment variant pages, with helper methods.
* Test anonymous users are redirected on content experiment page
* Test logged-in users get regular experience
* Test GA parameters on content experiment variants