### PR TITLE
Nearest-zone-job adjustments 944186

### DIFF
--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -17,7 +17,12 @@ class DocumentNearestZoneJob(KumaJob):
         document and going upwards via topic parents.
         """
         from .models import Document, DocumentZone
-        get_parent_id = Document.objects.values_list('parent_topic', flat=True).get
+
+        # Using "admin_objects" here to get around the
+        # filter that excludes deleted documents.
+        get_parent_id = (Document.admin_objects
+                                 .values_list('parent_topic', flat=True)
+                                 .get)
         while pk:
             try:
                 return DocumentZone.objects.get(document=pk)

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -8,7 +8,7 @@ from kuma.users.templatetags.jinja_helpers import gravatar_url
 
 
 class DocumentNearestZoneJob(KumaJob):
-    lifetime = 60 * 60 * 3
+    lifetime = 60 * 60 * 29
     refresh_timeout = 60
 
     def fetch(self, pk):

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -34,6 +34,20 @@ def test_nearest_zone(doc_hierarchy_with_zones, root_doc,
     assert DocumentNearestZoneJob().get(doc.pk) == zone
 
 
+def test_nearest_zone_when_deleted_parent_topic(doc_hierarchy_with_zones,
+                                                cleared_cacheback_cache):
+    """
+    Make sure we handle the case where we try to get the nearest
+    zone for a document whose parent-topic has been deleted.
+    """
+    bottom_doc = doc_hierarchy_with_zones.bottom
+    middle_top_zone = doc_hierarchy_with_zones.middle_top.zone
+    # Delete the parent-topic of the bottom doc.
+    doc_hierarchy_with_zones.middle_bottom.delete()
+    # We should still successfully get the nearest zone for the bottom doc.
+    assert DocumentNearestZoneJob().get(bottom_doc.pk) == middle_top_zone
+
+
 def test_nearest_zone_cache_invalidation_on_save_shallow(doc_hierarchy_with_zones,
                                                          cleared_cacheback_cache):
     job = DocumentNearestZoneJob()


### PR DESCRIPTION
This PR addresses two problems introduced in #4209 (addressing bug [944186](https://bugzilla.mozilla.org/show_bug.cgi?id=944186)):
- it hopefully eases the spike in celery tasks (see bug [1366044](https://bugzilla.mozilla.org/show_bug.cgi?id=1366044))
- fixes an exception when getting the nearest-zone for a document whose parent-topic has been deleted (bug [1365960](https://bugzilla.mozilla.org/show_bug.cgi?id=1365960))

I wanted to prove (via a test case) that using ``None`` for the "empty" value for the ``DocumentNearestZoneJob`` class effectively bypasses the cache, along the lines of something like this:
```
# doc is some document that doesn't have a nearest zone.
assert not DocumentNearestZoneJob().get(doc.pk) 
with mock.patch.object(DocumentNearestZoneJob, 'fetch') as mock_fetch:
    DocumentNearestZoneJob().get(doc.pk)
    mock_fetch.assert_not_called()
```
which I thought should fail (on the mock assertion) when using ``None`` for empty and succeed when using ``False``, but for the life of me I couldn't get it to fail when using ``None``. A long, detailed look at the ``django-cacheback`` code has me convinced that it should fail, but it doesn't in my tests.
