### PR TITLE
bug 1142576, 1142545: Improve notification email tags

### DIFF
--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -119,8 +119,14 @@ class EditDocumentInTreeEvent(InstanceEvent):
 def first_edit_email(revision):
     """Create a notification email for first-time editors."""
     user, doc = revision.creator, revision.document
-    subject = ("[MDN] [%(loc)s] %(user)s made their first edit, to: %(doc)s" %
-               {'loc': doc.locale, 'user': user.username, 'doc': doc.title})
+    if doc.revisions.only('id').first().id == revision.id:
+        subject_tmpl = ("[MDN][%(loc)s][New] %(user)s made their first edit,"
+                        " creating: %(doc)s")
+    else:
+        subject_tmpl = ("[MDN][%(loc)s] %(user)s made their first edit,"
+                        " to: %(doc)s")
+    subject = subject_tmpl % {'loc': doc.locale, 'user': user.username,
+                              'doc': doc.title}
     message = render_to_string('wiki/email/edited.ltxt',
                                notification_context(revision))
     email = EmailMessage(subject, message, settings.DEFAULT_FROM_EMAIL,

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -71,6 +71,8 @@ def extra_headers(user, document=None):
     }
     if document:
         headers['X-Kuma-Document-Url'] = document.get_full_url()
+        headers['X-Kuma-Document-Title'] = document.title
+        headers['X-Kuma-Document-Locale'] = document.locale
     return headers
 
 

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -133,8 +133,10 @@ def test_edit_document_event_emails_on_create(mock_emails, create_revision):
         'users_and_watches': users_and_watches,
         'default_locale': 'en-US',
         'headers': {
-            'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
-            'X-Kuma-Editor-Username': u'wiki_user'
+            'X-Kuma-Editor-Username': 'wiki_user',
+            'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+            'X-Kuma-Document-Title': 'Root Document',
+            'X-Kuma-Document-Locale': 'en-US',
         }
     }
     subject = kwargs['subject'] % kwargs['context_vars']
@@ -163,8 +165,10 @@ def test_first_edit_email_on_create(create_revision):
     assert mail.subject == ('[MDN][en-US][New] wiki_user made their first edit,'
                             ' creating: Root Document')
     assert mail.extra_headers == {
-        'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
-        'X-Kuma-Editor-Username': u'wiki_user'
+        'X-Kuma-Editor-Username': 'wiki_user',
+        'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+        'X-Kuma-Document-Title': 'Root Document',
+        'X-Kuma-Document-Locale': 'en-US',
     }
 
 
@@ -173,10 +177,6 @@ def test_first_edit_email_on_change(edit_revision):
     mail = first_edit_email(edit_revision)
     assert mail.subject == ('[MDN][en-US] wiki_user made their first edit,'
                             ' to: Root Document')
-    assert mail.extra_headers == {
-        'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
-        'X-Kuma-Editor-Username': u'wiki_user'
-    }
 
 
 def test_first_edit_email_on_translate(trans_revision):
@@ -185,8 +185,10 @@ def test_first_edit_email_on_translate(trans_revision):
     assert mail.subject == ('[MDN][fr][New] wiki_user made their first edit,'
                             ' creating: Racine du Document')
     assert mail.extra_headers == {
+        'X-Kuma-Editor-Username': u'wiki_user',
         'X-Kuma-Document-Url': u'https://example.com/fr/docs/Racine',
-        'X-Kuma-Editor-Username': u'wiki_user'
+        'X-Kuma-Document-Title': 'Racine du Document',
+        'X-Kuma-Document-Locale': 'fr',
     }
 
 
@@ -202,7 +204,7 @@ def test_spam_attempt_email_on_create(wiki_user):
     assert mail.subject == ('[MDN] Wiki spam attempt recorded with title'
                             ' My new spam page')
     assert mail.extra_headers == {
-        'X-Kuma-Editor-Username': u'wiki_user'
+        'X-Kuma-Editor-Username': 'wiki_user'
     }
 
 
