### PR TITLE
Bug 1370594: Redesign colours, icons and forms

### DIFF
--- a/jinja2/includes/newsletter.html
+++ b/jinja2/includes/newsletter.html
@@ -22,7 +22,7 @@
                 </label>
             </div>
             <div id="newsletterSubmit">
-                <button id="newsletter-submit" type="submit" class="button positive">{{ _('Sign up now') }}</button>
+                <button id="newsletter-submit" type="submit" class="button neutral newsletter-submit">{{ _('Sign up now') }}</button>
             </div>
         </div>
         {% if request.LANGUAGE_CODE != 'en-US' %}

--- a/kuma/static/styles/base/elements/forms.scss
+++ b/kuma/static/styles/base/elements/forms.scss
@@ -12,6 +12,7 @@ option {
     font-style: normal;
     font-weight: normal;
     font-family: $site-font-family;
+    line-height: 1.15;
     #{$selector-site-font-fallback} {
         font-family: $site-font-family-fallback;
     }
@@ -23,9 +24,13 @@ input[type=search],
 input[type=email],
 input[type=url],
 textarea {
-    background: #fff;
-    border: 1px solid #cbc8b9;
+    color: $form-text;
+    background: $form-background-color;
+    border: $form-border-width solid $form-border-color;
     padding: $content-vertical-spacing $content-horizontal-spacing;
+    font-weight: bold;
+
+    @include set-placeholder-style(color, $placeholder-text);
 }
 
 input[type='search'] {
@@ -63,55 +68,45 @@ input[type='button'] {
     cursor: pointer;
     display: inline-block;
     line-height: 1;
-    font-weight: normal;
+    font-weight: bold;
     letter-spacing: normal;
-    background-color: $button-background;
-    text-transform: uppercase;
+    border: $form-border-width solid $form-border-color;
+    background-color: $form-background-color;
     padding: 5px 11px;
-    border-radius: 4px;
-    box-shadow: inset 0 -1px $button-shadow-color;
-    color: $button-color;
+    color: $form-text;
     text-decoration: none;
 
-    &.disabled,
-    &[disabled] {
-        box-shadow: inset 0 -1px rgba($button-shadow-color, .5);
-    }
-
-    &.neutral,
-    &.negative,
-    &.positive {
-        color: #fff;
-    }
-
     &.neutral {
-        background-color: $blue;
-        box-shadow: inset 0 -1px $homepage-background-color;
+        border-color: $blue;
+        color: $blue-dark;
     }
 
     &.negative {
-        background-color: $red;
-        box-shadow: inset 0 -1px #c13832;
+        border-color: $red;
+        color: $red-dark;
     }
 
     &.positive {
-        background-color: $green;
-        box-shadow: inset 0 -1px #486900;
+        border-color: $green;
+        color: $green-dark;
     }
 
     &.transparent {
-        box-shadow: none;
         background-color: transparent;
+        border: 0;
+        padding-left: 0;
+        padding-right: 0;
     }
 
     &.link {
         @include vendorize(appearance, none);
+        font-size: inherit;
         font-weight: inherit;
         letter-spacing: inherit;
         background-color: transparent;
         text-transform: inherit;
+        border: 0;
         padding: 0;
-        box-shadow: none;
         color: $link-color;
 
         &:hover,
@@ -125,8 +120,17 @@ input[type='button'] {
         margin-bottom: -1px;
     }
 
+    #{$selector-icon} {
+        @include set-font-size($base-bump-font-size);
+    }
+
     #{$selector-icon}:before {
         cursor: pointer;
+    }
+
+    &:not(.only-icon) #{$selector-icon} {
+        @include bidi-value(float, left, right);
+        @include bidi-style(margin-right, $icon-margin, margin-left, 0);
     }
 }
 

--- a/kuma/static/styles/base/elements/sectioning.scss
+++ b/kuma/static/styles/base/elements/sectioning.scss
@@ -96,7 +96,7 @@ hr {
 
 @media #{$mq-tablet-and-down} {
     footer {
-        border-top: 1px solid $button-background;
+        border-top: 1px solid #000;
     }
 }
 

--- a/kuma/static/styles/base/icons.scss
+++ b/kuma/static/styles/base/icons.scss
@@ -1,6 +1,4 @@
 #{$selector-icon} {
-    @include bidi-style(margin-left, $icon-margin, margin-right, 0);
-    @include bidi-style(margin-right, 0, margin-left, $icon-margin);
     cursor: default;
     display: inline-block;
 
@@ -8,15 +6,9 @@
         display: inline-block;
         text-decoration: none;
     }
-
-    &.no-margin {
-        @include bidi-style(margin-left, 0, margin-right, 0);
-        @include bidi-style(margin-right, 0, margin-left, 0);
-    }
 }
 
-label #{$selector-icon} {
-    $label-icon-margin: ($grid-spacing / 2);
-    @include bidi-value(margin-left, 0, $label-icon-margin);
-    @include bidi-value(margin-right, $label-icon-margin, 0);
+label #{$selector-icon}:first-child {
+    @include bidi-value(margin-left, 0, $icon-margin);
+    @include bidi-value(margin-right, $icon-margin, 0);
 }

--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -160,8 +160,6 @@ Utility classes
 .only-icon {
     #{$selector-icon} {
         /* stylelint-disable declaration-no-important */
-        margin-left: 0 !important;
-        margin-right: 0 !important;
         margin-top: -1px !important;
         /* stylelint-enable */
     }

