### PR TITLE
Rework kubectl apply to work around namespace issue

### DIFF
--- a/Jenkinsfiles/demo.groovy
+++ b/Jenkinsfiles/demo.groovy
@@ -12,7 +12,8 @@ stage('Deploy') {
 
   sh 'make deis-create-and-or-config'
   sh 'make render-k8s-templates'
-  sh "KUBECONFIG=${env.KUBECONFIG} kubectl --namespace=${env.DEIS_APP} apply -f k8s/"
+  sh 'kubectl config use-context virginia'
+  sh 'kubectl apply -f k8s/ -n ' + env.DEIS_APP
   sh 'make deis-pull'
   sh 'make deis-migrate'
   sh 'make demo-db-import'


### PR DESCRIPTION
While trying to do a demo deploy in #4197 I ran into [namespace not found errors](https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_multibranch_pipeline/detail/meinheld-demo/6/pipeline) which at first didn't make sense as I repeatedly verified that the namespace did in fact exist. The problem appears to have been some sort of shell escaping issue in the Jenkinsfile, as this [fixes the issue](https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_multibranch_pipeline/detail/meinheld-demo/7/pipeline).