### PR TITLE
[WIP] Bug 1366868: Add PostCSS to asset pipeline

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ env:
         - PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor
         - PIPELINE_SASS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/node-sass
         - PIPELINE_UGLIFYJS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/uglifyjs
+        - PIPELINE_POSTCSS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/postcss
+        - PIPELINE_POSTCSS_ARGUMENTS="--config $TRAVIS_BUILD_DIR/postcss.config.js"
     matrix:
         - TOXENV=py27
           CREATE_DB=kuma

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -40,11 +40,15 @@ RUN npm install -g \
     node-sass@4.3.0 \
     uglify-js@2.4.13 \
     clean-css@3.4.23 \
-    stylelint@7.10.1
+    stylelint@7.10.1 \
+    postcss-cli@4.0.0 \
+    autoprefixer@7.1.1
 ENV PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor \
     PIPELINE_CSSMIN_BINARY=/usr/bin/cssmin \
     PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor \
-    PIPELINE_UGLIFYJS_BINARY=/usr/bin/uglifyjs
+    PIPELINE_UGLIFYJS_BINARY=/usr/bin/uglifyjs \
+    PIPELINE_POSTCSS_BINARY=/usr/bin/postcss \
+    PIPELINE_POSTCSS_ARGUMENTS='--config /app/postcss.config.js'
 
 COPY ./requirements /app/requirements
 RUN pip install --no-cache-dir -r requirements/dev.txt

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,7 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+const autoprefixer = require('autoprefixer');
 const gulp = require('gulp');
+const postcss = require('gulp-postcss');
 const sass = require('gulp-sass');
 const stylelint = require('gulp-stylelint');
 const watch = require('gulp-watch');
@@ -13,6 +15,7 @@ gulp.task('styles', () => {
     // all other .scss files are components/includes/libs
     gulp.src('./kuma/static/styles/*.scss')
         .pipe(sass().on('error', sass.logError))
+        .pipe(postcss([ autoprefixer() ]))
         // send compiled files to where expected by Django Pipeline
         .pipe(gulp.dest('./static/styles'));
 });

--- a/kuma/core/pipeline/sass.py
+++ b/kuma/core/pipeline/sass.py
@@ -1,3 +1,7 @@
+from os.path import dirname
+from tempfile import NamedTemporaryFile
+
+from django.conf import settings
 from pipeline.compilers.sass import SASSCompiler
 
 
@@ -10,3 +14,20 @@ class DebugSassCompiler(SASSCompiler):
 
     def compile_file(self, *args, **kwargs):
         return
+
+
+class SassThenPostCssCompiler(SASSCompiler):
+    """Run Sass then PostCSS on the file."""
+
+    def compile_file(self, infile, outfile, outdated=False, force=False):
+        with NamedTemporaryFile(suffix='.css') as middlefile:
+            middle_path = middlefile.name
+            super(SassThenPostCssCompiler, self).compile_file(
+                infile, middle_path, outdated, force)
+
+            command = (
+                settings.PIPELINE['POSTCSS_BINARY'],
+                settings.PIPELINE['POSTCSS_ARGUMENTS'].split(' '),
+                middle_path,
+                '-o', outfile)
+            return self.execute_command(command, cwd=dirname(outfile))

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1059,12 +1059,15 @@ PIPELINE = {
     'SHOW_ERRORS_INLINE': False,  # django-pipeline issue #614
     'COMPILERS': (
         ('kuma.core.pipeline.sass.DebugSassCompiler'
-            if DEBUG else
-            'pipeline.compilers.sass.SASSCompiler'),
+         if DEBUG else
+         'kuma.core.pipeline.sass.SassThenPostCssCompiler'),
     ),
     'SASS_BINARY': config('PIPELINE_SASS_BINARY',
                           default='/usr/bin/env node-sass'),
     'SASS_ARGUMENTS': config('PIPELINE_SASS_ARGUMENTS', default=''),
