### PR TITLE
Bug 1308322: Upgrade to selenium 3.x

### DIFF
--- a/Jenkinsfiles/prod-integration-tests.yml
+++ b/Jenkinsfiles/prod-integration-tests.yml
@@ -3,7 +3,7 @@ pipeline:
   script: "integration-tests"
 job:
   dockerfile: "docker/images/integration-tests/Dockerfile"
-  selenium: "2.48.2"
+  selenium: "3.8.1"
   selenium_nodes: 5
   base_url: 'https://developer.mozilla.org'
   tests: "not login"

--- a/Jenkinsfiles/stage-integration-tests.yml
+++ b/Jenkinsfiles/stage-integration-tests.yml
@@ -3,7 +3,7 @@ pipeline:
   script: "integration-tests"
 job:
   dockerfile: "docker/images/integration-tests/Dockerfile"
-  selenium: "2.48.2"
+  selenium: "3.8.1"
   selenium_nodes: 5
   base_url: 'https://stage.mdn.moz.works'
   tests: "not login"

--- a/Jenkinsfiles/upgrade_pytest_1308322.yml
+++ b/Jenkinsfiles/upgrade_pytest_1308322.yml
@@ -1,0 +1,9 @@
+pipeline:
+  enabled: true
+  script: "integration-tests"
+job:
+  dockerfile: "docker/images/integration-tests/Dockerfile"
+  selenium: "3.8.1"
+  selenium_nodes: 5
+  base_url: 'https://stage.mdn.moz.works'
+  tests: "not login"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -292,19 +292,40 @@ coverage==4.3.4 \
     --hash=sha256:9ddd809ce195ec60aec6d8dacec433b1ac55f6076f773253208dd35dfd9b59bc \
     --hash=sha256:0962e9764e44172a72fa6e486aeb87d714f7018619ff41eb7c67b03fc53d122a
 
+#
 # pytest-selenium
-pytest-base-url==1.1.0 \
-    --hash=sha256:90a1ce6a00a558231117b5aee32300edecbc0c2fd701c13e8cec62177900d28c \
-    --hash=sha256:001c1b2678dae82c2891db415251361b29ed6824cb2085e4821635119499071e
-pytest-html==1.10.1 \
-    --hash=sha256:f6fc1ccefe94fb17ba289ee385bebaeccfd44cf4f05eef9116572cae699af6d6 \
-    --hash=sha256:808ddd5e9346606300eeb38a7c9ee917ca3df1c51075d02449e9cf5956ae8efb
-pytest-variables==1.4 \
-    --hash=sha256:29dcb084ed5d0c357e925c9a6cb454dbe7ae6192fdea2f9d1929f521b4e532e3 \
-    --hash=sha256:bd2e152e64c8f670e7969c76219a7842cf8ede795703127981ed71af38cfe08a
-selenium==2.53.6 \
-    --hash=sha256:5071f43daa2e698d60d5633ab0a6630cc68a852b360be99144f1c4c1ace2746c \
-    --hash=sha256:f507181f13768d73b98dd9647a466ea5758ef5c7f07b62a285d2bd8de9b27016
+#
+# Plugin for URL based tests
+# Code, Docs: https://github.com/pytest-dev/pytest-base-url
+# Release Notes: https://github.com/pytest-dev/pytest-base-url/blob/master/CHANGES.rst
+pytest-base-url==1.4.1 \
+    --hash=sha256:7425e8163345494ac7f544e99c6f3e5a08f4228bee5e26013b98c462a4d31f6e \
+    --hash=sha256:31e42366a5fc22f450b398837dc819bb7569f5e6bd5d74e494b2b9ec239876d1
+# Plugin for generating HTML reports
+# Code, Docs: https://github.com/pytest-dev/pytest-html
+# Release Notes: https://github.com/pytest-dev/pytest-html/blob/master/CHANGES.rst
+pytest-html==1.16.1 \
+    --hash=sha256:d6ae1ae5d10158d290b603ccf46b5d103e93cf7d67df42bb7d6516fb4f1317f3 \
+    --hash=sha256:135ea10b9ec0a5e370dc1820a5552d761aa3fec8400eabc0b06646f90f5c820e
+# Plugin for accessing test session metadata
+# Code, Docs: https://github.com/pytest-dev/pytest-metadata
+# Release Notes: https://github.com/pytest-dev/pytest-metadata/blob/master/CHANGES.rst
+pytest-metadata==1.5.1 \
+    --hash=sha256:26761319ecc916f16dc95f166e41e041d50a6d587d8332300594dfcfda6a7199 \
+    --hash=sha256:e126a4ab80b77f08d3bc7da6ec1ed053317eaed042690eb5b4272b79a25c7f88
+# Plugin for providing variables to pytest tests/fixtures
+# Code, Docs: https://github.com/pytest-dev/pytest-variables
+# Release Notes: https://github.com/pytest-dev/pytest-variables/blob/master/CHANGES.rst
+pytest-variables==1.7.1 \
+    --hash=sha256:7808b77b643b9f8a24f1ee1c32132648b1c62ab93956f20fe101dde66db6d09a \
+    --hash=sha256:59c00b95779657532ac5f8209b28b5d447c8b4bc4210c1d6bdf9a42aa201f9b0
+# Python language bindings for Selenium Webdriver
+# Code: https://github.com/SeleniumHQ/selenium/tree/master/py
+# Docs: https://seleniumhq.github.io/selenium/docs/api/py/api.html
+# Release Notes: https://github.com/SeleniumHQ/selenium/blob/master/py/CHANGES
+selenium==3.8.1 \
+    --hash=sha256:5acb9cdbc2d1a7fbb3e16a8ce9246211cc371f0367ad9c6bc2273cca60a6b045 \
+    --hash=sha256:9abd2dbd4a5e9b778483ce7e5adf1ea9364fcbc29da488e979213c825a1515d3
 
 # pytest-xdist
 apipkg==1.4 \

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -23,9 +23,12 @@ pytest-rerunfailures==2.1.0 \
     --hash=sha256:82e6cd823c50ff2d1b2b183642302d42c1650bcf387b17d46f5711e08fa0995f
 
 # Test plugin: Run tests with selenium
