### PR TITLE
Bug 1328989: Simplify or remove allows_* methods

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -21,7 +21,7 @@
 {% endif %}
 
 {% set current_revision = document.current_revision %}
-{% if (is_logged_in and current_revision and document.allows_revision_by(user)) and (current_revision.needs_technical_review or current_revision.needs_editorial_review) %}
+{% if (is_logged_in and current_revision) and (current_revision.needs_technical_review or current_revision.needs_editorial_review) %}
   {% set approvals_html = get_approvals_html(document, request.user) %}
 {% endif %}
 

--- a/kuma/wiki/jinja2/wiki/includes/approvals.html
+++ b/kuma/wiki/jinja2/wiki/includes/approvals.html
@@ -1,5 +1,5 @@
 {% macro get_approvals_html(document, user) %}
-  {% if user.is_authenticated() and document.current_revision and document.allows_revision_by(user) %}
+  {% if user.is_authenticated() and document.current_revision %}
     {% if document.current_revision.needs_technical_review or document.current_revision.needs_editorial_review %}
     <section class="page-meta reviews">
       <p>{{ _('This article needs these reviews:') }}</p>

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -72,8 +72,6 @@
       </div>
     </details>
 
-    {% if document.allows_revision_by(request.user) %}
     <a href="{{ url('wiki.revert_document', document.slug, revision.id) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
-    {% endif %}
   </article>
 {% endblock %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -7,7 +7,7 @@ from constance import config
 from django_mysql.models import QuerySet
 
 from .constants import (ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
-                        ALLOWED_STYLES, TEMPLATE_TITLE_PREFIX)
+                        ALLOWED_STYLES)
 from .content import parse as parse_content
 from .queries import TransformQuerySet
 
@@ -52,20 +52,6 @@ class BaseDocumentManager(models.Manager):
         """Find documents whose renderings have gone stale"""
         return (self.exclude(render_expires__isnull=True)
                     .filter(render_expires__lte=datetime.now()))
-
-    def allows_add_by(self, user, slug):
-        """
-        Determine whether the user can create a document with the given
-        slug. Mainly for enforcing Template: editing permissions
-
-        TODO: Convert to a method that raises exceptions that are handled
-        by an exception middleware.
-        """
-        if (slug.startswith(TEMPLATE_TITLE_PREFIX) and
-                not user.has_perm('wiki.add_template_document')):
-            return False
-        # TODO: Add wiki.add_document check
-        return True
 
     def filter_for_list(self, locale=None, tag=None, tag_name=None,
                         errors=None, noparent=None, toplevel=None):

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1411,18 +1411,6 @@ Full traceback:
             parents.append(curr)
         return parents
 
-    def allows_revision_by(self, user):
-        """
-        Return whether `user` is allowed to create new revisions of me.
-
-        The motivation behind this method is that templates and other types of
-        docs may have different permissions.
-        """
-        if (self.slug.startswith(TEMPLATE_TITLE_PREFIX) and
-                not user.has_perm('wiki.change_template_document')):
-            return False
-        return True
-
     def allows_editing_by(self, user):
         """
         Return whether `user` is allowed to edit document-level metadata.

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1431,9 +1431,6 @@ Full traceback:
         all the Document fields are still editable. Once there is an approved
         Revision, the Document fields can only be edited by privileged users.
         """
-        if (self.slug.startswith(TEMPLATE_TITLE_PREFIX) and
-                not user.has_perm('wiki.change_template_document')):
-            return False
         return (not self.current_revision or
                 user.has_perm('wiki.change_document'))
 

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -169,48 +169,6 @@ def create_document_editor_user():
     return user
 
 
