### PR TITLE
bug 1356795: Use default PASSWORD_HASHERS

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -440,15 +440,6 @@ AUTHENTICATION_BACKENDS = (
     'allauth.account.auth_backends.AuthenticationBackend',
 )
 AUTH_USER_MODEL = 'users.User'
-
-# Django 1.8 strong defaults, plus legacy Sha256Hasher
-PASSWORD_HASHERS = (
-    'django.contrib.auth.hashers.PBKDF2PasswordHasher',
-    'django.contrib.auth.hashers.PBKDF2SHA1PasswordHasher',
-    'django.contrib.auth.hashers.BCryptPasswordHasher',
-    'kuma.users.backends.Sha256Hasher',
-)
-
 USER_AVATAR_PATH = 'uploads/avatars/'
 DEFAULT_AVATAR = STATIC_URL + 'img/avatar.png'
 AVATAR_SIZES = [  # in pixels


### PR DESCRIPTION
Use Django 1.8's default ``PASSWORD_HASHERS``, and drop support for custom ``Sha256Hasher``. When this has shipped to production and it is unused, the ``Sha256Hasher`` code can be removed in the next PR.