### PR TITLE
bug 1271509: Add ./manage.py scrape_document

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -50,7 +50,7 @@ following, replacing ``username`` with the desired user's username::
     ./manage.py scrape_user username
     ./manage.py scrape_user https://developer.mozilla.org/en-US/profiles/username
 
-Some useful options
+Some useful options:
 
 ``--email user@example.com``
   Set the email for the user, which can't be scraped from the profile. With
@@ -67,3 +67,41 @@ For full options, see ``./manage.py scrape_user --help``
 A local user can be promoted to staff with the command::
 
     ./manage.py ihavepower username --password=password
+
+Add an MDN Wiki Document
+========================
+If you need a wiki page that is not in the sample database, you can scrape it
+from production or another Kuma instance, using the ``scrape_document``
+command.  In the container (after ``make bash`` or similar), run the
+following, using the desired URL::
+
+    ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/CSS/display
+
+Scraping a document includes:
+
+- The parent documents (such as ``Web`` and ``Web/CSS`` for ``Web/CSS/display``)
+- The zone, if needed
+- A revision for each document, and the author for each revision
+- The English variant, if a translation is requested
+- Redirects, if a page move is detected
+
+It does not include:
+
+- Attachment data, or the attachments themselves. These will continue to use
+  production URLs.
+
+Some useful options:
+
+``--revisions REVS``
+  Scrape more than one revision
+
+``--translations``
+  Scrape the translations of a page as well
+
+``--depth DEPTH``
+  Scrape one or more levels of child pages as well
+
+``--force``
+  Refresh an existing Document, instead of skipping
+
+For full options, see ``./manage.py scrape_document --help``

--- a/kuma/scrape/__init__.py
+++ b/kuma/scrape/__init__.py
@@ -4,6 +4,6 @@ Scrape data from one Kuma instance to this one.
 This is useful for development, to test code against specific production data,
 and to create the basic sample database for development and testing.
 
-TODO: Document scraping from sample_database_wip_1271509
 TODO: Sample DB code from sample_database_wip_1271509
