### PR TITLE
bug 1357891: Update to ElasticSearch 2.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,7 +76,7 @@ services:
       - mysqlvolume:/var/lib/mysql
 
   elasticsearch:
-    image: elasticsearch:1.7
+    image: elasticsearch:2.4
 
   redis:
     image: redis

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -8,10 +8,10 @@ Kuma uses Elasticsearch_ to power its on-site search.
 Installed version
 =================
 Elasticsearch `releases new versions often`_, and Kuma is slow to upgrade. The
-Docker and Vagrant environments use 1.7, but production is older.
+Docker environment uses 2.4, and production uses 1.7, with a planned update to 2.4.
 
 The Kuma search tests use the configured Elasticsearch, and can be run inside
-the ``web`` Docker container or the Vagrant VM to confirm the engine works::
+the ``web`` Docker container to confirm the engine works::
 
     py.test kuma/search/
 
@@ -25,21 +25,25 @@ Using the Admin
 ---------------
 This process works both in a development environment and in production:
 
-- Open the Django admin search index list view
-  (on Docker, http://localhost:8000/admin/search/index/,
-  and on Vagrant, https://developer-local.allizom.org/admin/search/index/).
+- Open the Django admin search index list view. On Docker, this is located
+  at http://localhost:8000/admin/search/index/.
 
 - Add a search index by clicking on the "Add index" button in the top right
   corner. Optionally name it, or leave it blank to generate a valid name based
-  on the time. Click the "SAVE" button in the lower right corner.
+  on the time. Spaces are not allowed in the name. Click the "SAVE" button in
+  the lower right corner.
 
 - On the search index list, select the checkbox next to the newly created index
   (the top most) and select "Populate selected search index via Celery" from
   the Action dropdown menu. Click "Go" to start indexing asynchronously.
 
+- In the development environment, you can watch the indexing process with:
+
+    docker-compose logs -f elasticsearch worker
+
 - Refresh the search index list until the "populated" field changes to a green
-  checkbox image.  You will also get an email, if the environment is set up for
-  it (the default Docker environment is not), notifying you of the completion.
+  checkbox image.  In production, you will also get an email notifying you when
+  the index is populated.
 
 - Select the checkbox next to the populated index, then choose "Promote
   selected search index to current index" in the actions dropdox. Click "Go"
@@ -62,7 +66,7 @@ Elasticsearch as well.
 
 Using the shell
 ---------------
-Inside the ``web`` Docker container or Vagrant VM::
+Inside the ``web`` Docker container::
 
     ./manage.py reindex
 

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -53,7 +53,7 @@ class WikiDocumentType(document.DocType):
 
     class Meta(object):
         mapping = Mapping('wiki_document')
-        mapping.meta('_all', enalbed=False)
+        mapping.meta('_all', enabled=False)
 
     @classmethod
     def get_connection(cls, alias='default'):


### PR DESCRIPTION
We're preparing for an update to ElasticSearch 2.4 in SCL3, so I'm starting with the Docker environment.  The elasticsearch 1.x libraries are compatible with 2.x, sending deprecated but supported 1.x API commands.  Once all environments are updated, we can make the code changes for 2.x, and update to the 2.x libraries, which are not compatible with 1.x.

The changes are:
* Fix a typo in the wiki_document meta that 1.7 ignored and 2.4 doesn't.
* Update the docs to reflect the new version, to remove Vagrant references, and to refresh from a recent run.

Locally, a ``make up`` downloaded the ElasticSearch 2.4 image, and then restarted the elasticsearch and kuma containers.  ES 2.4 was able to update the 1.x search index in place.  I was able to create and promote a new index of the sample database, and confirmed that searches like "CSS" and macro usage worked.

@jgmize (or @metadave, @escattone ) - are there any concerns using ES 2.4 in AWS?

@stephaniehobson - you expressed an interest in getting your feet wet w/ ElasticSearch 😛 