### PR TITLE
bug 1269104: Refactor notification emails, provide diff for first translations

### DIFF
--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -1,11 +1,7 @@
-from constance import config
-
 from django.apps import AppConfig
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.mail import send_mail
 from django.db.models import signals
-from django.template.loader import render_to_string
 from django.utils.translation import ugettext_lazy as _
 
 from elasticsearch_dsl.connections import connections as es_connections
@@ -144,12 +140,5 @@ class WikiConfig(AppConfig):
         if raw or not created:
             # Only send for new instances, not fixtures or edits
             return
-        subject = u'[MDN] Wiki spam attempt recorded'
-        if instance.document:
-            subject = u'%s for document %s' % (subject, instance.document)
-        elif instance.title:
-            subject = u'%s with title %s' % (subject, instance.title)
-        body = render_to_string('wiki/email/spam.ltxt',
-                                {'spam_attempt': instance})
-        send_mail(subject, body, settings.DEFAULT_FROM_EMAIL,
-                  [config.EMAIL_LIST_SPAM_WATCH])
+        from .events import spam_attempt_email
+        spam_attempt_email(instance).send()

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -118,3 +118,21 @@ def first_edit_email(revision):
                          headers={'X-Kuma-Document-Url': doc.get_full_url(),
                                   'X-Kuma-Editor-Username': user.username})
     return email
+
+
+def spam_attempt_email(spam_attempt):
+    """
+    Create a notification email for a spam attempt.
+
+    Because the spam may be on document creation, the document might be null.
+    """
+    subject = '[MDN] Wiki spam attempt recorded'
+    if spam_attempt.document:
+        subject = '%s for document %s' % (subject, spam_attempt.document)
+    elif spam_attempt.title:
+        subject = '%s with title %s' % (subject, spam_attempt.title)
+    body = render_to_string('wiki/email/spam.ltxt',
+                            {'spam_attempt': spam_attempt})
+    email = EmailMessage(subject, body, settings.DEFAULT_FROM_EMAIL,
+                         to=[config.EMAIL_LIST_SPAM_WATCH])
+    return email

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1806,7 +1806,7 @@ class Revision(models.Model):
                 created__lt=self.created,
             ).order_by('-created')[0]
         except IndexError:
-            return None
+            return self.based_on
 
     @cached_property
     def needs_editorial_review(self):

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""py.test fixtures for kuma.wiki.tests."""
+
+import pytest
+from datetime import datetime
+
+from ..models import Document, Revision
+
+
+@pytest.fixture
+def wiki_user(db, django_user_model):
+    """A test user."""
+    return django_user_model.objects.create(
+        username='wiki_user',
+        email='wiki_user@example.com',
+        date_joined=datetime(2017, 4, 14, 12, 0))
+
+
+@pytest.fixture
+def root_doc(wiki_user):
+    """A newly-created top-level English document."""
+    root_doc = Document.objects.create(
+        locale='en-US', slug='Root', title='Root Document')
+    Revision.objects.create(
+        document=root_doc,
+        creator=wiki_user,
+        content='<p>Getting started...</p>',
+        title='Root Document',
+        created=datetime(2017, 4, 14, 12, 15))
+    return root_doc
+
+
+@pytest.fixture
+def create_revision(root_doc):
+    """A revision that created an English document."""
+    return root_doc.revisions.first()
+
+
+@pytest.fixture
+def edit_revision(root_doc, wiki_user):
+    """A revision that edits an English document."""
+    root_doc.current_revision = Revision.objects.create(
+        document=root_doc,
+        creator=wiki_user,
+        content='<p>The root document.</p>',
+        comment='Done with initial version.',
+        created=datetime(2017, 4, 14, 12, 30))
+    root_doc.save()
+    return root_doc.current_revision
+
+
+@pytest.fixture
+def trans_doc(create_revision, wiki_user):
+    """Translate the root document into French."""
+    trans_doc = Document.objects.create(
+        locale='fr',
+        parent=create_revision.document,
+        slug='Racine',
+        title='Racine du Document')
+    Revision.objects.create(
+        document=trans_doc,
+        creator=wiki_user,
+        based_on=create_revision,
+        content='<p>Mise en route...</p>',
+        title='Racine du Document',
+        created=datetime(2017, 4, 14, 12, 20))
+    return trans_doc
+
+
+@pytest.fixture
+def trans_revision(trans_doc):
+    return trans_doc.current_revision

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -4,76 +4,10 @@ from __future__ import unicode_literals
 from datetime import datetime
 
 import mock
-import pytest
 
 from ..events import (EditDocumentEvent, first_edit_email,
                       notification_context, spam_attempt_email)
-from ..models import Document, DocumentSpamAttempt, Revision
-
-
-@pytest.fixture
-def wiki_user(db, django_user_model):
-    """A test user."""
-    return django_user_model.objects.create(
-        username='wiki_user',
-        email='wiki_user@example.com',
-        date_joined=datetime(2017, 4, 14, 12, 0))
-
-
-@pytest.fixture
-def root_doc(wiki_user):
-    """A newly-created top-level English document."""
-    root_doc = Document.objects.create(
-        locale='en-US', slug='Root', title='Root Document')
-    Revision.objects.create(
-        document=root_doc,
-        creator=wiki_user,
-        content='<p>Getting started...</p>',
-        title='Root Document',
-        created=datetime(2017, 4, 14, 12, 15))
-    return root_doc
-
-
-@pytest.fixture
-def create_revision(root_doc):
-    """A revision that created an English document."""
-    return root_doc.revisions.first()
-
-
-@pytest.fixture
-def edit_revision(root_doc, wiki_user):
-    """A revision that edits an English document."""
-    root_doc.current_revision = Revision.objects.create(
-        document=root_doc,
-        creator=wiki_user,
-        content='<p>The root document.</p>',
-        comment='Done with initial version.',
-        created=datetime(2017, 4, 14, 12, 30))
-    root_doc.save()
-    return root_doc.current_revision
-
-
-@pytest.fixture
-def trans_doc(create_revision, wiki_user):
-    """Translate the root document into French."""
-    trans_doc = Document.objects.create(
-        locale='fr',
-        parent=create_revision.document,
-        slug='Racine',
-        title='Racine du Document')
-    Revision.objects.create(
-        document=trans_doc,
-        creator=wiki_user,
-        based_on=create_revision,
-        content='<p>Mise en route...</p>',
-        title='Racine du Document',
-        created=datetime(2017, 4, 14, 12, 20))
-    return trans_doc
-
-
-@pytest.fixture
-def trans_revision(trans_doc):
-    return trans_doc.current_revision
+from ..models import DocumentSpamAttempt
 
 
 def test_notification_context_for_create(create_revision):

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -133,16 +133,35 @@ def test_notification_context_for_edit(create_revision, edit_revision):
     assert context == expected
 
 
-def test_notification_context_for_translation(trans_revision):
+def test_notification_context_for_translation(trans_revision, create_revision):
     """Test the notification context for a created English page."""
     context = notification_context(trans_revision)
     utm_campaign = ('?utm_campaign=Wiki+Doc+Edits&utm_medium=email'
                     '&utm_source=developer.mozilla.org')
     url = '/fr/docs/Racine'
+    compare_url = (url +
+                   "$compare?to=%d" % trans_revision.id +
+                   "&from=%d" % create_revision.id +
+                   utm_campaign.replace("?", "&"))
+    diff = """\
+--- [en-US] #%d
+
++++ [fr] #%d
+
+@@ -5,7 +5,7 @@
+
+   </head>
+   <body>
+     <p>
+-      Getting started...
++      Mise en route...
+     </p>
+   </body>
+ </html>""" % (create_revision.id, trans_revision.id)
     expected = {
-        'compare_url': utm_campaign,
+        'compare_url': compare_url,
         'creator': trans_revision.creator,
-        'diff': 'Diff is unavailable.',
+        'diff': diff,
         'document_title': 'Racine du Document',
         'edit_url': url + '$edit' + utm_campaign,
         'history_url': url + '$history' + utm_campaign,

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -609,10 +609,16 @@ class RevisionTests(UserTestCase):
         last_rev = revision(document=rev.document, content="Finally",
                             is_approved=True,
                             created=datetime(2017, 4, 15, 9, 25), save=True)
+        trans = Document.objects.create(parent=rev.document, locale='fr',
+                                        title='In French')
+        trans_rev = revision(document=trans, is_approved=True,
+                             based_on=last_rev,
+                             created=datetime(2017, 4, 15, 9, 56), save=True)
 
         assert rev.previous is None
         assert next_rev.previous == rev
         assert last_rev.previous == next_rev
+        assert trans_rev.previous is None
 
     @pytest.mark.toc
     def test_show_toc(self):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -601,19 +601,18 @@ class RevisionTests(UserTestCase):
     def test_previous(self):
         """Revision.previous should return this revision's document's
         most recent approved revision."""
-        rev = revision(is_approved=True, save=True)
-        eq_(None, rev.previous)
-        # wait a second so next revision is a different datetime
-        time.sleep(1)
+        rev = revision(is_approved=True, created=datetime(2017, 4, 15, 9, 23),
+                       save=True)
         next_rev = revision(document=rev.document, content="Updated",
-                            is_approved=True)
-        next_rev.save()
-        eq_(rev, next_rev.previous)
-        time.sleep(1)
+                            is_approved=True,
+                            created=datetime(2017, 4, 15, 9, 24), save=True)
         last_rev = revision(document=rev.document, content="Finally",
-                            is_approved=True)
-        last_rev.save()
-        eq_(next_rev, last_rev.previous)
+                            is_approved=True,
+                            created=datetime(2017, 4, 15, 9, 25), save=True)
+
+        assert rev.previous is None
+        assert next_rev.previous == rev
+        assert last_rev.previous == next_rev
 
     @pytest.mark.toc
     def test_show_toc(self):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -618,7 +618,7 @@ class RevisionTests(UserTestCase):
         assert rev.previous is None
         assert next_rev.previous == rev
         assert last_rev.previous == next_rev
-        assert trans_rev.previous is None
+        assert trans_rev.previous == last_rev
 
     @pytest.mark.toc
     def test_show_toc(self):


### PR DESCRIPTION
There are [several requested changes](https://bugzilla.mozilla.org/showdependencytree.cgi?id=1142533&hide_resolved=1) for notification emails, which should be trivial to fix, but are tricky because the tests are incomplete and the code is spread over several files.

This PR:
* Moves the logic for "first edit", "page watch", and "spam attempt" emails into kuma.wiki.events
* Rewrites the tests to py.test standards, and tests against the three main edit types: English page creation, page edits, and first translations.
* Rewrites the test for ``Revision.previous``, setting creation dates rather than sleeping.
* Fixes [bug 1142533](https://bugzilla.mozilla.org/show_bug.cgi?id=1142533), so that notification emails for first translations include a diff to the English revision they are based on.

I've fixed a few other bugs (see [redo_emails_1269104](https://github.com/jwhitlock/kuma/tree/redo_emails_1269104)), but I want to get the refactor approved and merged so that the future PRs will be limited to the feature changes.