+TODO: Extract attachment data from documents
 """

--- a/kuma/scrape/management/commands/__init__.py
+++ b/kuma/scrape/management/commands/__init__.py
@@ -1,4 +1,5 @@
 """Common methods for scraping management commands."""
+from argparse import ArgumentTypeError
 import logging
 
 from django.core.management.base import BaseCommand
@@ -48,3 +49,14 @@ class ScrapeCommand(BaseCommand):
         logger = logging.getLogger(log_name)
         logger.setLevel(level)
         logger.addHandler(console)
+
+    def int_all_type(self, value):
+        """A command argument that can take an integer or 'all'."""
+        if value.strip().lower() == 'all':
+            return 'all'
+        try:
+            as_int = int(value)
+        except ValueError:
+            msg = "%r should be 'all' or an integer" % value
+            raise ArgumentTypeError(msg)
+        return as_int

--- a/kuma/scrape/management/commands/scrape_document.py
+++ b/kuma/scrape/management/commands/scrape_document.py
@@ -29,7 +29,7 @@ class Command(ScrapeCommand):
                                   ' ("all" for all)'))
 
     def handle(self, *arg, **options):
-        self.setup_logging(options.get('verbosity'))
+        self.setup_logging(options['verbosity'])
         host, ssl, path = self.parse_url_or_path(options['url'])
         scraper = self.make_scraper(host=host, ssl=ssl)
 

--- a/kuma/scrape/management/commands/scrape_document.py
+++ b/kuma/scrape/management/commands/scrape_document.py
@@ -1,0 +1,48 @@
+"""Scrape a wiki document from a Kuma website."""
+
+from . import ScrapeCommand
+
+
+class Command(ScrapeCommand):
+    help = 'Scrape a wiki document.'
+
+    def add_arguments(self, parser):
+        """Add arguments for scraping an MDN wiki document."""
+        parser.add_argument('url',
+                            metavar='URL_OR_PATH',
+                            help='URL or path to a wiki page')
+        parser.add_argument('--force',
+                            help='Update existing Document record',
+                            action='store_true')
+        parser.add_argument('--revisions',
+                            dest='revisions',
+                            metavar='REVS', type=int, default=1,
+                            help='Depth in revision history to scrape')
+        parser.add_argument('--translations',
+                            help='Include translations',
+                            action='store_true',
+                            dest='translations')
+        parser.add_argument('--depth',
+                            dest='depth',
+                            metavar='DEPTH', type=self.int_all_type, default=0,
+                            help=('Depth in the topic tree to scrape'
+                                  ' ("all" for all)'))
+
+    def handle(self, *arg, **options):
+        self.setup_logging(options.get('verbosity'))
+        host, ssl, path = self.parse_url_or_path(options['url'])
+        scraper = self.make_scraper(host=host, ssl=ssl)
+
+        params = {}
+        for param in ('force', 'translations', 'revisions', 'depth'):
+            if options[param]:
+                params[param] = options[param]
+        scraper.add_source("document", path, **params)
+
+        scraper.scrape()
+        source = scraper.sources['document:' + path]
+        if source.state == source.STATE_ERROR:
+            raise Exception('Unable to scrape document "%s".' % path)
+
+        elif source.freshness == source.FRESH_NO and not options['force']:
+            self.stderr.write('Document "%s" already exists. Use --force to update.' % path)

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -7,7 +7,10 @@ import time
 
 import requests
 
-from .sources import Source, UserSource
+from .sources import (
+    DocumentChildrenSource, DocumentHistorySource, DocumentMetaSource,
+    DocumentRenderedSource, DocumentSource, RevisionSource, Source, UserSource,
+    ZoneRootSource)
 from .storage import Storage
 
 logger = logging.getLogger('kuma.scraper')
@@ -62,7 +65,14 @@ class Scraper(object):
     """Scrape data from a running MDN instance."""
 
     source_types = {
+        'document': DocumentSource,
+        'document_children': DocumentChildrenSource,
+        'document_history': DocumentHistorySource,
+        'document_meta': DocumentMetaSource,
+        'document_rendered': DocumentRenderedSource,
+        'revision': RevisionSource,
         'user': UserSource,
+        'zone_root': ZoneRootSource,
     }
 
     def __init__(self, host='developer.mozilla.org', ssl=True):

--- a/kuma/scrape/sources/__init__.py
+++ b/kuma/scrape/sources/__init__.py
@@ -1,10 +1,25 @@
 """Data sources for scraping MDN."""
 from __future__ import absolute_import, unicode_literals
 
-from .base import Source
+from .base import DocumentBaseSource, Source
+from .document import DocumentSource
+from .document_children import DocumentChildrenSource
+from .document_history import DocumentHistorySource
+from .document_meta import DocumentMetaSource
+from .document_rendered import DocumentRenderedSource
+from .revision import RevisionSource
 from .user import UserSource
+from .zone_root import ZoneRootSource
 
 __all__ = [
+    DocumentBaseSource,
+    DocumentChildrenSource,
+    DocumentHistorySource,
+    DocumentMetaSource,
+    DocumentRenderedSource,
+    DocumentSource,
+    RevisionSource,
     Source,
     UserSource,
+    ZoneRootSource,
 ]

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -67,12 +67,13 @@ class DocumentSource(DocumentBaseSource):
     def load_prereq_parent_topic(self, storage, data):
         """Load the parent topic, if a child page."""
         assert self.normalized_path
-        parent_topic = None
-        if self.parent_slug:
-            parent_topic = storage.get_document(self.locale, self.parent_slug)
-            if parent_topic is None:
-                data['needs'].append(('document', self.parent_path, {}))
-        if parent_topic:
+        if not self.parent_slug:
+            return  # No parent to load
+
+        parent_topic = storage.get_document(self.locale, self.parent_slug)
+        if parent_topic is None:
+            data['needs'].append(('document', self.parent_path, {}))
+        else:
             data['parent_topic'] = parent_topic
 
     def load_prereq_rendered(self, storage, data):

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -1,0 +1,236 @@
+"""DocumentSource scrapes MDN wiki documents."""
+from __future__ import absolute_import, unicode_literals
+import logging
+
+import dateutil
+
+from .base import DocumentBaseSource
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class DocumentSource(DocumentBaseSource):
+    """Coordinate scraping and local cloning of an MDN Document."""
+
+    OPTIONS = DocumentBaseSource.STANDARD_DOC_OPTIONS
+
+    def load_and_validate_existing(self, storage):
+        """Load the document from storage in simple cases."""
+
+        just_this_doc = (not self.translations and
+                         self.depth == 0 and
+                         self.revisions == 1 and
+                         self.normalized_path)
+        if not self.force and just_this_doc:
+            document = storage.get_document(self.locale, self.slug)
+            if document:
+                return True, []
+        return False, []
+
+    def load_prereqs(self, requester, storage):
+        """Load the data needed for a document."""
+        data = {'needs': []}
+
+        # Load data, gathering further source needs
+        self.load_prereq_normalized_path(storage, data)
+        if self.normalized_path:
+            self.load_prereq_parent_topic(storage, data)
+            self.load_prereq_rendered(storage, data)
+            if data.get('has_rendered'):
+                self.load_prereq_redirect(storage, data)
+            if data.get('is_standard_page'):
+                self.load_prereq_metadata(storage, data)
+                self.load_prereq_english_parent(storage, data)
+                self.load_prereq_history(storage, data)
+                self.load_prereq_children(storage, data)
+
+        return not data['needs'], data
+
+    def load_prereq_normalized_path(self, storage, data):
+        """Load zone data to normalize path, if needed."""
+        if self.normalized_path:
+            return  # Already normalized, done
+
+        # Determine the standard path associated with the zone
+        zone_data = storage.get_zone_root(self.path)
+        if zone_data is None:
+            data['needs'].append(('zone_root', self.path, {}))
+        elif zone_data.get('errors'):
+            raise self.SourceError(
+                'Unable to load zone root for %s', self.path)
+        else:
+            self.normalized_path = self.path.replace(
+                zone_data['zone_path'], zone_data['doc_path'])
+            self.locale, self.slug = self.locale_and_slug(
+                self.normalized_path)
+
+    def load_prereq_parent_topic(self, storage, data):
+        """Load the parent topic, if a child page."""
+        assert self.normalized_path
+        parent_topic = None
+        if self.parent_slug:
+            parent_topic = storage.get_document(self.locale, self.parent_slug)
+            if parent_topic is None:
+                data['needs'].append(('document', self.parent_path, {}))
+        if parent_topic:
+            data['parent_topic'] = parent_topic
+
+    def load_prereq_rendered(self, storage, data):
+        """Load the rendered page, to detect redirects and zones."""
+        assert self.normalized_path
+        rendered = storage.get_document_rendered(self.locale, self.slug)
+        if rendered is None:
+            data['needs'].append(
+                ('document_rendered', self.normalized_path, {}))
+        else:
+            data['has_rendered'] = True
+            data['redirect_to'] = rendered.get('redirect_to')
+            data['is_zone_root'] = rendered.get('is_zone_root', False)
+            data['zone_css_slug'] = rendered.get('zone_css_slug', '')
+
+    def load_prereq_redirect(self, storage, data):
+        """Load the zone or standard redirect."""
+        assert self.normalized_path
+        data['is_standard_page'] = data.get('has_rendered')
+        redirect_to = data.get('redirect_to')
+        if not redirect_to:
+            return  # Not a redirect, don't follow
+
+        # Is it a zoned URL or a moved page?
+        try:
+            rd_locale, rd_slug = self.locale_and_slug(redirect_to)
+        except ValueError:
+            # Zoned URL
+            zone_redirect = storage.get_zone_root(redirect_to)
+            if zone_redirect is None:
+                data['needs'].append(('zone_root', redirect_to, {}))
+            elif zone_redirect.get('errors'):
+                raise self.SourceError('Unable to get zone_root "%s"',
+                                       redirect_to)
+            else:
+                data['zone_redirect_path'] = zone_redirect['zone_path']
+                z_path = zone_redirect['doc_path']
+                if z_path != self.path:
+                    z_locale, z_slug = self.locale_and_slug(z_path)
+                    zone_root_doc = storage.get_document(z_locale, z_slug)
+                    if zone_root_doc is None:
+                        data['needs'].append(('document', z_path, {}))
+        else:
+            # Moved Page
+            redirect = storage.get_document(rd_locale, rd_slug)
+            data['is_standard_page'] = False
+            if redirect is None:
+                data['needs'].append(('document', redirect_to, {}))
+
+    def load_prereq_metadata(self, storage, data):
+        """Load the document metadata."""
+        assert self.normalized_path
+        meta = storage.get_document_metadata(self.locale, self.slug)
+        if meta is None:
+            data['needs'].append(('document_meta', self.normalized_path,
+                                 self.current_options()))
+        elif 'error' in meta:
+            raise self.SourceError('Error getting metadata for %s',
+                                   self.normalized_path)
+        elif meta:
+            data['id'] = meta['id']
+            data['locale'] = meta['locale']
+            data['modified'] = dateutil.parser.parse(meta['modified'])
+            data['slug'] = meta['slug']
+            data['tags'] = meta['tags']
+            data['title'] = meta['title']
+            data['translations'] = meta['translations']
+
+            # Redirects don't have UUIDs
+            if 'uuid' in meta:
+                data['uuid'] = meta['uuid']
+            else:
+                logger.warning('No uuid: %s', self.path)
+
+    def load_prereq_english_parent(self, storage, data):
+        """Load the English parent, if this is a translation."""
+        if self.locale == 'en-US':
+            return  # No English parent for English docs
+        if 'translations' not in data:
+            return  # Metadata not loaded yet
+
+        # For translations - have we loaded the English document?
+        for translation in data['translations']:
+            if translation['locale'] == 'en-US':
+                en_path = self.decode_href(translation['url'])
+                try:
+                    en_locale, en_slug = self.locale_and_slug(en_path)
+                except ValueError:
+                    raise self.SourceError(
+                        'Invalid meta for "%s": In translations,'
+                        ' invalid path "%s" for "en-US"',
+                        self.path, en_path)
+                else:
+                    en_doc = storage.get_document(en_locale, en_slug)
+                    if en_doc is None:
+                        data['needs'].append(('document', en_path, {}))
+                    else:
+                        data['parent'] = en_doc
+
+    def load_prereq_history(self, storage, data):
+        """Load the revision history."""
+        history = storage.get_document_history(self.locale, self.slug)
+        if history is None:
+            data['needs'].append(('document_history', self.normalized_path,
+                                 {"revisions": self.revisions}))
+        elif len(history) == 0:
+            raise self.SourceError('Empty history for document "%s"',
+                                   self.normalized_path)
+
+    def load_prereq_children(self, storage, data):
+        """Load the document children."""
+        if self.depth == 0:
+            return
+        children = storage.get_document_children(self.locale, self.slug)
+        if children is None:
+            options = self.current_options()
+            data['needs'].append(('document_children', self.normalized_path,
+                                  options))
+
+    def save_data(self, storage, data):
+        """Save the document as a redirect or full document."""
+        redirect_to = data.get('redirect_to')
+        if redirect_to and not data.get('zone_redirect_path'):
+            # Prepare data for a redirect document
+            doc_data = {
+                'locale': self.locale,
+                'slug': self.slug,
+                'redirect_to': redirect_to
+            }
+        else:
+            # Prepare data for a full document
+            keys = (
+                'id',
+                'is_zone_root',
+                'locale',
+                'modified',
+                'parent',
+                'parent_topic',
+                'slug',
+                'tags',
+                'title',
+                'uuid',
+                'zone_css_slug',
+                'zone_redirect_path',
+            )
+            doc_data = {}
+            for key in keys:
+                if key in data:
+                    doc_data[key] = data[key]
+            if doc_data['slug'] != self.slug:
+                logger.warn(
+                    'Meta slug "%s" does not match slug for "%s".',
+                    doc_data['slug'], self.path)
+                doc_data['slug'] = self.slug
+            if doc_data['locale'] != self.locale:
+                logger.warn(
+                    'Meta locale "%s" does not match locale for "%s".',
+                    doc_data['locale'], self.path)
+                doc_data['locale'] = self.locale
+        storage.save_document(doc_data)
+        return []

--- a/kuma/scrape/sources/document_children.py
+++ b/kuma/scrape/sources/document_children.py
@@ -1,0 +1,53 @@
+"""DocumentChildrenSource gathers child docs."""
+from __future__ import absolute_import, unicode_literals
+
+from .base import DocumentBaseSource
+
+
+class DocumentChildrenSource(DocumentBaseSource):
+    """Recursively gather child docs ($children API)."""
+
+    OPTIONS = {
+        'depth': ('int_all', 0),    # Scrape the topic tree to this depth
+        'revisions': ('int', 1),    # Gather this many revisions for each doc
+        'translations': ('bool', False),  # Scrape the alternate translations
+    }
+
+    def source_path(self):
+        return '/%s/docs/%s$children?depth=1' % (self.locale, self.slug)
+
+    def load_and_validate_existing(self, storage):
+        """Load child data from a previous gather."""
+        child_data = storage.get_document_children(self.locale, self.slug)
+        if child_data:
+            children = self.extract_data(child_data)
+            return True, children
+        else:
+            return False, []
+
+    def load_prereqs(self, requester, storage):
+        """Load one level of document child data from the $children API."""
+        response = requester.request(self.source_path())
+        data = response.json()
+        return True, data
+
+    def save_data(self, storage, data):
+        """Save the raw child data, extract child documents."""
+        storage.save_document_children(self.locale, self.slug, data)
+        return self.extract_data(data)
+
+    def extract_data(self, data):
+        """Process child API data."""
+        children = []
+        if data['subpages']:
+            new_opts = self.current_options()
+            depth = new_opts.get('depth')
+            if depth and depth != 'all':
+                if depth == 1:
+                    del new_opts['depth']
+                else:
+                    new_opts['depth'] -= 1
+            for subpage in data['subpages']:
+                url = self.decode_href(subpage['url'])
+                children.append(('document', url, new_opts))
+        return children

--- a/kuma/scrape/sources/document_history.py
+++ b/kuma/scrape/sources/document_history.py
@@ -1,0 +1,72 @@
+"""DocumentHistorySource scrapes the wiki history page."""
+from __future__ import absolute_import, unicode_literals
+import logging
+
+from pyquery import PyQuery as pq
+
+from .base import DocumentBaseSource
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class DocumentHistorySource(DocumentBaseSource):
+    """Gather the revision data for an MDN Document."""
+
+    OPTIONS = {
+        'revisions': ('int', 1),  # Scrape this many past revisions
+    }
+
+    def source_path(self):
+        """Get MDN path for the document history."""
+        path = '/%s/docs/%s$history' % (self.locale, self.slug)
+        if self.revisions > 1:
+            path += '?limit=%d' % self.revisions
+        return path
+
+    def load_and_validate_existing(self, storage):
+        """Load history data from a previous operation."""
+        revs = storage.get_document_history(self.locale, self.slug)
+        if revs and len(revs) >= self.revisions:
+            requested_revisions = revs[:self.revisions]
+            requested_revisions.reverse()
+            return True, requested_revisions
+        else:
+            return False, []
+
+    def load_prereqs(self, requester, storage):
+        """Load history data from the server."""
+        path = self.source_path()
+        response = requester.request(path, raise_for_status=False)
+        if response.status_code == 200:
+            return True, response.content
+        else:
+            raise self.SourceError('status_code %s', response.status_code)
+
+    def save_data(self, storage, data):
+        """Extract revisions and save for next call."""
+        revs = self.extract_data(data)
+        storage.save_document_history(self.locale, self.slug, revs)
+        requested_revisions = revs[:self.revisions]
+        requested_revisions.reverse()
+        return requested_revisions
+
+    def extract_data(self, content):
+        """Convert a history pageview into history data."""
+        revs = []
+        parsed = pq(content)
+
+        # If translation, there may be an entry for the English source
+        en_source = parsed.find('li.revision-list-en-source'
+                                ' div.revision-list-date a')
+        if en_source:
+            en_href = self.decode_href(en_source[0].attrib['href'])
+        else:
+            en_href = None
+
+        for link in parsed.find('div.revision-list-date a'):
+            href = self.decode_href(link.attrib['href'])
+            if href == en_href:
+                revs[-1][-1]['based_on'] = en_href
+            else:
+                revs.append(('revision', href, {}))
+        return revs

--- a/kuma/scrape/sources/document_meta.py
+++ b/kuma/scrape/sources/document_meta.py
@@ -1,0 +1,51 @@
+"""DocumentMetaSource scrapes document metadata."""
+from __future__ import absolute_import, unicode_literals
+
+from .base import DocumentBaseSource
+
+
+class DocumentMetaSource(DocumentBaseSource):
+    """Gather the metadata for an MDN document ($json API)."""
+
+    OPTIONS = DocumentBaseSource.STANDARD_DOC_OPTIONS
+
+    def source_path(self):
+        return '/%s/docs/%s$json' % (self.locale, self.slug)
+
+    def load_and_validate_existing(self, storage):
+        """Load metadata from a previous gather."""
+        metadata = storage.get_document_metadata(self.locale, self.slug)
+        if metadata:
+            next_sources = self.extract_data(metadata)
+            return True, next_sources
+        else:
+            return False, []
+
+    def load_prereqs(self, requester, storage):
+        """Load the document metadata from the $json API."""
+        path = self.source_path()
+        response = requester.request(path, raise_for_status=False)
+        if response.status_code == 200:
+            data = response.json()
+        else:
+            data = {'error': 'status code %s' % response.status_code}
+        return True, data
+
+    def save_data(self, storage, data):
+        """Save the metadata, extract translations."""
+        storage.save_document_metadata(self.locale, self.slug, data)
+        return self.extract_data(data)
+
+    def extract_data(self, metadata):
+        """Process document metadata"""
+        if 'error' in metadata:
+            raise self.SourceError('Error fetching metadata for %s: %s',
+                                   self.source_path(), metadata['error'])
+        resources = []
+        if self.translations and metadata['translations']:
+            options = self.current_options()
+            del options['translations']
+            for translation in metadata['translations']:
+                url = self.decode_href(translation['url'])
+                resources.append(('document', url, options))
+        return resources

--- a/kuma/scrape/sources/document_rendered.py
+++ b/kuma/scrape/sources/document_rendered.py
@@ -1,0 +1,63 @@
+"""DocumentRenderedSource requests MDN wiki documents."""
+from __future__ import absolute_import, unicode_literals
+import re
+
+from django.utils.six.moves.urllib.parse import urlparse
+from pyquery import PyQuery as pq
+
+from .base import DocumentBaseSource
+
+
+class DocumentRenderedSource(DocumentBaseSource):
+    """
+    Request the rendered document.
+
+    This is used to detect zones and redirects.
+    """
+
+    # Regular expression for custom zone CSS, like zone-firefox.css
+    re_custom_href = re.compile("""(?x)  # Verbose RE mode
+        .*                # Match anything
+        \/zone-           # Match '/zone-'
+        (?P<slug>[^.]*)   # Capture the slug
+        (\.[0-9a-fA-F]+)? # There may be a hash in the filename
+        \.css             # Ends in .css
+        """)
+
+    def source_path(self):
+        return '/%s/docs/%s' % (self.locale, self.slug)
+
+    def load_prereqs(self, requester, storage):
+        """Request the document, and process the redirects and response."""
+        response = requester.request(self.source_path())
+        data = {}
+
+        # Is this a redirect?
+        if response.history:
+            redirect_from = urlparse(response.history[0].url).path
+            redirect_to = urlparse(response.url).path
+            if redirect_to != redirect_from:
+                data['redirect_to'] = self.decode_href(redirect_to)
+
+        # Is this a zone root?
+        parsed = pq(response.content)
+        body = parsed('body')
+        if body.has_class('zone-landing'):
+            data['is_zone_root'] = True
+
+            # Find the zone stylesheet
+            links = parsed('head link')
+            for link in links:
+                rel = link.attrib.get('rel')
+                href = self.decode_href(link.attrib.get('href'))
+                if rel == 'stylesheet' and href:
+                    match = self.re_custom_href.match(href)
+                    if match:
+                        data['zone_css_slug'] = match.group('slug')
+
+        return True, data
+
+    def save_data(self, storage, data):
+        """Save the rendered document data."""
+        storage.save_document_rendered(self.locale, self.slug, data)
+        return []

--- a/kuma/scrape/sources/revision.py
+++ b/kuma/scrape/sources/revision.py
@@ -1,0 +1,174 @@
+"""RevisionSource scrapes historical wiki revisions."""
+from __future__ import absolute_import, unicode_literals
+import re
+import logging
+
+from django.utils.translation import gettext, override
+from pyquery import PyQuery as pq
+import dateutil
+
+from .base import Source, DocumentBaseSource
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class RevisionSource(Source):
+    """Import a historical wiki revision."""
+    PARAM_NAME = 'path'
+    OPTIONS = {
+        'based_on': ('text', '')  # Revision this is based on
+    }
+
+    re_path = re.compile(r"""(?x) # Verbose mode
+        /(?P<locale>[^/]+)        # Locale, like en-US
+        /docs/                    # literal '/docs/'
+        (?P<slug>[^$]*)           # Slug, like Mozilla/Firefox
+        \$revision/               # literal '$revision/'
+        (?P<revision_id>\d+)      # Revision ID
+    """)
+
+    def __init__(self, path, **options):
+        """Parse and validate a revision path."""
+        super(RevisionSource, self).__init__(path, **options)
+        try:
+            self.locale, self.slug, self.revision_id = self.split_path(path)
+        except ValueError as exception:
+            logger.warn(exception)
+            self.state = self.STATE_ERROR
+
+    def split_path(self, path):
+        """Extract a revision parameters from a path."""
+        match = self.re_path.match(path)
+        if match:
+            locale, slug, raw_rev_id = match.groups()
+            return locale, slug, int(raw_rev_id)
+        else:
+            raise ValueError('Not a valid revision path: %s' % path)
+
+    def source_path(self):
+        """Return MDN URL path for revision source."""
+        return '/%s/docs/%s$revision/%d' % (self.locale, self.slug,
+                                            self.revision_id)
+
+    def load_and_validate_existing(self, storage):
+        """Load existing revision data from storage."""
+        self.document = storage.get_document(self.locale, self.slug)
+        revision = storage.get_revision(self.revision_id)
+        if revision and self.document:
+            if revision.document == self.document:
+                return True, []
+            else:
+                self.freshness = self.FRESH_NO
+                raise self.SourceError(
+                    'Revision %s is for Document "%s", expected "%s".',
+                    self.revision_id,
+                    revision.document.get_absolute_url(),
+                    self.document.get_absolute_url())
+        else:
+            return False, []
+
+    def load_prereqs(self, requester, storage):
+        """Load document, meta, revision source, and creator."""
+        needs = []
+        doc_path = '/%s/docs/%s' % (self.locale, self.slug)
+
+        # Load document, using pre-loaded if available
+        if not getattr(self, 'document', None):
+            self.document = storage.get_document(self.locale, self.slug)
+        if not self.document:
+            needs.append(('document', doc_path, {}))
+
+        # Load document metadata
+        meta = storage.get_document_metadata(self.locale, self.slug)
+        if meta is None:
+            options = {k: v for k, v in self.current_options().items()
+                       if k in DocumentBaseSource.STANDARD_DOC_OPTIONS}
+            needs.append(('document_meta', doc_path, options))
+
+        # Load revision HTML
+        path = self.source_path()
+        rev_source = storage.get_revision_html(path)
+        if not rev_source:
+            response = requester.request(path, raise_for_status=False)
+            if response.status_code != 200:
+                raise self.SourceError('status_code %s', response.status_code)
+            rev_source = response.content
+            storage.save_revision_html(path, rev_source)
+        data = self.extract_data(rev_source)
+
+        # Load revision creator
+        creator_username = data.pop('creator')
+        creator = storage.get_user(creator_username)
+        if not creator:
+            needs.append(('user', creator_username, {}))
+
+        # Load revision this is based on
+        if self.based_on:
+            b_locale, b_slug, b_id = self.split_path(self.based_on)
+            based_rev = storage.get_revision(b_id)
+            if not based_rev:
+                needs.append(('revision', self.based_on, {}))
+
+        if needs:
+            return False, {'needs': needs}
+        else:
+            data['id'] = self.revision_id
+            data['creator'] = creator
+            data['document'] = self.document
+            if data['is_current'] and data['slug'] != self.document.slug:
+                logger.warn('Current revision %d has slug "%s". Setting'
+                            ' to document slug "%s".',
+                            self.revision_id, data['slug'],
+                            self.document.slug)
+                data['slug'] = self.document.slug
+            if data['is_current']:
+                data['review_tags'] = meta.get('review_tags', [])
+                data['localization_tags'] = meta.get('localization_tags', [])
+            if self.based_on:
+                data['based_on_id'] = based_rev.id
+            return True, data
+
+    def save_data(self, storage, data):
+        """Save the extracted revision data."""
+        storage.save_revision(data)
+        return []
+
+    def extract_data(self, html):
+        """Extract revision source and metadata from HTML."""
+        data = {}
+        keys = ('slug', 'title', 'id', 'created', 'creator', 'is_current',
+                'comment')
+        parsed = pq(html)
+
+        # Parse revision-info list
+        rev_info = parsed.find('div.revision-info li span')
+        for key, span in zip(keys, rev_info):
+            raw = span.text
+            if key == 'id':
+                value = int(raw)
+            elif key == 'created':
+                created = span.cssselect('time')[0].attrib['datetime']
+                value = dateutil.parser.parse(created)
+                value = value.replace(tzinfo=None)
+            elif key == 'is_current':
+                with override(self.locale):
+                    yes = gettext('Yes')
+                value = (raw == yes.decode('utf8'))
+            elif key == 'comment':
+                value = raw or ''
+            else:
+                value = raw
+            data[key] = value
+
+        # Parse tags
+        tags = []
+        tag_links = parsed.find('ul.tags li a')
+        for tag_link in tag_links:
+            tags.append(tag_link.text)
+        data['tags'] = tags
+
+        # Revision content
+        source_elem = parsed.find('div#doc-source pre')[0]
+        data['content'] = source_elem.text
+
+        return data

--- a/kuma/scrape/sources/zone_root.py
+++ b/kuma/scrape/sources/zone_root.py
@@ -1,0 +1,85 @@
+"""ZoneRootSource determine zone URL redirects."""
+from __future__ import absolute_import, unicode_literals
+import re
+import logging
+
+from django.utils.six.moves.urllib.parse import unquote
+
+from .base import Source
+
+logger = logging.getLogger('kuma.scraper')
+
+
+class ZoneRootSource(Source):
+    """Gather data about the root of a DocumentZone."""
+    PARAM_NAME = 'path'
+    re_path = re.compile(r"/(?P<locale>[^/]+)/(?P<zone_subpath>[^/]+)")
+
+    def __init__(self, path, **options):
+        super(ZoneRootSource, self).__init__(path, **options)
+        if path != unquote(path):
+            raise ValueError('URL-encoded path "%s"' % path)
+        try:
+            self.locale, self.slug = self.locale_and_zone(path)
+        except ValueError as exception:
+            self.locale, self.slug = None, None
+            logger.warn(exception)
+            self.state = self.STATE_ERROR
+
+    def locale_and_zone(self, path):
+        """Extract a document locale and zone subpath from a path."""
+        match = self.re_path.match(path)
+        if match:
+            return match.groups()
+        else:
+            raise ValueError('Not a valid zoned document path "%s"' % path)
+
+    def raise_if_errors(self, errors):
+        """Raises errors to terminate zone processing."""
+        if errors:
+            raise self.SourceError('Bad JSON data for %s$json: %s',
+                                   self.path, ', '.join(errors))
+
+    def load_and_validate_existing(self, storage):
+        """Load existing zone root data."""
+        data = storage.get_zone_root(self.path)
+        if data:
+            self.raise_if_errors(data.get('errors'))
+            return True, [('document', data['doc_path'], {})]
+        else:
+            return False, None
+
+    def load_prereqs(self, requester, storage):
+        """Scrape JSON data for the zone root."""
+        response = requester.request(self.path + "$json")
+        data = self.extract_data(response.json())
+        return True, data
+
+    def save_data(self, storage, data):
+        """Save zone root for future processing."""
+        storage.save_zone_root(self.path, data)
+        self.raise_if_errors(data.get('errors'))
+        return [('document', data['doc_path'], {})]
+
+    def extract_data(self, metadata):
+        """Extract zone root data from JSON."""
+        err = []
+        url = self.decode_href(metadata['url'])
+        if url == self.path:
+            err.append('url "%s" should be the non-zone path' % url)
+        if metadata['locale'] != self.locale:
+            err.append('locale "%s" should be the same as the path locale' %
+                       metadata['locale'])
+        if err:
+            return {
+                'errors': err,
+                'doc_locale': self.locale,
+                'metadata_locale': metadata['locale'],
+                'metadata_url': url,
+                'zone_path': self.path,
+            }
+        else:
+            return {
+                'doc_path': url,
+                'zone_path': self.path,
+            }

--- a/kuma/scrape/tests/conftest.py
+++ b/kuma/scrape/tests/conftest.py
@@ -13,10 +13,3 @@ def simple_user(db, django_user_model):
         username='JackDeveloper',
         email='jack@example.com',
         date_joined=datetime(2016, 11, 4, 9, 1))
-
-
-@pytest.fixture
-def simple_user_html(simple_user, client):
-    """The profile HTML for a simple user."""
-    response = client.get('/en-US/profiles/' + simple_user.username)
-    return response.content

--- a/kuma/scrape/tests/conftest.py
+++ b/kuma/scrape/tests/conftest.py
@@ -5,6 +5,8 @@ from datetime import datetime
 
 import pytest
 
+from kuma.wiki.models import Document, Revision
+
 
 @pytest.fixture
 def simple_user(db, django_user_model):
@@ -13,3 +15,49 @@ def simple_user(db, django_user_model):
         username='JackDeveloper',
         email='jack@example.com',
         date_joined=datetime(2016, 11, 4, 9, 1))
+
+
+@pytest.fixture
+def simple_doc(db):
+    """A Document record with no revisions and no parent topic."""
+    return Document.objects.create(
+        locale='en-US', slug='Root', title='Root Document')
+
+
+@pytest.fixture
+def root_doc(simple_doc, simple_user):
+    """A Document record with two revisions and without a parent topic."""
+    Revision.objects.create(
+        document=simple_doc,
+        creator=simple_user,
+        content='<p>Getting started...</p>',
+        title='Root Document',
+        created=datetime(2016, 1, 1))
+    simple_doc.current_revision = Revision.objects.create(
+        document=simple_doc,
+        creator=simple_user,
+        content='<p>The root document.</p>',
+        created=datetime(2016, 2, 1))
+    simple_doc.save()
+    return simple_doc
+
+
+@pytest.fixture
+def translated_doc(root_doc):
+    """A translation of the root document."""
+    translated_doc = Document.objects.create(
+        parent=root_doc,
+        slug='Racine',
+        locale='fr',
+        title='Document Racine')
+    revision = Revision.objects.create(
+        document=translated_doc,
+        content='<p>Commencer...</p>',
+        title='Document Racine',
+        slug='Racine',
+        based_on=root_doc.current_revision,
+        creator=root_doc.current_revision.creator,
+        created=datetime(2017, 6, 1, 15, 28))
+    translated_doc.current_revision = revision
+    translated_doc.save()
+    return translated_doc

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -191,6 +191,14 @@ def test_scrape(scraper):
     assert sources.keys() == ['fake:loop', 'fake:loop2', 'fake:loop21']
 
 
+def test_scrape_error(scraper):
+    """The scraper will complete if a source is errored."""
+    scraper.add_source('fake', 'will_error', error=True)
+    sources = scraper.scrape()
+    source = sources['fake:will_error']
+    assert source.state == source.STATE_ERROR
+
+
 def test_scrape_none(scraper):
     """A scraper with no sources returns early."""
     sources = scraper.scrape()

--- a/kuma/scrape/tests/test_source_document.py
+++ b/kuma/scrape/tests/test_source_document.py
@@ -1,0 +1,522 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentSource class."""
+from __future__ import unicode_literals
+from datetime import datetime
+
+from kuma.scrape.sources import DocumentSource
+from . import mock_storage
+
+
+# Basic metadata for a Document
+doc_metadata = {
+    # Omitted: json_modified, label, last_edit, etc.
+    'id': 100,
+    'locale': 'en-US',
+    'localization_tags': [],
+    'modified': '2016-11-08T15:26:23.807948',
+    'review_tags': [],
+    'slug': 'Test',
+    'tags': [],
+    'title': 'Test Title',
+    'translations': [],
+    'url': '/en-US/docs/Test',
+    'uuid': 'f9f8e807-a98e-4106-867f-4e1c99cb7f2c',
+}
+
+# The data passed to Storage.save_document for this metadata
+doc_data = {
+    'id': 100,
+    'is_zone_root': False,
+    'locale': 'en-US',
+    'modified': datetime(2016, 11, 8, 15, 26, 23, 807948),
+    'slug': 'Test',
+    'tags': [],
+    'title': 'Test Title',
+    'uuid': 'f9f8e807-a98e-4106-867f-4e1c99cb7f2c',
+    'zone_css_slug': '',
+}
+
+
+def test_gather_root_no_prereqs():
+    doc_path = '/en-US/docs/RootDoc'
+    source = DocumentSource(doc_path)
+    storage = mock_storage(spec=['get_document', 'get_document_rendered'])
+    resources = source.gather(None, storage)
+    assert resources == [('document_rendered', doc_path, {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_document_in_storage():
+    """If the Document already exists, short-circuit downloads."""
+    source = DocumentSource('/en-US/docs/Root/Child')
+    storage = mock_storage(spec=['get_document'])
+    storage.get_document.return_value = "existing document"
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+
+
+def test_gather_forced():
+    """Resources are fetched if force=True."""
+    doc_path = '/en-US/docs/RootDoc'
+    source = DocumentSource(doc_path, force=True)
+    storage = mock_storage(spec=['get_document', 'get_document_rendered'])
+    storage.get_document.return_value = "existing document"
+    resources = source.gather(None, storage)
+    assert resources == [('document_rendered', doc_path, {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_child_doc():
+    """A child document requires the parent document."""
+    parent_path = '/en-US/docs/Root'
+    child_path = parent_path + '/Child'
+    source = DocumentSource(child_path)
+    storage = mock_storage(spec=['get_document', 'get_document_rendered'])
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', parent_path, {}),
+        ('document_rendered', child_path, {})]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_child_doc_parent_in_storage():
+    """If the parent document is available, it is not requested."""
+    parent_path = '/en-US/docs/Root'
+    child_path = parent_path + '/Child'
+    source = DocumentSource(child_path, force=True)
+    storage = mock_storage(spec=['get_document', 'get_document_rendered'])
+    storage.get_document.return_value = 'parent document'
+    resources = source.gather(None, storage)
+    assert resources == [('document_rendered', child_path, {})]
+    storage.get_document.assert_called_once_with('en-US', 'Root')
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_standard_doc():
+    """If the rendered document is standard, get next resources."""
+    path = '/en-US/docs/RootDoc'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history'])
+    storage.get_document_rendered.return_value = {}
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document_meta', path, {'force': True}),
+        ('document_history', path, {'revisions': 1})]
+    assert source.state == source.STATE_PREREQ
+    storage.get_document_metadata.assert_called_once_with('en-US', 'RootDoc')
+    storage.get_document_history.assert_called_once_with('en-US', 'RootDoc')
+
+
+def test_gather_standard_doc_empty_history_is_error():
+    path = '/en-US/docs/RootDoc'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    storage.get_document_metadata.return_value = {}  # Empty for now
+    storage.get_document_history.return_value = []   # No history
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_standard_doc_all_prereqs():
+    path = '/en-US/docs/Test'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    storage.get_document_metadata.return_value = doc_metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2016', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    storage.save_document.assert_called_once_with(doc_data)
+
+
+def test_gather_standard_doc_metdata_loses():
+    """If metadata doesn't match URL, use locale and slug from URL."""
+    path = '/en-US/docs/Test'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    metadata = doc_metadata.copy()
+    metadata['locale'] = 'EN-US'
+    metadata['slug'] = 'TEST'
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2016', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    storage.save_document.assert_called_once_with(doc_data)
+
+
+def test_gather_standard_doc_bad_metadata():
+    """If the metadata has an error, so does the document."""
+    path = '/en-US/docs/Test'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    metadata = doc_metadata.copy()
+    metadata['error'] = True
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2016', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_standard_doc_no_uuid():
+    path = '/en-US/docs/Test'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    metadata = doc_metadata.copy()
+    del metadata['uuid']
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2016', {})]
+
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    expected = doc_data.copy()
+    del expected['uuid']
+    storage.save_document.assert_called_once_with(expected)
+
+
+def test_gather_zoned_doc_init():
+    """A zone URL requests the zone doc."""
+    path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=['get_zone_root'])
+    resources = source.gather(None, storage)
+    assert resources == [('zone_root', path, {})]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_zoned_doc_error():
+    """If the zoned document fails (isn't a zone), then the doc errors too."""
+    path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=['get_zone_root'])
+    storage.get_zone_root.return_value = {'errors': ['failed']}
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_zoned_doc_is_normalized():
+    """The zoned doc is used to normalize the URL."""
+    path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    assert not source.normalized_path
+    assert not source.locale
+    assert not source.slug
+    storage = mock_storage(spec=[
+        'get_zone_root', 'get_document', 'get_document_rendered'])
+    storage.get_zone_root.return_value = {
+        'zone_path': path, 'doc_path': '/en-US/docs/Root/Zone'}
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', '/en-US/docs/Root', {}),
+        ('document_rendered', '/en-US/docs/Root/Zone', {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.normalized_path == '/en-US/docs/Root/Zone'
+    assert source.locale == 'en-US'
+    assert source.slug == 'Root/Zone'
+
+
+def test_gather_normalized_path_moved_page_needed():
+    """If a document is a redirect, request the target page."""
+    source = DocumentSource('/en-US/docs/Origin', force=True)
+    storage = mock_storage(spec=['get_document', 'get_document_rendered'])
+    storage.get_document_rendered.return_value = {
+        'redirect_to': '/en-US/docs/NewLocation'}
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', '/en-US/docs/NewLocation', {})]
+    storage.get_document.assert_called_once_with('en-US', 'NewLocation')
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_normalized_path_moved_page_followed():
+    """If a document is a redirect to a normal page, create a redirect."""
+    source = DocumentSource('/en-US/docs/Origin', force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'save_document'])
+    storage.get_document_rendered.return_value = {
+        'redirect_to': '/en-US/docs/NewLocation'}
+    storage.get_document.return_value = "Redirect Document"
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    expected_data = {
+        'locale': 'en-US',
+        'slug': 'Origin',
+        'redirect_to': '/en-US/docs/NewLocation'
+    }
+    storage.save_document.assert_called_once_with(expected_data)
+
+
+def test_gather_redirect_to_zone_page_first_pass():
+    """If a document is a redirect to a zone, request the zone root."""
+    parent_path = '/en-US/docs/Root'
+    path = parent_path + '/Zone'
+    zone_path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_zone_root',
+        'get_document_metadata', 'get_document_history'])
+    storage.get_document_rendered.return_value = {'redirect_to': zone_path}
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', parent_path, {}),
+        ('zone_root', zone_path, {}),
+        ('document_meta', path, {'force': True}),
+        ('document_history', path, {'revisions': 1})]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_redirect_to_errored_zone_page_is_error():
+    """If a document is a redirect to an errored zone, doc is also errored."""
+    parent_path = '/en-US/docs/Root'
+    path = parent_path + '/Zone'
+    zone_path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_zone_root',
+        'get_document_metadata', 'get_document_history'])
+    storage.get_document_rendered.return_value = {'redirect_to': zone_path}
+    storage.get_zone_root.return_value = {'errors': 'bad zone'}
+    source.gather(None, storage)
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_redirect_to_zone_page_complete():
+    """A zoned document has more data passed to storage.save_document()"""
+    parent_path = '/en-US/docs/Root'
+    path = parent_path + '/Zone'
+    zone_path = '/en-US/Zone'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_zone_root',
+        'get_document_metadata', 'get_document_history', 'save_document'])
+    storage.get_document.return_value = 'Root doc'
+    storage.get_document_rendered.return_value = {'redirect_to': zone_path}
+    storage.get_zone_root.return_value = {
+        'doc_path': path,
+        'zone_path': zone_path}
+    metadata = doc_metadata.copy()
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2017', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    expected = doc_data.copy()
+    expected['slug'] = 'Root/Zone'
+    expected['parent_topic'] = 'Root doc'
+    expected['zone_redirect_path'] = zone_path
+    assert storage.save_document.call_count == 1
+    assert storage.save_document.call_args[0][0] == expected  # Better diff
+    storage.save_document.assert_called_once_with(expected)
+
+
+def test_gather_redirect_to_zone_subpage():
+    """If a document is a redirect to zone subpage, request the zone root."""
+    parent_path = '/en-US/docs/Root/Zone'
+    path = parent_path + '/Child'
+    zone_root_path = '/en-US/Zone'
+    zone_path = zone_root_path + '/Child'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_zone_root',
+        'get_document_metadata', 'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {'redirect_to': zone_path}
+    storage.get_zone_root.return_value = {
+        'doc_path': parent_path, 'zone_path': zone_root_path}
+    resources = source.gather(None, storage)
+    assert resources == [
+        ('document', parent_path, {}),  # Parerent of current page
+        ('document', parent_path, {}),  # zone_path from zone root
+        ('document_meta', path, {'force': True}),
+        ('document_history', path, {'revisions': 1}),
+    ]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_redirect_to_zone_subpage_complete():
+    """A zoned subpage has more data passed to storage.save_document()"""
+    parent_path = '/en-US/docs/Root/Zone'
+    path = parent_path + '/Child'
+    zone_root_path = '/en-US/Zone'
+    zone_path = zone_root_path + '/Child'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_zone_root',
+        'get_document_metadata', 'get_document_history', 'save_document'])
+    storage.get_document.return_value = 'Root doc'
+    storage.get_document_rendered.return_value = {'redirect_to': zone_path}
+    storage.get_zone_root.return_value = {
+        'doc_path': parent_path, 'zone_path': '/en-US/Zone'}
+    metadata = doc_metadata.copy()
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2018', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    expected = doc_data.copy()
+    expected['slug'] = 'Root/Zone/Child'
+    expected['parent_topic'] = 'Root doc'
+    expected['zone_redirect_path'] = zone_root_path
+    assert storage.save_document.call_count == 1
+    assert storage.save_document.call_args[0][0] == expected  # Better diff
+    storage.save_document.assert_called_once_with(expected)
+
+
+def test_gather_localized_doc_without_metadata():
+    """A localized document will wait for metadata."""
+    path = '/fr/docs/Racine'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2020', {})]
+    resources = source.gather(None, storage)
+    assert resources == [('document_meta', path, {'force': True})]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_localized_doc_with_metadata():
+    """A localized document will request the English document."""
+    path = '/fr/docs/Racine'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}
+    metadata = doc_metadata.copy()
+    metadata['locale'] = 'fr'
+    metadata['slug'] = 'Racine'
+    metadata['url'] = path
+    metadata['translations'] = [
+        {'locale': 'es', 'url': '/es/docs/Raíz'},
+        {'locale': 'en-US', 'url': '/en-US/docs/Root'},
+    ]
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2020', {})]
+    resources = source.gather(None, storage)
+    assert resources == [('document', '/en-US/docs/Root', {})]
+    assert source.state == source.STATE_PREREQ
+
+
+def test_gather_localized_doc_invalid_english():
+    """An invalid English document path is an error."""
+    path = '/fr/docs/Racine'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history'])
+    storage.get_document_rendered.return_value = {}
+    metadata = doc_metadata.copy()
+    metadata['locale'] = 'fr'
+    metadata['slug'] = 'Racine'
+    metadata['url'] = path
+    metadata['translations'] = [
+        {'locale': 'en-US', 'url': '/en-US/ZoneRoot'},
+    ]
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2020', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_localized_doc_sets_parent():
+    """A localized document will set the English document as parent."""
+    path = '/fr/docs/Racine'
+    source = DocumentSource(path, force=True)
+    storage = mock_storage(spec=[
+        'get_document', 'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'save_document'])
+    storage.get_document_rendered.return_value = {}
+    metadata = doc_metadata.copy()
+    metadata['locale'] = 'fr'
+    metadata['slug'] = 'Racine'
+    metadata['url'] = path
+    metadata['translations'] = [
+        {'locale': 'en-US', 'url': '/en-US/docs/Root'},
+    ]
+    storage.get_document.return_value = 'English document'
+    storage.get_document_metadata.return_value = metadata
+    storage.get_document_history.return_value = [
+        ('revisions', path + '$revision/2020', {})]
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    expected = doc_data.copy()
+    expected['locale'] = 'fr'
+    expected['slug'] = 'Racine'
+    expected['parent'] = 'English document'
+    assert storage.save_document.call_count == 1
+    assert storage.save_document.call_args[0][0] == expected  # Better diff
+    storage.save_document.assert_called_once_with(expected)
+
+
+def test_gather_document_children():
+    """A depth > 0 will require the $children resource."""
+    doc_path = '/en-US/docs/RootDoc'
+    source = DocumentSource(doc_path, depth=1, force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'get_document_children', 'save_document'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    storage.get_document_metadata.return_value = doc_metadata
+    storage.get_document_history.return_value = [
+        ('revisions', doc_path + '$revision/2016', {})]
+    resources = source.gather(None, storage)
+    assert resources == [('document_children', doc_path,
+                          {'depth': 1, 'force': True})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_document_children_loaded():
+    """If the $children resource is loaded, use it."""
+    doc_path = '/en-US/docs/RootDoc'
+    source = DocumentSource(doc_path, depth='all', force=True)
+    storage = mock_storage(spec=[
+        'get_document_rendered', 'get_document_metadata',
+        'get_document_history', 'get_document_children', 'save_document'])
+    storage.get_document_rendered.return_value = {}  # Standard doc
+    storage.get_document_metadata.return_value = doc_metadata
+    storage.get_document_history.return_value = [
+        ('revisions', doc_path + '$revision/2016', {})]
+    storage.get_document_children.return_value = []
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES

--- a/kuma/scrape/tests/test_source_document_base.py
+++ b/kuma/scrape/tests/test_source_document_base.py
@@ -1,0 +1,43 @@
+"""Tests for the DocumentBaseSource class."""
+import pytest
+
+from kuma.scrape.sources import DocumentBaseSource
+
+
+def test_top_level_doc():
+    """A DocumentBaseSource with a top-level slug has no parent."""
+    source = DocumentBaseSource('/locale/docs/slug')
+    assert source.path == '/locale/docs/slug'
+    assert source.locale == 'locale'
+    assert source.slug == 'slug'
+    assert source.normalized_path == '/locale/docs/slug'
+    assert source.parent_slug is None
+    assert source.parent_path is None
+
+
+def test_child_doc():
+    """A DocumentBaseSource with a child-level slug has a parent."""
+    source = DocumentBaseSource('/locale/docs/parent/child')
+    assert source.path == '/locale/docs/parent/child'
+    assert source.locale == 'locale'
+    assert source.slug == 'parent/child'
+    assert source.normalized_path == '/locale/docs/parent/child'
+    assert source.parent_slug == 'parent'
+    assert source.parent_path == '/locale/docs/parent'
+
+
+def test_zone_doc():
+    """A DocumentBaseSource with a zone slug starts un-normalized."""
+    source = DocumentBaseSource('/locale/zone')
+    assert source.path == '/locale/zone'
+    assert source.locale is None
+    assert source.slug is None
+    assert source.normalized_path is None
+    assert source.parent_slug is None
+    assert source.parent_path is None
+
+
+def test_url_escaped_raises():
+    """Initializing with a URL-encoded path raises an exception."""
+    with pytest.raises(ValueError):
+        DocumentBaseSource('/en-US/docs/traducci%C3%B3n')

--- a/kuma/scrape/tests/test_source_document_children.py
+++ b/kuma/scrape/tests/test_source_document_children.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentChildrenSource class ($children API)."""
+from __future__ import unicode_literals
+
+from kuma.scrape.sources import DocumentChildrenSource
+from . import mock_requester, mock_storage
+
+# Partial data from
+# https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5$children
+child_data = {
+    'locale': 'en-US',
+    'slug': 'Web/Guide/HTML/HTML5',
+    'subpages': [
+        {
+            # Full child data
+            'locale': 'en-US',
+            'slug': 'Web/Guide/HTML/HTML5/Validation',
+            'subpages': [],
+            'title': 'Constraint validation',
+            'url': '/en-US/docs/Web/Guide/HTML/HTML5/Validation'
+        }, {
+            # Minimum data actually used
+            'url': u'/en-US/docs/Web/Guide/HTML/HTML5/Parser',
+        }
+    ],
+    'title': 'HTML5',
+    'url': '/en-US/docs/Web/Guide/HTML/HTML5'
+}
+
+
+def test_extract_no_subpages():
+    """If a document has no subpages, none are extracted."""
+    data = child_data.copy()
+    data['subpages'] = []
+    children = DocumentChildrenSource(data['url']).extract_data(data)
+    assert children == []
+
+
+def test_gather_with_subpages():
+    """Document Subpages are returned as new resources to fetch."""
+    source = DocumentChildrenSource(child_data['url'])
+    requester = mock_requester(response_spec=['json'], json=child_data)
+    storage = mock_storage(['get_document_children', 'save_document_children'])
+    resources = source.gather(requester, storage)
+    assert resources == [
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Validation', {}),
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Parser', {}),
+    ]
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    storage.get_document_children.assert_called_once_with(
+        'en-US', 'Web/Guide/HTML/HTML5')
+    storage.save_document_children.assert_called_once_with(
+        'en-US', 'Web/Guide/HTML/HTML5', child_data)
+
+
+def test_gather_existing():
+    source = DocumentChildrenSource(child_data['url'])
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(['get_document_children', 'save_document_children'])
+    storage.get_document_children.return_value = child_data
+    resources = source.gather(requester, storage)
+    assert resources == [
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Validation', {}),
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Parser', {}),
+    ]
+    storage.get_document_children.assert_called_once_with(
+        'en-US', 'Web/Guide/HTML/HTML5')
+    assert not storage.save_document_children.called
+
+
+def test_depth_all():
+    """depth=all is propagated to child pages."""
+    opts = {'depth': 'all'}
+    source = DocumentChildrenSource(child_data['url'], **opts)
+    children = source.extract_data(child_data)
+    assert children == [
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Validation', opts),
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Parser', opts),
+    ]
+
+
+def test_depth_decreases():
+    """depth=n is propagated as depth=n-1 to child pages."""
+    source_opts = {'depth': 3, 'translations': True}
+    source = DocumentChildrenSource(child_data['url'], **source_opts)
+    children = source.extract_data(child_data)
+    opts = {'depth': 2, 'translations': True}
+    assert children == [
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Validation', opts),
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Parser', opts),
+    ]
+
+
+def test_final_depth():
+    """depth=1 is not propagated to child pages."""
+    source_opts = {'depth': 1, 'revisions': 3}
+    source = DocumentChildrenSource(child_data['url'], **source_opts)
+    children = source.extract_data(child_data)
+    opts = {'revisions': 3}
+    assert children == [
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Validation', opts),
+        ('document', '/en-US/docs/Web/Guide/HTML/HTML5/Parser', opts),
+    ]

--- a/kuma/scrape/tests/test_source_document_history.py
+++ b/kuma/scrape/tests/test_source_document_history.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentHistorySource class ($history API)."""
+from __future__ import unicode_literals
+
+from kuma.scrape.sources import DocumentHistorySource
+from . import mock_requester, mock_storage
+
+
+def test_gather_revisions_default(root_doc, client):
+    """The default is requests if revision count is unspecified."""
+    path = root_doc.get_absolute_url()
+    source = DocumentHistorySource(path)
+    html = client.get(path + '$history').content
+    requester = mock_requester(content=html, status_code=200)
+    storage = mock_storage(spec=[
+        'get_document_history', 'save_document_history'])
+    resources = source.gather(requester, storage)
+    history_path = path + '$history'
+    requester.request.assert_called_once_with(history_path,
+                                              raise_for_status=False)
+    rev1, rev2 = root_doc.revisions.all()
+    revision_pattern = path + '$revision/%d'
+    expected_resources = [
+        ('revision', revision_pattern % rev.id, {}) for rev in [rev2]]
+    assert resources == expected_resources
+    assert source.state == source.STATE_DONE
+    expected_stored = [
+        ('revision', revision_pattern % rev.id, {}) for rev in [rev2, rev1]]
+    storage.save_document_history.assert_called_once_with(
+        'en-US', 'Root', expected_stored)
+
+
+def test_gather_revisions_multiple(root_doc, client):
+    """If a revision count is specified, that many are requested."""
+    path = root_doc.get_absolute_url()
+    source = DocumentHistorySource(path, revisions=2)
+    html = client.get(path + '$history').content
+    requester = mock_requester(content=html, status_code=200)
+    storage = mock_storage(spec=[
+        'get_document_history', 'save_document_history'])
+    resources = source.gather(requester, storage)
+    history_path = path + '$history?limit=2'
+    requester.request.assert_called_once_with(history_path,
+                                              raise_for_status=False)
+    rev1, rev2 = root_doc.revisions.all()
+    revision_pattern = path + '$revision/%d'
+    expected_resources = [
+        ('revision', revision_pattern % rev.id, {}) for rev in [rev1, rev2]]
+    assert resources == expected_resources
+    assert source.state == source.STATE_DONE
+    storage.save_document_history.assert_called_once_with(
+        'en-US', 'Root', expected_resources[::-1])
+
+
+def test_gather_error():
+    """If the $history endpoint errors, scraping stops."""
+    source = DocumentHistorySource('/en-US/docs/Error')
+    requester = mock_requester(content="missing", status_code=404)
+    storage = mock_storage(spec=[
+        'get_document_history', 'save_document_history'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert not storage.save_document_history.called
+
+
+def test_gather_rev_existing():
+    """If previously called, populate history from storage."""
+    source = DocumentHistorySource('/en-US/docs/Root')
+    storage = mock_storage(spec=['get_document_history'])
+    storage.get_document_history.return_value = [
+        ('revision', '/en-US/docs/Root$revision/%d' % num, {})
+        for num in range(10, 1, -1)]
+    resources = source.gather(None, storage)
+    assert resources == [('revision', '/en-US/docs/Root$revision/10', {})]
+    assert source.state == source.STATE_DONE
+
+
+def test_gather_translated(translated_doc, client):
+    """A translated document may include the English source doc."""
+    path = translated_doc.get_absolute_url()
+    source = DocumentHistorySource(path)
+    html = client.get(path + '$history').content
+    requester = mock_requester(content=html, status_code=200)
+    storage = mock_storage(spec=[
+        'get_document_history', 'save_document_history'])
+    resources = source.gather(requester, storage)
+    history_path = path + '$history'
+    requester.request.assert_called_once_with(history_path,
+                                              raise_for_status=False)
+    rev = translated_doc.current_revision
+    rev_path = rev.get_absolute_url()
+    based_on_path = rev.based_on.get_absolute_url()
+    expected_resources = [('revision', rev_path, {'based_on': based_on_path})]
+    assert resources == expected_resources
+    assert source.state == source.STATE_DONE
+    storage.save_document_history.assert_called_once_with(
+        'fr', 'Racine', expected_resources)

--- a/kuma/scrape/tests/test_source_document_meta.py
+++ b/kuma/scrape/tests/test_source_document_meta.py
@@ -1,0 +1,117 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentMetaSource class ($json API)."""
+from __future__ import unicode_literals
+
+from kuma.scrape.sources import DocumentMetaSource
+from . import mock_requester, mock_storage
+
+
+# Partial meta from
+# /en-US/docs/Learn/Getting_started_with_the_web$json
+meta_with_trans = {
+    'id': 125461,
+    'locale': 'en-US',
+    'slug': 'Learn/Getting_started_with_the_web',
+    'translations': [
+        {
+            'locale': 'fr',
+            'url': '/fr/docs/Apprendre/Commencer_avec_le_web',
+        }, {
+            'locale': 'tr',
+            'url': '/tr/docs/%C3%96%C4%9Fren/Getting_started_with_the_web',
+        }],
+    'url': '/en-US/docs/Learn/Getting_started_with_the_web'
+}
+
+meta_without_trans = {
+    'id': 101,
+    'translations': [],
+    'url': '/en-US/docs/Parent/Child',
+}
+
+
+def test_gather_no_resources():
+    """All metadata prereqs can be satisfied in the first call."""
+    opts = {
+        'translations': True,
+        'depth': 5,
+    }
+    source = DocumentMetaSource(meta_without_trans['url'], **opts)
+    requester = mock_requester(
+        response_spec=['status_code', 'json'], status_code=200,
+        json=meta_without_trans)
+    storage = mock_storage(
+        spec=['get_document_metadata', 'save_document_metadata'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    storage.save_document_metadata.assert_called_once_with(
+        'en-US', 'Parent/Child', meta_without_trans)
+
+
+def test_gather_uses_stored():
+    """All metadata prereqs can be satisfied in the first call."""
+    source = DocumentMetaSource('/en-US/docs/Done')
+    requester = mock_requester()
+    storage = mock_storage(spec=['get_document_metadata'])
+    storage.get_document_metadata.return_value = meta_without_trans
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+
+
+def test_gather_error():
+    """If the metadata 404s, the source is in error."""
+    source = DocumentMetaSource('/en-US/docs/Error')
+    requester = mock_requester(response_spec=['status_code'], status_code=404)
+    storage = mock_storage(
+        spec=['get_document_metadata', 'save_document_metadata'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_YES
+    storage.save_document_metadata.assert_called_once_with(
+        'en-US', 'Error', {'error': 'status code 404'})
+
+
+def test_extract_translations():
+    """If translations are requested, they are extracted from metadata."""
+    opts = {'translations': True}
+    source = DocumentMetaSource(meta_with_trans['url'], **opts)
+    result = source.extract_data(meta_with_trans)
+    assert result == [
+        ('document', '/fr/docs/Apprendre/Commencer_avec_le_web', {}),
+        ('document',
+            '/tr/docs/Öğren/Getting_started_with_the_web', {}),
+    ]
+
+
+def test_extract_translation_with_depth():
+    """Child resources also get the translations request."""
+    opts = {'translations': True, 'depth': 1}
+    source = DocumentMetaSource(meta_with_trans['url'], **opts)
+    result = source.extract_data(meta_with_trans)
+    result_opts = {'depth': 1}
+    assert result == [
+        ('document', '/fr/docs/Apprendre/Commencer_avec_le_web',
+            result_opts),
+        ('document',
+            '/tr/docs/Öğren/Getting_started_with_the_web',
+            result_opts),
+    ]
+
+
+def test_extract_translation_with_revisions():
+    """Child resources also get the revisions request."""
+    opts = {'translations': True, 'revisions': 5}
+    source = DocumentMetaSource(meta_with_trans['url'], **opts)
+    result = source.extract_data(meta_with_trans)
+    result_opts = {'revisions': 5}
+    assert result == [
+        ('document', '/fr/docs/Apprendre/Commencer_avec_le_web',
+            result_opts),
+        ('document', '/tr/docs/Öğren/Getting_started_with_the_web',
+            result_opts),
+    ]

--- a/kuma/scrape/tests/test_source_document_rendered.py
+++ b/kuma/scrape/tests/test_source_document_rendered.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+"""Tests for the DocumentRenderedSource class (GET document)."""
+from __future__ import unicode_literals
+from datetime import datetime
+
+import pytest
+
+from kuma.scrape.sources import DocumentRenderedSource
+from kuma.wiki.models import Document, DocumentZone, Revision
+from . import mock_requester, mock_storage
+
+
+@pytest.fixture
+def zone_root_doc(root_doc, settings):
+    """A Document record with a DocumentZone with style and a redirect."""
+    settings.PIPELINE_CSS['zone-special'] = {
+        'output_filename': 'build/styles/zone-special.css'}
+    doc = Document.objects.create(
+        locale='en-US',
+        slug=root_doc.slug + '/Zone',
+        parent_topic=root_doc)
+    DocumentZone.objects.create(
+        document=doc,
+        url_root='Zone',
+        css_slug='special')
+    doc.current_revision = Revision.objects.create(
+        document=doc,
+        creator=root_doc.current_revision.creator,
+        content='<p>This is the Zone.</p>',
+        created=datetime(2016, 12, 14))
+    doc.rendered_html = doc.current_revision.content
+    doc.save()
+    return doc
+
+
+@pytest.fixture
+def zone_child_doc(zone_root_doc):
+    """A Document record that is below the zone root."""
+    doc = Document.objects.create(
+        locale='en-US',
+        slug=zone_root_doc.slug + '/Child',
+        parent_topic=zone_root_doc)
+    creator = zone_root_doc.current_revision.creator
+    doc.current_revision = Revision.objects.create(
+        content='<p>A zone subpage.</p>',
+        creator=creator,
+        document=doc)
+    doc.save()
+    return doc
+
+
+def test_root_doc(root_doc, client):
+    """Test a page without redirects."""
+    url = root_doc.get_absolute_url()
+    html = client.get(url).content
+    source = DocumentRenderedSource(url)
+    requester = mock_requester(content=html)
+    storage = mock_storage(spec=['save_document_rendered'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    storage.save_document_rendered.assert_called_once_with(
+        'en-US', 'Root', {})
+
+
+def test_non_zone_redirect(root_doc, client):
+    """
+    Test a page with non-zone redirects.
+
+    For example, a page might redirect from http:// to https:// without
+    changing the path.
+    """
+    url = root_doc.get_absolute_url()
+    html = client.get(url).content
+    source = DocumentRenderedSource(url)
+    requester = mock_requester(
+        response_spec=['content', 'history', 'url'],
+        history=[(301, url)],
+        final_path=url,
+        content=html)
+    storage = mock_storage(spec=['save_document_rendered'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    storage.save_document_rendered.assert_called_once_with(
+        'en-US', 'Root', {})
+
+
+def test_zone_root_doc(zone_root_doc, client):
+    """The zone_css_slug is extracted from zone roots."""
+    url = zone_root_doc.get_absolute_url()
+    html = client.get(url, follow=True).content
+    source = DocumentRenderedSource(url)
+    requester = mock_requester(
+        response_spec=['content', 'history', 'url'],
+        history=[(302, url)],
+        final_path=zone_root_doc.zone.url_root,
+        content=html)
+    storage = mock_storage(spec=['save_document_rendered'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    context = {
+        'redirect_to': 'Zone',
+        'is_zone_root': True,
+        'zone_css_slug': 'special'}
+    storage.save_document_rendered.assert_called_once_with(
+        'en-US', 'Root/Zone', context)
+
+
+def test_zone_child_doc(zone_root_doc, zone_child_doc, client):
+    """The zone_css_slug is not extracted from zone children."""
+    url = zone_child_doc.get_absolute_url()
+    html = client.get(url, follow=True).content
+    source = DocumentRenderedSource(url)
+    requester = mock_requester(
+        response_spec=['content', 'history', 'url'],
+        history=[(302, url)],
+        final_path=zone_root_doc.zone.url_root,
+        content=html)
+    storage = mock_storage(spec=['save_document_rendered'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    context = {'redirect_to': 'Zone'}
+    storage.save_document_rendered.assert_called_once_with(
+        'en-US', 'Root/Zone/Child', context)

--- a/kuma/scrape/tests/test_source_revision.py
+++ b/kuma/scrape/tests/test_source_revision.py
@@ -1,0 +1,360 @@
+# -*- coding: utf-8 -*-
+"""Tests for the RevisionSource class ($revision/ID API)."""
+from __future__ import unicode_literals
+from datetime import datetime
+
+import mock
+import pytest
+
+from kuma.scrape.sources import RevisionSource
+from kuma.wiki.models import Document, Revision
+from . import mock_requester, mock_storage
+
+
+@pytest.fixture
+def tagged_doc(db, django_user_model):
+    """A root document with one tagged revision."""
+    document = Document.objects.create(
+        locale='en-US', slug='Test', title='Test Document')
+    creator = django_user_model.objects.create(username='creator')
+    revision = Revision.objects.create(
+        content='<p>The HTML element <code>&lt;input&gt;</code>...',
+        comment='Frist Post!',
+        creator=creator,
+        created=datetime(2016, 12, 15, 17, 23),
+        document=document,
+        title='Test Document',
+        tags='"One" "Two" "Three"'
+    )
+    document.current_revision = revision
+    document.save()
+    return document
+
+
+def test_invalid_path():
+    """A bad revision path is detected at initialization."""
+    source = RevisionSource('/bad/path')
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather_no_prereqs(tagged_doc, client):
+    """On the first call, multiple items are requested from storage."""
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%d' % tagged_doc.current_revision_id
+    html = client.get(rev_path).content
+    source = RevisionSource(rev_path)
+    requester = mock_requester(content=html)
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'save_revision_html', 'get_user'])
+    resources = source.gather(requester, storage)
+    assert resources == [
+        ('document', doc_path, {}),
+        ('document_meta', doc_path, {}),
+        ('user', 'creator', {})
+    ]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    storage.save_revision_html.assert_called_once_with(rev_path, html)
+
+
+def test_gather_existing_rev_and_doc():
+    """If prereqs are present then source is done."""
+    doc_path = '/en-US/docs/Test'
+    rev_path = doc_path + '$revision/100'
+    source = RevisionSource(rev_path)
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=['get_document', 'get_revision'])
+    storage.get_document.return_value = "existing"
+    revision = mock.Mock(spec_set=['document'])
+    revision.document = "existing"
+    storage.get_revision.return_value = revision
+
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+    storage.get_document.assert_called_once_with('en-US', 'Test')
+    storage.get_revision.assert_called_once_with(100)
+
+
+def test_gather_existing_doc(tagged_doc, client):
+    """If only the doc is present, then full gather is performed."""
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%d' % tagged_doc.current_revision_id
+    html = client.get(rev_path).content
+    source = RevisionSource(rev_path)
+    requester = mock_requester(content=html)
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'save_revision_html', 'get_user'])
+    storage.get_document.return_value = tagged_doc
+    resources = source.gather(requester, storage)
+    assert resources == [
+        ('document_meta', doc_path, {}),
+        ('user', 'creator', {})
+    ]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+    storage.save_revision_html.assert_called_once_with(rev_path, html)
+
+
+def test_gather_doc_mismatch_is_error():
+    """If stored doc does not agree with stored revision doc, then error."""
+    doc_path = '/en-US/docs/Test'
+    rev_path = doc_path + '$revision/100'
+    source = RevisionSource(rev_path)
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=['get_document', 'get_revision'])
+    doc1 = mock.Mock(spec_set=['get_absolute_url'])
+    doc1.get_absolute_url.return_value = '/en-US/docs/Foo'
+    doc2 = mock.Mock(spec_set=['get_absolute_url'])
+    doc2.get_absolute_url.return_value = '/en-US/docs/Test'
+    storage.get_document.return_value = doc1
+    revision = mock.Mock(spec_set=['document'])
+    revision.document = doc2
+    storage.get_revision.return_value = revision
+
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_NO
+    storage.get_document.assert_called_once_with('en-US', 'Test')
+    storage.get_revision.assert_called_once_with(100)
+
+
+def test_gather_with_prereqs(tagged_doc, client):
+    """On the first call, multiple items are requested from storage."""
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%d' % tagged_doc.current_revision_id
+    html = client.get(rev_path).content
+    source = RevisionSource(rev_path)
+    source.state = source.STATE_PREREQ
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = tagged_doc
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    expected_data = {
+        'id': tagged_doc.current_revision_id,
+        'comment': 'Frist Post!',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'created': datetime(2016, 12, 15, 17, 23),
+        'creator': {u'username': u'creator'},
+        'document': tagged_doc,
+        'is_current': True,
+        'localization_tags': [],
+        'review_tags': [],
+        'slug': 'Test',
+        'tags': ['One', 'Three', 'Two'],
+        'title': 'Test Document',
+    }
+    storage.save_revision.assert_called_once_with(expected_data)
+
+
+def test_gather_second_pass(tagged_doc, client):
+    """A revision will request a document on the second pass."""
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%d' % tagged_doc.current_revision_id
+    html = client.get(rev_path).content
+    source = RevisionSource(rev_path)
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = None
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+
+    # First pass, document is not available from storage (None twice)
+    resources = source.gather(requester, storage)
+    assert resources == [('document', doc_path, {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+    # Second pass, document is available from storage
+    storage.get_document.return_value = tagged_doc
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    expected_data = {
+        'id': tagged_doc.current_revision_id,
+        'comment': 'Frist Post!',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'created': datetime(2016, 12, 15, 17, 23),
+        'creator': {u'username': u'creator'},
+        'document': tagged_doc,
+        'is_current': True,
+        'localization_tags': [],
+        'review_tags': [],
+        'slug': 'Test',
+        'tags': ['One', 'Three', 'Two'],
+        'title': 'Test Document',
+    }
+    storage.save_revision.assert_called_once_with(expected_data)
+
+
+def test_gather_document_slug_wins(tagged_doc, client):
+    """
+    If the document slug is different from the revision, doc wins.
+
+    This appears to be common around page moves.
+    """
+    orig_doc_path = tagged_doc.get_absolute_url()
+    orig_rev_path = orig_doc_path + ('$revision/%d' %
+                                     tagged_doc.current_revision_id)
+    html = client.get(orig_rev_path).content
+    tagged_doc.slug = 'Other'
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%d' % tagged_doc.current_revision_id
+    source = RevisionSource(rev_path)
+    source.state = source.STATE_PREREQ
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = tagged_doc
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    expected_data = {
+        'id': tagged_doc.current_revision_id,
+        'comment': 'Frist Post!',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'created': datetime(2016, 12, 15, 17, 23),
+        'creator': {u'username': u'creator'},
+        'document': tagged_doc,
+        'is_current': True,
+        'localization_tags': [],
+        'review_tags': [],
+        'slug': 'Other',
+        'tags': ['One', 'Three', 'Two'],
+        'title': 'Test Document',
+    }
+    storage.save_revision.assert_called_once_with(expected_data)
+
+
+def test_gather_older_revision(root_doc, client):
+    """Older revisions can be imported without some tags."""
+    doc_path = root_doc.get_absolute_url()
+    old_rev = root_doc.revisions.order_by('id')[0]
+    assert old_rev != root_doc.current_revision
+    rev_path = doc_path + '$revision/%d' % old_rev.id
+    html = client.get(rev_path).content
+    source = RevisionSource(rev_path)
+    source.state = source.STATE_PREREQ
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = root_doc
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    # Missing review and localization tags if it is not the current revision
+    expected_data = {
+        'id': old_rev.id,
+        'comment': '',
+        'content': '<p>Getting started...</p>',
+        'created': datetime(2016, 1, 1),
+        'creator': {u'username': u'creator'},
+        'document': root_doc,
+        'is_current': False,
+        'slug': 'Root',
+        'tags': [],
+        'title': 'Root Document',
+    }
+    storage.save_revision.assert_called_once_with(expected_data)
+
+
+def test_gather_missing_revision_is_error(tagged_doc):
+    """If the revision HTML can't be fetched, the source is errored."""
+    doc_path = tagged_doc.get_absolute_url()
+    rev_path = doc_path + '$revision/%s' % tagged_doc.current_revision_id
+    source = RevisionSource(rev_path)
+    requester = mock_requester(status_code=404)
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_based_on_is_needed(translated_doc, client):
+    """If a based_on revision is specified, it is required."""
+    rev = translated_doc.current_revision
+    rev_path = rev.get_absolute_url()
+    based_on_path = rev.based_on.get_absolute_url()
+    source = RevisionSource(rev_path, based_on=based_on_path)
+    html = client.get(rev_path).content
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = translated_doc
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+    resources = source.gather(requester, storage)
+    assert resources == [('revision', based_on_path, {})]
+    assert source.state == source.STATE_PREREQ
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
+def test_gather_based_on_is_available(translated_doc, client):
+    """If a based_on revision is specified and available, it is used."""
+    rev = translated_doc.current_revision
+    rev_path = rev.get_absolute_url()
+    based_on_path = rev.based_on.get_absolute_url()
+    source = RevisionSource(rev_path, based_on=based_on_path)
+    html = client.get(rev_path).content
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=[
+        'get_document', 'get_revision', 'get_document_metadata',
+        'get_revision_html', 'get_user', 'save_revision'])
+    storage.get_document.return_value = translated_doc
+    storage.get_document_metadata.return_value = {'is_meta': True}
+    storage.get_revision_html.return_value = html
+    storage.get_user.return_value = {'username': 'creator'}
+    # First call is for this revision, return None to scrape
+    # Second call is for the based_on revision, return it
+    storage.get_revision.side_effect = [None, rev.based_on]
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    expected_data = {
+        'id': rev.id,
+        'based_on_id': rev.based_on.id,
+        'comment': '',
+        'content': '<p>Commencer...</p>',
+        'created': datetime(2017, 6, 1, 15, 28),
+        'creator': {u'username': u'creator'},
+        'document': translated_doc,
+        'is_current': True,
+        'localization_tags': [],
+        'review_tags': [],
+        'slug': 'Racine',
+        'tags': [],
+        'title': 'Document Racine',
+    }
+    storage.save_revision.assert_called_once_with(expected_data)

--- a/kuma/scrape/tests/test_source_zone_root.py
+++ b/kuma/scrape/tests/test_source_zone_root.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Tests for the ZoneRootSource class (zone redirect URL)."""
+from __future__ import unicode_literals
+
+import pytest
+
+from kuma.scrape.sources import ZoneRootSource
+from . import mock_requester, mock_storage
+
+
+def test_escaped_url():
+    """Detect URL-encoded paths and fail at init."""
+    with pytest.raises(ValueError) as error:
+        ZoneRootSource('/tr/docs/%C3%96%C4%9Fren/CSS')
+    expected_message = 'URL-encoded path "/tr/docs/%C3%96%C4%9Fren/CSS"'
+    assert str(error.value) == expected_message
+
+
+def test_invalid_url():
+    """Detect invalid paths and fail at init."""
+    source = ZoneRootSource('/en-US')
+    assert source.state == source.STATE_ERROR
+
+
+def test_gather():
+    """Zone root data can be gathered from metadata on the first pass."""
+    metadata = {
+        'url': '/en-US/docs/Root/Zone',
+        'locale': 'en-US'
+    }
+    source = ZoneRootSource('/en-US/Zone')
+    requester = mock_requester(response_spec=['json'], json=metadata)
+    storage = mock_storage(spec=['get_zone_root', 'save_zone_root'])
+    resources = source.gather(requester, storage)
+    assert resources == [('document', '/en-US/docs/Root/Zone', {})]
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_YES
+    data = {
+        'doc_path': '/en-US/docs/Root/Zone',
+        'zone_path': '/en-US/Zone',
+    }
+    storage.save_zone_root.assert_called_once_with('/en-US/Zone', data)
+
+
+def test_gather_when_stored():
+    """Previously stored zone root data prevents scraping."""
+    data = {
+        'doc_path': '/en-US/docs/Root/Zone',
+        'zone_path': '/en-US/Zone',
+    }
+    source = ZoneRootSource('/en-US/Zone')
+    requester = mock_requester(requester_spec=[])
+    storage = mock_storage(spec=['get_zone_root'])
+    storage.get_zone_root.return_value = data
+    resources = source.gather(requester, storage)
+    assert resources == [('document', '/en-US/docs/Root/Zone', {})]
+    assert source.state == source.STATE_DONE
+    assert source.freshness == source.FRESH_NO
+
+
+def test_gather_notzone_is_error():
+    """Passing a non-zone URL is detected when processing metadata."""
+    metadata = {
+        'url': '/en-US/docs/Root/Zone',
+        'locale': 'en-US'
+    }
+    source = ZoneRootSource('/en-US/docs/Root/Zone')
+    requester = mock_requester(response_spec=['json'], json=metadata)
+    storage = mock_storage(spec=['get_zone_root', 'save_zone_root'])
+    resources = source.gather(requester, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_YES
+    expected = {
+        'errors': ['url "/en-US/docs/Root/Zone" should be the non-zone path'],
+        'doc_locale': 'en-US',
+        'metadata_locale': 'en-US',
+        'metadata_url': '/en-US/docs/Root/Zone',
+        'zone_path': '/en-US/docs/Root/Zone',
+    }
+    storage.save_zone_root.assert_called_once_with(
+        '/en-US/docs/Root/Zone', expected)
+
+
+def test_extract_locale_mismatch_is_error():
+    """
+    If the metadata locale doesn't match the URL, it is an error.
+
+    This appears to be common on zoned URLs with only one translation,
+    and requires reseting the stored JSON data.
+    """
+    source = ZoneRootSource('/en-US/Zone')
+    metadata = {
+        'url': '/es/docs/Root/Zone',
+        'locale': 'es'
+    }
+    data = source.extract_data(metadata)
+    expected = {
+        'errors': ['locale "es" should be the same as the path locale'],
+        'doc_locale': 'en-US',
+        'metadata_locale': 'es',
+        'metadata_url': '/es/docs/Root/Zone',
+        'zone_path': '/en-US/Zone',
+    }
+    assert data == expected


### PR DESCRIPTION
Fix some stuff that should have been in the last PR (less user test fixtures, improve the scraper), and then add the ``./manage.py scrape_document`` command.  Some manual tests:

    ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Archive/SAX # Will also add Archive zone
    ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array --depth 1  # Will scrape child docs as well
    ./manage.py scrape_document https://developer.mozilla.org/fr/docs/Web/CSS/display  # Will scrape the English document as well
