### PR TITLE
bug 944186: drop styles column from DocumentZone

### DIFF
--- a/kuma/wiki/migrations/0033_remove_zone_styles.py
+++ b/kuma/wiki/migrations/0033_remove_zone_styles.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0032_alt-zone-css'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='documentzone',
+            name='styles',
+        ),
+    ]


### PR DESCRIPTION
Completes the update of the DocumentZone table by dropping the "styles" column, which is already no longer used in the deployed code. This is a follow-on to PR #4209.