-def create_template_test_users():
-    """Create users for template editing tests."""
-    perms = dict(
-        (x, [Permission.objects.get(codename='%s_template_document' % x)])
-        for x in ('add', 'change',)
-    )
-    perms['all'] = perms['add'] + perms['change']
-
-    groups = {}
-    for x in ('add', 'change', 'all'):
-        group, created = Group.objects.get_or_create(
-            name='templaters_%s' % x)
-        if created:
-            group.permissions = perms[x]
-            group.save()
-        groups[x] = [group]
-    editor_group = create_document_editor_group()
-
-    users = {}
-    User = get_user_model()
-    for x in ('none', 'add', 'change', 'all'):
-        user, created = User.objects.get_or_create(
-            username='user_%s' % x,
-            defaults=dict(email='user_%s@example.com',
-                          is_active=True, is_staff=False, is_superuser=False))
-        if created:
-            user.set_password('testpass')
-            user.groups = groups.get(x, []) + [editor_group]
-            user.save()
-        users[x] = user
-
-    superuser, created = User.objects.get_or_create(
-        username='superuser_1', defaults=dict(
-            email='superuser_1@example.com',
-            is_active=True, is_staff=True, is_superuser=True))
-    if created:
-        superuser.set_password('testpass')
-        superuser.save()
-
-    return (perms, groups, users, superuser)
-
-
 def create_topical_parents_docs():
     d1 = document(title='HTML7')
     d1.save()

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -376,10 +376,6 @@ class PermissionTests(KumaTestCase):
                             doc.allows_revision_by(trial_user),
                             'User %s %s able to revise %s' % (
                                 trial_user, msg[expected], slug))
-                        eq_(expected,
-                            doc.allows_editing_by(trial_user),
-                            'User %s %s able to edit %s' % (
-                                trial_user, msg[expected], slug))
 
 
 class UserDocumentTests(UserTestCase):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -366,10 +366,7 @@ class PermissionTests(KumaTestCase):
                 for expected, trial_user in trials:
                     slug = slug_tmpl % trial_user.username
                     if is_add:
