### PR TITLE
Send GA event indicating position of TOC when it's clicked

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -373,13 +373,21 @@
         var $thisLink = $(this);
         var url = $thisLink.attr('href');
 
-        var data = {
+        var linkData = {
             category: 'TOC Links',
             action: $thisLink.text(),
             label: $thisLink.attr('href')
         };
 
-        mdn.analytics.trackLink(event, url, data);
+        mdn.analytics.trackLink(event, url, linkData);
+
+        var fixed = $('#toc.fixed').length > 0 ? 'fixed' : 'not fixed';
+        var clickData = {
+            category: 'TOC Click',
+            action: fixed
+        };
+
+        mdn.analytics.trackLink(event, url, clickData);
     });
 
     /*


### PR DESCRIPTION
Do people even use the sticky TOC? I ask myself this every time someone files a duplicate of [bug 1005977](https://bugzilla.mozilla.org/show_bug.cgi?id=1005977)
