### PR TITLE
Fix bug 1249492: Remove article title from watch menu

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -105,8 +105,8 @@
 {% macro watch_tree_item(document, user) -%}
 {% set title = document.title %}
                   <li class="page-watch">
-                    {% set subscribe_tree_text = _('Subscribe to %(title)s and all its sub-articles', title=title) %}
-                    {% set unsubscribe_tree_text = _('Unsubscribe from %(title)s and all its sub-articles', title=title) %}
+                    {% set subscribe_tree_text = _('Subscribe to this article and all its sub-articles') %}
+                    {% set unsubscribe_tree_text = _('Unsubscribe from this article and all its sub-articles') %}
                     <form action="{{ url('wiki.subscribe_to_tree', document.slug, locale=document.locale) }}" method="post">
                         {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_tree_text }}" data-unsubscribe-text="{{ unsubscribe_tree_text }}" data-subscribe-message="{{ _('You are now subscribed to this article and all its sub-articles.') }}" data-unsubscribe-message="{{ _('You have been unsubscribed from this article and all its sub-articles.') }}">
@@ -121,8 +121,8 @@
                   <li class="page-watch">
                     {% set title = document.title %}
                     {% set subscribe_status = _('Updating subscription status') %}
-                    {% set subscribe_text = _('Subscribe to %(title)s', title=title) %}
-                    {% set unsubscribe_text = _('Unsubscribe from %(title)s', title=title) %}
+                    {% set subscribe_text = _('Subscribe to this article') %}
+                    {% set unsubscribe_text = _('Unsubscribe from this article') %}
                     <form action="{{ url('wiki.subscribe', document.slug, locale=document.locale) }}" method="post">
                         {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_text }}" data-unsubscribe-text="{{ unsubscribe_text }}" data-subscribe-message="{{ _('You are now subscribed to %(title)s.', title=title) }}" data-unsubscribe-message="{{ _('You have been unsubscribed from %(title)s.', title=title) }}">
@@ -135,9 +135,9 @@
 
                   {% if document.parent %}
                     <li class="page-watch">
-                    {% set parent_language = document.parent.language %}
-                    {% set subscribe_parent_text = _('Subscribe to <bdi>%(language)s</bdi> version', language=parent_language) %}
-                    {% set unsubscribe_parent_text = _('Unsubscribe from <bdi>%(language)s</bdi> version', language=parent_language) %}
+                    {% set parent_language = get_locale_localized(document.parent.locale) %}
+                    {% set subscribe_parent_text = _('Subscribe to the %(language)s version', language=parent_language) %}
+                    {% set unsubscribe_parent_text = _('Unsubscribe from the %(language)s version', language=parent_language) %}
                       <form action="{{ url('wiki.subscribe', document.parent.slug, locale=document.parent.locale) }}" method="post">
                           {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_parent_text }}" data-unsubscribe-text="{{ unsubscribe_parent_text }}" data-subscribe-message="{{ _('You are now subscribed to the %(language)s version of this article.', language=parent_language) }}" data-unsubscribe-message="{{ _('You have been unsubscribed from the %(language)s version of this article.', language=parent_language) }}">


### PR DESCRIPTION
We cannot add demarcations around the titles because they must be stored in plain text in `data` attributes to be swapped in/out as the user interacts.

However, I agree that it is difficult to understand what the menu items mean without a demarcation around the article title.

Given that the user already knows which page they are on, we do not need to repeat the article title, so I removed it.

I also optimized the link to subscribe to the original instead of the translation to remove the need for the `<bdi>` tags which have the same problems.