### PR TITLE
bug 1271509: Add scrape_user command and framework

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -1,0 +1,69 @@
+============
+Getting Data
+============
+
+A Kuma instance without data is useless. You can view the front page, but
+almost all interactive testing requires users, wiki documents, and other data.
+
+The Sample Database
+===================
+The sample database has a minimal set of data, based on production data, that
+is useful for manual and automated testing.  This includes:
+
+- All documents linked from the English homepage, including:
+
+  - Translations
+  - Some historical revisions
+  - Minimal author profiles for revisions
+
+- Additional documents for automated testing and feature coverage
+- Good defaults for contance variables ``KUMASCRIPT_TIMEOUT`` and
+  ``KUMASCRIPT_MAX_AGE``
+- Waffle flags and switches
+- Search filters and tags (but not a search index, which must be created
+  locally - see :ref:`indexing-documents`)
+- The Mozilla Hacks feed
+- Test users, with appropriate groups and permissions:
+
+  - ``test-super`` - A user with full permissions
+  - ``test-moderator`` - A staff content moderator
+  - ``test-new`` - A regular user account
+  - ``test-banned`` - A banned user
+  - ``viagra-test-123`` - An unbanned spammer
+
+Test accounts can be accessed by entering the password ``test-password`` in the
+`Django admin`_, and then returning to the site_.
+
+See :ref:`provision-the-database` for instructions on loading the latest sample
+database.
+
+.. _`Django admin`: localhost:8000/admin/login/?next=/
+.. _site: http://localhost:8000/en-US/
+
+Add an MDN User
+===============
+If you need a user profile that is not in the sample database, you can scrape
+it from production or another Kuma instance, using the ``scrape_user``
+command.  In the container (after ``make bash`` or similar), run the
+following, replacing ``username`` with the desired user's username::
+
+    ./manage.py scrape_user username
+    ./manage.py scrape_user https://developer.mozilla.org/en-US/profiles/username
+
+Some useful options
+
+``--email user@example.com``
+  Set the email for the user, which can't be scraped from the profile. With
+  the correct email, the user's profile image will be available.
+
+``--social``
+  Scrape social data for the user, which is not scraped by default
+
+``--force``
+  If a user exists in the current database, update it with scraped data.
+
+For full options, see ``./manage.py scrape_user --help``
+
+A local user can be promoted to staff with the command::
+
+    ./manage.py ihavepower username --password=password

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -17,6 +17,8 @@ the ``web`` Docker container to confirm the engine works::
 
 .. _releases new versions often: https://en.wikipedia.org/wiki/Elasticsearch#History
 
+.. _indexing-documents:
+
 Indexing documents
 ==================
 To see search results, you will need to index the documents.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,4 +23,5 @@ Contents:
    elasticsearch
    localization
    ckeditor
+   data
    documentation

--- a/kuma/scrape/__init__.py
+++ b/kuma/scrape/__init__.py
@@ -1,0 +1,9 @@
+"""
+Scrape data from one Kuma instance to this one.
+
+This is useful for development, to test code against specific production data,
+and to create the basic sample database for development and testing.
+
+TODO: Document scraping from sample_database_wip_1271509
+TODO: Sample DB code from sample_database_wip_1271509
+"""

--- a/kuma/scrape/management/commands/__init__.py
+++ b/kuma/scrape/management/commands/__init__.py
@@ -1,0 +1,50 @@
+"""Common methods for scraping management commands."""
+import logging
+
+from django.core.management.base import BaseCommand
+from django.utils.six.moves.urllib.parse import urlparse
+
+from kuma.scrape.scraper import Scraper
+
+
+class ScrapeCommand(BaseCommand):
+    """Common base class for scraping management commands."""
+    def make_scraper(self, **options):
+        """Create a Scraper instance for management commands."""
+        return Scraper(**options)
+
+    def parse_url_or_path(self, url_or_path):
+        if url_or_path.startswith('http'):
+            bits = urlparse(url_or_path)
+            host = bits.netloc
+            path = bits.path
+            ssl = (bits.scheme == 'https')
+        else:
+            host = 'developer.mozilla.org'
+            ssl = True
+            path = url_or_path
+        return host, ssl, path
+
+    def setup_logging(self, verbosity):
+        """Update logger for desired verbosity."""
+        log_format = '%(levelname)s: %(message)s'
+        log_name = 'kuma.scraper'
+        console = logging.StreamHandler(self.stderr)
+
+        if verbosity == 0:
+            level = logging.WARNING
+        elif verbosity == 1:  # default
+            level = logging.INFO
+        elif verbosity == 2:
+            level = logging.DEBUG
+        elif verbosity > 2:
+            level = logging.DEBUG
+            log_format = '%(name)s:%(levelname)s: %(message)s'
+            log_name = ''
+
+        formatter = logging.Formatter(log_format)
+        console.setLevel(level)
+        console.setFormatter(formatter)
+        logger = logging.getLogger(log_name)
+        logger.setLevel(level)
+        logger.addHandler(console)

