### PR TITLE
Bug 1353134: Remove or nofollow banned user links

### DIFF
--- a/kuma/attachments/jinja2/attachments/includes/attachment_list.html
+++ b/kuma/attachments/jinja2/attachments/includes/attachment_list.html
@@ -101,9 +101,9 @@
           </td>
           <td>{{ datetimeformat(attachment.file.modified, format='datetime') }}</td>
           <td>
-            <a href="{{ attachment.file.current_revision.creator.get_absolute_url() }}">
-              {{ user_display(attachment.file.current_revision.creator) }}
-            </a>
+            <a href="{{ attachment.file.current_revision.creator.get_absolute_url() }}"
+               {%- if not attachment.file.current_revision.creator.is_active %} rel="nofollow"{% endif -%}
+               >{{ user_display(attachment.file.current_revision.creator) }}</a>
           </td>
           <td>
           {% if is_original %}

--- a/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
@@ -45,7 +45,9 @@
                         {{ format_comment(revision) }}
                     </td>
                     <td class="dashboard-author">
-                        <a href="{{ revision.creator.get_absolute_url() }}">{{ revision.creator }}</a><br>
+                        <a href="{{ revision.creator.get_absolute_url() }}"
+                           {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
+                           >{{ revision.creator }}</a><br>
                         {% set revision_ip = revision.revisionip_set.first() %}
                         {% if show_ips and revision_ip %}
                             {% set ban_ip_url = url('admin:core_ipban_add')|urlparams(ip=revision_ip.ip) %}

--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -15,13 +15,17 @@
     <h1>{{ _('Delete') }} <a href="{{ document.get_absolute_url() }}">{{ document.title }}</a></h1>
 
     <strong>{{ _('Creator') }}</strong>
-    <p><a href="{{ revision.creator.get_absolute_url() }}">{{ user_display(revision.creator) }}</a></p>
+    <p><a href="{{ revision.creator.get_absolute_url() }}"
+          {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
+          >{{ user_display(revision.creator) }}</a></p>
 
     <strong>{{ _('Creation Date') }}</strong>
     <p>{{ datetimeformat(revision.created, format='longdatetime') }}</p>
 
     <strong>{{ _('Last Change By') }}</strong>
-    <p><a href="{{ document.current_revision.creator.get_absolute_url() }}">{{ user_display(document.current_revision.creator) }}</a></p>
+    <p><a href="{{ document.current_revision.creator.get_absolute_url() }}"
+          {%- if not document.current_revision.creator.is_active %} rel="nofollow"{% endif -%}
+          >{{ user_display(document.current_revision.creator) }}</a></p>
 
     <strong>{{ _('Last Change Date') }}</strong>
     <p>{{ datetimeformat(document.current_revision.created, format='longdatetime') }}</p>

--- a/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
@@ -19,7 +19,9 @@
         <div>{{ document.title }}</div>
 
         <label><strong>{{ _('Creator') }}</strong></label>
-        <div><a href="{{ revision.creator.get_absolute_url() }}">{{ revision.creator }}</a></div>
+        <div><a href="{{ revision.creator.get_absolute_url() }}"
+                {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
+                >{{ revision.creator }}</a></div>
         <label><strong>{{ _('Date') }}</strong></label>
         <div>{{ datetimeformat(revision.created, format='longdatetime') }}</div>
         <label><strong>{{ _('Content') }}</strong></label>

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -377,7 +377,9 @@
                   {% if current_revision.creator %}
                     <div class="contributors-sub">
                       <i aria-hidden="true" class="icon-clock-o icon-fw"></i>&nbsp;<strong>{{ _('Last updated by:') }}</strong>
-                      <a href="{{ current_revision.creator.get_absolute_url() }}">{{ current_revision.creator }}</a>,
+                      <a href="{{ current_revision.creator.get_absolute_url() }}"
+                         {%- if not current_revision.creator.is_active %} rel="nofollow"{% endif -%}
+                         >{{ current_revision.creator }}</a>,
                       {{ datetimeformat(current_revision.created, format='datetime') }}
                     </div>
                   {% endif %}

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -40,8 +40,12 @@
               <div>
                   <h3>{{ _('Your Changes') }}</h3>
                   <p>
-                  {% trans id=original_revision.id, user_profile_url=original_revision.creator.get_absolute_url(), user=original_revision.creator, date=datetimeformat(original_revision.created, format='longdatetime') %}
-                    Revision {{ id }} by <a href="{{ user_profile_url }}">{{ user }}</a> on {{ date }}
+                  {% trans id=original_revision.id,
+                           user_profile_url=original_revision.creator.get_absolute_url(),
+                           rel='' if original_revision.creator.is_active else 'rel="nofollow"',
+                           user=original_revision.creator,
+                           date=datetimeformat(original_revision.created, format='longdatetime') %}
+                     Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
                   {% endtrans %}
                   </p>
               </div>
@@ -52,8 +56,12 @@
                     </a>
                 </h3>
                 <p>
-                {% trans id=current_revision.id, user_profile_url=current_revision.creator.get_absolute_url(), user=current_revision.creator, date=datetimeformat(current_revision.created, format='longdatetime') %}
-                  Revision {{ id }} by <a href="{{ user_profile_url }}">{{ user }}</a> on {{ date }}
+                {% trans id=current_revision.id,
+                         user_profile_url=current_revision.creator.get_absolute_url(),
+                         user=current_revision.creator,
+                         rel='' if current_revision.creator.is_active else 'rel="nofollow"',
+                         date=datetimeformat(current_revision.created, format='longdatetime') %}
+                   Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
                 {% endtrans %}
                 </p>
               </div>

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -39,8 +39,12 @@
             {% endif %}
           </h3>
           <p>
-          {% trans id=revision_from.id, user_profile_url=revision_from.creator.get_absolute_url(), user=revision_from.creator, date=datetimeformat(revision_from.created, format='longdatetime') %}
-            Revision {{ id }} by <a href="{{ user_profile_url }}">{{ user }}</a> on {{ date }}
+          {% trans id=revision_from.id,
+                   user_profile_url=revision_from.creator.get_absolute_url(),
+                   user=revision_from.creator,
+                   rel='' if revision_from.creator.is_active else 'rel="nofollow"',
+                   date=datetimeformat(revision_from.created, format='longdatetime') %}
+             Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
           {% endtrans %}
           </p>
         </div>
@@ -55,8 +59,12 @@
             {% endif %}
           </h3>
           <p>
-          {% trans id=revision_to.id, user_profile_url=revision_to.creator.get_absolute_url(), user=revision_to.creator, date=datetimeformat(revision_to.created, format='longdatetime') %}
-            Revision {{ id }} by <a href="{{ user_profile_url }}">{{ user }}</a> on {{ date }}
+          {% trans id=revision_to.id,
+                   user_profile_url=revision_to.creator.get_absolute_url(),
+                   user=revision_to.creator,
+                   rel='' if revision_to.creator.is_active else 'rel="nofollow"',
+                   date=datetimeformat(revision_to.created, format='longdatetime') %}
+                   Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
           {% endtrans %}
           </p>
         </div>

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -60,7 +60,9 @@
                 <a href="{{ url('wiki.revision', document.slug, rev.id) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='datetime') }}</a>
               </div>
               <div class="revision-list-cell revision-list-creator">
-                <a href="{{ rev.creator.get_absolute_url() }}">{{ rev.creator }}</a>
+                <a href="{{ rev.creator.get_absolute_url() }}"
+                   {%- if not rev.creator.is_active %} rel="nofollow"{% endif -%}
+                   >{{ rev.creator }}</a>
               </div>
               <div class="revision-list-cell revision-list-comment">
                 {% if rev.document.locale != document.locale %}

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -62,9 +62,9 @@ def test_contributors(db, cleared_cacheback_cache, settings, wiki_user_3,
     # Delete the ban.
     fixture.contributors.banned.ban.delete()
 
-    # The freshly un-banned user is not among the contributors
-    # because the cache has not been invalidated.
-    assert banned_user.pk not in set(c['id'] for c in job.get(root_doc.pk))
+    # The freshly un-banned user is now among the contributors because the
+    # cache has been invalidated.
+    assert banned_user.pk in set(c['id'] for c in job.get(root_doc.pk))
 
     # Another revision should invalidate the job's cache.
     root_doc.current_revision = Revision.objects.create(


### PR DESCRIPTION
* Refresh the document contributor list when a user is banned or un-banned, so that it is quickly updated.
* If a user is inactive (from a ban or otherwise), add ``rel="nofollow"`` to links to their profile page

Asking for review from @stephaniehobson for doing most of the research on [bug 1353134](https://bugzilla.mozilla.org/show_bug.cgi?id=1353134), feel free to reassign.