### PR TITLE
bug 1328989: Move Template:CustomSampleCSS to CSS

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -773,6 +773,13 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'build/styles/maintenance-mode-global.css',
     },
+    # embeded iframe for live samples
+    'samples': {
+        'source_filenames': (
+            'styles/samples.scss',
+        ),
+        'output_filename': 'build/styles/samples.css',
+    },
 }
 
 PIPELINE_JS = {
@@ -1230,13 +1237,6 @@ CONSTANCE_CONFIG = dict(
         'Maximum acceptable age (in seconds) of a cached response from '
         'kumascript. Passed along in a Cache-Control: max-age={value} header, '
         'which tells kumascript whether or not to serve up a cached response.'
-    ),
-    KUMA_CUSTOM_SAMPLE_CSS_PATH=(
-        '/en-US/docs/Template:CustomSampleCSS',
-        'Path to a wiki document whose raw content will be loaded as a CSS '
-        'stylesheet for live sample template. Will also cause the ?raw '
-        'parameter for this path to send a Content-Type: text/css header. Empty '
-        'value disables the feature altogether.',
     ),
     DIFF_CONTEXT_LINES=(
         0,

--- a/kuma/static/styles/samples.scss
+++ b/kuma/static/styles/samples.scss
@@ -1,0 +1,33 @@
+/* Style for the iframe added by the macro EmbedLiveSample */
+
+body {
+    padding: 0;
+    margin: 0;
+}
+
+svg:not(:root) {
+    display: block;
+}
+
+/* Canvas docs, playable samples */
+.playable-code {
+    background-color: #f4f7f8;
+    border: none;
+    border-left: 6px solid #558abb;
+    border-width: medium medium medium 6px;
+    color: #4d4e53;
+    height: 100px;
+    width: 90%;
+    padding: 10px 10px 0;
+}
+
+.playable-canvas {
+    border: 1px solid #4d4e53;
+    border-radius: 2px;
+}
+
+.playable-buttons {
+    text-align: right;
+    width: 90%;
+    padding: 5px 10px 5px 26px;
+}

--- a/kuma/wiki/jinja2/wiki/code_sample.html
+++ b/kuma/wiki/jinja2/wiki/code_sample.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
-        <link rel="stylesheet" type="text/css" href="{{ '%s%s' % (settings.SITE_URL, config.KUMA_CUSTOM_SAMPLE_CSS_PATH) }}?raw=1" />
+        {% stylesheet 'samples' %}
         {% if css %}
         <style type="text/css">
             {{ css|safe }}

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -415,32 +415,6 @@ class ViewTests(UserTestCase, WikiTestCase):
         eq_(page.find('#wikiArticle').parent().attr('open'), 'open')
         eq_(page.find('#doc-source').parent().attr('open'), None)
 
-    def test_raw_css_view(self):
-        """The raw source for a document can be requested"""
-        self.client.login(username='admin', password='testpass')
-        doc = document(title='Template:CustomSampleCSS',
-                       slug='Template:CustomSampleCSS',
-                       save=True)
-        revision(
-            save=True,
-            is_approved=True,
-            document=doc,
-            content="""
-                /* CSS here */
-
-                body {
-                    padding: 0;
-                    margin: 0;
-                }
-
-                svg:not(:root) {
-                    display:block;
-                }
-            """)
-        response = self.client.get('%s?raw=true' %
-                                   reverse('wiki.document', args=[doc.slug]))
-        ok_('text/css' in response['Content-Type'])
-
 
 class PermissionTests(UserTestCase, WikiTestCase):
     localizing_client = True

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -7,7 +7,6 @@ except ImportError:
     from StringIO import StringIO
 
 import newrelic.agent
-from constance import config
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -15,7 +14,6 @@ from django.http import (Http404, HttpResponse, HttpResponseBadRequest,
                          HttpResponsePermanentRedirect, JsonResponse)
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.http import urlunquote_plus
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.views.decorators.csrf import csrf_exempt
@@ -561,11 +559,8 @@ def _document_raw(request, doc, doc_html, rendering_params):
     response = HttpResponse(doc_html)
     response['X-Frame-Options'] = 'Allow'
     response['X-Robots-Tag'] = 'noindex'
-    absolute_url = urlunquote_plus(doc.get_absolute_url())
 
-    if absolute_url in (config.KUMA_CUSTOM_SAMPLE_CSS_PATH):
-        response['Content-Type'] = 'text/css; charset=utf-8'
-    elif doc.is_template:
+    if doc.is_template:
         # Treat raw, un-bleached template source as plain text, not HTML.
         response['Content-Type'] = 'text/plain; charset=utf-8'
 


### PR DESCRIPTION
Live samples load in an iframe, and include [Template:CustomSampleCSS](https://developer.mozilla.org/en-US/docs/Template:CustomSampleCSS?raw) as a stylesheet. This PR coverts the contents to a regular asset styles.css, and used that in the samples iframe source.

The macros [LiveSampleURL](https://github.com/mozilla/kumascript/blob/master/macros/LiveSampleURL.ejs) creates the iframe source href, and will change the URL from http://localhost:8000 to the SSL version at https://localhost:8000. You'll need to change this macro to get live samples in your development environment.  There will be a KumaScript PR to fix this soon.