+    'POSTCSS_BINARY': config('PIPELINE_POSTCSS_BINARY',
+                             default='/usr/bin/postcss'),
+    'POSTCSS_ARGUMENTS': config('PIPELINE_POSTCSS_ARGUMENTS', default='--no-map'),
     'CSS_COMPRESSOR': config('PIPELINE_CSS_COMPRESSOR',
                              default='kuma.core.pipeline.cleancss.CleanCSSCompressor'),
     'JS_COMPRESSOR': config('PIPELINE_JS_COMPRESSOR',

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -45,7 +45,7 @@ PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = True
 
 # We need the real Sass compiler here instead of the pass-through used for
 # local dev.
-PIPELINE['COMPILERS'] = ('pipeline.compilers.sass.SASSCompiler',)
+PIPELINE['COMPILERS'] = ('kuma.core.pipeline.sass.SassThenPostCssCompiler',)
 
 # Testing with django-pipeline 1.6.8, PipelineStorage
 # Enabled=T, Collector=T -   482s

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -154,7 +154,7 @@
     },
     "autoprefixer": {
       "version": "6.7.7",
-      "from": "autoprefixer@>=6.0.0 <7.0.0",
+      "from": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
       "dev": true
     },
@@ -227,7 +227,7 @@
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <1.1.0",
+      "from": "buffer-shims@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
       "dev": true
     },
@@ -632,7 +632,7 @@
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "escape-string-regexp@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "dev": true
     },
@@ -1650,7 +1650,7 @@
       "dependencies": {
         "object-assign": {
           "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
+          "from": "object-assign@4.1.1",
           "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "dev": true
         }
@@ -1822,7 +1822,7 @@
     },
     "graceful-fs": {
       "version": "3.0.11",
-      "from": "graceful-fs@>=3.0.0 <4.0.0",
+      "from": "graceful-fs@>=3.0.1 <3.1.0",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
       "dev": true
     },
@@ -1832,9 +1832,29 @@
       "resolved": "https://registry.npmjs.org/gulp/-/gulp-3.9.1.tgz",
       "dev": true
     },
+    "gulp-postcss": {
+      "version": "7.0.0",
+      "from": "gulp-postcss@>=7.0.0 <8.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-postcss/-/gulp-postcss-7.0.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "postcss": {
+          "version": "6.0.1",
+          "from": "postcss@>=6.0.0 <7.0.0",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.1.tgz",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "supports-color@>=3.2.3 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dev": true
+        }
+      }
+    },
     "gulp-sass": {
       "version": "3.1.0",
-      "from": "gulp-sass@>=3.1.0 <4.0.0",
+      "from": "gulp-sass@latest",
       "resolved": "https://registry.npmjs.org/gulp-sass/-/gulp-sass-3.1.0.tgz",
       "dev": true
     },
@@ -1920,7 +1940,7 @@
     },
     "har-validator": {
       "version": "4.2.1",
-      "from": "har-validator@>=4.2.1 <4.3.0",
+      "from": "har-validator@>=4.2.0 <4.3.0",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
       "dev": true
     },
@@ -2028,7 +2048,7 @@
     },
     "ini": {
       "version": "1.3.4",
-      "from": "ini@>=1.3.4 <2.0.0",
+      "from": "ini@>=1.2.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
       "dev": true
     },
@@ -2896,7 +2916,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "path-is-absolute@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "dev": true
     },
@@ -2932,7 +2952,7 @@
       "dependencies": {
         "graceful-fs": {
           "version": "4.1.11",
-          "from": "graceful-fs@>=4.1.2 <5.0.0",
+          "from": "graceful-fs@4.1.11",
           "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "dev": true
         }
@@ -2946,7 +2966,7 @@
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "pify@>=2.3.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "dev": true
     },