--- a/kuma/scrape/management/commands/scrape_user.py
+++ b/kuma/scrape/management/commands/scrape_user.py
@@ -1,0 +1,51 @@
+"""Scrape a user profile from a Kuma website."""
+
+
+from . import ScrapeCommand
+
+
+class Command(ScrapeCommand):
+    help = 'Scrape a wiki document.'
+
+    def add_arguments(self, parser):
+        """Add arguments for scraping an MDN wiki document."""
+        parser.add_argument('--email',
+                            help='Set the email address')
+        parser.add_argument('--social',
+                            help='Include social links',
+                            action='store_true')
+        parser.add_argument('--force',
+                            help='Update existing User record',
+                            action='store_true')
+        parser.add_argument('url',
+                            metavar='url_or_profile',
+                            help='URL or profile name of a MDN user')
+
+    def parse_url_or_profile(self, url_or_profile):
+        host, ssl, path = self.parse_url_or_path(url_or_profile)
+        if path.startswith('/en-US'):
+            profile = path.split('/')[-1]
+        else:
+            profile = path
+        return host, ssl, profile
+
+    def handle(self, *arg, **options):
+        self.setup_logging(options['verbosity'])
+        url_or_profile = options['url']
+        host, ssl, profile = self.parse_url_or_profile(url_or_profile)
+        scraper = self.make_scraper(host=host, ssl=ssl)
+
+        params = {}
+        for param in ('social', 'force'):
+            if options[param]:
+                params[param] = options[param]
+        if options['email']:
+            params['email'] = options['email'].decode('utf8')
+        scraper.add_source("user", profile, **params)
+
+        scraper.scrape()
+        source = scraper.sources['user:' + profile]
+        if source.state == source.STATE_ERROR:
+            raise Exception('Unable to scrape user "%s".' % profile)
+        elif source.freshness == source.FRESH_NO and not options['force']:
+            self.stderr.write('User "%s" already exists. Use --force to update.' % profile)

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -1,0 +1,174 @@
+"""Content scraper for MDN."""
+from __future__ import unicode_literals
+
+from collections import OrderedDict
+import logging
+import time
+
+import requests
+
+from .sources import Source, UserSource
+from .storage import Storage
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class Requester(object):
+    """Request pages from a running MDN instance."""
+
+    MAX_ATTEMPTS = 3
+    TIMEOUT = 1.0
+
+    def __init__(self, host, ssl):
+        self.host = host
+        self.ssl = ssl
+        self._session = None
+        scheme = 'https' if ssl else 'http'
+        self.base_url = '%s://%s' % (scheme, host)
+
+    @property
+    def session(self):
+        if not self._session:
+            self._session = requests.Session()
+        return self._session
+
+    def request(self, path, raise_for_status=True):
+        url = self.base_url + path
+        logger.debug("GET %s", url)
+        attempts = 0
+        response = None
+        timeout = self.TIMEOUT
+        while response is None and 0 <= attempts < self.MAX_ATTEMPTS:
+            attempts += 1
+            err = None
+            try:
+                response = self.session.get(url, timeout=timeout)
+            except requests.exceptions.Timeout as err:
+                logger.warn("Timeout on request %d for %s", attempts, url)
+                time.sleep(timeout)
+                timeout *= 2
+            except requests.exceptions.ConnectionError as err:
+                logger.warn("Error request %d for %s: %s", attempts, url, err)
+            if response is None and attempts >= self.MAX_ATTEMPTS:
+                raise err
+
+        assert response is not None
+        if raise_for_status:
+            response.raise_for_status()
+        return response
+
+
+class Scraper(object):
+    """Scrape data from a running MDN instance."""
+
+    source_types = {
+        'user': UserSource,
+    }
+
+    def __init__(self, host='developer.mozilla.org', ssl=True):
+        """Initialize Scraper."""
+        self.requester = Requester(host, ssl)
+        self.sources = OrderedDict()
+        self.storage = Storage()
+        self.defaults = {}
+        self.overrides = {}
+
+    def add_source(self, source_type, source_param='', **options):
+        """Add a source of MDN data."""
+        source_key = "%s:%s" % (source_type, source_param)
+        if source_key in self.sources:
+            changes = self.sources[source_key].merge_options(**options)
+            if changes:
+                logger.debug('Updating source "%s" with options %s',
+                             source_key, changes)
+                return True
+            else:
+                return False
+        else:
+            logger.debug('Adding source "%s" with options %s', source_key, options)
+            source_options = self.defaults.get(source_type, {})
+            source_options.update(options)
+            source = self.create_source(source_key, **source_options)
+            self.sources[source_key] = source
+            return True
+
+    def create_source(self, source_key, **options):
+        source_type, source_param = source_key.split(':', 1)
+        return self.source_types[source_type](source_param, **options)
+
+    def scrape(self):
+        """Scrape data from MDN sources."""
+        if not self.sources:
+            logger.warn("No sources to scrape.")
+            return self.sources
+        first = True
+        repeat = False
+        cycle = 0
+        state_counts = OrderedDict((state, 0) for state in Source.STATES)
+        state_counts[Source.STATE_INIT] = len(self.sources)
+        while first or repeat:
+            first = False
+            repeat = False
+            source_total = (len(self.sources) -
+                            state_counts[Source.STATE_DONE] -
+                            state_counts[Source.STATE_ERROR])
+            last_counts = state_counts
+            state_counts = OrderedDict((state, 0) for state in Source.STATES)
+            new_sources = []
+            cycle += 1
+
+            # Iterate over existing sources
+            source_num = 0
+            for source_key, source in self.sources.items():
+
+                # If terminal condition, no processing to do
+                if source.state in (Source.STATE_DONE, Source.STATE_ERROR):
+                    state_counts[source.state] += 1
+                    continue
+
+                # Gather dependent sources
+                source_num += 1
+                old_state = source.state
+                dependencies = source.gather(self.requester, self.storage)
+                new_sources.extend(dependencies)
+                dep_count = len(dependencies)
+                state_counts[source.state] += 1
+                for dep in dependencies:
+                    if "%" in dep[1]:
+                        logger.warn('Source "%s" has a percent in deps',
+                                    source_key)
+
+                # At verbosity=debug, report on changed state
+                if source.state not in (Source.STATE_DONE, Source.STATE_ERROR):
+                    repeat = True
+                    logger.debug('%d:%d/%d Source "%s" in state "%s" with %d'
+                                 ' dependant source%s.',
+                                 cycle, source_num, source_total,
+                                 source_key, source.state, dep_count,
+                                 '' if dep_count == 1 else 's')
+                    for num, dep in enumerate(dependencies):
+                        logger.debug('* Dep %d: %s', num + 1, dep)
+                else:
+                    assert old_state != Source.STATE_DONE
+                    logger.debug('%d:%d/%d Source "%s" complete, '
+                                 'freshness=%s, with %d dependant source%s.',
+                                 cycle, source_num, source_total,
+                                 source_key, source.freshness, dep_count,
+                                 '' if dep_count == 1 else 's')
+
+            # Add new sources
+            repeat = repeat or bool(new_sources)
+            for source_type, source_param, options in new_sources:
+                if self.add_source(source_type, source_param, **options):
+                    state_counts[Source.STATE_INIT] += 1
+
+            logger.info('Scrape progress, cycle %d: %s',
+                        cycle,
+                        ", ".join(("%d %s" % (v, k)
+                                   for k, v in state_counts.items()
+                                   if v > 0)))
+            if last_counts == state_counts:
+                logger.warn("Dependency block detected. Aborting.")
+                return self.sources
+        logger.info('Scrape complete.')
+        return self.sources

