### PR TITLE
bug 1269104: Fix revision history

### DIFF
--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -44,7 +44,7 @@
           {% endif %}
           {% for rev in revisions %}
             {% if loop.first %}<ul class="revision-list">{% endif %}
-            <li>
+            <li {%- if document != rev.document %} class="revision-list-en-source"{% endif %}>
               <div class="revision-list-cell revision-list-radio">
                 {% if not current %}<input type="radio" name="from" value="{{ rev.id }}" {% if loop.index == 2 %}checked="checked"{% endif %} />{% endif %}
               </div>
@@ -57,7 +57,7 @@
               {% endif %}
               </div>
               <div class="revision-list-cell revision-list-date">
-                <a href="{{ url('wiki.revision', document.slug, rev.id) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='datetime') }}</a>
+                <a href="{{ url('wiki.revision', rev.document.slug, rev.id, locale=rev.document.locale) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='datetime') }}</a>
               </div>
               <div class="revision-list-cell revision-list-creator">
                 <a href="{{ rev.creator.get_absolute_url() }}">{{ rev.creator }}</a>
@@ -68,9 +68,9 @@
                 {% endif %}
                 {{ format_comment(rev) }}
               </div>
-              {% if document.current_revision.id != rev.id and user_can_delete %}
-              <div class="revision-list-cell">
-                <a href="{{ url('wiki.revert_document', document.slug, rev.id) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
+              {% if document.current_revision.id != rev.id and document == rev.document and user_can_delete %}
+              <div class="revision-list-cell revision-list-revert">
+                <a href="{{ url('wiki.revert_document', rev.document.slug, rev.id, locale=rev.document.locale) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
               </div>
               {% endif %}
             </li>

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -120,6 +120,20 @@ def trans_revision(trans_doc):
 
 
 @pytest.fixture
+def trans_edit_revision(trans_doc, edit_revision, wiki_user):
+    """A further edit to the translated document."""
+    trans_doc.current_revision = Revision.objects.create(
+        document=trans_doc,
+        creator=wiki_user,
+        based_on=edit_revision,
+        content='<p>Le document racine.</p>',
+        title='Racine du Document',
+        created=datetime(2017, 4, 14, 20, 25))
+    trans_doc.save()
+    return trans_doc.current_revision
+
+
+@pytest.fixture
 def doc_hierarchy_with_zones(settings, wiki_user, wiki_user_2, wiki_user_3):
     top_doc = Document.objects.create(
         locale='en-US',


### PR DESCRIPTION
Fix some issues introduced by PR #4144:

* Ensure the "view revision" link has the right URL
* Omit the "Revert to this revision" action for first translation, English source revision
* Add additional CSS classes to ease testing