### PR TITLE
Bug 1218563: Update "make clean", git and docker ignore lists

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,45 +1,100 @@
-# From kuma .gitignore
-*.pyc
-*.pyo
-*.sw?
-*devmo*.sql*
-.DS_Store
-.awsconfig
-.cache
+#
+# From kuma .gitigore
+#
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox
 .coverage
-.env
+.coverage.*
+.cache
 .noseids
 .noserc
-.tox
-.vagrant
-bower_components
-static/*/*
-build.py
-build/assets/css/*
-build/locale/
-celeryev.pid
+nosetests.xml
 coverage.xml
+
+# Translations
+*.mo
+*.pot
+
+# Sphinx documentation
 docs/_build/
-htmlcov/
+
+# pyenv
+.python-version
+
+# Celery
+celerybeat-schedule
+celeryev.pid
+
+# .dotenv
+.env
+
+# Virtualenv
+.venv
+venv/
+ENV/
+
+# Swapfiles
+*.sw?
+
+# Vagrant
+.vagrant
+kuma.box
+
+# macOS finder files
+.DS_Store
+
+# Kuma-specfic
+*devmo*.sql*
+bower_components
+build.py
+developer.mozilla.org.tar.gz
+docker-compose.dev.yml
 humans.txt
 james.ini
-kuma.box
 kuma/static/js/libs/ckeditor/source/ckbuilder
-kumascript.log
 kumascript_settings_local.json
-locale/**/*.mo
-logs/
+kumascript_settings_local.json*
+mdn_sample_db.sql
+mdn_sample_db.sql.gz
+mdntests/
 media/attachments
 media/sitemap*
 media/uploads
+media/revision.txt
+media/kumascript-revision.txt
 node_modules/
-nosetests.xml
-pip-log.txt
+settings_local.py
+settings_local.py*
+static/
 tmp
-uploads/
-webroot/.htaccess
-wheelhouse
+
+# Selenium
+geckodriver.log
+
+# Legacy
+.awsconfig
+logs/
 xfers/*
+wheelhouse
+webroot/.htaccess
+uploads/
+kumascript.log
+
+#
+# End kuma .gitignore
+#
 
 # From kumascript .gitignore
 kumascript/*.swp
@@ -55,8 +110,7 @@ kumascript/*.o
 kumascript/*.a
 kumascript/*.dylib
 kumascript/*.un~
-kumascript/node_modules/fibers
-kumascript/node_modules/underscore/raw
+kumascript/node_modules/
 kumascript/npm-debug.log
 
 # Additional ignores

--- a/.gitignore
+++ b/.gitignore
@@ -1,43 +1,90 @@
-!static/fonts/.htaccess
-!build/assets/css/README.md
-*.pyc
-*.pyo
-*.sw?
-*devmo*.sql*
-.DS_Store
-.awsconfig
-.cache
+# Modeled after https://github.com/github/gitignore/blob/master/Python.gitignore
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Distribution / packaging
+build/
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox
 .coverage
-.env
+.coverage.*
+.cache
 .noseids
 .noserc
-.tox
-.vagrant
-bower_components
-/static/
-build.py
-build/
+nosetests.xml
+coverage.xml
+
+# Translations
+*.mo
+
+# Sphinx documentation
+docs/_build/
+
+# pyenv
+.python-version
+
+# Celery
 celerybeat-schedule
 celeryev.pid
-coverage.xml
-docs/_build/
-htmlcov/
+
+# .dotenv
+.env
+
+# Virtualenv
+.venv
+venv/
+ENV/
+
+# Swapfiles
+*.sw?
+
+# Vagrant
+.vagrant
+kuma.box
+
+# macOS finder files
+.DS_Store
+
+# Kuma-specfic
+*devmo*.sql*
+bower_components
+build.py
+developer.mozilla.org.tar.gz
+docker-compose.dev.yml
 humans.txt
 james.ini
-kuma.box
 kuma/static/js/libs/ckeditor/source/ckbuilder
-kumascript.log
 kumascript_settings_local.json
-locale/**/*.mo
-logs/
+kumascript_settings_local.json*
+mdn_sample_db.sql
+mdn_sample_db.sql.gz
+mdntests/
 media/attachments
 media/sitemap*
 media/uploads
+media/revision.txt
+media/kumascript-revision.txt
 node_modules/
-nosetests.xml
-pip-log.txt
+settings_local.py
+settings_local.py*
+static/
 tmp
-uploads/
-webroot/.htaccess
-wheelhouse
+
+# Selenium
+geckodriver.log
+
+# Legacy
+.awsconfig
+logs/
 xfers/*
+wheelhouse
+webroot/.htaccess
+uploads/
+kumascript.log

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install:
 
 clean:
 	rm -rf .coverage build/
-	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -prune -exec rm -rf {} +
+	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -delete
 	mkdir -p build/locale
 
 locale:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ install:
 
 clean:
 	rm -rf .coverage build/
-	find kuma -name '*.pyc' -exec rm {} \;
+	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -prune -exec rm -rf {} +
 	mkdir -p build/locale
 
 locale:


### PR DESCRIPTION
``make clean`` cleans out Python 3 compiled folders, and covers the functional test directory as well.

``.gitignore`` has been updated to model [GitHub's sample for Python projects](https://github.com/github/gitignore/blob/master/Python.gitignore), and includes a few more patterns.  I've added some files that have been created from following the development instructions, as well as ones created by the SCL3 deployment process.

``.dockerignore`` gets a copy of ``.gitignore``, so this has been updated as well.

A couple of notable changes:

* There were some "Don't ignore" patterns in ``.gitignore`` which appear left-over from previous iterations, and have been removed.
* GitHub ignores ``.pot`` files, which are locale template files.  However, we use these in our TravisCI locale build to detect if strings need to be updated.  It is possible we could switch to the English locale files for that check.

I've put the branch on this repo so that Jenkins will also try building the Docker images, and we can detect any issues from the ``.dockerignore`` earlier.