### PR TITLE
Bug 1370594: Move and style newsletter for redesign

### DIFF
--- a/jinja2/includes/newsletter.html
+++ b/jinja2/includes/newsletter.html
@@ -1,27 +1,29 @@
 <div class="newsletter">
-    <form id="newsletterForm" name="newsletter-form" class="nodisable" action="https://www.mozilla.org/en-US/newsletter/" method="post">
+    <form id="newsletterForm" class="newsletter-form nodisable" name="newsletter-form" action="https://www.mozilla.org/en-US/newsletter/" method="post">
         <h2 class="newsletter-teaser">{{ _('Learn the best of web development') }}</h2>
-        <p class="newsletter-description">{{ _('Sign up for our newsletter:') }}</p>
+        <p class="newsletter-description">{{ _('Get the latest and greatest from MDN delivered straight to your inbox.') }}</p>
         <input type="hidden" id="fmt" name="fmt" value="H">
         <input type="hidden" id="newsletterNewslettersInput" name="newsletters" value="app-dev" />
 
-        <div id="newsletterErrors" class="newsletter-errors"></div>
+        <div class="newsletter-fields">
+            <div id="newsletterErrors" class="newsletter-errors"></div>
 
-        <div id="newsletterEmail" class="form-group">
-            <label for="newsletterEmailInput" class="form-label offscreen">{{ _('E-mail') }}</label>
-            <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="{{ _('you@example.com') }}" size="30">
-        </div>
+            <div id="newsletterEmail" class="form-group">
+                <label for="newsletterEmailInput" class="form-label offscreen">{{ _('E-mail') }}</label>
+                <input type="email" id="newsletterEmailInput" name="email" class="form-input newsletter-input-email" required placeholder="{{ _('you@example.com') }}" size="30">
+            </div>
 
-        <div id="newsletterPrivacy" class="form-group form-group-agree hidden">
-            <input type="checkbox" id="newsletterPrivacyInput" name="privacy" required>
-            <label for="newsletterPrivacyInput">
-            {% trans policy_url="https://www.mozilla.org/privacy/" %}
-                I'm okay with Mozilla handling my info as explained in this <a href="{{ policy_url }}">Privacy Policy</a>.
-            {% endtrans %}
-            </label>
-        </div>
-        <div id="newsletterSubmit">
-            <button id="newsletter-submit" type="submit" class="button positive">{{ _('Sign up now') }}</button>
+            <div id="newsletterPrivacy" class="form-group form-group-agree hidden">
+                <input type="checkbox" id="newsletterPrivacyInput" name="privacy" required>
+                <label for="newsletterPrivacyInput">
+                {% trans policy_url="https://www.mozilla.org/privacy/" %}
+                    I'm okay with Mozilla handling my info as explained in this <a href="{{ policy_url }}">Privacy Policy</a>.
+                {% endtrans %}
+                </label>
+            </div>
+            <div id="newsletterSubmit">
+                <button id="newsletter-submit" type="submit" class="button positive">{{ _('Sign up now') }}</button>
+            </div>
         </div>
         {% if request.LANGUAGE_CODE != 'en-US' %}
         <p class="newsletter-lang">{{ _('The newsletter is offered in English only at the moment.') }}</p>

--- a/kuma/static/styles/components/newsletter.scss
+++ b/kuma/static/styles/components/newsletter.scss
@@ -1,25 +1,15 @@
-.newsletter-box {
-    position: relative;
-    @include notification-theme($default);
-    margin-bottom: $grid-spacing;
-    border: none;
-    padding: $grid-spacing;
-
-    .wiki-block + & {
-        margin-top: ($grid-spacing * 2);
-    }
-}
-
 .newsletter-teaser {
+    @include set-font-size(26px);
     margin-bottom: $grid-spacing;
-
-    .wiki-block-newsletter & {
-        @include bidi-style(padding-right, ($grid-spacing * 3), padding-left, 0); // leave space for close button
-    }
 }
 
 .newsletter-description {
-    margin-bottom: 0;
+    margin-bottom: $grid-spacing;
+    @include set-font-size(20px);
+    font-family: $heading-font-family;
+    #{$selector-heading-font-fallback} {
+        font-family: $heading-font-family-fallback;
+    }
 }
 
 .newsletter-errors .errorlist {
@@ -39,16 +29,94 @@
     max-width: 450px;
 }
 
+.newsletter-fields {
+    margin-bottom: $grid-spacing;
+}
+
 .newsletter-hide {
     position: absolute;
-    top: $grid-spacing;
-    @include bidi-style(right, $grid-spacing, left, auto);
+    top: ($grid-spacing / 2);
+    @include bidi-style(right, ($grid-spacing / 2), left, auto);
     z-index: 11;
 }
 