--- a/kuma/scrape/sources/__init__.py
+++ b/kuma/scrape/sources/__init__.py
@@ -1,0 +1,10 @@
+"""Data sources for scraping MDN."""
+from __future__ import absolute_import, unicode_literals
+
+from .base import Source
+from .user import UserSource
+
+__all__ = [
+    Source,
+    UserSource,
+]

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -1,0 +1,203 @@
+"""Shared interface for data sources."""
+from __future__ import absolute_import, unicode_literals
+import logging
+
+from django.utils.six import binary_type, text_type, python_2_unicode_compatible
+from django.utils.six.moves.urllib.parse import unquote
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class Source(object):
+    """
+    An MDN data source.
+
+    This represents data that requires a request to a running MDN server.
+
+    Derived classes should set some class variables to customize behaviour:
+    PARAM_NAME - The attribute name of the "key" parameter for the data source
+    OPTIONS - A dictionary of option names to (type, default value) pairs.
+    """
+    # Scraping states
+    STATES = (
+        'Initializing',
+        'Gathering Requirements',
+        'Done',
+        'Error',
+    )
+    STATE_INIT, STATE_PREREQ, STATE_DONE, STATE_ERROR = STATES
+
+    # Freshness of scraped data
+    FRESHNESS = (
+        'Unknown',
+        'Fresh',
+        'Existing',
+    )
+    FRESH_UNKNOWN, FRESH_YES, FRESH_NO = FRESHNESS
+
+    # Friendly name of the source's key parameter
+    PARAM_NAME = 'param'
+
+    # Types of source options. Used when merging options, to determine if
+    # the new or existing option value should win, possible resetting scraping.
+    OPTION_TYPES = set((
+        'bool',     # True > False
+        'int',      # 2 > 1 > 0
+        'int_all',  # 'all' > 2 > 0
+        'text',     # any new value > old value > ''
+    ))
+
+    # The scrape options for this source, defaulting to no valid settings
+    # Format is name -> (option_type, default value)
+    OPTIONS = {}
+
+    @python_2_unicode_compatible
+    class SourceError(Exception):
+        """An error raised during gathering."""
+        def __init__(self, *args, **kwargs):
+            self.format = args[0]
+            self.format_args = args[1:]
+            super(Source.SourceError, self).__init__(*args, **kwargs)
+
+        def __str__(self):
+            return self.format % self.format_args
+
+    def __init__(self, param, **options):
+        """Initialize an MDN data source."""
+        setattr(self, self.PARAM_NAME, param)
+        self.state = self.STATE_INIT
+        self.freshness = self.FRESH_UNKNOWN
+
+        for name, params in self.OPTIONS.items():
+            option_type, default = params
+            assert option_type in self.OPTION_TYPES
+            self.assert_option_value_allowed(option_type, default)
+            setattr(self, name, default)
+
+        self.merge_options(**options)
+
+    def assert_option_value_allowed(self, option_type, value):
+        """Assert that an option value is valid."""
+        if option_type == 'bool':
+            valid = (value is True or value is False)
+        elif option_type == 'int':
+            valid = (value == int(value))
+        elif option_type == 'int_all':
+            valid = (value == 'all' or value == int(value))
+        else:
+            assert option_type == 'text'
+            valid = isinstance(value, text_type)
+
+        if not valid:
+            raise ValueError('invalid value "%s" for type "%s"' %
+                             (repr(value), option_type))
+
+    def merge_options(self, **options):
+        """
+        Merge new options with current options, returning changed options.
+
+        The new option wins if it is "higher" than the existing option.
+        """
+        changed = {}
+        for name, value in options.items():
+            option_type = self.OPTIONS[name][0]
+            self.assert_option_value_allowed(option_type, value)
+            current = getattr(self, name)
+            if option_type == 'bool':
+                if value and not current:
+                    changed[name] = value
+                    setattr(self, name, True)
+            elif option_type == 'int':
+                value = int(value)
+                if value > current:
+                    changed[name] = value
+                    setattr(self, name, value)
+            elif option_type == 'int_all':
+                if text_type(value).lower() == 'all':
+                    if current != 'all':
+                        changed[name] = 'all'
+                        setattr(self, name, 'all')
+                else:
+                    value = int(value)
+                    if value > current:
+                        changed[name] = value
+                        setattr(self, name, value)
+            else:
+                assert option_type == 'text'
+                if value and value != current:
+                    changed[name] = value
+                    setattr(self, name, value)
+        if changed:
+            self.state = self.STATE_INIT
+        return changed
+
+    def current_options(self):
+        """Return the current non-default options."""
+        current = {}
+        for name, spec in self.OPTIONS.items():
+            opt_type, default = spec
+            value = getattr(self, name, default)
+            if value != default:
+                current[name] = value
+        return current
+
+    def decode_href(self, href):
+        """Convert URL-escaped href attributes to unicode."""
+        decoded = unquote(binary_type(href))
+        assert isinstance(decoded, binary_type)
+        decoded = decoded.decode('utf8')
+        return decoded
+
+    def gather(self, requester, storage):
+        """
+        Gather prerequisites and store data for a source.
+
+        Return is a list of source specifications, such as prerequisites
+        needed to load the source, or follow-on sources identified by the
+        source.
+        """
+        if self.state == self.STATE_INIT:
+            # If possible, load and validate existing data for the source
+            try:
+                load_return = self.load_and_validate_existing(storage)
+            except self.SourceError as error:
+                logger.warn(error.format, *error.format_args)
+                self.state = self.STATE_ERROR
+            else:
+                has_existing, next_sources = load_return
+                if has_existing:
+                    self.state = self.STATE_DONE
+                    self.freshness = self.FRESH_NO
+                    return next_sources
+                else:
+                    self.state = self.STATE_PREREQ
+
+        if self.state == self.STATE_PREREQ:
+            try:
+                has_prereqs, data = self.load_prereqs(requester, storage)
+            except self.SourceError as error:
+                logger.warn(error.format, *error.format_args)
+                self.state = self.STATE_ERROR
+            else:
+                if has_prereqs:
+                    self.freshness = self.FRESH_YES
+                    # Save the data and load follow-on sources
+                    try:
+                        next_sources = self.save_data(storage, data)
+                    except self.SourceError as error:
+                        logger.warn(error.format, *error.format_args)
+                        self.state = self.STATE_ERROR
+                    else:
+                        self.state = self.STATE_DONE
+                        return next_sources
+                else:
+                    # Return the additional prerequisite sources
+                    return data['needs']
+
+        # Load no more sources in a "done" state
+        assert self.state in [self.STATE_ERROR, self.STATE_DONE]
+        return []
+
+    def load_and_validate_existing(self, storage):
+        """Default: Can not load existing data from storage."""
+        return False, []

--- a/kuma/scrape/sources/user.py
+++ b/kuma/scrape/sources/user.py
@@ -35,7 +35,8 @@ class UserSource(Source):
                                      raise_for_status=False)
         if response.status_code == 200:
             data = self.extract_data(response.content)
