### PR TITLE
Bug 1370594: TOC stays collapsed until 1400px

### DIFF
--- a/kuma/static/styles/components/wiki/structure.scss
+++ b/kuma/static/styles/components/wiki/structure.scss
@@ -45,7 +45,7 @@
     }
 }
 
-@media #{$media-query-small-desktop} {
+@media #{$mq-large-desktop-and-down} {
 
     /* when there's a left sidebar, we need to adjust the layout to look like:  |= */
     .wiki-left-present:not(.wiki-left-closed) {

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -116,6 +116,7 @@ $small-desktop-starts : $tablet-ends + 1px;
 $tablet-starts : $mobile-ends + 1px;
 $mobile-starts : $small-mobile-ends + 1px;
 
+$mq-large-desktop-and-down : 'all and (max-width: #{$max-width-default})';
 $media-query-small-desktop : 'all and (max-width: #{$small-desktop-ends})';
 $media-query-tablet : 'all and (max-width: #{$tablet-ends})';
 $media-query-mobile : 'all and (max-width: #{$mobile-ends})';


### PR DESCRIPTION
TOC aka right column "in this article" menu, now stays collapsed until screens are 1400px.

Shout out to @darkwing for getting the JS to watch the CSS for the cue to initiate the toggle behaviour. This change was ridiculously easy.