### PR TITLE
bug 1218563: Omit built static, others in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -96,31 +96,25 @@ kumascript.log
 # End kuma .gitignore
 #
 
-# From kumascript .gitignore
-kumascript/*.swp
-kumascript/*.swo
-kumascript/tmp
-kumascript/logs
-kumascript/docs
-kumascript/.monitor
-kumascript/.nodemonignore
-kumascript/*.node
-kumascript/*.dSYM
-kumascript/*.o
-kumascript/*.a
-kumascript/*.dylib
-kumascript/*.un~
-kumascript/node_modules/
-kumascript/npm-debug.log
+# Different patterns for .dockerignore syntax
+static/*
+**/__pycache__/
+**/__pycache__/*
+**/*.pyc
+**/*.pyo
+**/*.pyd
+docs/_build/*
 
 # Additional ignores
 .git
 .gitignore
-kumascript/.git
-kumascript/.gitignore
 provisioning
 k8s
 docker
 docker-compose*
 Dockerfile
 Dockerfile*
+# Not needed in kuma image
+kumascript/*
+# Rebuilt in Docker
+locale/*/LC_MESSAGES/*.mo


### PR DESCRIPTION
.dockerignore has a different syntax than .gitignore. Removed some additional files from the Docker build context:

* /static - Build static files, rebuilt on image creation, ~100MB
* Python compiled files, size varies
* Locale machine object (.mo) files, rebuilt, 3 MB
* KumaScript, not needed in Kuma, 3 MB

Context drops from 150 MB to 44 MB for me.