### PR TITLE
bug 1351403: fix functional tests for maintenance mode

### DIFF
--- a/Jenkinsfiles/prod-integration-tests.yml
+++ b/Jenkinsfiles/prod-integration-tests.yml
@@ -6,4 +6,4 @@ job:
   selenium: "2.48.2"
   selenium_nodes: 5
   base_url: 'https://developer.mozilla.org'
-  tests: "not login and not maintenance_mode"
+  tests: "not login"

--- a/Jenkinsfiles/stage-integration-tests.yml
+++ b/Jenkinsfiles/stage-integration-tests.yml
@@ -6,4 +6,4 @@ job:
   selenium: "2.48.2"
   selenium_nodes: 5
   base_url: 'https://developer.allizom.org'
-  tests: "not login and not maintenance_mode"
+  tests: "not login"

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -366,7 +366,7 @@ You can deploy a hosted demo instance of Kuma by following these steps:
 
 #. Connecting to the demo database instance
 
-If you have access to Kubernetes, you can run the following command to connect 
+If you have access to Kubernetes, you can run the following command to connect
 to the MySQL instance::
 
     MY_GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
@@ -429,7 +429,7 @@ For local Docker-based development in maintenance mode:
 You should be good to go!
 
 There is a set of integration tests for maintenance mode. If you'd like to run
-them against your local Docker instance, you must first have done the
+them against your local Docker instance, you will first have to do the
 following:
 
 #. Loaded the latest sample database (see :ref:`provision-the-database`).
@@ -474,7 +474,7 @@ following:
 
 Now you should be ready for a successful test run::
 
-    py.test -m "maintenance_mode and not search" tests/functional --base-url http://localhost:8000 --driver Chrome --driver-path /path/to/chromedriver
+    py.test --maintenance-mode -m "not search" tests/functional --base-url http://localhost:8000 --driver Chrome --driver-path /path/to/chromedriver
 
 Note that the "search" tests are excluded. This is because the tests marked
 "search" are not currently designed to run against the sample database.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -429,11 +429,10 @@ For local Docker-based development in maintenance mode:
 You should be good to go!
 
 There is a set of integration tests for maintenance mode. If you'd like to run
-them against your local Docker instance, you will first have to do the
-following:
+them against your local Docker instance, first do the following:
 
-#. Loaded the latest sample database (see :ref:`provision-the-database`).
-#. Ensured that the test document "en-US/docs/User:anonymous:uitest" has been
+#. Load the latest sample database (see :ref:`provision-the-database`).
+#. Ensure that the test document "en-US/docs/User:anonymous:uitest" has been
    rendered (all of its macros have been executed). You can check this by
    browsing to `http://localhost:8000/en-US/docs/User:anonymous:uitest`_. If
    there is no message about un-rendered content, you are good to go. If there

--- a/docs/tests-ui.rst
+++ b/docs/tests-ui.rst
@@ -56,7 +56,7 @@ server.
 
 In the virtual environment run::
 
-   $ py.test -m "not login and not maintenance_mode" tests/functional/ --driver Chrome --driver-path /path/to/chromedriver
+   $ py.test -m "not login" tests/functional/ --driver Chrome --driver-path /path/to/chromedriver
 
 You will be prompted "Do you want the application 'python' to accept incoming
 network connections?" The tests seem to run fine no matter how you answer.
@@ -71,7 +71,7 @@ Only running tests in one file
 
 Add the name of the file to the test location::
 
-   $ py.test -m "not login and not maintenance_mode" tests/functional/test_search.py --driver Chrome --driver-path /path/to/chromedriver
+   $ py.test -m "not login" tests/functional/test_search.py --driver Chrome --driver-path /path/to/chromedriver
 
 Run the tests against a different url
 -------------------------------------
@@ -80,7 +80,7 @@ By default the tests will run against the staging server. If you'd like to run
 the tests against a different URL (e.g., your local environment) pass the
 desired URL to the command with ``--base-url``::
 
-   $ py.test -m "not login and not maintenance_mode" tests/functional/ --base-url http://localhost:8000 --driver Chrome --driver-path /path/to/chromedriver
+   $ py.test -m "not login" tests/functional/ --base-url http://localhost:8000 --driver Chrome --driver-path /path/to/chromedriver
 
 Run the tests in parallel
 -------------------------