@@ -2976,7 +2996,7 @@
     },
     "postcss": {
       "version": "5.2.16",
-      "from": "postcss@>=5.0.20 <6.0.0",
+      "from": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.16.tgz",
       "dev": true,
       "dependencies": {
@@ -2993,6 +3013,48 @@
       "from": "postcss-less@>=0.14.0 <0.15.0",
       "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-0.14.0.tgz",
       "dev": true
+    },
+    "postcss-load-config": {
+      "version": "1.2.0",
+      "from": "postcss-load-config@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "postcss-load-options": {
+      "version": "1.2.0",
+      "from": "postcss-load-options@>=1.2.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@^4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "postcss-load-plugins": {
+      "version": "2.3.0",
+      "from": "postcss-load-plugins@>=2.3.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@^4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "dev": true
+        }
+      }
     },
     "postcss-media-query-parser": {
       "version": "0.2.3",
@@ -3246,13 +3308,13 @@
       "dependencies": {
         "glob": {
           "version": "7.1.1",
-          "from": "glob@>=7.0.5 <8.0.0",
+          "from": "glob@7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "minimatch@3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         }
@@ -3272,7 +3334,7 @@
       "dependencies": {
         "glob": {
           "version": "7.1.1",
-          "from": "glob@>=7.0.0 <8.0.0",
+          "from": "glob@7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
           "dev": true
         },
@@ -3284,7 +3346,7 @@
         },
         "minimatch": {
           "version": "3.0.3",
-          "from": "minimatch@>=3.0.2 <4.0.0",
+          "from": "minimatch@3.0.3",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
           "dev": true
         }
@@ -3741,7 +3803,7 @@
     },
     "user-home": {
       "version": "1.1.1",
-      "from": "user-home@>=1.1.1 <2.0.0",
+      "from": "user-home@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
       "dev": true
     },
@@ -3895,7 +3957,7 @@
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.1 <4.1.0",
+      "from": "xtend@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -17,8 +17,10 @@
     "precommit": "npm run lint"
   },
   "devDependencies": {
+    "autoprefixer" : "^6.7.7",
     "eslint": "^3.19.0",
     "gulp": "^3.9.1",
+    "gulp-postcss": "^7.0.0",
     "gulp-sass": "^3.1.0",
     "gulp-stylelint": "^3.9.0",
     "gulp-watch": "^4.3.6",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,8 @@
+/* Configuration file for postcss-cli */
+
+module.exports = (ctx) => ({
+  map: false,
+  plugins: {
+      'autoprefixer': {},
+  }
+})

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -93,9 +93,9 @@ django-picklefield==0.3.2 \
     --hash=sha256:5489fef164de43725242d56e65e016137d3df0d1a00672bda72d807f5b2b0d99
 
 # Asset packaging (CSS, JS concatenation and compression, etc.)
-django-pipeline==1.6.8 \
-    --hash=sha256:a6a9ce2003ae10e729768b6d79a4b3db330d876b86225eb7743b6f5696bafa59 \
-    --hash=sha256:b7cdc2efe27e478ddd38e878dd7b5e5ac121c2898fd85accf3187e19137fe6b7
+django-pipeline==1.6.13 \
+    --hash=sha256:81d8dd2db4c582bdfd0dc1df875c6b538c0a5ee233e954a52ae17f3ce904f604 \
+    --hash=sha256:d67ac0fc2556e3c5b5080ee96f8e661bda9a1e4b46b8fffbef3fb5524b6ef11e
 
 # Rate limit access to some views
 django-ratelimit==0.6.0 \

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -32,6 +32,8 @@ then
     npm install
     npm install cssmin@0.4.3
     npm install uglify-js@2.4.13
+    npm install postcss-cli@4.0.0
+    npm install autoprefixer@7.1.1
 fi
 
 # Install docker-compose


### PR DESCRIPTION
Here's a first pass at adding PostCSS to the asset pipeline.  I'm not sure if this is anything close to what we want.

This is the first time I've looked seriously at Kuma's asset pipeline, and it is in bad shape.  There's files that are being copied to the ``static`` folder that shouldn't be, such as the ckeditor builder java .jar file, and Photoshop .psd files.  In addition, all of the ``.scss`` files are being copied.  I would expect only final files served to end users to appear in this folder.  It may be possible to work within the Django staticfiles app configuration to omit most of these files.  A better solution would be to omit all files from a ``static`` folder that shouldn't be auto-processed into end user assets.  That would mean moving some files to a new place, including all the ``.scss`` files.

Our django-pipeline implementation is a mess.  It relies on the ``.scss`` files being copied to the root``static`` folder.  The output doesn't make a lot of sense - ``Post-processed 'build/styles/wiki.css' as 'build/styles/wiki.css'`` is misleading, claiming to have processed a file onto itself.  It doesn't support our use case of processing a file with Sass and then PostCSS, although I've hacked it here.  I've dug into the project itself, and it needs a maintainer.  I'd rather not pick up another abandoned project.

We have a parallel build system written in gulp, which is the one used by the front-end devs.  As we add PostCSS plugins, we'll be installing node packages.  This will require parallel installs in the Dockerfile and in the local developer's environment.  This feels like a step backwards, and asking for pain and bugs as we move forward.

At the same time, gulp is a better fit for both Sass and PostCSS workflows.  I suspect it would be trivial to teach it to process JS with UglifyJS. I'd want to move it into a Docker container.  I may need to watch while a front end dev does development to understand the issues.

I also can't tell if the PostCSS output is correct, or an improvement on the existing CSS created by Sass.  It looks worse to me.

But, here's the PR! Don't merge, but feel free to try it out.  If it is close enough to start moving functionality to PostCSS, we can start setting up SCL3 for it.  If not, I'd rather have a few rounds of fixing our assets and workflow first.