--- a/kuma/static/styles/components/components.scss
+++ b/kuma/static/styles/components/components.scss
@@ -13,9 +13,9 @@ toggler component: a basic slide up and slide now system
     position: relative;
 
     #{$selector-icon} {
-        @include bidi-style(right, $icon-margin, left, auto);
         position: absolute;
         top: 3px;
+        @include bidi-style(right, $icon-margin, left, auto);
         color: $text-color;
     }
 
@@ -55,8 +55,8 @@ subnav component:  used within the wiki
     }
 
     #{$selector-icon} {
-        top: ($grid-spacing + 3px);
-        right: $grid-spacing;
+        top: 23px;
+        @include bidi-style(right, 20px, left, auto);
     }
 
     .toggle-container {
@@ -143,7 +143,6 @@ $notification-button-padding: 2px 5px 3px;
     button.close {
         background: transparent;
         border: 0;
-        box-shadow: none;
         display: block;
         padding: 2px;
         position: absolute;
@@ -153,19 +152,19 @@ $notification-button-padding: 2px 5px 3px;
 
     /* theme the various notification states */
     & {
-        @include notification-theme($default);
+        @include notification-theme('default');
     }
 
     &.info {
-        @include notification-theme($neutral);
+        @include notification-theme('neutral');
     }
 
     &.success {
-        @include notification-theme($positive);
+        @include notification-theme('positive');
     }
 
     &.warning {
-        @include notification-theme($warning);
+        @include notification-theme('warning');
 
         /* warning clashes with a class in CustomCSS so we have to re-assert border-width and link color
            the CustomCSS class might be changeable in the future but we can't change the notifier class
@@ -189,7 +188,7 @@ $notification-button-padding: 2px 5px 3px;
     }
 
     &.error {
-        @include notification-theme($negative);
+        @include notification-theme('negative');
     }
 }
 
@@ -216,7 +215,6 @@ $notification-button-padding: 2px 5px 3px;
 .notification-button {
     border: 1px solid;
     border-radius: 2px;
-    box-shadow: none;
     display: inline-block;
     line-height: 1;
     margin: 5px 5px 0 0;

--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -159,8 +159,8 @@ $table-cell-border: 2px solid #fff;
     .licenseblock,
     .originaldocinfo {
         @include set-message-base(true);
-        background: #f1f1f1;
-        border: 2px solid #cccccc;
+        background: #{map-get( map-get($colors-lookup, 'default'), 'light')};
+        border: 2px solid #{map-get( map-get($colors-lookup, 'default'), 'medium')};
         font-size: $smaller-font-size;
     }
 
@@ -290,7 +290,7 @@ div.bug {
 p.footnote {
     font-size: $smaller-font-size;
     font-style: italic;
-    color: #716d65;
+    color: $grey;
 }
 
 /*

--- a/kuma/static/styles/components/doc-title.scss
+++ b/kuma/static/styles/components/doc-title.scss
@@ -9,13 +9,7 @@ except we can't call them page titles because demos already has a class with tha
     position: relative;
     margin-bottom: 10px;
 
-    h1 {
-        line-height: 40px;
-        margin-bottom: 20px;
-    }
-
     em {
-        color: #333;
         font-style: normal;
         @include bidi-style(margin-left, -3px, margin-right, 0);
         text-transform: none;
@@ -33,6 +27,5 @@ except we can't call them page titles because demos already has a class with tha
 .title-prefix {
     @include set-larger-font-size();
     display: block;
-    line-height: 20px;
-    color: #888;
+    color: $grey;
 }

--- a/kuma/static/styles/components/errorlist.scss
+++ b/kuma/static/styles/components/errorlist.scss
@@ -1,5 +1,5 @@
 ul.errorlist {
-    color: #900;
+    color: $error;
     font-weight: bold;
 
     li {

--- a/kuma/static/styles/components/form.scss
+++ b/kuma/static/styles/components/form.scss
@@ -1,7 +1,3 @@
 .form-group {
     margin-bottom: $grid-spacing;
 }
-
-.form-input {
-    border-radius: 3px;
-}

--- a/kuma/static/styles/components/home/base.scss
+++ b/kuma/static/styles/components/home/base.scss
@@ -29,39 +29,13 @@
         background: transparent;
     }
 
-    h2,
-    h3 {
-        > #{$selector-icon} {
-            display: inline-block;
-            position: relative;
-            background-image: url($logo-sprite-url);
-            background-size: 132px;
-            background-position: 0 -143px;
-            background-repeat: no-repeat;
-        }
-    }
-
     h2 {
         > #{$selector-icon} {
-            width: 64px;
-            height: 64px;
-            color: #0095dd;
-            background-position: 0 -222px;
-            background-size: 205px auto;
+            position: relative;
+            top: -5px; // try to center icon vertically
             @include set-font-size(30px);
-            @include bidi-value(margin-right, ($icon-margin / 2), 0);
-            @include bidi-value(margin-left, 0, ($icon-margin / 2));
-
-            &.blue {
-                background-position: 0 -340px;
-                color: $blue-background-text-color;
-            }
-
-            &[class^='icon-']:before {
-                margin: 18px 0 0 0;
-                display: block;
-                text-align: center;
-            }
+            @include bidi-value(margin-right, $icon-margin, 0);
+            @include bidi-value(margin-left, 0, $icon-margin);
         }
     }
 

--- a/kuma/static/styles/components/home/column-callout.scss
+++ b/kuma/static/styles/components/home/column-callout.scss
@@ -145,7 +145,6 @@ DevRel Survey promo
             padding: 10px 15px;
             border: 3px solid #fff;
             border-radius: 0;
-            box-shadow: none;
             font-weight: bold;
             text-transform: none;
         }

--- a/kuma/static/styles/components/home/home-features.scss
+++ b/kuma/static/styles/components/home/home-features.scss
@@ -26,17 +26,11 @@ List of four feature columns within the masthead
         #{$selector-icon} {
             width: 42px;
             height: 39px;
-            background-position: 0 -147px;
-            background-size: 134px auto;
-            color: #0095dd;
             @include bidi-value(float, left, right);
-            @include bidi-value(margin-right, $icon-margin, 0);
-            @include bidi-value(margin-left, 0, $icon-margin);
 
             &:before {
                 margin: 11px 0 0 0;
                 display: block;
-                text-align: center;
             }
         }
 

--- a/kuma/static/styles/components/home/home-hacks.scss
+++ b/kuma/static/styles/components/home/home-hacks.scss
@@ -77,15 +77,6 @@ $home-involved-background-y : 50px;
         @include set-font-size(30px);
         font-weight: bold;
     }
-
-    .button {
-        /* stylelint-disable declaration-no-important */
-        background-color: #48ade4 !important;
-        font-size: $smaller-font-size !important;
-        color: $blue-background-text-color !important;
-        /* stylelint-enable */
-        font-weight: bold;
-    }
 }
 
 @media #{$mq-mobile-and-down} {

--- a/kuma/static/styles/components/home/home-masthead.scss
+++ b/kuma/static/styles/components/home/home-masthead.scss
@@ -37,7 +37,8 @@ homepage masthead (search, feature callouts)
 
     .search-icon {
         position: absolute;
-        top: ($grid-spacing * 2 + 7);
+        top: 48px;
+        @include bidi-style(left, $icon-margin, right, auto);
     }
 
     input#home-q {

--- a/kuma/static/styles/components/newsletter.scss
+++ b/kuma/static/styles/components/newsletter.scss
@@ -23,10 +23,11 @@
     font-style: italic;
 }
 