@@ -219,8 +221,10 @@ def test_spam_attempt_email_on_change(wiki_user, root_doc):
     assert mail.subject == ('[MDN] Wiki spam attempt recorded for document'
                             ' /en-US/docs/Root (Root Document)')
     assert mail.extra_headers == {
-        'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
-        'X-Kuma-Editor-Username': u'wiki_user'
+        'X-Kuma-Editor-Username': 'wiki_user',
+        'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+        'X-Kuma-Document-Title': 'Root Document',
+        'X-Kuma-Document-Locale': 'en-US',
     }
 
 
@@ -247,5 +251,5 @@ def test_spam_attempt_email_partial_model(wiki_user):
     mail = spam_attempt_email(spam_attempt)
     assert mail.subject == ('[MDN] Wiki spam attempt recorded')
     assert mail.extra_headers == {
-        'X-Kuma-Editor-Username': u'wiki_user'
+        'X-Kuma-Editor-Username': 'wiki_user',
     }

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -23,6 +23,7 @@ def test_notification_context_for_create(create_revision):
         'document_title': 'Root Document',
         'edit_url': url + '$edit' + utm_campaign,
         'history_url': url + '$history' + utm_campaign,
+        'locale': 'en-US',
         'user_url': '/profiles/wiki_user' + utm_campaign,
         'view_url': url + utm_campaign
     }
@@ -61,6 +62,7 @@ def test_notification_context_for_edit(create_revision, edit_revision):
         'document_title': 'Root Document',
         'edit_url': url + '$edit' + utm_campaign,
         'history_url': url + '$history' + utm_campaign,
+        'locale': 'en-US',
         'user_url': '/profiles/wiki_user' + utm_campaign,
         'view_url': url + utm_campaign
     }
@@ -99,6 +101,7 @@ def test_notification_context_for_translation(trans_revision, create_revision):
         'document_title': 'Racine du Document',
         'edit_url': url + '$edit' + utm_campaign,
         'history_url': url + '$history' + utm_campaign,
+        'locale': 'fr',
         'user_url': '/profiles/wiki_user' + utm_campaign,
         'view_url': url + utm_campaign
     }
@@ -131,7 +134,22 @@ def test_edit_document_event_emails_on_create(mock_emails, create_revision):
         'default_locale': 'en-US'
     }
     subject = kwargs['subject'] % kwargs['context_vars']
-    expected = '[MDN] Page "Root Document" changed by wiki_user'
+    expected = '[MDN][en-US][New] Page "Root Document" created by wiki_user'
+    assert subject == expected
+
+
+@mock.patch('kuma.wiki.events.emails_with_users_and_watches')
+def test_edit_document_event_emails_on_change(mock_emails, edit_revision):
+    """Test event email parameters for changing an English page."""
+    users_and_watches = [('fake_user', [None])]
+    EditDocumentEvent(edit_revision)._mails(users_and_watches)
+    assert mock_emails.call_count == 1
+    args, kwargs = mock_emails.call_args
+    assert not args
+    context = notification_context(edit_revision)
+    assert kwargs['context_vars'] == context
+    subject = kwargs['subject'] % context
+    expected = '[MDN][en-US] Page "Root Document" changed by wiki_user'
     assert subject == expected
 
 

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -153,10 +153,21 @@ def test_edit_document_event_emails_on_change(mock_emails, edit_revision):
     assert subject == expected
 
 
+def test_first_edit_email_on_create(create_revision):
+    """A first edit email is formatted for a new English page."""
+    mail = first_edit_email(create_revision)
+    assert mail.subject == ('[MDN][en-US][New] wiki_user made their first edit,'
+                            ' creating: Root Document')
+    assert mail.extra_headers == {
+        'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
+        'X-Kuma-Editor-Username': u'wiki_user'
+    }
+
+
 def test_first_edit_email_on_change(edit_revision):
     """A first edit email is formatted for an English change."""
     mail = first_edit_email(edit_revision)
