### PR TITLE
bug 1353079: Add meta tag to avoid search indexing

### DIFF
--- a/kuma/attachments/jinja2/attachments/edit_attachment.html
+++ b/kuma/attachments/jinja2/attachments/edit_attachment.html
@@ -2,7 +2,7 @@
 {# L10n: 'title' is the title of the document. #}
 {% set title = _('Attachments | %(title)s', title=document.title) %}
 {% block title %}{{ page_title(document.title) }}{% endblock %}
-{% set meta = [('robots', 'noindex, nofollow')] %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 {% from 'includes/common_macros.html' import li_field %}
 {% from "includes/error_list.html" import errorlist %}

--- a/kuma/dashboards/jinja2/dashboards/macros.html
+++ b/kuma/dashboards/jinja2/dashboards/macros.html
@@ -4,6 +4,7 @@
 {% set github_macro_list = "https://github.com/mozilla/kumascript/tree/master/macros/" %}
 {% set github_macro_view_prefix = "https://github.com/mozilla/kumascript/blob/master/macros/" %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}
 <h1>{{ title }}</h1>

--- a/kuma/dashboards/jinja2/dashboards/revisions.html
+++ b/kuma/dashboards/jinja2/dashboards/revisions.html
@@ -4,6 +4,7 @@
 {% set classes = 'compare' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}
 

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -3,6 +3,7 @@
 {% set title = 'Spam Dashboard' %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set stat_ids=(('spam_viewers_change', '% Change', 'rate'),
                  ('spam_viewers', 'Spam Viewers', 'data'),

--- a/kuma/landing/jinja2/landing/maintenance-mode.html
+++ b/kuma/landing/jinja2/landing/maintenance-mode.html
@@ -3,7 +3,7 @@
 {% set styles = ('maintenance-mode',) %}
 
 {% block title %}{{ page_title(_('Maintenance Mode')) }}{% endblock %}
-{% set meta = [('robots', 'noindex, nofollow')] %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}
 

--- a/kuma/users/jinja2/users/ban_user_and_cleanup.html
+++ b/kuma/users/jinja2/users/ban_user_and_cleanup.html
@@ -5,6 +5,7 @@
 {% block bodyclass %}user ban-user{% endblock %}
 
 {% block title %}{{ _('Ban %(user)s', user=detail_user) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 

--- a/kuma/users/jinja2/users/ban_user_and_cleanup_summary.html
+++ b/kuma/users/jinja2/users/ban_user_and_cleanup_summary.html
@@ -5,6 +5,7 @@
 {% block bodyclass %}user ban-user{% endblock %}
 
 {% block title %}{{ _('Ban %(user)s', user=detail_user) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 

--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -8,6 +8,7 @@
 {% block bodyclass %}user user-display{% endblock %}
 
 {% block title %}{{ page_title(detail_user) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -9,6 +9,7 @@
 {% block bodyclass %}user user-edit{% endblock %}
 
 {% block title %}{{ page_title(_('Edit Your Profile')) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/kuma/wiki/jinja2/wiki/compare_revisions.html
+++ b/kuma/wiki/jinja2/wiki/compare_revisions.html
@@ -3,7 +3,7 @@
 
 {% set title = _('Compare Revisions | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% set meta = [('robots', 'noindex, nofollow')] %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'compare' %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -1,6 +1,7 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/document_macros.html" import build_document_crumbs with context %}
 {% block title %}{{ page_title(_('Delete Document | %(document)s', document=document.title)) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% block content %}
 
   <article class="delete-document">

--- a/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
@@ -1,6 +1,7 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revert Revision | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}revert-document{% endblock %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/create.html
+++ b/kuma/wiki/jinja2/wiki/create.html
@@ -4,6 +4,7 @@
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Create a New Article') %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'new' %}
 {% block bodyclass %}new{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -3,6 +3,7 @@
 {% from 'wiki/includes/page_buttons.html' import page_buttons %}
 
 {% block title %}{{ page_title(_('%(title)s | Edit Article', title=document.title)) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set classes = 'edit' %}
 {% block bodyclass %}edit{% endblock %}

--- a/kuma/wiki/jinja2/wiki/list/documents.html
+++ b/kuma/wiki/jinja2/wiki/list/documents.html
@@ -12,6 +12,7 @@
   {% set title = _('All documents') %}
 {% endif %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block extrahead %}

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -1,6 +1,7 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision History | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}
     {{ super() }}

--- a/kuma/wiki/jinja2/wiki/move.html
+++ b/kuma/wiki/jinja2/wiki/move.html
@@ -1,7 +1,7 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Move Article | %(document)s', document=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% set meta = [('robots', 'noindex, nofollow')] %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}move-page{% endblock %}
 
 {% block site_css %}

--- a/kuma/wiki/jinja2/wiki/preview.html
+++ b/kuma/wiki/jinja2/wiki/preview.html
@@ -1,5 +1,6 @@
 {% extends "wiki/base.html" %}
 {% block title %}{{ title }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 {% block bodyclass %}document{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -1,7 +1,7 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision %(id)s | %(title)s', id=revision.id, title=document.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
-{% set meta = [('robots', 'noindex, nofollow')] %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -6,6 +6,7 @@
 
 {% set title = _('Translate Article | %(document)s', document=parent.title) %}
 {% block title %}{{ page_title(title) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass%}translate{% endblock %}
 
 {% block extrahead %}


### PR DESCRIPTION
For pages that we don't want indexed (based on robots.txt), set a head tag:

```
<meta name="robots" content="noindex, nofollow">
```

Remove some Jinja "set meta=" declarations that weren't doing anything.