### PR TITLE
Add seperate zone style sheets, doesn't remove combined zone.css yet

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -684,6 +684,48 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'build/styles/zones.css',
     },
+    'zone-addons': {
+        'source_filenames': (
+            'styles/zones-addons.scss',
+        ),
+        'output_filename': 'build/styles/zones-addons.css',
+    },
+    'zone-apps': {
+        'source_filenames': (
+            'styles/zones-apps.scss',
+        ),
+        'output_filename': 'build/styles/zones-apps.css',
+    },
+    'zone-archive': {
+        'source_filenames': (
+            'styles/zones-archive.scss',
+        ),
+        'output_filename': 'build/styles/zones-archive.css',
+    },
+    'zone-b2g': {
+        'source_filenames': (
+            'styles/zones-b2g.scss',
+        ),
+        'output_filename': 'build/styles/zones-b2g.css',
+    },
+    'zone-connect': {
+        'source_filenames': (
+            'styles/zones-connect.scss',
+        ),
+        'output_filename': 'build/styles/zones-connect.css',
+    },
+    'zone-ten': {
+        'source_filenames': (
+            'styles/zones-ten.scss',
+        ),
+        'output_filename': 'build/styles/zones-ten.css',
+    },
+    'zone-tools': {
+        'source_filenames': (
+            'styles/zones-tools.scss',
+        ),
+        'output_filename': 'build/styles/zones-tools.css',
+    },
     'sphinx': {
         'source_filenames': (
             'styles/wiki.scss',

--- a/kuma/static/styles/zone-addons.scss
+++ b/kuma/static/styles/zone-addons.scss
@@ -1,0 +1,18 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/webext-summary-compat-table';
+
+.addon-sdk-api-name {
+    background-color: rgba(212, 221, 228, .15);
+    padding: 3px;
+}
+
+dd > dl.reference-values {
+    padding-left: 40px;
+}
+
+li.webextension-api-sidebar {
+    background-color: #f4f7f8;
+}

--- a/kuma/static/styles/zone-apps.scss
+++ b/kuma/static/styles/zone-apps.scss
@@ -1,0 +1,5 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/initial-steps';

--- a/kuma/static/styles/zone-archive.scss
+++ b/kuma/static/styles/zone-archive.scss
@@ -1,0 +1,5 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/archive';

--- a/kuma/static/styles/zone-b2g.scss
+++ b/kuma/static/styles/zone-b2g.scss
@@ -1,0 +1,6 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/archive';
+@import 'zones/components/outer-apps-box';

--- a/kuma/static/styles/zone-connect.scss
+++ b/kuma/static/styles/zone-connect.scss
@@ -1,0 +1,20 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/dev-program';
+@import 'zones/components/stack-form';
+
+.zone {
+    background-color: rgb(245, 241, 232);
+}
+
+.masthead-text,
+.zone-landing h1 {
+    color: rgb(52, 52, 52) !important; /* stylelint-disable-line declaration-no-important */
+    padding-bottom: 20px;
+}
+
+.column-container img {
+    border: 1px solid #000;
+}

--- a/kuma/static/styles/zone-ten.scss
+++ b/kuma/static/styles/zone-ten.scss
@@ -1,0 +1,60 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/quote';
+@import 'zones/components/promo10';
+@import 'zones/components/chapters';
+@import 'zones/components/learnmore';
+
+.zone {
+    background-color: #0952a8;
+    background-image: url($path-to-images + 'zones/mdn10/head.png'), url($path-to-images + 'zones/blueprint.png'), linear-gradient(to bottom, #153985, #044ca2 600px);
+    background-repeat: no-repeat, repeat, repeat-x;
+    background-position: center -37px;
+}
+
+.zone.zone-landing {
+    background-position: center -6px;
+}
+
+@media #{$media-query-mobile-only} {
+    .zone {
+        background-image: url($path-to-images + 'zones/blueprint.png'), linear-gradient(to bottom, #153985, #044ca2 600px);
+        background-repeat: repeat, repeat-x;
+    }
+}
+
+.zone-landing {
+
+    @media #{$media-query-tablet-and-up} {
+        .masthead-text p {
+            @include heading-1();
+            margin-bottom: $grid-spacing;
+            font-family: $heading-font-family;
+            font-weight: $light-font-weight;
+            line-height: 1.2;
+        }
+    }
+
+    @media #{$media-query-small-desktop-and-up} {
+
+        h1 {
+            display: none;
+        }
+        .zone-landing-header-preview {
+            margin-top: 250px;
+        }
+
+        .masthead-text {
+            width: -calc-col-width(6);
+            margin-top: -180px;
+            margin-bottom: 110px;
+            text-align: center;
+        }
+    }
+}
+
+.contributor-avatars {
+    display: none;
+}

--- a/kuma/static/styles/zone-tools.scss
+++ b/kuma/static/styles/zone-tools.scss
@@ -1,0 +1,5 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'zones/base';
+@import 'zones/components/articulated-diagram';

--- a/kuma/static/styles/zones/archive.scss
+++ b/kuma/static/styles/zones/archive.scss
@@ -1,6 +1,4 @@
 /* set the article's background color to something obviously odd */
 body[data-slug^='Archive'] .wiki-main-content {
-    background-color: rgba(255, 217, 217, 1);
-    border: 20px solid #f00;
-    border-image: repeating-linear-gradient(-45deg, rgba(255, 0, 0, 1) 0, rgba(255, 0, 0, 1) 10px, rgba(255, 168, 0, 1) 10px, rgba(255, 168, 0, 1) 20px, rgba(255, 0, 0, 1) 20px) 20 20 repeat;
+    @import 'components/archive';
 }

--- a/kuma/static/styles/zones/components/archive.scss
+++ b/kuma/static/styles/zones/components/archive.scss
@@ -1,0 +1,6 @@
+/* set the article's background color to something obviously odd */
+.wiki-main-content {
+    background-color: rgba(255, 217, 217, 1);
+    border: 20px solid #f00;
+    border-image: repeating-linear-gradient(-45deg, rgba(255, 0, 0, 1) 0, rgba(255, 0, 0, 1) 10px, rgba(255, 168, 0, 1) 10px, rgba(255, 168, 0, 1) 20px, rgba(255, 0, 0, 1) 20px) 20 20 repeat;
+}

--- a/kuma/static/styles/zones/components/chapters.scss
+++ b/kuma/static/styles/zones/components/chapters.scss
@@ -52,6 +52,10 @@ $chapter-space-between : 120px;
     }
 }
 
+.chapter-audio .open-in-host-container {
+    display: none;
+}
+
 /* box with portrait in it gets different header */
 .chapter-portrait {
     h2 {

--- a/kuma/static/styles/zones/connect.scss
+++ b/kuma/static/styles/zones/connect.scss
@@ -8,7 +8,7 @@ body[data-slug^='Mozilla/Connect'] {
     }
 
     .masthead-text,
-    .zone-landing h1 {
+    &.zone-landing h1 {
         color: rgb(52, 52, 52) !important; /* stylelint-disable-line declaration-no-important */
         padding-bottom: 20px;
     }


### PR DESCRIPTION
Adds separate CSS files for individual zones, to be pulled in using the admin interface after PR #4209.

Does not remove the individual zone styles from zones.scss yet, so there's a bunch of duplicated styles. A follow up PR will remove that duplication once we've transitioned to using the new separate files.