@@ -88,7 +88,28 @@ Run the tests in parallel
 By default the tests will run one after the other but you can run several at
 the same time by specifying a value for ``-n``::
 
-   $ py.test -m "not login and not maintenance_mode" tests/functional/ -n auto --driver Chrome --driver-path /path/to/chromedriver
+   $ py.test -m "not login" tests/functional/ -n auto --driver Chrome --driver-path /path/to/chromedriver
+
+Run the tests against a server configured in maintenance mode
+-------------------------------------------------------------
+
+By default the tests will run against a server assumed to be configured
+normally. If you'd like to run them against a server configured in
+maintenance mode, simply add ``--maintenance-mode`` to the ``py.test`` command
+line. For example, if you've configured your local environment to run in
+maintenance mode::
+
+   $ py.test --maintenance-mode -m "not search" tests/functional/ --base-url http://localhost:8000 --driver Chrome --driver-path /path/to/chromedriver
+
+Note that the tests marked "search" were excluded assuming you've loaded the
+sample database. If you've loaded a full copy of the production database, you
+can drop the ``-m "not search"``.
+
+The ``--maintenance-mode`` command-line switch does two things. It will skip
+any tests that don't make sense in maintenance mode (e.g., making sure the
+signin link works), and include the tests that only make sense in maintenance
+mode (e.g., making sure that endpoints related to editing redirect to the
+maintenance-mode page).
 
 Run tests on SauceLabs
 ----------------------
@@ -103,7 +124,7 @@ machine.
 #. Run a test specifying ``SauceLabs`` as your driver, and pass your credentials
    and the browser to test::
 
-   $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 py.test -m "not login and not maintenance_mode" tests/functional/ --driver SauceLabs --capability browsername MicrosoftEdge
+   $ SAUCELABS_USERNAME=thedude SAUCELABS_API_KEY=123456789 py.test -m "not login" tests/functional/ --driver SauceLabs --capability browsername MicrosoftEdge
 
 Alternatively you can save your credentials `in a configuration file`_ so you
 don't have to type them each time.
@@ -206,14 +227,6 @@ Markers
   These tests require the testing accounts to exist on the target site. For
   security reasons these accounts will not be on production. Exclude these tests
   with ``-m "not login"``
-
-* ``maintenance_mode``
-
-  These tests can be run against an instance of Kuma in maintenance mode.
-  They cover all of the key aspects, such as testing all of the endpoints that
-  should redirect to the maintenance-mode description page, as well as ensuring
-  that the buttons and links that initiate write operations (like editing a
-  document) are hidden.
 
 Guidelines for writing tests
 ============================

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,14 @@ VIEWPORT = {
     'small': {'width': 320, 'height': 480}}
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--maintenance-mode",
+        action="store_true",
+        help="run tests assuming target server is in maintenance mode",
+    )
+
+
 @pytest.fixture(scope='session')
 def base_url(base_url, request):
     return base_url or 'https://developer.allizom.org'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--maintenance-mode",
         action="store_true",
-        help="run tests assuming target server is in maintenance mode",
+        help="run tests against a server in maintenance mode",
     )
 
 

--- a/tests/functional/test_article.py
+++ b/tests/functional/test_article.py
@@ -1,6 +1,10 @@
 import pytest
 
 from pages.article import ArticlePage
+from utils.decorators import (
+    skip_if_maintenance_mode,
+    skip_if_not_maintenance_mode,
+)
 
 ARTICLE_NAME = 'User:anonymous:uitest'
 ARTICLE_TITLE_SUFIX = " | MDN"