-pytest-selenium==1.4.0 \
-    --hash=sha256:7cd05ec19393f717aeee72f7b5cb628856e20ad0327f2d36d5318cb8c53980be \
-    --hash=sha256:888aa5d11221c1e2e39883d9b5d7637597d8e0d07bafd5081c2a7f4bebe48dd4
+# Code: https://github.com/pytest-dev/pytest-selenium
+# Docs: http://pytest-selenium.readthedocs.io/en/latest/index.html
+# Release Notes: http://pytest-selenium.readthedocs.io/en/latest/news.html
+pytest-selenium==1.11.4 \
+    --hash=sha256:b66651fe7cbeee02b511f7b59f250ca77fcdb6024f193ca10da27d1d91240688 \
+    --hash=sha256:9a0c48c434b538387ed6fa9d0c2f0b2e32f4fb71a4c41754df49be0aa4c64ae1
 
 # Test plugin: Run tests in parallel
 pytest-xdist==1.16.0 \

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -69,7 +69,7 @@ else
 fi
 
 # SELENIUM_TAG: Docker image tag, see https://hub.docker.com/r/selenium/hub/tags/
-SELENIUM_TAG=${SELENIUM_TAG:-2.48.2}
+SELENIUM_TAG=${SELENIUM_TAG:-3.8.1}
 
 # SELENIUM_HUB: 1 to test with Selenium Hub / Node, somewhat like Jenkins
 SELENIUM_HUB=${SELENIUM_HUB:-0}

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -22,6 +22,14 @@ def test_dashboard(base_url, selenium):
     assert not first_row.is_spam_ham_button_present
     # no dashboard-details
     assert page.details_items_length is 0
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_dashboard_open_details(base_url, selenium):
+    page = DashboardPage(selenium, base_url).open()
+    # no dashboard-details
+    assert page.details_items_length is 0
     # click first cell
     page.open_first_details()
     # dashboard-details exist and are visible
@@ -29,6 +37,12 @@ def test_dashboard(base_url, selenium):
     assert page.is_first_details_displayed
     # contains a diff
     page.wait_for_first_details_diff_displayed()
+
+
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_dashboard_load_page_two(base_url, selenium):
+    page = DashboardPage(selenium, base_url).open()
     # save id of first revision on page one
     first_row_id = page.first_row_id
     # click on page two link


### PR DESCRIPTION
Builds on py.test updates in #4210 with Selenium updates:

* selenium 2.53.6 -> 3.4.1: Support for GeckoDriver 0.15.0+, Firefox 52+. Many fixes
* pytest-base-url 1.1.0 -> 1.3.0: specify by env, add to metadata
* pytest-html 1.10.1 -> 1.16.0: add metadata to report
* pytest-selenium 1.4.0 -> 1.9.1: Move cloud testing credentials from default config files to new files or environment. Re-write Firefox options method. Work with metadata.
* pytest-metadata==1.3.0: New dependency of pytest-selenium

Django tests and coverage worked for me.  I was able to run the functional tests locally with Chrome and Firefox.  I tried running the Selenium hub and remote locally, but wasn't able to get it working (``KeyError: 'moz:firefoxOptions'`` issue), and Jenkins has the same issue.

**Update Sep 19, 2017**: The tests now run, and pass in Chrome, but they fail when run with ``node-firefox`` (timeouts) and when run locally (2 tests that open new URLS, maybe in a tab)

**Update Oct 6, 2017**: Selenium 3.6.0. The tests pass locally in Chrome and Firefox. They pass with ``node-chrome``, but now do not run with ``node-firefox``.

**Update Nov 7, 2017**: Selenium 3.7.1. The tests pass in Chrome (with one flaky test for a recently changed feature), and 5 test failures in Firefox.

**Update Dec 6, 2017**: Selenium 3.8.1. The tests pass in Chrome and local Firefox. I've found a way to make hover tests pass in Remote, and might be able to fix the failures.

**Update Jan 16, 2017**: Selenium 3.8.1-erbium. After breaking up ``test-dashboard``, tests pass in Chrome and Firefox. There are selective ``xfails`` for Firefox breakage around hover tests. The base functionality has been merged in other PRs, now we're down to just the Selenium 3.x update.