### PR TITLE
bug 1350014: Record KumaScript revision on deployment

### DIFF
--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -107,6 +107,8 @@ def update_info(ctx):
         ctx.local("git submodule status")
         ctx.local("python2.7 ./manage.py migrate --list")
         ctx.local("git rev-parse HEAD > media/revision.txt")
+    with ctx.lcd(os.path.join(settings.SRC_DIR, 'kumascript')):
+        ctx.local("git rev-parse HEAD > ../media/kumascript-revision.txt")
 
 
 @task

--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -81,12 +81,6 @@ def restart_kumascript(ctx):
     ctx.remote("/usr/bin/supervisorctl stop all; /usr/bin/killall nodejs; /usr/bin/supervisorctl start all")
 
 
-@hostgroups(settings.WEB_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
-def prime_app(ctx):
-    for http_port in range(80, 82):
-        ctx.remote("for i in {1..10}; do curl -so /dev/null -H 'Host: %s' -I http://localhost:%s/ & sleep 1; done" % (settings.REMOTE_HOSTNAME, http_port))
-
-
 @hostgroups(settings.CELERY_HOSTGROUP, remote_kwargs={'ssh_key': settings.SSH_KEY})
 def restart_celery(ctx):
     ctx.remote('/usr/bin/supervisorctl mrestart celery\*')
@@ -171,7 +165,6 @@ def deploy(ctx):
     restart_kumascript()
     restart_celery()
     ping_newrelic()
-#    prime_app()
 
 
 @task


### PR DESCRIPTION
* Drop the unused ``prime_app`` task
* Record the KumaScript revision on deployment.  This will allow a page like [What's Deployed](https://whatsdeployed.io/?owner=mozilla&repo=kuma&name[]=Stage&url[]=https://developer.allizom.org/media/revision.txt&name[]=Prod&url[]=https://developer.mozilla.org/media/revision.txt) for KumaScript.