### PR TITLE
bug 1356923: Exclude 'Array' from the experiment

### DIFF
--- a/kuma/settings/content_experiments.json
+++ b/kuma/settings/content_experiments.json
@@ -210,10 +210,6 @@
                 "control": "Experiment:StaticExamplesOnTop/CSS/z-index",
                 "example": "Web/CSS/z-index"
             },
-            "en-US:Web/JavaScript/Reference/Global_Objects/Array": {
-                "control": "Experiment:StaticExamplesOnTop/JavaScript/Array",
-                "example": "Web/JavaScript/Reference/Global_Objects/Array"
-            },
             "en-US:Web/JavaScript/Reference/Global_Objects/Array/Reduce": {
                 "control": "Experiment:StaticExamplesOnTop/JavaScript/Array/reduce",
                 "example": "Web/JavaScript/Reference/Global_Objects/Array/Reduce"


### PR DESCRIPTION
The 'Array' page has had examples on top for years, and doesn't have a variant without them.