-                        eq_(expected,
-                            Document.objects.allows_add_by(trial_user, slug),
-                            'User %s %s able to create %s' % (
-                                trial_user, msg[expected], slug))
+                        pass
                     else:
                         doc = document(slug=slug, title=slug)
                         eq_(expected,

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -14,11 +14,11 @@ from django.core.exceptions import ValidationError
 
 from kuma.core.exceptions import ProgrammingError
 from kuma.core.urlresolvers import reverse
-from kuma.core.tests import KumaTestCase, eq_, get_user, ok_
+from kuma.core.tests import eq_, get_user, ok_
 from kuma.attachments.models import Attachment, AttachmentRevision
 from kuma.users.tests import UserTestCase
 
-from . import (create_document_tree, create_template_test_users,
+from . import (create_document_tree,
                create_topical_parents_docs, document, normalize_html,
                revision)
 from .. import tasks
@@ -330,49 +330,6 @@ class DocumentTests(UserTestCase):
         old_slug_document = Document.objects.get(slug=doc_first_slug)
 
         assert old_slug_document.get_redirect_document().id == doc.id
-
-
-class PermissionTests(KumaTestCase):
-
-    def setUp(self):
-        """Set up the permissions, groups, and users needed for the tests"""
-        super(PermissionTests, self).setUp()
-        (self.perms, self.groups, self.users, self.superuser) = (
-            create_template_test_users())
-
-    def test_template_permissions(self):
-        msg = ('should not', 'should')
-
-        for is_add in (True, False):
-
-            slug_trials = (
-                ('test_for_%s', (
-                    (True, self.superuser),
-                    (True, self.users['none']),
-                    (True, self.users['all']),
-                    (True, self.users['add']),
-                    (True, self.users['change']),
-                )),
-                ('Template:test_for_%s', (
-                    (True, self.superuser),
-                    (False, self.users['none']),
-                    (True, self.users['all']),
-                    (is_add, self.users['add']),
-                    (not is_add, self.users['change']),
-                ))
-            )
-
-            for slug_tmpl, trials in slug_trials:
-                for expected, trial_user in trials:
-                    slug = slug_tmpl % trial_user.username
-                    if is_add:
-                        pass
-                    else:
-                        doc = document(slug=slug, title=slug)
-                        eq_(expected,
-                            doc.allows_revision_by(trial_user),
-                            'User %s %s able to revise %s' % (
-                                trial_user, msg[expected], slug))
 
 
 class UserDocumentTests(UserTestCase):

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -40,9 +40,8 @@ from kuma.spam.constants import SPAM_CHECKS_FLAG, SPAM_SUBMISSIONS_FLAG, SPAM_UR
 from kuma.users.tests import UserTestCase, user
 
 from . import (WikiTestCase, create_document_editor_group,
-               create_document_editor_user, create_document_tree,
-               create_template_test_users, document, make_translation,
-               new_document_data, normalize_html, revision)
+               create_document_editor_user, create_document_tree, document,
+               make_translation, new_document_data, normalize_html, revision)
 from ..content import get_seo_description
 from ..events import EditDocumentEvent, EditDocumentInTreeEvent
 from ..forms import MIDAIR_COLLISION
@@ -416,96 +415,8 @@ class ViewTests(UserTestCase, WikiTestCase):
         eq_(page.find('#doc-source').parent().attr('open'), None)
 
 
-class PermissionTests(UserTestCase, WikiTestCase):
-    localizing_client = True
-
-    def setUp(self):
-        """Set up the permissions, groups, and users needed for the tests"""
-        super(PermissionTests, self).setUp()
-        self.perms, self.groups, self.users, self.superuser = (
-            create_template_test_users())
-
-    def test_template_revert_permission(self):
-        locale = 'en-US'
-        slug = 'Template:test-revert-perm'
-        doc = document(save=True, slug=slug, title=slug, locale=locale)
-        rev = revision(save=True, document=doc)
-
-        # Revision template should not show revert button
-        url = reverse('wiki.revision', args=([doc.slug, rev.id]))
-        resp = self.client.get(url)
-        ok_('Revert' not in resp.content)
-
-        # Revert POST should give permission denied to user without perm
-        username = self.users['none'].username
-        self.client.login(username=username, password='testpass')
-        url = reverse('wiki.revert_document', args=([doc.slug, rev.id]))
-        resp = self.client.post(url, {'comment': 'test'})
-        eq_(403, resp.status_code)
-
-        # Revert POST should give success to user with perm
-        username = self.users['change'].username
-        self.client.login(username=username, password='testpass')
-        url = reverse('wiki.revert_document', args=([doc.slug, rev.id]))
-        resp = self.client.post(url, {'comment': 'test'}, follow=True)
-        eq_(200, resp.status_code)
-
-    def test_template_permissions(self):
-        msg = ('edit',)
-
-        for is_add in (False,):
-
-            slug_trials = (
-                ('test_for_%s', (
-                    (True, self.superuser),
-                    (True, self.users['none']),
-                    (True, self.users['all']),
-                    (True, self.users['add']),
-                    (True, self.users['change']),
-                )),
-                ('Template:test_for_%s', (
-                    (True, self.superuser),
-                    (False, self.users['none']),
-                    (True, self.users['all']),
-                    (is_add, self.users['add']),
-                    (not is_add, self.users['change']),
-                ))
-            )
-
-            for slug_tmpl, trials in slug_trials:
-                for expected, tmp_user in trials:
-
-                    username = tmp_user.username
-                    slug = slug_tmpl % username
-                    locale = settings.WIKI_DEFAULT_LANGUAGE
-
-                    Document.objects.all().filter(slug=slug).delete()
-                    if not is_add:
-                        doc = document(save=True, slug=slug, title=slug,
-                                       locale=locale)
-                        revision(save=True, document=doc)
-
-                    self.client.login(username=username, password='testpass')
-
-                    data = new_document_data()
-                    slug = slug_tmpl % username
-                    data.update({"title": slug, "slug": slug})
-
-                    data['form-type'] = 'rev'
-                    url = reverse('wiki.edit', args=(slug,), locale=locale)
-                    resp = self.client.post(url, data, follow=False)
-
-                    if expected:
-                        eq_(302, resp.status_code,
-                            "%s should be able to %s %s" %
-                            (user, msg[is_add], slug))
-                        Document.objects.filter(slug=slug).delete()
-                    else:
-                        eq_(403, resp.status_code,
-                            "%s should not be able to %s %s" %
-                            (user, msg[is_add], slug))
-
-    def test_add_document_permission(self):
+class PermissionTests(WikiTestCase):
+    def test_new_user_does_not_have_add_document_permission(self):
         newuser = user(save=True, username='newuser', password='password')
         assert not newuser.has_perm('wiki.add_document')
         url = reverse('wiki.create', locale='en-US')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -451,9 +451,9 @@ class PermissionTests(UserTestCase, WikiTestCase):
         eq_(200, resp.status_code)
 
     def test_template_permissions(self):
-        msg = ('edit', 'create')
+        msg = ('edit',)
 
-        for is_add in (True, False):
+        for is_add in (False,):
 
             slug_trials = (
                 ('test_for_%s', (
@@ -491,13 +491,9 @@ class PermissionTests(UserTestCase, WikiTestCase):
                     slug = slug_tmpl % username
                     data.update({"title": slug, "slug": slug})
 
-                    if is_add:
-                        url = reverse('wiki.create', locale=locale)
-                        resp = self.client.post(url, data, follow=False)
-                    else:
-                        data['form-type'] = 'rev'
-                        url = reverse('wiki.edit', args=(slug,), locale=locale)
-                        resp = self.client.post(url, data, follow=False)
+                    data['form-type'] = 'rev'
+                    url = reverse('wiki.edit', args=(slug,), locale=locale)
+                    resp = self.client.post(url, data, follow=False)
 
                     if expected:
                         eq_(302, resp.status_code,

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -2,7 +2,6 @@
 import newrelic.agent
 
 from constance import config
-from django.core.exceptions import PermissionDenied
 from django.shortcuts import render, redirect
 
 from kuma.attachments.forms import AttachmentRevisionForm
@@ -29,9 +28,6 @@ def create(request):
     """
     initial_slug = request.GET.get('slug', '')
 
-    # Try to head off disallowed Template:* creation, right off the bat
-    if not Document.objects.allows_add_by(request.user, initial_slug):
-        raise PermissionDenied
     # TODO: Integrate this into a new exception-handling middleware
     if not request.user.has_perm('wiki.add_document'):
         context = {
@@ -137,10 +133,6 @@ def create(request):
                                 parent_slug=parent_slug)
 
         if doc_form.is_valid() and rev_form.is_valid():
-            slug = doc_form.cleaned_data['slug']
-            if not Document.objects.allows_add_by(request.user, slug):
-                raise PermissionDenied
-
             doc = doc_form.save(parent=None)
             rev_form.save(doc)
             if doc.current_revision.is_approved:

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from django.core.exceptions import PermissionDenied
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext
@@ -27,9 +26,6 @@ def revert_document(request, document_path, revision_id):
     revision = get_object_or_404(Revision.objects.select_related('document'),
                                  pk=revision_id,
                                  document__slug=document_slug)
-
-    if not revision.document.allows_revision_by(request.user):
-        raise PermissionDenied
 
     if request.method == 'GET':
         # Render the confirmation page

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -158,8 +158,7 @@ def _filter_doc_html(request, doc, doc_html, rendering_params):
     # If this user can edit the document, inject section editing links.
     # TODO: Rework so that this happens on the client side?
     if ((rendering_params['edit_links'] or not rendering_params['raw']) and
-            request.user.is_authenticated() and
-            doc.allows_revision_by(request.user)):
+            request.user.is_authenticated()):
         tool.injectSectionEditingLinks(doc.slug, doc.locale)
 
     doc_html = tool.serialize()
@@ -806,8 +805,6 @@ def _document_PUT(request, document_slug, document_locale):
         # Look for existing document to edit:
         doc = Document.objects.get(locale=document_locale,
                                    slug=document_slug)
-        if not doc.allows_revision_by(request.user):
-            raise PermissionDenied
         section_id = request.GET.get('section', None)
         is_new = False
 

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -823,10 +823,6 @@ def _document_PUT(request, document_slug, document_locale):
                 return resp
 
     except Document.DoesNotExist:
-        # No existing document, so this is an attempt to create a new one...
-        if not Document.objects.allows_add_by(request.user, document_slug):
-            raise PermissionDenied
-
         # TODO: There should be a model utility for creating a doc...
 
         # Let's see if this slug path implies a parent...

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -115,13 +115,12 @@ def edit(request, document_slug, document_locale, revision_id=None):
     disclose_description = bool(request.GET.get('opendescription'))
 
     doc_form = rev_form = None
-    if doc.allows_revision_by(request.user):
-        rev_form = RevisionForm(request=request,
-                                instance=rev,
-                                initial={'based_on': rev.id,
-                                         'current_rev': rev.id,
-                                         'comment': ''},
-                                section_id=section_id)
+    rev_form = RevisionForm(request=request,
+                            instance=rev,
+                            initial={'based_on': rev.id,
+                                     'current_rev': rev.id,
+                                     'comment': ''},
+                            section_id=section_id)
     if doc.allows_editing_by(request.user):
         doc_form = DocumentForm(initial=document_form_initial(doc))
 
@@ -175,106 +174,103 @@ def edit(request, document_slug, document_locale, revision_id=None):
                 raise PermissionDenied
 
         elif which_form == 'rev':
-            if not doc.allows_revision_by(request.user):
-                raise PermissionDenied
+            post_data = request.POST.copy()
+
+            rev_form = RevisionForm(request=request,
+                                    data=post_data,
+                                    is_async_submit=is_async_submit,
+                                    section_id=section_id)
+            rev_form.instance.document = doc  # for rev_form.clean()
+
+            # Come up with the original revision to which these changes
+            # would be applied.
+            orig_rev_id = request.POST.get('current_rev', False)
+            if orig_rev_id is False:
+                orig_rev = None
             else:
-                post_data = request.POST.copy()
+                orig_rev = Revision.objects.get(pk=orig_rev_id)
+            # Get the document's actual current revision.
+            curr_rev = doc.current_revision
 
-                rev_form = RevisionForm(request=request,
-                                        data=post_data,
-                                        is_async_submit=is_async_submit,
-                                        section_id=section_id)
-                rev_form.instance.document = doc  # for rev_form.clean()
+            if not rev_form.is_valid():
+                # If this was an Ajax POST, then return a JsonResponse
+                if is_async_submit:
+                    # Was there a mid-air collision?
+                    if 'current_rev' in rev_form._errors:
+                        # Make the error message safe so the '<' and '>' don't
+                        # get turned into '&lt;' and '&gt;', respectively
+                        rev_form.errors['current_rev'][0] = mark_safe(
+                            rev_form.errors['current_rev'][0])
+                    errors = [rev_form.errors[key][0] for key in rev_form.errors.keys()]
 
-                # Come up with the original revision to which these changes
-                # would be applied.
-                orig_rev_id = request.POST.get('current_rev', False)
-                if orig_rev_id is False:
-                    orig_rev = None
+                    data = {
+                        "error": True,
+                        "error_message": errors,
+                        "new_revision_id": curr_rev.id,
+                    }
+                    return JsonResponse(data=data)
+                    # Jump out to a function to escape indentation hell
+                    return _edit_document_collision(
+                        request, orig_rev, curr_rev, is_async_submit,
+                        is_raw, rev_form, doc_form, section_id,
+                        rev, doc)
+                # Was this an Ajax submission that was marked as spam?
+                if is_async_submit and '__all__' in rev_form._errors:
+                    # Return a JsonResponse
+                    data = {
+                        "error": True,
+                        "error_message": mark_safe(rev_form.errors['__all__'][0]),
+                        "new_revision_id": curr_rev.id,
+                    }
+                    return JsonResponse(data=data)
+            if rev_form.is_valid():
+                rev_form.save(doc)
+                if (is_raw and orig_rev is not None and
+                        curr_rev.id != orig_rev.id):
+                    # If this is the raw view, and there was an original
+                    # revision, but the original revision differed from the
+                    # current revision at start of editing, we should tell
+                    # the client to refresh the page.
+                    response = HttpResponse('RESET')
+                    response['X-Frame-Options'] = 'SAMEORIGIN'
+                    response.status_code = 205
+                    return response
+                # Is this an Ajax POST?
+                if is_async_submit:
+                    # This is the most recent revision id
+                    new_rev_id = rev.document.revisions.order_by('-id').first().id
+                    data = {
+                        "error": False,
+                        "new_revision_id": new_rev_id
+                    }
+                    return JsonResponse(data)
+
+                if rev_form.instance.is_approved:
+                    view = 'wiki.document'
                 else:
-                    orig_rev = Revision.objects.get(pk=orig_rev_id)
-                # Get the document's actual current revision.
-                curr_rev = doc.current_revision
+                    view = 'wiki.document_revisions'
 
-                if not rev_form.is_valid():
-                    # If this was an Ajax POST, then return a JsonResponse
-                    if is_async_submit:
-                        # Was there a mid-air collision?
-                        if 'current_rev' in rev_form._errors:
-                            # Make the error message safe so the '<' and '>' don't
-                            # get turned into '&lt;' and '&gt;', respectively
-                            rev_form.errors['current_rev'][0] = mark_safe(
-                                rev_form.errors['current_rev'][0])
-                        errors = [rev_form.errors[key][0] for key in rev_form.errors.keys()]
-
-                        data = {
-                            "error": True,
-                            "error_message": errors,
-                            "new_revision_id": curr_rev.id,
-                        }
-                        return JsonResponse(data=data)
-                        # Jump out to a function to escape indentation hell
-                        return _edit_document_collision(
-                            request, orig_rev, curr_rev, is_async_submit,
-                            is_raw, rev_form, doc_form, section_id,
-                            rev, doc)
-                    # Was this an Ajax submission that was marked as spam?
-                    if is_async_submit and '__all__' in rev_form._errors:
-                        # Return a JsonResponse
-                        data = {
-                            "error": True,
-                            "error_message": mark_safe(rev_form.errors['__all__'][0]),
-                            "new_revision_id": curr_rev.id,
-                        }
-                        return JsonResponse(data=data)
-                if rev_form.is_valid():
-                    rev_form.save(doc)
-                    if (is_raw and orig_rev is not None and
-                            curr_rev.id != orig_rev.id):
-                        # If this is the raw view, and there was an original
-                        # revision, but the original revision differed from the
-                        # current revision at start of editing, we should tell
-                        # the client to refresh the page.
-                        response = HttpResponse('RESET')
-                        response['X-Frame-Options'] = 'SAMEORIGIN'
-                        response.status_code = 205
-                        return response
-                    # Is this an Ajax POST?
-                    if is_async_submit:
-                        # This is the most recent revision id
-                        new_rev_id = rev.document.revisions.order_by('-id').first().id
-                        data = {
-                            "error": False,
-                            "new_revision_id": new_rev_id
-                        }
-                        return JsonResponse(data)
-
-                    if rev_form.instance.is_approved:
-                        view = 'wiki.document'
-                    else:
-                        view = 'wiki.document_revisions'
-
-                    # Construct the redirect URL, adding any needed parameters
-                    url = reverse(view, args=[doc.slug], locale=doc.locale)
-                    params = {}
-                    if is_raw:
-                        params['raw'] = 'true'
-                        if need_edit_links:
-                            # Only need to carry over ?edit_links with ?raw,
-                            # because they're on by default in the normal UI
-                            params['edit_links'] = 'true'
-                        if section_id:
-                            # If a section was edited, and we're using the raw
-                            # content API, constrain to that section.
-                            params['section'] = section_id
-                    # Parameter for the document saved, so that we can delete the cached draft on load
-                    params['document_saved'] = 'true'
-                    url = '%s?%s' % (url, urlencode(params))
-                    if not is_raw and section_id:
-                        # If a section was edited, jump to the section anchor
-                        # if we're not getting raw content.
-                        url = '%s#%s' % (url, section_id)
-                    return redirect(url)
+                # Construct the redirect URL, adding any needed parameters
+                url = reverse(view, args=[doc.slug], locale=doc.locale)
+                params = {}
+                if is_raw:
+                    params['raw'] = 'true'
+                    if need_edit_links:
+                        # Only need to carry over ?edit_links with ?raw,
+                        # because they're on by default in the normal UI
+                        params['edit_links'] = 'true'
+                    if section_id:
+                        # If a section was edited, and we're using the raw
+                        # content API, constrain to that section.
+                        params['section'] = section_id
+                # Parameter for the document saved, so that we can delete the cached draft on load
+                params['document_saved'] = 'true'
+                url = '%s?%s' % (url, urlencode(params))
+                if not is_raw and section_id:
+                    # If a section was edited, jump to the section anchor
+                    # if we're not getting raw content.
+                    url = '%s#%s' % (url, section_id)
+                return redirect(url)
 
     parent_path = parent_slug = ''
     if slug_dict['parent']:

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -128,9 +128,6 @@ def quick_review(request, document_slug, document_locale):
                             locale=document_locale,
                             slug=document_slug)
 
-    if not doc.allows_revision_by(request.user):
-        raise PermissionDenied
-
     rev_id = request.POST.get('revision_id')
     if not rev_id:
         raise Http404


### PR DESCRIPTION
There are some methods that can be simplified or removed when we assume ``Document.is_template`` is False:

* ``Document.allows_editing_by`` - Simplified to "change document" permissions
* ``Document.allows_revision_by`` - Always returns True, so removed
* ``Document.objects.allows_add_by`` - Always returns True, so removed

Some tests can be dropped, and some code paths are eliminated.  Reducing indent makes some diffs looks bigger than they are, enough to justify a PR for ease of review.

There are two more PRs planned.  [bye-templates-1328989](https://github.com/mozilla/kuma/compare/master...jwhitlock:bye-templates-1328989?expand=1) contains all the changes, but I think it's too overwhelming for a single PR.