### PR TITLE
bug 1352492: Update coverage in TravisCI

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -248,6 +248,7 @@ lxml==3.5.0 \
     --hash=sha256:78a1ec1e674ab6dc8a0644bb4401f3fb5787b636b0aaf0c9a720923491547b1b
 
 # pytest-cov
+# Keep in sync with travis.txt
 coverage==4.3.4 \
     --hash=sha256:e1fb21a807aa0b5cc79806d8ef09078acaa83f994e15f0f7277489ca8eda51b7 \
     --hash=sha256:8a82664931a071399d703d65af2521e2202b34f2d8db20fa22a922fec0339022 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -37,6 +37,7 @@ pytest-django==3.1.2 \
     --hash=sha256:00995c2999b884a38ae9cd30a8c00ed32b3d38c1041250ea84caf18085589662
 
 # Run tests in a virtual environment
+# Keep in sync w/ travis.txt
 tox==2.3.1 \
     --hash=sha256:1823c93ca378092c10bbde428213d3f5066b30adb09e5c001087a83e3e0a402a \
     --hash=sha256:bf7fcc140863820700d3ccd65b33820ba747b61c5fe4e2b91bb8c64cb21a47ee

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -2,5 +2,7 @@
 # Travis CI specific requirements
 ansible==1.9.2
 codecov==1.6.3
+# Keep in sync w/ dev.txt
 tox==2.3.1
-coverage==4.0.3
+# Keep in sync w/ constraints.txt
+coverage==4.3.4


### PR DESCRIPTION
Update [coverage](https://pypi.python.org/pypi/coverage/4.3.4) from 4.0.3 to 4.3.4, like in the development environment, and add notes to keep them in sync in the future.