-.newsletter-input-email {
+input.newsletter-input-email {
     box-sizing: border-box;
     width: 100%;
     max-width: 450px;
+    padding: ($grid-spacing / 2);
 }
 
 .newsletter-fields {
@@ -118,6 +119,10 @@
             grid-row: 1 / 3;
         }
     }
+}
+
+.newsletter-submit {
+    padding: ($grid-spacing / 2);
 }
 
 @media print {

--- a/kuma/static/styles/components/structure/login.scss
+++ b/kuma/static/styles/components/structure/login.scss
@@ -31,15 +31,15 @@ Header login link
 }
 
 .logout {
+    border: 0;
     @include bidi-style(border-left, 1px solid #bbb, border-right, 0);
     @include bidi-style(padding, 0 0 0 6px, padding, 0 6px 0 0);
     @include bidi-style(margin, 0 0 0 2px, margin, 0 2px 0 0);
     background-color: transparent;
-    border-radius: 0;
-    box-shadow: none;
     color: $menu-link-color;
     line-height: inherit;
-    text-transform: none;
+    font-size: inherit;
+    font-weight: normal;
 
     &:hover {
         text-decoration: underline;

--- a/kuma/static/styles/components/structure/main-nav.scss
+++ b/kuma/static/styles/components/structure/main-nav.scss
@@ -26,10 +26,6 @@ Main navigation menu
                 margin-left: 0;
             }
 
-            > a i {
-                opacity: .85;
-            }
-
             > a,
             .search-trigger {
                 text-transform: uppercase;
@@ -52,6 +48,10 @@ Main navigation menu
             .search-wrap {
                 padding: 4px 8px;
             }
+
+            #{$selector-icon} {
+                @include left-icons();
+            }
         }
     }
 
@@ -68,10 +68,6 @@ Main navigation menu
 
     .nav-search-link {
         display: none;
-
-        #{$selector-icon} {
-            margin: 0;
-        }
     }
 
     .submenu {

--- a/kuma/static/styles/components/structure/nav-sec.scss
+++ b/kuma/static/styles/components/structure/nav-sec.scss
@@ -15,6 +15,10 @@ Secondary navigation, site tools and login info
         display: inline-block;
         @include bidi-value(padding, 0 0 0 16px, 0 16px 0 0); /* same as main nav but we double it because only putting on left */
     }
+
+    #{$selector-icon} {
+        @include left-icons();
+    }
 }
 
 

--- a/kuma/static/styles/components/structure/search-wrap.scss
+++ b/kuma/static/styles/components/structure/search-wrap.scss
@@ -61,7 +61,7 @@ Main navigation search box and its wrapper
 .search-trigger {
     cursor: text;
     position: absolute;
-    top: 3px;
+    top: 0;
     @include bidi-style(right, 12px, left, auto);
     z-index: 1;
 }

--- a/kuma/static/styles/components/structure/socialaccount-providers.scss
+++ b/kuma/static/styles/components/structure/socialaccount-providers.scss
@@ -92,7 +92,6 @@ a.github-button {
         }
 
         #{$selector-icon} {
-            margin-left: 0;
             top: 0;
             left: 8px;
         }