-.newsletter-thanks {
-    h2 {
-        @include bidi-style(padding-right, ($grid-spacing * 3), padding-left, 0); // leave space for close button
+.newsletter-thanks h2 {
+    margin-bottom: $grid-spacing;
+}
+
+/* modifications for when it appears on articles */
+.newsletter-box {
+    position: relative;
+    margin: $grid-spacing 0;
+    border-top: 2px solid $text-color;
+    padding: $grid-spacing 0;
+
+
+    .newsletter-teaser {
+        @include set-font-size(48px);
+
+        /* small box to give .newsletter-hide button some space */
+        &:before {
+            content: '';
+            display: block;
+            @include bidi-value(float, right, left);
+            height: $grid-spacing;
+            width: $grid-spacing;
+        }
+    }
+
+    .newsletter-description {
+        @include set-font-size(24px);
+    }
+
+    .newsletter-fields {
+        margin-bottom: 0;
+    }
+}
+
+
+@media #{$media-query-tablet-and-up} {
+    .newsletter-box {
+        padding: ($grid-spacing * 2);
+    }
+}
+
+@media #{$media-query-large-desktop-and-up} {
+    @supports (display: grid) {
+        .newsletter-box {
+
+            .newsletter-form {
+                display: grid;
+                grid-column-gap: $grid-spacing;
+                grid-template-columns: 2fr 1fr;
+                grid-template-rows: auto auto;
+
+                &.hidden {
+                    display: none;
+                }
+            }
+
+            .newsletter-description {
+                margin-bottom: 0;
+            }
+        }
+
+        /* other grid stuff does not need .newsletter-box specificity
+           since it has no affect without display: grid */
+        .newsletter-teaser,
+        .newsletter-description {
+            grid-column: 1 / 2;
+        }
+
+        .newsletter-teaser {
+            align-self: end;
+        }
+
+        .newsletter-fields {
+            align-self: end;
+            grid-column: 2 / 3;
+            grid-row: 1 / 3;
+        }
     }
 }
 

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -123,6 +123,7 @@ $media-query-small-mobile : 'all and (max-width : #{$small-mobile-ends})';
 
 $media-query-between-small-desktop-and-max-width : 'all and (min-width: #{$small-desktop-starts}) and (max-width: #{$max-width-default})';
 
+$media-query-large-desktop-and-up : 'all and (min-width: #{$small-desktop-ends})';
 $media-query-small-desktop-and-up : 'all and (min-width: #{$small-desktop-starts})';
 $media-query-tablet-and-up : 'all and (min-width: #{$tablet-starts})';
 $media-query-mobile-and-up : 'all and (min-width: #{$mobile-starts})';

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -123,9 +123,7 @@
       </div>
       <div class="column-4">
         {% if waffle.switch('newsletter') %}
-          <div class="newsletter-box">
             {% include "includes/newsletter.html" %}
-          </div>
           <h3>Unsubscribe</h3>
           <p><a href="https://www.mozilla.org/en-US/newsletter/recovery/">{{ _('Manage your Mozilla Newsletter Subscriptions.') }}</a></p>
         {% endif %}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -346,7 +346,7 @@
                 </div>
               {% endif %}
 
-              {% if waffle.switch('newsletter') and waffle.switch('newsletter_article') %}
+              {% if waffle.switch('newsletter') and waffle.switch('newsletter_article') and not waffle.flag('redesign') %}
                   <div class="newsletter-box">
                     {% include "includes/newsletter.html" %}
                   </div>
@@ -382,6 +382,12 @@
         </div>
       </div>
     </div> <!-- ends "main-content" -->
+
+    {% if waffle.switch('newsletter') and waffle.switch('newsletter_article') and waffle.flag('redesign') %}
+      <div class="newsletter-box">
+      {% include "includes/newsletter.html" %}
+      </div>
+    {% endif %}
 
   <menu type="context" id="edit-history-menu">
     <menuitem data-action="{{ document.get_edit_url() }}" label="{{_('Edit page')}}"></menuitem>


### PR DESCRIPTION
Things to test:
- [x] newsletter takes up full width of page immediately above footer
- [x] at 1200px the newsletter box becomes a 2 column layout
- [x] privacy checkbox (revealed when input gets focus) isn't broken
- [x] error message (revealed if you use the email address failure@example.com) isn't broken
- [x] success message (reveled if you use the email success@example.com) isn't broken 
- [x] other stuff you'd normally test to make sure I'm paying attention ;)
- [x] looks good on homepage still
- [x] look good on user profile edit page still

Notes:
- you will have to delete your local storage variable newsletterHide to see it again after submitting

Spec:
- form field and button adjustments are coming in later PR
- increased spacing is also coming in later PR
![screen shot 2017-06-13 at 15 04 35](https://user-images.githubusercontent.com/854701/27107168-807398e4-504b-11e7-97c4-ccf1dd235c8a.png)
