### PR TITLE
bug 1352492: Upgrade hashin

### DIFF
--- a/requirements/README.rst
+++ b/requirements/README.rst
@@ -23,11 +23,11 @@ To help gather packages and add hashes, we use hashin_, which computes the
 hashes and updates requirement files. For example, to install a particular
 Django version::
 
-    hashin Django==1.8.13 requirements/default.txt
+    hashin Django==1.8.13 -r requirements/default.txt
 
 Or, to update to the latest version of a package::
 
-    hashin django-allauth requirements/default.txt
+    hashin django-allauth -r requirements/default.txt
 
 It is still up to you to install the requirements, and to specify any
 requirements of your requirements, in ``constraints.txt``.

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,9 +17,9 @@ flake8==3.1.1 \
     --hash=sha256:941fa78f61f2524cb7aee4aa4fe9876f4b0dcf5aba9fabd3e780d24918f498b7
 
 # Calculate hashes for pip 8.x+
-hashin==0.6.0 \
---hash=sha256:8d54551aae64dc8c135dfd5c89efd81a5014f7ce79da642b3fc3eef44ccf7a26 \
---hash=sha256:7563490ec8c9c361e48c7623898b3585143d379714a03bee4c3d52fb13e85086
+hashin==0.9.0 \
+    --hash=sha256:814eb85c3cede62e85b11572bfef3f86ff955e89a172e73ef52fe63ca5c95168 \
+    --hash=sha256:e07bb03a35dc6d973a61196cd6d11442649f8faf6085159e7bf4f9d521eec160
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
* hashin 0.6.0 -> 0.9.0: Requirements is keyword (``-r requirements/common.txt``), and can pass multiple packages to upgrade. Case-insensitive matching of package names.
