### PR TITLE
Fix bug 1372752: Zilla shouldn't be in editor yet

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -852,8 +852,8 @@ PIPELINE_CSS = {
     },
     'editor-content': {
         'source_filenames': (
-            'styles/main.scss',
-            'styles/wiki.scss',
+            'styles/main-blue.scss',
+            'styles/wiki-blue.scss',
             'styles/wiki-wysiwyg.scss',
             'styles/wiki-syntax.scss',
             'styles/libs/font-awesome/css/font-awesome.min.css',


### PR DESCRIPTION
Swap editor to use old MDN files, not new redesign ones.