@@ -8,7 +12,6 @@ ARTICLE_TITLE_SUFIX = " | MDN"
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_title(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert (ARTICLE_NAME + ARTICLE_TITLE_SUFIX) == selenium.title
@@ -19,7 +22,6 @@ def test_title(base_url, selenium):
 # layout
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_article_layout(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.is_article_displayed
@@ -33,6 +35,7 @@ def test_article_layout(base_url, selenium):
 # page buttons
 @pytest.mark.smoke
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_page_buttons_displayed(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.is_language_menu_displayed
@@ -42,7 +45,7 @@ def test_page_buttons_displayed(base_url, selenium):
 
 # page buttons in maintenance mode
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_page_buttons_displayed_in_mm(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.is_language_menu_displayed
@@ -56,7 +59,6 @@ def test_page_buttons_displayed_in_mm(base_url, selenium):
 # header tests
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_header_displays(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.header.is_displayed
@@ -65,6 +67,7 @@ def test_header_displays(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_header_signin(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     # click on sign in widget
@@ -75,7 +78,6 @@ def test_header_signin(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_header_platform_submenu(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.header.is_platform_submenu_trigger_displayed
@@ -86,7 +88,6 @@ def test_header_platform_submenu(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_header_feedback_submenu(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.header.is_feedback_submenu_trigger_displayed
@@ -98,7 +99,6 @@ def test_header_feedback_submenu(base_url, selenium):
 # footer tests
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_footer_displays(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.footer.is_displayed

--- a/tests/functional/test_article_edit.py
+++ b/tests/functional/test_article_edit.py
@@ -2,10 +2,12 @@ import pytest
 
 from pages.article import ArticlePage
 from pages.admin import AdminLogin
+from utils.decorators import skip_if_maintenance_mode
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_edit_sign_in(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     # click edit
@@ -17,6 +19,7 @@ def test_edit_sign_in(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.login
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_edit(base_url, selenium):
     admin = AdminLogin(selenium, base_url).open()
     admin.login_new_user()

--- a/tests/functional/test_article_new.py
+++ b/tests/functional/test_article_new.py
@@ -2,10 +2,12 @@ import pytest
 
 from pages.article_new import NewPage
 from pages.admin import AdminLogin
+from utils.decorators import skip_if_maintenance_mode
 
 
 @pytest.mark.smoke
 @pytest.mark.login
+@skip_if_maintenance_mode
 def test_new(base_url, selenium):
     admin = AdminLogin(selenium, base_url).open()
     admin.login_moderator_user()

--- a/tests/functional/test_article_revision.py
+++ b/tests/functional/test_article_revision.py
@@ -2,10 +2,11 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
+from utils.decorators import skip_if_not_maintenance_mode
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_revision_in_mm(base_url, selenium):
     # Get the link for the first (could be any) revision of the test document.
     page = BasePage(selenium, base_url)
@@ -26,7 +27,7 @@ def test_revision_in_mm(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_compare_revisions_in_mm(base_url, selenium):
     # Load the page that compares two revisions of a document.
     page = BasePage(selenium, base_url)

--- a/tests/functional/test_article_translate.py
+++ b/tests/functional/test_article_translate.py
@@ -2,11 +2,13 @@ import pytest
 
 from pages.article_edit import EditPage
 from pages.admin import AdminLogin
+from utils.decorators import skip_if_maintenance_mode
 
 
 @pytest.mark.smoke
 @pytest.mark.login
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_translation(base_url, selenium):
     admin = AdminLogin(selenium, base_url).open()
     admin.login_moderator_user()

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -2,11 +2,14 @@ import pytest
 
 from pages.dashboard import DashboardPage
 from pages.admin import AdminLogin
+from utils.decorators import (
+    skip_if_maintenance_mode,
+    skip_if_not_maintenance_mode,
+)
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_dashboard(base_url, selenium):
     page = DashboardPage(selenium, base_url).open()
     first_row = page.first_row
@@ -38,7 +41,7 @@ def test_dashboard(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_dashboard_in_mm(base_url, selenium):
     page = DashboardPage(selenium, base_url).open()
     assert page.is_maintenance_mode_banner_displayed
@@ -48,6 +51,7 @@ def test_dashboard_in_mm(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.login
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_dashboard_moderator(base_url, selenium):
     admin = AdminLogin(selenium, base_url).open()
     admin.login_moderator_user()
@@ -64,6 +68,7 @@ def test_dashboard_moderator(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.login
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_dashboard_super(base_url, selenium):
     admin = AdminLogin(selenium, base_url).open()
     admin.login_super_user()

--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -8,7 +8,6 @@ ARTICLE_NAME = 'Send feedback (about|on) MDN'
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_location(base_url, selenium):
     article_page = ArticlePage(selenium, base_url).open()
     page = article_page.header.open_feedback()
@@ -19,7 +18,6 @@ def test_location(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_feedback_layout(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.is_article_displayed
@@ -32,7 +30,6 @@ def test_feedback_layout(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_page_links(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     # get all page links

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -2,13 +2,16 @@ import pytest
 
 from pages.home import HomePage
 from utils.urls import assert_valid_url
+from utils.decorators import (
+    skip_if_maintenance_mode,
+    skip_if_not_maintenance_mode,
+)
 
 
 # homepage tests
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_masthead_displayed(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.is_masthead_displayed
@@ -16,7 +19,6 @@ def test_masthead_displayed(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_hacks_blog(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.hacks_items_length == 5
@@ -26,7 +28,6 @@ def test_hacks_blog(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_callouts(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     # three of them?
@@ -45,7 +46,6 @@ def test_callouts(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_header_displays(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.header.is_displayed
@@ -54,7 +54,6 @@ def test_header_displays(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_header_platform_submenu(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.header.is_platform_submenu_trigger_displayed
@@ -66,6 +65,7 @@ def test_header_platform_submenu(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
+@skip_if_maintenance_mode
 def test_header_signin(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     # click on sign in widget
@@ -75,7 +75,7 @@ def test_header_signin(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_header_no_signin(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.is_maintenance_mode_banner_displayed
@@ -86,7 +86,6 @@ def test_header_no_signin(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_footer_displays(base_url, selenium):
     page = HomePage(selenium, base_url).open()
     assert page.footer.is_displayed

--- a/tests/functional/test_language_selector.py
+++ b/tests/functional/test_language_selector.py
@@ -5,7 +5,6 @@ from pages.home import HomePage
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 @pytest.mark.parametrize('locale', ['fr'])
 def test_footer_language_selector(base_url, selenium, locale):
     # open homepge

--- a/tests/functional/test_maintenance_mode_redirects.py
+++ b/tests/functional/test_maintenance_mode_redirects.py
@@ -6,10 +6,11 @@ from pyquery import PyQuery
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
+from utils.decorators import skip_if_not_maintenance_mode
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 @pytest.mark.parametrize("method, uri", [
     ('get', 'admin/login'),
     ('post', 'admin/login'),

--- a/tests/functional/test_notfound.py
+++ b/tests/functional/test_notfound.py
@@ -3,6 +3,7 @@ import requests
 
 from pages.notfound import NotFoundPage
 from utils.urls import assert_valid_url
+from utils.decorators import skip_if_not_maintenance_mode
 
 ARTICLE_NAME = 'Not Found'
 ARTICLE_TITLE_SUFIX = " | MDN"
@@ -12,14 +13,13 @@ ARTICLE_TITLE_SUFIX = " | MDN"
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_is_not_found_status(base_url, selenium):
     NotFoundPage(selenium, base_url).open()
     assert_valid_url(selenium.current_url, status_code=requests.codes.not_found)
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_is_not_found_status_in_mm(base_url, selenium):
     page = NotFoundPage(selenium, base_url).open()
     assert page.is_maintenance_mode_banner_displayed
@@ -29,7 +29,6 @@ def test_is_not_found_status_in_mm(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_is_expected_content(base_url, selenium):
     page = NotFoundPage(selenium, base_url).open()
     assert (ARTICLE_NAME + ARTICLE_TITLE_SUFIX) == selenium.title

--- a/tests/functional/test_profiles.py
+++ b/tests/functional/test_profiles.py
@@ -2,10 +2,11 @@ import pytest
 from selenium.webdriver.common.by import By
 
 from pages.base import BasePage
+from utils.decorators import skip_if_not_maintenance_mode
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_user_profile_in_mm(base_url, selenium):
     # Check that the edit button is not displayed for a user profile.
     page = BasePage(selenium, base_url)

--- a/tests/functional/test_report.py
+++ b/tests/functional/test_report.py
@@ -8,7 +8,6 @@ ARTICLE_TITLE_SUFIX = " | MDN"
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_report_content(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.header.is_feedback_submenu_trigger_displayed
@@ -26,7 +25,6 @@ def test_report_content(base_url, selenium):
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_report_bug(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
     assert page.header.is_feedback_submenu_trigger_displayed

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -4,6 +4,7 @@ from utils.urls import assert_valid_url
 from pages.home import HomePage
 from pages.article import ArticlePage
 from pages.search import SearchPage
+from utils.decorators import skip_if_not_maintenance_mode
 
 SEARCH_TERM = 'css'
 SEARCH_TERM_ZERO = 'skwiz'
@@ -13,7 +14,6 @@ ARTICLE_PATH = 'docs/User:anonymous:uitest'
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_homepage(base_url, selenium):
     # open homepage
     page = HomePage(selenium, base_url).open()
@@ -29,7 +29,6 @@ def test_search_homepage(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_home_header(base_url, selenium):
     # open homepage
     page = HomePage(selenium, base_url).open()
@@ -50,7 +49,6 @@ def test_search_home_header(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_article_header(base_url, selenium):
     # open article page
     page = ArticlePage(selenium, base_url).open()
@@ -70,7 +68,6 @@ def test_search_article_header(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_layout(base_url, selenium):
     page = SearchPage(selenium, base_url, term=SEARCH_TERM).open()
     # search term is in search box
@@ -101,7 +98,6 @@ def test_search_layout(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_zero_results(base_url, selenium):
     page = SearchPage(selenium, base_url, term=SEARCH_TERM_ZERO).open()
     # results found
@@ -111,7 +107,6 @@ def test_search_zero_results(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
 def test_search_filters(base_url, selenium):
     page = SearchPage(selenium, base_url, term=SEARCH_TERM).open()
     documents_found_initial = page.documents_found
@@ -121,7 +116,7 @@ def test_search_filters(base_url, selenium):
 
 
 @pytest.mark.nondestructive
-@pytest.mark.maintenance_mode
+@skip_if_not_maintenance_mode
 def test_search_in_mm(base_url, selenium):
     page = SearchPage(selenium, base_url, term=SEARCH_TERM_ZERO).open()
     assert page.is_maintenance_mode_banner_displayed

--- a/tests/utils/decorators.py
+++ b/tests/utils/decorators.py
@@ -3,11 +3,11 @@ import pytest
 
 skip_if_maintenance_mode = pytest.mark.skipif(
     pytest.config.getoption('--maintenance-mode'),
-    reason='because the target server is in maintenance mode'
+    reason='the server is in maintenance mode'
 )
 
 
 skip_if_not_maintenance_mode = pytest.mark.skipif(
     not pytest.config.getoption('--maintenance-mode'),
-    reason='because the target server is not in maintenance mode'
+    reason='the server is not in maintenance mode'
 )

--- a/tests/utils/decorators.py
+++ b/tests/utils/decorators.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+skip_if_maintenance_mode = pytest.mark.skipif(
+    pytest.config.getoption('--maintenance-mode'),
+    reason='because the target server is in maintenance mode'
+)
+
+
+skip_if_not_maintenance_mode = pytest.mark.skipif(
+    not pytest.config.getoption('--maintenance-mode'),
+    reason='because the target server is not in maintenance mode'
+)


### PR DESCRIPTION
This corrects a problem I introduced with the work I did that was added via https://github.com/mozilla/kuma/pull/4150. Specifically, I used the "maintenance_mode" pytest marker to mark not only tests that should only be run in maintenance mode, but also tests that should be run in both normal mode as well as maintenance mode. This made it impossible to specify the correct set of tests to run in normal mode, since we had to use ``-m "not maintenance_mode"`` to exclude the tests that ran only in maintenance mode, but that in turn excluded the set of tests that we want to run in both modes.

This fix adds a [new command-line switch](https://github.com/escattone/kuma/blob/fix-mm-functional-tests-1351403/tests/conftest.py#L13) (``--maintenance-mode``) to the ``py.test`` command and then uses [two new decorators](https://github.com/escattone/kuma/blob/fix-mm-functional-tests-1351403/tests/utils/decorators.py) that use that switch to either exclude the maintenance-mode-only tests in normal mode, or exclude the normal-mode-only tests in maintenance mode.
