### PR TITLE
bug 1328839: improve kumascript npm package updates

### DIFF
--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -140,6 +140,9 @@ def setup_dependencies(ctx):
     with ctx.lcd(os.path.join(settings.SRC_DIR, 'kumascript')):
         ctx.local('rm -rf node_modules')
         ctx.local('npm install --production')
+        # Update any top-level npm packages listed in package.json,
+        # as allowed by each package's given "semver".
+        ctx.local('npm update --production')
 
 
 @task


### PR DESCRIPTION
This PR is a companion to [Kumascript PR #194](https://github.com/mozilla/kumascript/pull/194).

This PR updates SCL3 deployment to use the [``npm update`` command](https://docs.npmjs.com/cli/update) to update any top-level npm packages listed in Kumascript's ``package.json``, while respecting each package's given [``semver``](https://docs.npmjs.com/getting-started/semantic-versioning).

This allows us to update to the latest ``mdn-browser-compat-data`` npm package allowed by its given ``semver`` in Kumascript's ``package.json``, via deployment only. No code changes would be required.