### PR TITLE
bug 1363916: add liveness/readiness endpoints for k8s

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -1,0 +1,31 @@
+import mock
+import pytest
+from django.db import DatabaseError
+from django.core.urlresolvers import reverse
+
+
+@pytest.mark.parametrize('http_method',
+                         ['get', 'head', 'put', 'post', 'delete', 'options'])
+def test_liveness(db, client, http_method):
+    url = reverse('health.liveness')
+    response = getattr(client, http_method)(url)
+    assert (response.status_code ==
+            204 if http_method in ('get', 'head') else 405)
+
+
+@pytest.mark.parametrize('http_method',
+                         ['get', 'head', 'put', 'post', 'delete', 'options'])
+def test_readiness(db, client, http_method):
+    url = reverse('health.readiness')
+    response = getattr(client, http_method)(url)
+    assert (response.status_code ==
+            204 if http_method in ('get', 'head') else 405)
+
+
+def test_readiness_with_db_error(db, client):
+    url = reverse('health.readiness')
+    with mock.patch('kuma.wiki.models.Document.objects') as mock_manager:
+        mock_manager.filter.side_effect = DatabaseError('fubar')
+        response = client.get(url)
+    assert response.status_code == 503
+    assert 'fubar' in response.reason_phrase

--- a/kuma/health/urls.py
+++ b/kuma/health/urls.py
@@ -1,0 +1,13 @@
+from django.conf.urls import url
+
+from . import views
+
+
+urlpatterns = [
+    url(r'^healthz/?$',
+        views.liveness,
+        name='health.liveness'),
+    url(r'^readiness/?$',
+        views.readiness,
+        name='health.readiness'),
+]

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -1,0 +1,39 @@
+from django.db import DatabaseError
+from django.http import HttpResponse
+from django.views.decorators.http import require_safe
+
+from kuma.wiki.models import Document
+
+
+@require_safe
+def liveness(request):
+    """
+    A successful response from this endpoint simply proves
+    that Django is up and running. It doesn't mean that its
+    supporting services (like MySQL, memcached, Celery) can
+    be successfully used from within this service.
+    """
+    return HttpResponse(status=204)
+
+
+@require_safe
+def readiness(request):
+    """
+    A successful response from this endpoint goes a step further
+    and means not only that Django is up and running, but also that
+    the database can be successfully used from within this service.
+    The other supporting services are not checked, but we may find
+    that we want/need to add them later.
+    """
+    try:
+        # Confirm that we can use the database by making a fast query
+        # against the Document table. It's not important that the document
+        # with the requested primary key exists or not, just that the query
+        # completes without error.
+        Document.objects.filter(pk=1).exists()
+    except DatabaseError as e:
+        reason_tmpl = 'service unavailable due to database issue ({!s})'
+        status, reason = 503, reason_tmpl.format(e)
+    else:
+        status, reason = 204, None
+    return HttpResponse(status=status, reason=reason)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -368,6 +368,8 @@ SERVE_MEDIA = False
 
 # Paths that don't require a locale prefix.
 LANGUAGE_URL_IGNORED_PATHS = (
+    'healthz',
+    'readiness',
     'media',
     'admin',
     'robots.txt',

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -17,6 +17,7 @@ handler404 = core_views.handler404
 handler500 = core_views.handler500
 
 urlpatterns = [
+    url('', include('kuma.health.urls')),
     url('', include('kuma.landing.urls')),
     url(
         r'^events',


### PR DESCRIPTION
This PR implements "liveness" and "readiness" endpoints as used by Kubernetes.
- They are implemented as Middleware and placed at the beginning of the middleware stack to avoid unnecessary processing (sessions, authentication, etc.) for endpoints that will be hit frequently.
- The philosophy of the "liveness" endpoint is to simply indicate whether the service itself is up and running, while the "readiness" endpoint goes one step further to also include whether its essential supporting services are also running and usable. I've made the decision for now that for Kuma "essential supporting services" means the database only, not the other supporting services (elasticsearch, Celery, memcached, kumascript), since Kuma can remain usable without them.
- The "readiness" endpoint checks the usability of the database via a simple, indexed (fast) [query on the Document table](https://github.com/escattone/kuma/blob/k8s-health-checks-1363916/kuma/health/middleware.py#L47), but I also had briefly explored using something like this instead:
```
with connection.cursor() as cursor:
    cursor.execute("SELECT 1")
```
- I also tested the "readiness" endpoint locally, by stopping the "mysql" service (``docker-compose stop mysql``) and ensuring that the "readiness" endpoint returned a 503 (with a detailed reason).