### PR TITLE
bug 1341770: More analytics 

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -18,6 +18,9 @@
         {% if request.user.is_beta_tester %}
             ga('set', 'dimension2', 'Yes');
         {% endif %}
+
+        // dimension18 == "Staff"
+        ga('set', 'dimension18', '{{ request.user.is_staff | yesno }}');
     {% endif %}
 
     // dimension9 == "Section editing"

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -26,7 +26,7 @@
     {% endif %}
 
     {%- if analytics_page_revision %}
-        // dimension12 == 'Page Revision"
+        // dimension12 == 'Page Revision'
         ga('set', 'dimension12', '{{ analytics_page_revision }}');
     {%- endif %}
 

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -39,6 +39,11 @@
         ga('set', 'dimension16', '{{ content_experiment.original_path }}');
     {%- endif %}
 
+    {%- if analytics_en_slug %}
+        // dimension17 == 'English Slug'
+        ga('set', 'dimension17', '{{analytics_en_slug}}');
+    {%- endif %}
+
     (function() {
         // http://cfsimplicity.com/61/removing-analytics-clutter-from-campaign-urls
         var win = window;

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -8,6 +8,7 @@ import pytest
 from constance import config
 from constance.test import override_config
 from django.conf import settings
+from django.contrib.auth.models import Group
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.test.utils import override_settings
@@ -17,6 +18,7 @@ from pyquery import PyQuery as pq
 from kuma.core.tests import eq_, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
+from kuma.users.models import User
 from kuma.users.tests import UserTestCase
 
 from . import (WikiTestCase, create_topical_parents_docs, document,
@@ -360,7 +362,10 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
 class GoogleAnalyticsTests(UserTestCase, WikiTestCase):
 
     ga_create = "ga('create', 'fake', 'mozilla.org');"
+    dim1 = "ga('set', 'dimension1', 'Yes');"
+    dim2 = "ga('set', 'dimension2', 'Yes');"
     dim17_tmpl = "ga('set', 'dimension17', '%s');"
+    dim18_tmpl = "ga('set', 'dimension18', '%s');"
 
     def test_en_doc(self):
         doc = _create_document()
@@ -392,6 +397,48 @@ class GoogleAnalyticsTests(UserTestCase, WikiTestCase):
         assert self.ga_create in content
         dim17 = "ga('set', 'dimension17',"
         assert dim17 not in content
+
+    def test_anon_user(self):
+        response = self.client.get('/en-US/')
+        assert response.status_code == 200
+        content = response.content.decode('utf8')
+        assert self.ga_create in content
+        assert self.dim1 not in response.content.decode('utf8')
+        assert self.dim2 not in response.content.decode('utf8')
+        assert "ga('set', 'dimension18'," not in content
+
+    def test_regular_user(self):
+        assert self.client.login(username='testuser', password='testpass')
+        response = self.client.get('/en-US/')
+        assert response.status_code == 200
+        content = response.content.decode('utf8')
+        assert self.ga_create in content
+        assert self.dim1 in response.content.decode('utf8')
+        assert self.dim2 not in response.content.decode('utf8')
+        assert (self.dim18_tmpl % 'No') in content
+
+    def test_beta_user(self):
+        testuser = User.objects.get(username='testuser')
+        beta = Group.objects.get(name='Beta Testers')
+        testuser.groups.add(beta)
+        assert self.client.login(username='testuser', password='testpass')
+        response = self.client.get('/en-US/')
+        assert response.status_code == 200
+        content = response.content.decode('utf8')
+        assert self.ga_create in content
+        assert self.dim1 in response.content.decode('utf8')
+        assert self.dim2 in response.content.decode('utf8')
+        assert (self.dim18_tmpl % 'No') in content
+
+    def test_staff_user(self):
+        assert self.client.login(username='admin', password='testpass')
+        response = self.client.get('/en-US/')
+        assert response.status_code == 200
+        content = response.content.decode('utf8')
+        assert self.ga_create in content
+        assert self.dim1 in response.content.decode('utf8')
+        assert self.dim2 not in response.content.decode('utf8')
+        assert (self.dim18_tmpl % 'Yes') in content
 
 
 class RevisionTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -708,6 +708,14 @@ def document(request, document_slug, document_locale):
         zone_subnav_html = doc.get_zone_subnav_html()
         body_html = doc.get_body_html()
 
+    # Record the English slug in Google Analytics, to associate translations
+    if original_doc.locale == 'en-US':
+        en_slug = original_doc.slug
+    elif original_doc.parent and original_doc.parent.locale == 'en-US':
+        en_slug = original_doc.parent.slug
+    else:
+        en_slug = ''
+
     share_text = ugettext(
         'I learned about %(title)s on MDN.') % {"title": doc.title}
 
@@ -735,6 +743,7 @@ def document(request, document_slug, document_locale):
         'share_text': share_text,
         'search_url': get_search_url_from_referer(request) or '',
         'analytics_page_revision': doc.current_revision_id,
+        'analytics_en_slug': en_slug,
         'content_experiment': rendering_params['experiment'],
     }
     response = render(request, 'wiki/document.html', context)


### PR DESCRIPTION
Add a few more custom dimensions that came up during the design discussion:

* ``dimension17`` - The English slug (for example, ``Learn/CSS``), so that performance can be tracked across translations of a page.
* ``dimension18`` - ``Yes`` if a user is staff, ``No`` if they are not.