--- a/kuma/static/styles/components/structure/submenu.scss
+++ b/kuma/static/styles/components/structure/submenu.scss
@@ -2,7 +2,7 @@
 
 .submenu {
     @include submenu();
-    @include submenu-set(160px, 1px, $light-background-color, $button-shadow-color);
+    @include submenu-set(160px, 1px, $light-background-color, #bbbfc2);
 }
 
 @media #{$mq-mobile-and-down} {

--- a/kuma/static/styles/components/tagit.scss
+++ b/kuma/static/styles/components/tagit.scss
@@ -48,7 +48,7 @@ overrides for tagit widget
 
 .tagit-new {
     background-color: #fff;
-    border-color: #cbc8b9;
+    border-color: $tag-border-color;
     margin-bottom: 0; /* will always be last, no tags underneath it, and bottom margins on form elements dont' collapse */
 
     input {

--- a/kuma/static/styles/components/tags.scss
+++ b/kuma/static/styles/components/tags.scss
@@ -1,3 +1,4 @@
+$tag-border-color: #cee9f9;
 /*
 - default styles for all tags.
 - needs qualifying ul because to pass classes to tagit widget it must be input.tags
@@ -5,7 +6,7 @@
 
 %tag-item {
     background: $light-background-color;
-    border: 1px solid #cee9f9;
+    border: 1px solid $tag-border-color;
     border-radius: 2px;
     display: inline-block;
     @include bidi-value(margin, 0 ($grid-spacing / 2) ($grid-spacing / 2) 0, 0 0 ($grid-spacing / 2) ($grid-spacing / 2));

--- a/kuma/static/styles/components/users/user-edit.scss
+++ b/kuma/static/styles/components/users/user-edit.scss
@@ -1,8 +1,4 @@
 .user-edit {
-    h1 > #{$selector-icon} {
-        margin: 0;
-    }
-
 
     h1,
     fieldset {

--- a/kuma/static/styles/components/users/user-head.scss
+++ b/kuma/static/styles/components/users/user-head.scss
@@ -53,7 +53,7 @@
 }
 
 .user-since {
-    color: #6a9412;
+    color: $green-dark;
     @include set-smaller-font-size();
     font-style: italic;
 }

--- a/kuma/static/styles/components/users/user-links.scss
+++ b/kuma/static/styles/components/users/user-links.scss
@@ -9,10 +9,7 @@
     }
 
     i {
+        @include right-icons();
         @include set-font-size($base-font-size);
-    }
-
-    a {
-        @include bidi-style(padding-left, $content-horizontal-spacing, padding-right, 0);
     }
 }

--- a/kuma/static/styles/components/wiki/_mixins.scss
+++ b/kuma/static/styles/components/wiki/_mixins.scss
@@ -37,6 +37,6 @@ mixins applying only to the wiki
 }
 
 %review-base {
-    @include box-theme($yellow);
+    @include box-theme('warning');
     color: $text-color;
 }

--- a/kuma/static/styles/components/wiki/communitybox.scss
+++ b/kuma/static/styles/components/wiki/communitybox.scss
@@ -9,17 +9,9 @@ $communitybox-spacing : 13px;
 
 .communitybox {
     padding: $communitybox-spacing;
-    background-color: $homepage-background-color;
-    background-image: url($path-to-images + 'blueprint.png');
+    background-color: $blue-light;
+    @include bidi-value(border, 0, 0);
     @include set-font-size($base-font-size);
-
-    &,
-    & a,
-    & a:hover,
-    & a:focus,
-    & a:visited {
-        color: $blue-background-text-color;
-    }
 
     strong {
         @include set-larger-font-size();
@@ -33,11 +25,10 @@ $communitybox-spacing : 13px;
 
     h2 {
         margin-bottom: 0;
-        color: $blue-background-text-color;
     }
 
     h3 {
-        color: $blue-background-text-color;
+        font-style: normal;
     }
 }
 
@@ -64,7 +55,7 @@ ul.communitymailinglist { /* needs specificity to get past .text-content ul */
 }
 
 .communitymailinglist a {
-    @include rgba-fallback(background, #fff, .3, $homepage-background-color);
+    background: $neutral;
     display: inline-block;
     color: #fff;
     padding: 3px 6px;

--- a/kuma/static/styles/components/wiki/contributor-avatars.scss
+++ b/kuma/static/styles/components/wiki/contributor-avatars.scss
@@ -13,7 +13,7 @@ $avatar-limit: 6;
     margin-top: 23px;
     @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
     margin-bottom: $grid-spacing;
-    color: #777;
+    color: $grey;
     @include set-smaller-font-size();
     @include bidi-value(text-align, right, left);
 

--- a/kuma/static/styles/components/wiki/contributors.scss
+++ b/kuma/static/styles/components/wiki/contributors.scss
@@ -3,14 +3,9 @@ contributors block at the bottom of the article
 ********************************************************************** */
 
 .contributors {
-    color: #777;
+    color: $grey;
 
     @include set-smaller-font-size();
-
-    #{$selector-icon} {
-        @include bidi-style(margin-left, 0, margin-right, $icon-margin);
-        @include bidi-style(margin-right, $icon-margin, margin-left, 0);
-    }
 }
 
 .contributors-sub {

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -21,7 +21,7 @@ wiki article cookie crumbs
             display: inline-block;
             font-family: FontAwesome;
             text-decoration: none;
-            color: #c1c2c4;
+            color: $grey;
             @include set-font-size(70%);
         }
     }

--- a/kuma/static/styles/components/wiki/customcss.scss
+++ b/kuma/static/styles/components/wiki/customcss.scss
@@ -19,12 +19,6 @@ eventually emptying this file.
     font-size: 60%;
 }
 
-/* remove left margin from Font Awesome icons inside wiki
-     content; this is messing up document content */
-#wikiArticle #{$selector-icon} {
-    margin-left: 0;
-}
-
 /* In index, dim obsolete, deprecated or non-standard element instead of striking through them */
 s.deprecatedElement,
 s.obsoleteElement,
