### PR TITLE
Bug 1218563: Only ignore /static/ in root

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -77,7 +77,7 @@ media/kumascript-revision.txt
 node_modules/
 settings_local.py
 settings_local.py*
-static/
+/static/
 tmp
 
 # Selenium

--- a/.gitignore
+++ b/.gitignore
@@ -74,7 +74,7 @@ media/kumascript-revision.txt
 node_modules/
 settings_local.py
 settings_local.py*
-static/
+/static/
 tmp
 
 # Selenium


### PR DESCRIPTION
There's multiple `static/` folders in the repo, we only want to ignore the one at the root.