-    assert mail.subject == ('[MDN] [en-US] wiki_user made their first edit,'
+    assert mail.subject == ('[MDN][en-US] wiki_user made their first edit,'
                             ' to: Root Document')
     assert mail.extra_headers == {
         'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
@@ -167,8 +178,8 @@ def test_first_edit_email_on_change(edit_revision):
 def test_first_edit_email_on_translate(trans_revision):
     """A first edit email is formatted for a first translation."""
     mail = first_edit_email(trans_revision)
-    assert mail.subject == ('[MDN] [fr] wiki_user made their first edit,'
-                            ' to: Racine du Document')
+    assert mail.subject == ('[MDN][fr][New] wiki_user made their first edit,'
+                            ' creating: Racine du Document')
     assert mail.extra_headers == {
         'X-Kuma-Document-Url': u'https://example.com/fr/docs/Racine',
         'X-Kuma-Editor-Username': u'wiki_user'

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -131,7 +131,11 @@ def test_edit_document_event_emails_on_create(mock_emails, create_revision):
         'html_template': None,
         'context_vars': notification_context(create_revision),
         'users_and_watches': users_and_watches,
-        'default_locale': 'en-US'
+        'default_locale': 'en-US',
+        'headers': {
+            'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
+            'X-Kuma-Editor-Username': u'wiki_user'
+        }
     }
     subject = kwargs['subject'] % kwargs['context_vars']
     expected = '[MDN][en-US][New] Page "Root Document" created by wiki_user'
@@ -197,6 +201,9 @@ def test_spam_attempt_email_on_create(wiki_user):
     mail = spam_attempt_email(spam_attempt)
     assert mail.subject == ('[MDN] Wiki spam attempt recorded with title'
                             ' My new spam page')
+    assert mail.extra_headers == {
+        'X-Kuma-Editor-Username': u'wiki_user'
+    }
 
 
 def test_spam_attempt_email_on_change(wiki_user, root_doc):
@@ -211,6 +218,10 @@ def test_spam_attempt_email_on_change(wiki_user, root_doc):
     mail = spam_attempt_email(spam_attempt)
     assert mail.subject == ('[MDN] Wiki spam attempt recorded for document'
                             ' /en-US/docs/Root (Root Document)')
+    assert mail.extra_headers == {
+        'X-Kuma-Document-Url': u'https://example.com/en-US/docs/Root',
+        'X-Kuma-Editor-Username': u'wiki_user'
+    }
 
 
 def test_spam_attempt_email_on_translate(wiki_user, trans_doc):
@@ -235,3 +246,6 @@ def test_spam_attempt_email_partial_model(wiki_user):
     )
     mail = spam_attempt_email(spam_attempt)
     assert mail.subject == ('[MDN] Wiki spam attempt recorded')
+    assert mail.extra_headers == {
+        'X-Kuma-Editor-Username': u'wiki_user'
+    }

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -705,8 +705,8 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
 
         edited_email = mail.outbox[1]
         expected_to = [u'sam@example.com']
-        expected_subject = u'[MDN] Page "%s" changed by %s' % (self.d.title,
-                                                               new_rev.creator)
+        expected_subject = (u'[MDN][en-US] Page "%s" changed by %s'
+                            % (self.d.title, new_rev.creator))
         eq_(expected_subject, edited_email.subject)
         eq_(expected_to, edited_email.to)
         ok_('%s changed %s.' % (unicode(self.username), unicode(self.d.title))

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -695,7 +695,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         first_edit_email = mail.outbox[0]
         expected_to = [config.EMAIL_LIST_SPAM_WATCH]
         expected_subject = (
-            u'[MDN] [%(loc)s] %(user)s made their first edit, to: %(title)s' %
+            u'[MDN][%(loc)s] %(user)s made their first edit, to: %(title)s' %
             {'loc': self.d.locale,
              'user': new_rev.creator.username,
              'title': self.d.title}

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2834,7 +2834,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         def _check_message_for_headers(message, username):
             ok_("%s made their first edit" % username in message.subject)
             eq_({'X-Kuma-Document-Url': "https://dev.mo.org%s" % doc.get_absolute_url(),
-                 'X-Kuma-Editor-Username': username}, message.extra_headers)
+                 'X-Kuma-Editor-Username': username,
+                 'X-Kuma-Document-Locale': doc.locale,
+                 'X-Kuma-Document-Title': doc.title}, message.extra_headers)
 
         testuser_message = mail.outbox[0]
         admin_message = mail.outbox[1]


### PR DESCRIPTION
* [bug 1142545](https://bugzilla.mozilla.org/show_bug.cgi?id=1142545) - Add a ``[New]`` tag to first edit emails, and localize the subject of watch emails.
* [bug 1142576](https://bugzilla.mozilla.org/show_bug.cgi?id=1142576) - Add more headers to email for more mail client filtering