### PR TITLE
bug 1373720: adjust DocumentNearestZoneJob cache staleness thresholds

### DIFF
--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -1,3 +1,4 @@
+import time
 import random
 import collections
 
@@ -13,11 +14,12 @@ class DocumentNearestZoneJob(KumaJob):
     # the task has failed and allowing another to be enqueued.
     refresh_timeout = 180
 
-    @property
-    def lifetime(self):
+    def expiry(self, *args, **kwargs):
         # Spread the cache expiration times across a random
         # number of days from 1 to 10 (in units of seconds).
-        return random.randint(1, 10) * 24 * 60 * 60
+        seconds_per_day = 24 * 60 * 60
+        return time.time() + random.randint(1 * seconds_per_day,
+                                            10 * seconds_per_day)
 
     def fetch(self, pk):
         """

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -1,3 +1,4 @@
+import random
 import collections
 
 from django.conf import settings
@@ -8,8 +9,15 @@ from kuma.users.templatetags.jinja_helpers import gravatar_url
 
 
 class DocumentNearestZoneJob(KumaJob):
-    lifetime = 60 * 60 * 29
-    refresh_timeout = 60
+    # Allow up to three minutes to refresh the cache before assuming
+    # the task has failed and allowing another to be enqueued.
+    refresh_timeout = 180
+
+    @property
+    def lifetime(self):
+        # Spread the cache expiration times across a random
+        # number of days from 1 to 10 (in units of seconds).
+        return random.randint(1, 10) * 24 * 60 * 60
 
     def fetch(self, pk):
         """

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -13,12 +13,13 @@ def test_document_zone_unicode(doc_hierarchy_with_zones):
         top_doc.get_absolute_url(), top_doc.title)
 
 
-def test_nearest_zone_lifetime():
+def test_nearest_zone_expiry():
     """
-    Ensure that the lifetime is not constant.
+    Ensure that the expiry is not constant.
     """
     job = DocumentNearestZoneJob()
-    assert len(set(job.lifetime for _ in range(0, 1000))) > 1
+    with mock.patch('time.time', return_value=0):
+        assert len(set(job.expiry() for _ in range(0, 1000))) > 1
 
 
 @pytest.mark.parametrize('doc_name,expected_zone_name', [

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -13,6 +13,14 @@ def test_document_zone_unicode(doc_hierarchy_with_zones):
         top_doc.get_absolute_url(), top_doc.title)
 
 
+def test_nearest_zone_lifetime():
+    """
+    Ensure that the lifetime is not constant.
+    """
+    job = DocumentNearestZoneJob()
+    assert len(set(job.lifetime for _ in range(0, 1000))) > 1
+
+
 @pytest.mark.parametrize('doc_name,expected_zone_name', [
     ('top', 'top'),
     ('middle_top', 'middle_top'),


### PR DESCRIPTION
See [bugzilla 1373720](https://bugzilla.mozilla.org/show_bug.cgi?id=1373720).

* increase ``DocumentNearestZoneJob.refresh_timeout`` from 60 to 180 seconds
* change ``DocumentNearestZoneJob.lifetime`` from a constant to a property
  that returns a random number of days between 1 and 10 (in seconds)