### PR TITLE
Remove stray " on Email Addresses page

### DIFF
--- a/kuma/users/jinja2/account/email.html
+++ b/kuma/users/jinja2/account/email.html
@@ -42,7 +42,7 @@
 
     {% else %}
 
-      <p>{% trans %}<strong>Warning:</strong>"You have not added any email addresses to this profile. Without one you cannot receive notifications.{% endtrans %}</p>
+      <p>{% trans %}<strong>Warning:</strong> You have not added any email addresses to this profile. Without one you cannot receive notifications.{% endtrans %}</p>
 
     {% endif %}
 


### PR DESCRIPTION
Remove a double-quote that is only visible for users with no email accounts, such as those created through the Django admin.