### PR TITLE
bug 957802: Set default KUMASCRIPT_TIMEOUT=30s

### DIFF
--- a/kuma/search/tests/test_indexes.py
+++ b/kuma/search/tests/test_indexes.py
@@ -1,5 +1,5 @@
+from constance.test import override_config
 from django.conf import settings
-
 from elasticsearch_dsl.connections import connections
 from elasticsearch.exceptions import RequestError
 
@@ -57,6 +57,7 @@ class TestIndexes(ElasticTestCase):
         ok_(index2.promoted)
         ok_(not index1.promoted)
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_outdated(self):
         # first create and populate an index
         main_index = Index.objects.create(name='first')

--- a/kuma/search/tests/test_tasks.py
+++ b/kuma/search/tests/test_tasks.py
@@ -1,3 +1,5 @@
+from constance.test import override_config
+
 from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 from kuma.wiki.tests import revision
@@ -8,6 +10,7 @@ from ..models import Index
 
 class TestLiveIndexing(ElasticTestCase):
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_live_indexing_docs(self):
         # Live indexing uses tasks which pass the index by pk, so we need to
         # create and save one to the database here.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1324,7 +1324,7 @@ CONSTANCE_CONFIG = dict(
         'queue for future renders.'
     ),
     KUMASCRIPT_TIMEOUT=(
-        0.0,
+        30.0,
         'Maximum seconds to wait for a response from the kumascript service. '
         'On timeout, the document gets served up as-is and without macro '
         'evaluation as an attempt at graceful failure. NOTE: a value of 0 '

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from urlparse import urljoin
 
+from constance.test import override_config
 from cssselect.parser import SelectorSyntaxError
 from django.conf import settings
 from django.test import TestCase
@@ -1147,6 +1148,7 @@ class AllowedHTMLTests(KumaTestCase):
 class ExtractorTests(UserTestCase):
     """Tests for document parsers that extract content"""
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_css_classname_extraction(self):
         expected = ('foobar', 'barfoo', 'bazquux')
         rev = revision(is_approved=True, save=True, content="""
@@ -1158,6 +1160,7 @@ class ExtractorTests(UserTestCase):
         result = rev.document.extract.css_classnames()
         eq_(sorted(expected), sorted(result))
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_html_attribute_extraction(self):
         expected = (
             'class="foobar"',

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from constance.test import override_config
 from django.test import RequestFactory
 
 from kuma.core.cache import memcache
@@ -152,6 +153,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
 
 
+@override_config(KUMASCRIPT_TIMEOUT=0)
 class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
     """bug 1267197 -- Locales and DocumentZones do not always play nicely together,
     particularly with the middleware that attempts to redirect requests to the

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -1239,6 +1239,7 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
         response = self.client.get(reverse('wiki.preview'), follow=True)
         eq_(405, response.status_code)
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_preview(self):
         """Preview the wiki syntax content."""
         response = self.client.post(reverse('wiki.preview'),

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -104,6 +104,7 @@ class LocaleRedirectTests(UserTestCase, WikiTestCase):
     # Some of these may fail or be invalid if your WIKI_DEFAULT_LANGUAGE is de.
     localizing_client = True
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_fallback_to_translation(self):
         """If a slug isn't found in the requested locale but is in the default
         locale and if there is a translation of that default-locale document to
@@ -115,6 +116,7 @@ class LocaleRedirectTests(UserTestCase, WikiTestCase):
                                    follow=True)
         self.assertRedirects(response, de_doc.get_absolute_url())
 
+    @override_config(KUMASCRIPT_TIMEOUT=0)
     def test_fallback_with_query_params(self):
         """The query parameters should be passed along to the redirect."""
 


### PR DESCRIPTION
Set the constance variable ``KUMASCRIPT_TIMEOUT`` to 30 seconds, which enables KumaScript rendering by default. Set it to 0 (disabling KS rendering) for a handful of tests that call ``doc.render()`` for the side effects, such as populating the search index and rebuilding JSON.