-        elif response.status_code == 403:
+        elif (response.status_code == 404 and
+                self.is_banned(response.content)):
             data = {
                 'username': self.username,
                 'banned': True
@@ -102,3 +103,9 @@ class UserSource(Source):
         data['date_joined'] = date_joined.replace(tzinfo=None)
 
         return data
+
+    def is_banned(self, html):
+        """Detect if a 404 is for a banned user."""
+        parsed = pq(html)
+        ban_text = parsed.find('p.notice')
+        return 'banned' in ban_text.text()

--- a/kuma/scrape/sources/user.py
+++ b/kuma/scrape/sources/user.py
@@ -1,0 +1,104 @@
+"""UserSource scrapes MDN user profiles."""
+from __future__ import absolute_import, unicode_literals
+
+from pyquery import PyQuery as pq
+import dateutil
+
+from .base import Source
+
+
+class UserSource(Source):
+    """Scrape a user's profile."""
+
+    PARAM_NAME = 'username'
+
+    OPTIONS = {
+        'force': ('bool', False),   # Update existing User records
+        'social': ('bool', False),  # Scrape social links
+        'email': ('text', ''),      # Set the email for the User
+    }
+
+    def load_and_validate_existing(self, storage):
+        """Load user data from previous runs."""
+        user = None
+        if not self.force:
+            user = storage.get_user(self.username)
+        return user is not None, []
+
+    def source_path(self):
+        """MDN path for this user."""
+        return '/en-US/profiles/%s' % self.username
+
+    def load_prereqs(self, requester, storage):
+        """Load and process the profile HTML."""
+        response = requester.request(self.source_path(),
+                                     raise_for_status=False)
+        if response.status_code == 200:
+            data = self.extract_data(response.content)
+        elif response.status_code == 403:
+            data = {
+                'username': self.username,
+                'banned': True
+            }
+        else:
+            raise self.SourceError('status code %s', response.status_code)
+        if self.email:
+            data['email'] = self.email
+        return True, data
+
+    def save_data(self, storage, data):
+        """Save the user data for future calls."""
+        storage.save_user(data)
+        return []
+
+    def extract_data(self, html):
+        """Extract user data from profile HTML."""
+        data = {}
+        parsed = pq(html)
+        username_elem = parsed.find("h1.user-title span.nickname")[0]
+        data['username'] = username_elem.text
+        fullname_elems = parsed.find("h1.user-title span.fn")
+        if fullname_elems:
+            data['fullname'] = fullname_elems[0].text
+
+        if parsed.find('ul.user-info'):
+            for cls, name in (
+                    ('title', 'title'),
+                    ('org', 'organization'),
+                    ('loc', 'location'),
+                    ('irc', 'irc_nickname')):
+                elem = parsed.find('ul.user-info li.%s' % cls)
+                if elem:
+                    if cls == 'irc':
+                        raw = elem[0].text
+                        data[name] = raw.replace('IRC: ', '')
+                    else:
+                        data[name] = elem[0].text
+
+        tags_divs = parsed.find("div.user-tags")
+        for tag_div in tags_divs:
+            h2 = tag_div.find('h2')
+            if 'Interests' in h2.text:
+                tag_type = 'interest'
+            else:
+                assert 'Expertise' in h2.text
+                tag_type = 'expertise'
+            tags = sorted([tag.text for tag in tag_div.cssselect('span')])
+            data[tag_type] = tags
+
+        if self.social:
+            socials = ('twitter', 'github', 'stackoverflow', 'linkedin',
+                       'mozillians', 'facebook')
+            for social in socials:
+                cssselect = 'ul.user-links li.%s a' % social
+                social_elem = parsed.find(cssselect)
+                if social_elem:
+                    social_href = self.decode_href(social_elem.attr('href'))
+                    data['%s_url' % social] = social_href
+
+        since_elem = parsed.find('div.user-since time')
+        raw_date_joined = since_elem.attr('datetime')
+        date_joined = dateutil.parser.parse(raw_date_joined)
+        data['date_joined'] = date_joined.replace(tzinfo=None)
+
+        return data

--- a/kuma/scrape/storage.py
+++ b/kuma/scrape/storage.py
@@ -1,0 +1,70 @@
+"""Store temporary data and interact with the database."""
+from collections import OrderedDict
+import logging
+
+from taggit.models import Tag
+
+from kuma.users.models import User, UserBan
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class Storage(object):
+    """Store temporary objects and interact with the database."""
+
+    def sorted_tags(self, tags):
+        """
+        Return tags in the desired creation order.
+
+        Tags may include case look-alikes, such as 'Firefox' and 'firefox'.
+        With taggit 0.18.0, setting both at the same time will result in an
+        IntegrityError.  This returns the tags with the most capital letters
+        first, so that 'Firefox' will be prioritized over 'firefox'.
+        """
+        tag_sort = sorted([(sum(1 for c in tag if c.islower()), tag)
+                           for tag in tags])
+        return [tag for _, tag in tag_sort]
+
+    def deduped_tags(self, tags):
+        """Filter tags to remove those that only differ by case."""
+        deduped = OrderedDict()
+        for tag in self.sorted_tags(tags):
+            deduped.setdefault(tag.lower(), tag)
+        return list(deduped.values())
+
+    def safe_add_tags(self, tags, tag_type, tag_relation):
+        """Add tags to object, working around duplicate tag issues."""
+        for tag in self.deduped_tags(tags):
+            existing_tags = tag_type.objects.filter(name=tag)
+            tag_count = existing_tags.count()
+            assert tag_count <= 1
+            if tag_count == 1:
+                dt = existing_tags.get()
+            else:
+                dt = tag_type.objects.create(name=tag)
+            tag_relation.add(dt)
+
+    def get_user(self, username):
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist:
+            return None
+        else:
+            return user
+
+    def save_user(self, data):
+        username = data.pop('username')
+        banned = data.pop('banned', False)
+        user, created = User.objects.get_or_create(username=username)
+        for name, value in data.items():
+            if name in ('interest', 'expertise'):
+                tags = ['profile:%s:%s' % (name, tag) for tag in value]
+                self.safe_add_tags(tags, Tag, user.tags)
+            else:
+                setattr(user, name, value)
+        user.save()
+
+        if banned:
+            ban, ban_created = UserBan.objects.get_or_create(
+                user=user,
+                defaults={'by': user, 'reason': 'Ban detected by scraper'})

--- a/kuma/scrape/tests/__init__.py
+++ b/kuma/scrape/tests/__init__.py
@@ -1,0 +1,68 @@
+"""Tests for scraping live data and creating sample data."""
+from __future__ import unicode_literals
+
+import mock
+
+
+def mock_requester(
+        requester_spec=None, response_spec=None, content=None, json=None,
+        status_code=200, history=None, final_path=None):
+    """
+    Create mock production data requester for Source.gather testing.
+
+    Keyword Arguments:
+    requester_spec - Requester attributes (default request)
+    response_spec - Response attributes (default content, history)
+    content - Content of response (default "")
+    json - Decoded JSON of response (default not JSON)
+    status_code - Status code of response (default 200, None to error on check)
+    history - (status_code, path) pairs for redirect history of request
+        (default no redirects)
+    final_path - Final path for request (default None)
+    """
+    if requester_spec is None:
+        requester_spec = ['request']
+    if response_spec is None:
+        response_spec = ['content', 'history']
+        if status_code is not None:
+            response_spec.append('status_code')
+
+    requester = mock.Mock(spec_set=requester_spec)
+    if 'request' in requester_spec:
+        mock_response = mock.Mock(spec_set=response_spec)
+        if 'content' in response_spec:
+            mock_response.content = content or ""
+        if 'history' in response_spec:
+            redirect_history = []
+            for status_code, path in (history or []):
+                redirect_response = mock.Mock(spec_set=['status_code', 'url'])
+                redirect_response.status_code = status_code
+                redirect_response.url = path
+                redirect_history.append(redirect_response)
+            mock_response.history = redirect_history
+        if 'json' in response_spec and json:
+            mock_response.json.return_value = json
+        if 'status_code' in response_spec and status_code:
+            mock_response.status_code = status_code
+        if 'url' in response_spec:
+            assert final_path, "Need a final_path for response.url"
+            mock_response.url = final_path
+        requester.request.return_value = mock_response
+    return requester
+
+
+def mock_storage(spec=None):
+    """
+    Create mock database storage for Source.gather testing.
+
+    Keyword Arguments:
+    spec - List of expected Storage method calls (default [])
+
+    Any spec that starts with "get_" is initialized to return None.
+    """
+    spec_set = spec or []
+    storage = mock.Mock(spec_set=spec_set)
+    for item in spec_set:
+        if item.startswith('get_'):
+            getattr(storage, item).return_value = None
+    return storage

--- a/kuma/scrape/tests/conftest.py
+++ b/kuma/scrape/tests/conftest.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""py.test fixtures"""
+from __future__ import unicode_literals
+from datetime import datetime
+
+import pytest
+
+
+@pytest.fixture
+def simple_user(db, django_user_model):
+    """A simple User record with only the basic information."""
+    return django_user_model.objects.create(
+        username='JackDeveloper',
+        email='jack@example.com',
+        date_joined=datetime(2016, 11, 4, 9, 1))
+
+
+@pytest.fixture
+def simple_user_html(simple_user, client):
+    """The profile HTML for a simple user."""
+    response = client.get('/en-US/profiles/' + simple_user.username)
+    return response.content

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -1,0 +1,222 @@
+import mock
+import pytest
+import requests
+
+from kuma.scrape.scraper import Requester, Scraper
+from kuma.scrape.sources import Source
+
+#
+# Requester tests (mostly for coverage)
+#
+
+
+def test_session():
+    """A session is created once on request."""
+    requester = Requester('example.com', True)
+    session = requester.session
+    assert isinstance(session, requests.Session)
+    session2 = requester.session
+    assert session == session2
+
+
+def test_request():
+    """A successful request calls raise_for_status by default."""
+    requester = Requester('example.com', True)
+    mock_session = mock.Mock(spec_set=['get'])
+    mock_response = mock.Mock(spec_set=['raise_for_status'])
+    mock_session.get.return_value = mock_response
+    requester._session = mock_session
+
+    response = requester.request('/path')
+    assert response == mock_response
+    mock_session.get.assert_called_once_with(
+        'https://example.com/path', timeout=1.0)
+    mock_response.raise_for_status.assert_called_once_with()
+
+
+def test_request_no_raise():
+    """The call to raise_for_status can be omitted."""
+    requester = Requester('example.net', False)
+    mock_session = mock.Mock(spec_set=['get'])
+    mock_response = mock.Mock(spec_set=['raise_for_status'])
+    mock_session.get.return_value = mock_response
+    requester._session = mock_session
+
+    response = requester.request('/path', raise_for_status=False)
+    assert response == mock_response
+    mock_session.get.assert_called_once_with(
+        'http://example.net/path', timeout=1.0)
+    assert not mock_response.raise_for_status.called
+
+
+@mock.patch('kuma.scrape.scraper.time.sleep')
+def test_timeout_success(mock_sleep):
+    """Requests are retried with back off after a Timeout."""
+    requester = Requester('example.com', True)
+    mock_session = mock.Mock(spec_set=['get'])
+    mock_session.get.side_effect = [
+        requests.exceptions.Timeout(),
+        requests.exceptions.Timeout(),
+        'response']
+    requester._session = mock_session
+
+    response = requester.request('/path', raise_for_status=False)
+    assert response == 'response'
+    full_path = 'https://example.com/path'
+    expected_calls = [
+        mock.call(full_path, timeout=1.0),
+        mock.call(full_path, timeout=2.0),  # Timeout doubles
+        mock.call(full_path, timeout=4.0),  # Timeout doubles again
+    ]
+    assert mock_session.get.call_args_list == expected_calls
+    expected_sleep_calls = [mock.call(1.0), mock.call(2.0)]
+    assert mock_sleep.call_args_list == expected_sleep_calls
+
+
+def test_connectionerror_success():
+    """Requests are retried after expected exceptions."""
+    requester = Requester('example.com', True)
+    mock_session = mock.Mock(spec_set=['get'])
+    mock_session.get.side_effect = [
+        requests.exceptions.ConnectionError(),
+        requests.exceptions.ConnectionError(),
+        'response']
+    requester._session = mock_session
+
+    response = requester.request('/path', raise_for_status=False)
+    assert response == 'response'
+    full_path = 'https://example.com/path'
+    expected_calls = [mock.call(full_path, timeout=1.0)] * 3
+    assert mock_session.get.call_args_list == expected_calls
+
+
+@mock.patch('kuma.scrape.scraper.time.sleep')
+def test_timeout_failure(mock_sleep):
+    """Request fail after too many Timeouts."""
+    assert Requester.MAX_ATTEMPTS == 3
+    requester = Requester('example.com', True)
+    mock_session = mock.Mock(spec_set=['get'])
+    mock_session.get.side_effect = [requests.exceptions.Timeout] * 3
+    requester._session = mock_session
+
+    with pytest.raises(requests.exceptions.Timeout):
+        requester.request('/path', raise_for_status=False)
+    full_path = 'https://example.com/path'
+    expected_calls = [
+        mock.call(full_path, timeout=1.0),
+        mock.call(full_path, timeout=2.0),
+        mock.call(full_path, timeout=4.0),
+    ]
+    assert mock_session.get.call_args_list == expected_calls
+    expected_sleep_calls = [mock.call(1.0), mock.call(2.0), mock.call(4.0)]
+    assert mock_sleep.call_args_list == expected_sleep_calls
+
+
+#
+# Tests for Scraper
+#
+
+class FakeSource(Source):
+    """A Fake source for testing scraping."""
+
+    PARAM_NAME = 'name'
+    OPTIONS = {
+        'length': ('int', 0),         # Number of gather rounds until done
+        'depth': ('int', 0),          # Generations of sources emitted
+        'error': ('bool', False),     # Set state to STATE_ERROR
+    }
+
+    def gather(self, requester, storage):
+        """
+        Run for [length] rounds and emit [depth] generations of sources.
+
+        This does nothing except exercise all the branches of Scraper.scrape.
+        """
+        sources = []
+        if self.state == self.STATE_INIT:
+            self.remaining_length = self.length
+            self.state = self.STATE_PREREQ
+
+        if self.state == self.STATE_PREREQ:
+            if self.depth:
+                sources.append(('fake', "%s%d" % (self.name, self.depth),
+                                {'length': self.length,
+                                'depth': self.depth - 1}))
+
+            if self.remaining_length == 0:
+                if self.error:
+                    self.state = self.STATE_ERROR
+                else:
+                    self.state = self.STATE_DONE
+            else:
+                self.remaining_length -= 1
+
+        return sources
+
+
+@pytest.fixture()
+def scraper():
+    """Setup a test Scraper that handles FakeSource sources."""
+    scraper = Scraper()
+    scraper.source_types['fake'] = FakeSource
+    return scraper
+
+
+@pytest.yield_fixture()
+def mock_logger():
+    with mock.patch('kuma.scrape.scraper.logger') as mock_logger:
+        yield mock_logger
+
+
+def test_add_new_source(scraper):
+    """The add_source method initializes a source."""
+    assert scraper.add_source('fake', 'bob')
+    source = scraper.sources['fake:bob']
+    assert isinstance(source, FakeSource)
+    assert source.name == 'bob'
+
+
+def test_add_existing_source(scraper):
+    """Adding a existing source returns True if options were updated."""
+    assert scraper.add_source('fake', 'jane')
+    assert not scraper.add_source('fake', 'jane')
+    assert scraper.add_source('fake', 'jane', length=1)
+    assert not scraper.add_source('fake', 'jane', length=1)
+
+
+def test_scrape(scraper):
+    """The scraper will loop through sources until complete."""
+    scraper.add_source('fake', 'loop', length=2, depth=2)
+    sources = scraper.scrape()
+    assert sources.keys() == ['fake:loop', 'fake:loop2', 'fake:loop21']
+
+
+def test_scrape_none(scraper):
+    """A scraper with no sources returns early."""
+    sources = scraper.scrape()
+    assert not sources
+
+
+def test_warn_percent_in_param(scraper, mock_logger):
+    """
+    The scraper will warn if there is a percent in a source.
+
+    This indicates a JSON-encoded URL was not decoded.
+    """
+    scraper.add_source('fake', 'loop%0d', depth=1)
+    scraper.scrape()
+    expected_fmt = 'Source "%s" has a percent in deps'
+    mock_logger.warn.assert_called_once_with(expected_fmt, 'fake:loop%0d')
+
+
+def test_warn_dependency_block(scraper, mock_logger):
+    """
+    The scraper will warn if a dependency block is detected.
+
+    If no progress is made in a loop, it implies that a dependency is in
+    error, and further loops will not make any further progress.
+    """
+    scraper.add_source('fake', 'bad_document', length=2, error=True)
+    scraper.scrape()
+    expected_msg = 'Dependency block detected. Aborting.'
+    mock_logger.warn.assert_called_once_with(expected_msg)

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -16,7 +16,7 @@ def test_session():
     session = requester.session
     assert isinstance(session, requests.Session)
     session2 = requester.session
-    assert session == session2
+    assert session is session2
 
 
 def test_request():

--- a/kuma/scrape/tests/test_source.py
+++ b/kuma/scrape/tests/test_source.py
@@ -1,0 +1,260 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Source class."""
+from __future__ import unicode_literals
+
+import mock
+import pytest
+
+from kuma.scrape.sources import Source
+from . import mock_requester, mock_storage
+
+
+class FakeSource(Source):
+    """A Fake source for testing shared Source functionality."""
+
+    PARAM_NAME = 'name'
+
+    OPTIONS = {
+        'pressed': ('bool', False),
+        'length': ('int', 0),
+        'unbounded': ('int_all', 0),
+        'flavor': ('text', ''),
+    }
+
+
+def test_init_param():
+    """Omitted Source parameters are initialized to defaults."""
+    source = FakeSource('param')
+    assert source.name == 'param'
+    assert source.length == 0
+    assert source.pressed is False
+    assert source.unbounded == 0
+    assert source.flavor == ''
+
+
+@pytest.mark.parametrize(
+    'option,value',
+    (('pressed', True),
+     ('length', 1),
+     ('unbounded', 'all'),
+     ('flavor', 'curry'),
+     ), ids=('bool', 'int', 'int_all', 'text'))
+def test_init_options(option, value):
+    """Source parameters are initialized by name."""
+    source = FakeSource('popcorn', **{option: value})
+    assert source.name == 'popcorn'
+    assert getattr(source, option) == value
+
+
+def test_init_invalid_option():
+    """An invalid parameter name raises an exception."""
+    with pytest.raises(Exception):
+        FakeSource('param', unknown=1)
+
+
+def test_merge_none():
+    """An empty merge does not change the Source state."""
+    source = FakeSource('merge')
+    source.state = source.STATE_PREREQ
+    assert source.merge_options() == {}
+    assert source.state == source.STATE_PREREQ
+
+
+@pytest.mark.parametrize(
+    'option,lesser_value,greater_value',
+    (('pressed', False, True),
+     ('length', 1, 2),
+     ('unbounded', 2, 3),
+     ), ids=('bool', 'int', 'int_all'))
+def test_merge_less(option, lesser_value, greater_value):
+    """A merge to smaller parameters keeps the current values and state."""
+    source = FakeSource('merge', **{option: greater_value})
+    source.state = source.STATE_PREREQ
+    assert source.merge_options(**{option: lesser_value}) == {}
+    assert getattr(source, option) == greater_value
+    assert source.state == source.STATE_PREREQ
+
+
+@pytest.mark.parametrize(
+    'option,value',
+    (('pressed', True),
+     ('length', 2),
+     ('unbounded', 1),
+     ('flavor', 'country'),
+     ), ids=('bool', 'int', 'int_all', 'text'))
+def test_merge_same(option, value):
+    """A merge with the current values keeps the current state."""
+    source = FakeSource('merge', **{option: value})
+    source.state = source.STATE_PREREQ
+    assert source.merge_options(**{option: value}) == {}
+    assert getattr(source, option) == value
+    assert source.state == source.STATE_PREREQ
+
+
+@pytest.mark.parametrize(
+    'option,lesser_value,greater_value',
+    (('pressed', False, True),
+     ('length', 1, 2),
+     ('unbounded', 2, 3),
+     ), ids=('bool', 'int', 'int_all'))
+def test_merge_upgrade(option, lesser_value, greater_value):
+    """An updating merge updates the values and resets the state."""
+    source = FakeSource('merge', **{option: lesser_value})
+    source.state = source.STATE_PREREQ
+    result = source.merge_options(**{option: greater_value})
+    assert result == {option: greater_value}
+    assert getattr(source, option) == greater_value
+    assert source.state == source.STATE_INIT
+
+
+def test_merge_more_multiple():
+    """Multiple parameters can be updated in one merge call."""
+    source = FakeSource('merge')
+    res = source.merge_options(
+        length=1, pressed=True, unbounded=1, flavor='salty')
+    assert res == {
+        'length': 1, 'pressed': True, 'unbounded': 1, 'flavor': 'salty'}
+
+
+def test_merge_int_all():
+    """For the 'int_all' parameter type, 'all' is a valid and maximum value."""
+    source = FakeSource('merge')
+    assert source.merge_options(unbounded='all') == {'unbounded': 'all'}
+    assert source.merge_options(unbounded='all') == {}
+
+
+def test_merge_text():
+    """For the 'text' parameter type, any non-empty change is an update."""
+    source = FakeSource('merge')
+    assert source.merge_options(flavor='sweet') == {'flavor': 'sweet'}
+    assert source.merge_options(flavor='sour') == {'flavor': 'sour'}
+    assert source.merge_options(flavor='sour') == {}
+    assert source.merge_options(flavor='sweet') == {'flavor': 'sweet'}
+    assert source.merge_options(flavor='') == {}
+
+
+def test_current_options_default():
+    """current_options returns empty dict for default options."""
+    source = FakeSource('default')
+    assert source.current_options() == {}
+
+
+@pytest.mark.parametrize(
+    'option,value',
+    (('pressed', True),
+     ('length', 1),
+     ('unbounded', 'all'),
+     ('flavor', 'curry'),
+     ), ids=('bool', 'int', 'int_all', 'text'))
+def test_current_options_nondefault(option, value):
+    """current_options returns the non-default options as a dict."""
+    source = FakeSource('default', **{option: value})
+    assert source.current_options() == {option: value}
+
+
+@pytest.mark.parametrize(
+    'option_type,option,bad_value',
+    (('bool', 'pressed', 1),
+     ('int', 'length', '0'),
+     ('int_all', 'unbounded', '1'),
+     ('text', 'flavor', 1),
+     ), ids=('bool', 'int', 'int_all', 'text'))
+def test_invalid_values(option_type, option, bad_value):
+    """Invalid parameter values raise a ValueError."""
+    with pytest.raises(ValueError) as err:
+        FakeSource('fails', **{option: bad_value})
+    assert option_type in err.value.message
+
+
+@pytest.mark.parametrize(
+    "href,decoded", [
+        (b'binary', u'binary'),
+        (b'%E7%A7%BB%E8%A1%8C%E4%BA%88%E5%AE%9A', u'移行予定'),
+    ])
+def test_decode_href(href, decoded):
+    """Source.decode_href() turns URL-encoded hrefs into unicode strings."""
+    source = FakeSource('conversions')
+    assert decoded == source.decode_href(href)
+
+
+def test_source_error_str():
+    """The Source.Error exception can be turned into a string."""
+    error1 = Source.SourceError('A simple error')
+    assert "%s" % error1 == 'A simple error'
+    error2 = Source.SourceError('A formatted error, like "%s" and %d.',
+                                "a string", 123)
+    assert "%s" % error2 == 'A formatted error, like "a string" and 123.'
+
+
+def test_gather_done_is_done():
+    """A source that is done can still be gathered."""
+    source = FakeSource('existing')
+    source.state = source.STATE_DONE
+    assert source.gather(mock_requester(), mock_storage()) == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_load_storage_existing():
+    """A source that is already in storage loads quickly."""
+    source = FakeSource('existing')
+    source.load_and_validate_existing = mock.Mock(
+        return_value=(True, ['next']))
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == ['next']
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+
+
+def test_gather_load_storage_error():
+    """A source can raise an error when loading from storage."""
+    source = FakeSource('existing')
+    source.load_and_validate_existing = mock.Mock(
+        side_effect=source.SourceError('Storage complained.'))
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_load_prereqs_more_needed():
+    """A source can request other sources as prerequisites."""
+    source = FakeSource('needs_prereqs')
+    data = {'needs': ['bonus']}
+    source.load_prereqs = mock.Mock(return_value=(False, data))
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == ['bonus']
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_load_prereqs_error():
+    """A source may raise an error when loading prerequisites."""
+    source = FakeSource('bad_prereqs')
+    source.load_prereqs = mock.Mock(side_effect=source.SourceError('bad'))
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_save_data_error():
+    """A source can fail when saving the data."""
+    source = FakeSource('needs_prereqs')
+    source.load_prereqs = mock.Mock(return_value=(True, {}))
+    source.save_data = mock.Mock(side_effect=source.SourceError('failed'))
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_YES
+
+
+def test_gather_success_with_more_sources():
+    """A source with all prereqs can request further sources."""
+    source = FakeSource('needs_prereqs')
+    source.load_prereqs = mock.Mock(return_value=(True, {}))
+    source.save_data = mock.Mock(return_value=['bonus'])
+    ret = source.gather(mock_requester(), mock_storage())
+    assert ret == ['bonus']
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES

--- a/kuma/scrape/tests/test_source_user.py
+++ b/kuma/scrape/tests/test_source_user.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""Tests for the UserSource class (/profiles/USERNAME)."""
+from __future__ import unicode_literals
+from datetime import datetime
+
+import pytest
+
+from kuma.scrape.sources import UserSource
+from . import mock_requester, mock_storage
+
+
+@pytest.fixture
+def complex_user(db, django_user_model):
+    """A complex User record with social and other profile data."""
+    user = django_user_model.objects.create(
+        username='JillDeveloper',
+        fullname='Jill Developer',
+        email='jill@example.com',
+        title='Web Developer',
+        organization='Acme, Inc.',
+        location='Springfield, USA',
+        date_joined=datetime(1999, 1, 1, 10, 40, 23),
+        twitter_url='http://twitter.com/jilldev1999',
+        github_url='https://github.com/jilldev1999',
+        stackoverflow_url='http://stackoverflow.com/users/1/jilldev1999',
+        linkedin_url='http://www.linkedin.com/in/jilldev1999',
+        mozillians_url='http://mozillians.org/u/jilldev/')
+    user.tags.set_ns('profile:interest:', 'JavaScript', 'HTML', 'CSS')
+    user.tags.set_ns('profile:expertise:', 'HTML')
+    return user
+
+
+@pytest.fixture
+def complex_user_html(complex_user, client):
+    """The profile HTML for a complex user."""
+    user_path = '/en-US/profiles/' + complex_user.username
+    return client.get(user_path).content
+
+
+@pytest.fixture
+def irc_user(complex_user):
+    """A complex User record that also has an IRC nickname."""
+    complex_user.irc_nickname = 'jilldev'
+    complex_user.save()
+    return complex_user
+
+
+@pytest.fixture
+def irc_user_html(irc_user, client):
+    """The profile HTML for the user with an IRC nickname."""
+    user_path = '/en-US/profiles/' + irc_user.username
+    return client.get(user_path).content
+
+
+@pytest.mark.parametrize("email", ['', 'jack@example.com'])
+def test_gather_simple(email, simple_user, simple_user_html):
+    source = UserSource(simple_user.username, email=email, social=True)
+    requester = mock_requester(content=simple_user_html, status_code=200)
+    storage = mock_storage(spec=['get_user', 'save_user'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    storage.get_user.assert_called_once_with(simple_user.username)
+    expected_data = {
+        'username': 'JackDeveloper',
+        'date_joined': datetime(2016, 11, 4, 9, 1)
+    }
+    if email:
+        expected_data['email'] = email
+    storage.save_user.assert_called_once_with(expected_data)
+
+
+def test_gather_existing_user():
+    source = UserSource('existing', social=True)
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=['get_user'])
+    storage.get_user.return_value = {'username': 'existing'}
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+
+
+def test_gather_banned():
+    source = UserSource('banned', force=True)
+    requester = mock_requester(content="banned", status_code=403)
+    storage = mock_storage(spec=['save_user'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    expected_data = {
+        'username': 'banned',
+        'banned': True
+    }
+    storage.save_user.assert_called_once_with(expected_data)
+
+
+def test_gather_missing():
+    source = UserSource('missing', force=True)
+    requester = mock_requester(content="not found", status_code=404)
+    storage = mock_storage()
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+
+
+def test_extract_complex(complex_user, complex_user_html):
+    source = UserSource(complex_user.username)
+    data = source.extract_data(complex_user_html)
+    expected_data = {
+        'username': 'JillDeveloper',
+        'fullname': 'Jill Developer',
+        'title': 'Web Developer',
+        'organization': 'Acme, Inc.',
+        'location': 'Springfield, USA',
+        'interest': ['CSS', 'HTML', 'JavaScript'],
+        'expertise': ['HTML'],
+        'date_joined': datetime(1999, 1, 1, 10, 40, 23),
+    }
+    assert data == expected_data
+
+
+def test_extract_complex_social(complex_user, complex_user_html):
+    source = UserSource(complex_user.username, social=True)
+    data = source.extract_data(complex_user_html)
+    expected_data = {
+        'username': 'JillDeveloper',
+        'fullname': 'Jill Developer',
+        'title': 'Web Developer',
+        'organization': 'Acme, Inc.',
+        'location': 'Springfield, USA',
+        'interest': ['CSS', 'HTML', 'JavaScript'],
+        'expertise': ['HTML'],
+        'twitter_url': 'http://twitter.com/jilldev1999',
+        'github_url': 'https://github.com/jilldev1999',
+        'stackoverflow_url': 'http://stackoverflow.com/users/1/jilldev1999',
+        'linkedin_url': 'http://www.linkedin.com/in/jilldev1999',
+        'mozillians_url': 'http://mozillians.org/u/jilldev/',
+        'date_joined': datetime(1999, 1, 1, 10, 40, 23),
+    }
+    assert data == expected_data
+
+
+def test_extract_irc(irc_user, irc_user_html):
+    source = UserSource(irc_user.username, social=True)
+    data = source.extract_data(irc_user_html)
+    assert data['irc_nickname'] == irc_user.irc_nickname

--- a/kuma/scrape/tests/test_storage.py
+++ b/kuma/scrape/tests/test_storage.py
@@ -1,0 +1,95 @@
+from __future__ import unicode_literals
+from datetime import datetime
+
+from taggit.models import Tag
+import pytest
+
+from kuma.scrape.storage import Storage
+
+
+def test_safe_add_tags_new(simple_user):
+    tag = 'profile:interest:testing'
+    Storage().safe_add_tags([tag], Tag, simple_user.tags)
+    assert list(simple_user.tags.names()) == [tag]
+
+
+def test_safe_add_tags_existing(simple_user):
+    tag = 'profile:expertise:existence'
+    Tag.objects.create(name=tag)
+    Storage().safe_add_tags([tag], Tag, simple_user.tags)
+    assert list(simple_user.tags.names()) == [tag]
+
+
+def test_safe_add_tags_case_mismatch(simple_user):
+    tag = 'profile:interest:css'
+    Tag.objects.create(name=tag)
+    upper_tag = 'profile:interest:CSS'
+    Storage().safe_add_tags([upper_tag], Tag, simple_user.tags)
+    assert list(simple_user.tags.names()) == [tag]
+
+
+@pytest.mark.django_db
+def test_get_user_missing():
+    assert Storage().get_user('missing') is None
+
+
+def test_get_user_present(simple_user):
+    user = Storage().get_user(simple_user.username)
+    assert user == simple_user
+
+
+@pytest.mark.django_db
+def test_save_user(django_user_model):
+    data = {
+        'username': 'JoeDeveloper',
+        'fullname': 'Joe Developer',
+        'title': 'Web Developer',
+        'organization': 'Acme, Inc.',
+        'location': 'Springfield, USA',
+        'irc_nickname': 'joedev',
+        'interest': ['CSS', 'HTML', 'JavaScript'],
+        'expertise': ['HTML'],
+        'twitter_url': 'http://twitter.com/joedev1999',
+        'github_url': 'https://github.com/joedev1999',
+        'stackoverflow_url': 'http://stackoverflow.com/users/1/joedev1999',
+        'linkedin_url': 'http://www.linkedin.com/in/joedev1999',
+        'mozillians_url': 'http://mozillians.org/u/joedev/',
+        'date_joined': datetime(1999, 1, 1, 10, 40, 23),
+    }
+    Storage().save_user(data)
+    user = django_user_model.objects.get(username='JoeDeveloper')
+    assert user.fullname == 'Joe Developer'
+    assert user.title == 'Web Developer'
+    assert user.organization == 'Acme, Inc.'
+    assert user.location == 'Springfield, USA'
+    assert user.irc_nickname == 'joedev'
+    assert user.twitter_url == 'http://twitter.com/joedev1999'
+    assert user.github_url == 'https://github.com/joedev1999'
+    assert user.stackoverflow_url == (
+        'http://stackoverflow.com/users/1/joedev1999')
+    assert user.linkedin_url == 'http://www.linkedin.com/in/joedev1999'
+    assert user.mozillians_url == 'http://mozillians.org/u/joedev/'
+    assert user.date_joined == datetime(1999, 1, 1, 10, 40, 23)
+    tags = sorted(user.tags.names())
+    expected_tags = [
+        'profile:expertise:HTML',
+        'profile:interest:CSS',
+        'profile:interest:HTML',
+        'profile:interest:JavaScript',
+    ]
+    assert tags == expected_tags
+
+
+@pytest.mark.django_db
+def test_save_user_banned(django_user_model):
+    data = {
+        'username': 'banned',
+        'date_joined': datetime(2016, 12, 19),
+        'banned': True
+    }
+    Storage().save_user(data)
+    user = django_user_model.objects.get(username='banned')
+    assert user.bans.count() == 1
+    ban = user.bans.first()
+    assert ban.by == user
+    assert ban.reason == 'Ban detected by scraper'

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -499,6 +499,7 @@ INSTALLED_APPS = (
     'kuma.feeder',
     'kuma.landing',
     'kuma.redirects',
+    'kuma.scrape',
     'kuma.search',
     'kuma.users',
     'kuma.wiki',


### PR DESCRIPTION
Add a content scraping framework, for adding or updating data to a local Kuma instance. The first user of the framework is the management command ``scrape_user``, which can mirror a production user locally, using only public data on the user's profile.

Some things to try:

    ./manage.py scrape_user username
    ./manage.py scrape_user username --force
    ./manage.py scrape_user username --force --social
    ./manage.py scrape_user username --force --social --email name@example.com

Some of the framework may seem like overkill, but it's needed for the much more complex task of scraping a document, coming in the next PR.