### PR TITLE
Nobug : Adds eslint and husky for linting goodness

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+kuma/static/js/libs/*
+kuma/static/js/prism-mdn/*
+kuma/wiki/jinja2/wiki/ckeditor_config.js
+
+!kuma/static/js/libs/mozilla.cookiehelper.js
+!kuma/static/js/libs/mozilla.dnthelper.js
+!kuma/static/js/libs/mozilla.trafficcop.js
+!kuma/static/js/libs/tag-it.js

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,7 @@
 module.exports = {
     "env": {
         "browser": true,
-        "es6": true,
-        "jquery": true,
-        "jasmine": true
+        "jquery": true
     },
     "extends": "eslint:recommended",
     "rules": {
@@ -61,6 +59,7 @@ module.exports = {
         "gettext": true,
         "interpolate": true,
         "mdn": true,
-        "Mozilla": true
+        "Mozilla": true,
+        "waffle": true
     }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,66 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true,
+        "jquery": true,
+        "jasmine": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "no-global-assign": 1,
+        "indent": [
+            1,
+            4
+        ],
+        "linebreak-style": [
+            1,
+            "unix"
+        ],
+        "camelcase": 1,
+        "indent": 1,
+        "no-cond-assign": 1,
+        "no-console": 1,
+        "no-empty": 1,
+        "no-extra-semi": 1,
+        "no-fallthrough": 1,
+        "no-redeclare": 1,
+        "no-undef": 1,
+        "no-unused-vars": 1,
+        "quotes": [
+            1,
+            "single"
+        ],
+        "semi": [
+            1,
+            "always"
+        ],
+        "curly": [
+            1,
+            "all"
+        ],
+        "camelcase": [
+            1,
+            {
+                "properties": "always"
+            }
+        ],
+        "eqeqeq": [
+            1,
+            "smart"
+        ],
+        "one-var-declaration-per-line": [
+            1,
+            "always"
+        ],
+        "new-cap": 1
+    },
+    "globals": {
+        "CKEDITOR": true,
+        "FontFaceObserver": true,
+        "ga": true,
+        "gettext": true,
+        "interpolate": true,
+        "mdn": true,
+        "Mozilla": true
+    }
+};

--- a/package.json
+++ b/package.json
@@ -12,10 +12,16 @@
   "bugs": {
     "url": "https://bugzilla.mozilla.org/"
   },
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint kuma/",
+    "precommit": "npm run lint"
+  },
   "devDependencies": {
+    "eslint": "^3.19.0",
     "gulp": "^3.9.1",
     "gulp-sass": "^3.1.0",
     "gulp-stylelint": "^3.9.0",
-    "gulp-watch": "^4.3.6"
+    "gulp-watch": "^4.3.6",
+    "husky": "^0.13.3"
   }
 }


### PR DESCRIPTION
Hey @stephaniehobson 

This adds `eslint` to the project. If you use an `eslint` linter plugin for your editor, you should get real time linting feedback. There is also a lint target with:

`npm run lint`

I have marked most things as warnings so, the pre-commit hook introduced here will pass for the moment.