@@ -732,25 +726,11 @@ a.download-button {
     margin-bottom: 20px;
     padding: 10px;
     text-align: center;
-    border-radius: 4px;
     display: inline-block;
-    background-color: #81bc2e;
+    border: 2px solid;
     white-space: nowrap;
-    color: #fff;
-    text-shadow: 0 1px 0 rgba(0, 0, 0, .25);
-    box-shadow: 0 1px 0 0 rgba(0, 0, 0, .2), 0 -1px 0 0 rgba(0, 0, 0, .3) inset;
-}
-
-a.download-button:hover {
-    color: #c8c8c8;
-}
-
-a.download-button:visited {
-    color: #fff;
-}
-
-a.download-button:link {
-    color: #fff;
+    color: $green;
+    background-color: #fff;
 }
 
 

--- a/kuma/static/styles/components/wiki/edit/guide-links.scss
+++ b/kuma/static/styles/components/wiki/edit/guide-links.scss
@@ -6,5 +6,5 @@ link to editor and style guide editor that appear above text editor
     @include bidi-value(text-align, right, left);
     margin-top: $grid-spacing;
     padding: 0 4px 2px 0;
-    color: #999;
+    color: $grey;
 }

--- a/kuma/static/styles/components/wiki/edit/metadata.scss
+++ b/kuma/static/styles/components/wiki/edit/metadata.scss
@@ -34,7 +34,6 @@
 
     label,
     legend {
-        color: #888;
         display: block;
         float: left;
         font-weight: bold;

--- a/kuma/static/styles/components/wiki/edit/page-attachments.scss
+++ b/kuma/static/styles/components/wiki/edit/page-attachments.scss
@@ -20,7 +20,7 @@ $border-value : 1px solid #e0e0dc;
 
     th {
         font-weight: bold;
-        color: #666;
+        color: $grey;
     }
 
     td {
@@ -38,7 +38,7 @@ $border-value : 1px solid #e0e0dc;
 }
 
 .attachment-error {
-    color: #900;
+    color: $error;
     @include set-font-size(11px);
 }
 
@@ -47,7 +47,7 @@ $border-value : 1px solid #e0e0dc;
         width: 90%;
 
         .attachment-required {
-            border: 1px solid #900;
+            border: 1px solid $error;
         }
     }
 
@@ -61,11 +61,6 @@ $border-value : 1px solid #e0e0dc;
     h3 #{$selector-icon} {
         @include right-icons();
     }
-}
-
-/* page attachments block at the bottom of the article */
-#page-attachments-button {
-    @include set-smaller-font-size();
 }
 
 @media #{$mq-mobile-and-down} {

--- a/kuma/static/styles/components/wiki/elements.scss
+++ b/kuma/static/styles/components/wiki/elements.scss
@@ -12,7 +12,7 @@ article {
 
         /* 404 link */
         &.new {
-            color: #900;
+            color: $error;
         }
     }
 }

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -209,14 +209,6 @@ Colours for both types
     @extend %indicator-danger;
 }
 
-/* experimental */
-.experimental,
-.experimentalBadge,
-.prefixBox,
-.secureContexts {
-    @extend %indicator-warning;
-}
-
 /* if you don't know this it won't work */
 .warning.warning-review,
 .draft,
@@ -224,12 +216,16 @@ Colours for both types
 .note,
 .notice,
 .renamed,
+.secureContexts,
+.prefixBox,
 .privilegedBadge,
 .translationInProgress {
     @extend %indicator-warning;
 }
 
 /* version info */
+.experimental,
+.experimentalBadge,
 .htmlVer,
 .domLevel,
 .jsMinVer,
@@ -263,16 +259,16 @@ Special snowflakes
 #kserrors.warning,
 #doc-rendering-in-progress.warning,
 #doc-rendering-scheduled.warning {
-    border-color: #b54d48;
-    background-color: #ca5651;
+    border-color: #{map-get( map-get($colors-lookup, 'negative'), 'dark')};
+    background-color: #{map-get( map-get($colors-lookup, 'negative'), 'dark')};
     @extend %indicator-link-invert;
     @extend %indicator-text-invert;
 }
 
 /* code colouration */
 .inheritsbox {
-    border-color: $code-block-border-color; /*orignally #D1D1FF*/
-    background: $code-block-background-alt-color; /* orignally #F5F5FF*/
+    border-color: $code-block-border-color;
+    background: $code-block-background-alt-color;
 }
 
 /* bright red */
@@ -290,6 +286,14 @@ Special snowflakes
     @extend %indicator-text-invert;
     @extend %indicator-link-invert;
 }
+
+/* harmony */
+.overheadIndicator[style='background: #9CF49C;'],
+.overheadIndicator[style='background: rgb(156, 244, 156);'] {
+    border-color: #{map-get( map-get($colors-lookup, 'positive'), 'medium')} !important; /* stylelint-disable-line declaration-no-important */
+    background: #{map-get( map-get($colors-lookup, 'positive'), 'light')} !important; /* stylelint-disable-line declaration-no-important */
+}
+
 
 /* heading that goes in with geckoVersionNote */
 .geckoVersionHeading {

--- a/kuma/static/styles/components/wiki/page-buttons.scss
+++ b/kuma/static/styles/components/wiki/page-buttons.scss
@@ -13,32 +13,7 @@ edit, language, settings, save, and cancel buttons
         display: inline-block;
         position: relative;
         @include bidi-value(text-align, left, right);
-
-        a,
-        button,
-        input[type='submit'],
-        input[type='button'] {
-            @include set-smaller-font-size();
-        }
-
-        .transparent {
-            padding-left: 0;
-            padding-right: 0;
-        }
-
-        #{$selector-icon} {
-            @include set-font-size($base-bump-font-size);
-        }
     }
