### PR TITLE
Bug 1370965: Fix context menu to work again.

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -483,7 +483,7 @@
             }
 
             $contextMenu.on('click', function(e) {
-                location.href = $(e.target).data('action') + '?src=context';
+                window.location.href = $(e.target).data('action') + '?src=context';
             });
     });
 


### PR DESCRIPTION
Firefox has made it so you need to set the location object with window.location instead of just location recently, so this changes the code to work again.