### PR TITLE
fix bug 1140091: Omit Compare link for new pages

### DIFF
--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -55,7 +55,10 @@ def notification_context(revision):
     }
 
     for name, url in link_urls.items():
-        context[name] = add_utm(url, 'Wiki Doc Edits')
+        if url:
+            context[name] = add_utm(url, 'Wiki Doc Edits')
+        else:
+            context[name] = url
 
     return context
 

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -17,7 +17,7 @@ def test_notification_context_for_create(create_revision):
                     '&utm_source=developer.mozilla.org')
     url = '/en-US/docs/Root'
     expected = {
-        'compare_url': utm_campaign,
+        'compare_url': '',
         'creator': create_revision.creator,
         'diff': 'Diff is unavailable.',
         'document_title': 'Root Document',


### PR DESCRIPTION
For new pages, there is no compare link, but it was being decorated with a Google Analytics campaign, so it was being included as a link to the homepage.  This was 154 of the 1,078 clicks (14%) from new edit and page watch emails over the last month.