-}
-
-/* Use a dark blue background color for all document edit buttons except those
-   that appear on zone landing pages. Superusers can customize zone landing page
-   style and we can't be sure that dark blue will look good on the background
-   colors they choose. */
-body:not(.zone-landing) #edit-button {
-    background-color: $blue;
-    color: $blue-background-text-color;
 }
 
 @media #{$mq-mobile-and-down} {
@@ -92,13 +67,6 @@ body:not(.zone-landing) #edit-button {
 
         li {
             margin-bottom: 10px;
-        }
-
-        a,
-        button {
-            border: 0;
-            display: inline-block;
-            box-shadow: 1px 1px 0 rgba(0, 0, 0, .25);
         }
     }
 }

--- a/kuma/static/styles/components/wiki/properties.scss
+++ b/kuma/static/styles/components/wiki/properties.scss
@@ -71,8 +71,8 @@ $properties-indent: ($grid-spacing * 2) - $properties-item-spacing;
 }
 
 .text-content .learn-box {
-    border-color: #f69855;
-    background-color: #fce1ce;
+    border-color: $orange;
+    background-color: $orange-light;
 }
 
 /* small screen improvements to table display, only need to apply to .properties and .learn-box

--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -22,7 +22,7 @@ $see-also-outdent : 6px;
 
         /* 404 link */
         &.new {
-            color: #900;
+            color: $error;
         }
     }
 
@@ -81,8 +81,6 @@ $see-also-outdent : 6px;
 
         #{$selector-icon} {
             @include set-font-size($base-font-size);
-            @include bidi-style(margin-left, 0, margin-right, 0);
-            @include bidi-style(margin-right, 0, margin-left, 0);
             position: realtive;
             top: 3px;
             min-width: 15px;
@@ -100,6 +98,6 @@ $see-also-outdent : 6px;
         @include set-font-size($base-font-size);
         position: absolute;
         top: 1px;
-        @include bidi-style(left, -6px, right, auto);
+        @include bidi-style(left, 0, right, auto);
     }
 }

--- a/kuma/static/styles/components/wiki/revision-list.scss
+++ b/kuma/static/styles/components/wiki/revision-list.scss
@@ -95,7 +95,6 @@ html[dir=rtl] .revision-list-controls:before {
 }
 
 .revision-list-creator {
-    color: #333;
     width: 175px;
 }
 

--- a/kuma/static/styles/components/wiki/toc.scss
+++ b/kuma/static/styles/components/wiki/toc.scss
@@ -15,7 +15,7 @@
             @include bidi-value(text-align, left, right);
             @include bidi-style(left, -($grid-spacing * 1.5), right, auto);
             position: absolute;
-            color: #484848;
+            color: $grey-dark;
         }
     }
 

--- a/kuma/static/styles/components/wiki/wiki-block.scss
+++ b/kuma/static/styles/components/wiki/wiki-block.scss
@@ -2,7 +2,7 @@
     @include clearfix();
     padding-top: ($grid-spacing * 2);
     margin-top: ($grid-spacing * 2);
-    border-top: 1px solid $button-background;
+    border-top: 1px solid #000;
     padding-left: 0;
     padding-right: 0;
 

--- a/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
+++ b/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
@@ -33,7 +33,7 @@
 }
 
 .helpful-survey {
-    background: #58779d;
+    background: #{map-get( map-get($colors-lookup, 'neutral'), 'dark')};
     color: #fff;
     float: none;
     margin: 0 auto;

--- a/kuma/static/styles/diff.scss
+++ b/kuma/static/styles/diff.scss
@@ -73,10 +73,6 @@ Slug change callout
     margin: 4px 0;
     clear: both;
 
-    #{$selector-icon} {
-        @include bidi-style(margin-left, 0, margin-right, 0);
-    }
-
     span {
         white-space: nowrap;
     }

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -151,60 +151,19 @@ Colours
     }
 }
 
