### PR TITLE
Move statici18n file ahead of main.js in page source

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -236,6 +236,7 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
+    <script type="text/javascript" src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'main' %}
     {% if not is_sphinx %}
       <script>
@@ -245,7 +246,7 @@
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}
-    <script type="text/javascript" src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+
   {% endblock %}
 
   {% block js %}{% endblock %}


### PR DESCRIPTION
There's the occasional error when main.js loads faster then statici18n.js so I'm switching their order in the source. 