-/*
-functions to transform the base colors into variations of themselves
--------------------------------------------------------------- */
-
-@function -theme-pale-light($color) {
-    @return mix(white, $color, 80%);
-}
-
-@function -theme-pale-dark($color) {
-    @return mix(black, $color, 20%);
-}
-
-@function -theme-pale-medium($color) {
-    @return mix(white, $color, 45%);
-}
-
-/*
-functions to get correct text colors for variations of theme colors
--------------------------------------------------------------- */
-
-@function -theme-pale-text($color) {
-    $color : -theme-pale-light($color);
-    $color : mix(#000, $color, 60%);
-    @return $color;
-}
-
-@function -theme-pale-contrast-text($color) {
-    $hu : hue($color);
-    $lite : lightness($color);
-    $sat : saturation($color);
-    @if (($hu < 20deg or $hu > 199deg) and $sat > 30% and $lite < 70%) {
-        $color : $text-light;
-    }
-    @else if ($lite < 50%) {
-        $color : $text-light;
-    }
-    @else {
-        $color : $text-dark;
-    }
-    @return $color;
-}
 
 /*
 function to apply all the generated colors to a notification to theme it
 -------------------------------------------------------------- */
 
 @mixin notification-theme($color) {
-    background-color: -theme-pale-light($color);
-    border-color: -theme-pale-medium($color);
-    color: -theme-pale-contrast-text(-theme-pale-light($color));
+    background-color: #{map-get( map-get($colors-lookup, $color), 'light')};
+    border-color: #{map-get( map-get($colors-lookup, $color), 'medium')};
+    color: $text-color;
 
     .notification-button {
-        background-color: -theme-pale-medium($color);
-        color: -theme-pale-text($color);
+        background-color: #{map-get( map-get($colors-lookup, $color), 'medium')};
+        color: $text-color;
 
         &:hover,
         &:focus {
@@ -214,15 +173,15 @@ function to apply all the generated colors to a notification to theme it
     }
 
     .notification-img i {
-        color: -theme-pale-dark($color);
+        color: #{map-get( map-get($colors-lookup, $color), 'dark')};
     }
 
     button.close {
-        color: -theme-pale-medium($color);
+        color: #{map-get( map-get($colors-lookup, $color), 'medium')};
 
         &:hover,
         &:focus {
-            color: -theme-pale-dark($color);
+            color: #{map-get( map-get($colors-lookup, $color), 'dark')};
         }
     }
 }
@@ -232,8 +191,8 @@ coloured boxes
 -------------------------------------------------------------- */
 
 @mixin box-theme($color) {
-    background: -theme-pale-light($color);
-    border-color: -theme-pale-medium($color);
+    background: #{map-get( map-get($colors-lookup, $color), 'light')};
+    border-color: #{map-get( map-get($colors-lookup, $color), 'medium')};
 }
 
 
@@ -384,15 +343,19 @@ Home & Zones
 
 /* sets an input tag's placeholder styles */
 @mixin set-placeholder-style($prop, $value) {
-    &::-webkit-input-placeholder {
+    &::-webkit-input-placeholder { // old Chrome & Safari, we can remove this soon
         #{$prop}: $value;
     }
 
-    &::-moz-placeholder {
+    &:-ms-input-placeholder { // IE 9-11, Edge
         #{$prop}: $value;
     }
 
-    &:-ms-input-placeholder { // IE 9 & 10, Edge suppoerts -webkit-
+    &::-moz-placeholder { // Old Firefox, we can remove this soon
+        #{$prop}: $value;
+    }
+
+    &::placeholder { // Current Firefox, Chrome, Safari
         #{$prop}: $value;
     }
 }
@@ -431,8 +394,11 @@ Bidi / l10n
 }
 
 @mixin right-icons() {
-    @include bidi-value(margin-left, 0 !important, 10px !important);
-    @include bidi-value(margin-right, 10px !important, 0 !important);
+    @include bidi-value(margin-right, $icon-margin, 0);
+}
+
+@mixin left-icons() {
+    @include bidi-value(margin-left, $icon-margin, 0);
 }
 
 
@@ -465,18 +431,12 @@ These are not dynamic but serve as mixins
 }
 
 @mixin big-search() {
-    @include rgba-fallback(background, #fff, .2);
+    background: #fff;
     @include set-larger-font-size();
     display: block;
     margin: 0 auto;
-    border: 0;
-    border-radius: 3px;
     width: 100%;
-
-    font-family: $heading-font-family;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
+    padding: ($grid-spacing / 2);
 }
 
 @mixin clearfix() {

--- a/kuma/static/styles/includes/_mixins_indicators.scss
+++ b/kuma/static/styles/includes/_mixins_indicators.scss
@@ -116,17 +116,17 @@ colours for both indicator types
 
 %indicator-info,
 %indicator-obsolete {
-    @include box-theme($default);
+    @include box-theme('default');
 }
 
 %indicator-version {
-    @include box-theme($neutral);
+    @include box-theme('neutral');
 }
 
 %indicator-warning {
-    @include box-theme($warning);
+    @include box-theme('warning');
 }
 
 %indicator-danger {
-    @include box-theme($negative);
+    @include box-theme('negative');
 }

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -12,29 +12,70 @@ $VENDOR-PREFIXES : '-webkit-', '-moz-', '-ms-';
 /*
 colors
 ====================================================================== */
-$text-color : #000;
-$heading-color : $text-color;
-$link-color : #217ac0;
-$menu-link-color : $text-color;
-$blue-background-text-color : #fff;
-$header-background-color : #eaeff2;
-$light-background-color : #f4f7f8;
-$homepage-background-color : #00539f;
-$border-width : 5px;
-$code-block-background-color : #fafbfc;
-$code-block-background-alt-color : #dde4e9;
-$code-block-border-color : #558abb;
-$code-block-padding : 15px;
-$code-block-border-width : $border-width;
-$code-block-border-style : solid;
-$table-blue : #d4dde4;
+$red : #e66465;
+$orange : #f69d3c;
+$yellow : #f6b73c;
+$green : #4d9f0c;
+$blue : #3f87a6;
+$purple : #9198e5;
+$grey : #696969;
 
-$red : #ea3b28;
-$yellow : #ffcb00;
-$green : #70a300;
-$blue : #0095dd;
-$grey : #c7ccce;
-$orange : #c55200;
+$red-light : #ffe7e8;
+$orange-light : #ffe8d4;
+$yellow-light : #fff3d4;
+$green-light : #ebf8e1;
+$blue-light : #e4f0f5;
+$purple-light: #d7d9f2;
+$grey-light : #eee;
+
+$red-vdark : #5d3739;
+$orange-vdark : #332206;
+$yellow-vdark : #332807;
+$green-vdark : #162300;
+$blue-vdark : #001d33;
+$purple-vdark : #303253;
+$grey-vdark : #151515;
+
+$red-dark : mix($red, $red-vdark, 65);
+$orange-dark : mix($orange, $orange-vdark, 65);
+$yellow-dark : mix($yellow, $yellow-vdark, 65);
+$green-dark : mix($green, $green-vdark, 65);
+$blue-dark : mix($blue, $blue-vdark, 65);
+$purple-dark : mix($purple, $purple-vdark, 65);
+$grey-dark : mix($grey, $grey-vdark, 65);
+
+$colors-lookup: (
+    'negative': (
+        'light': $red-light,
+        'medium': $red,
+        'dark': $red-dark,
+        'vdark': $red-vdark,
+    ),
+    'warning': (
+        'light': $yellow-light,
+        'medium': $yellow,
+        'dark': $yellow-dark,
+        'vdark': $yellow-vdark,
+    ),
+    'positive': (
+        'light': $green-light,
+        'medium': $green,
+        'dark': $green-dark,
+        'vdark': $green-vdark,
+    ),
+    'neutral': (
+        'light': $blue-light,
+        'medium': $blue,
+        'dark': $blue-dark,
+        'vdark': $blue-vdark,
+    ),
+    'default': (
+        'light': $grey-light,
+        'medium': $grey,
+        'dark': $grey-dark,
+        'vdark': $grey-vdark,
+    ),
+);
 
 $negative : $red;
 $warning : $yellow;
@@ -42,8 +83,26 @@ $positive : $green;
 $neutral : $blue;
 $default : $grey;
 
+$text-color : #000;
+$heading-color : $text-color;
+$link-color : darken($blue, 5);
+$menu-link-color : $text-color;
+$blue-background-text-color : #fff;
+$light-background-color : #{map-get( map-get($colors-lookup, 'default'), 'light')};
+$header-background-color : $light-background-color;
+$homepage-background-color : $blue-dark;
+$border-width : 5px;
+$code-block-background-color : #{map-get( map-get($colors-lookup, 'default'), 'light')};
+$code-block-background-alt-color : #{map-get( map-get($colors-lookup, 'neutral'), 'light')}; /* TODO */
+$code-block-border-color : #{map-get( map-get($colors-lookup, 'neutral'), 'medium')};
+$code-block-padding : 15px;
+$code-block-border-width : $border-width;
+$code-block-border-style : solid;
+$table-blue : #d4dde4;
+
 $text-dark : $text-color;
 $text-light : #fff;
+$error: #900;
 
 
 /*
@@ -73,11 +132,13 @@ $base-bump-font-size : 17px;
 
 
 /*
-buttons
+forms
 ====================================================================== */
-$button-background : #eaeff2;
-$button-color : $menu-link-color;
-$button-shadow-color : #bbbfc2;
+$form-border-width: 2px;
+$form-border-color: #9b9b9b;
+$form-text: $grey-dark;
+$form-background-color: #fff;
+$placeholder-text: lighten($form-border-color, 2);
 
 
 /*
@@ -176,7 +237,7 @@ $content-horizontal-spacing : 8px;
 $content-vertical-spacing : 6px;
 $list-item-spacing : $content-horizontal-spacing;
 
-$icon-margin : 10px;
+$icon-margin : ($grid-spacing / 2);
 
 
 /*

--- a/kuma/static/styles/search-suggestions.scss
+++ b/kuma/static/styles/search-suggestions.scss
@@ -117,10 +117,6 @@
                 @include bidi-style(margin-left, 5px, margin-right, 0);
                 @include bidi-value(padding, 5px 0 5px 5px  !important, 5px 5px 5px 0  !important);
                 /* stylelint-enable */
-
-                #{$selector-icon} {
-                    margin-left: 0;
-                }
             } /* end button.close */
 
             &:last-child {

--- a/kuma/static/styles/search.scss
+++ b/kuma/static/styles/search.scss
@@ -112,8 +112,7 @@ fieldset #{$selector-icon} {
     font-style: italic;
 
     #{$selector-icon} {
-        margin-right: 6px !important; /* stylelint-disable-line declaration-no-important */
-        margin-left: 0;
+        @include right-icons();
     }
 
     a {

--- a/kuma/static/styles/zones-blue/components/landing.scss
+++ b/kuma/static/styles/zones-blue/components/landing.scss
@@ -63,6 +63,7 @@ Zone landing page styles
 
     a.button,
     button {
+        border-color: $blue-background-text-color;
         color: $blue-background-text-color;
 
         &:not(.transparent) {

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -44,7 +44,7 @@
             content_experiment and
             content_experiment.selection_is_valid) %}
       {% if (not is_experiment) %}
-      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button" data-optimizely-hook="button-edit-doc" id="edit-button" rel="nofollow, noindex">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
+      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button neutral" data-optimizely-hook="button-edit-doc" id="edit-button" rel="nofollow, noindex">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
       {% endif %}
 
         {% if user.is_authenticated() and document %}


### PR DESCRIPTION
- add colour sass map
- default icons to 0 margin, add back where appropriate
- move icons to left side of buttons
- add button styles
- separate button styles from button context
- form field styling (excluding header, footer, search page)
- replaced hard coded colours with variables where possible

Notes:
- form submit button will change to blue in production, this isn't a problem
- adding `.neutral` to the edit button should not effect production
- some colours are not in split files and can't be updated yet: diffs, dashboards, search, wiki-syntax.