### PR TITLE
Fix display of KumaScript errors for document/preview endpoints

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
@@ -17,7 +17,7 @@
   </button>
   <div class="kserrors-details hidden">
       <p>{% trans %}
-        Anyone with an MDN profile can edit a document to fix an error. Use the <a href="/docs/MDN/Kuma/Troubleshooting_KumaScript_errors">KumaScript troubleshooting guide</a> as a starting point.
+        Anyone with an MDN profile can edit a document to fix an error. Use the <a href="/docs/MDN/Contribute/Tools/KumaScript/Troubleshooting">KumaScript troubleshooting guide</a> as a starting point.
       {% endtrans %}</p>
 
       <ul id="kserrors-list">
@@ -32,26 +32,20 @@
               </dd>
               {% set error_meta = error.args[2] %}
               {% if error_meta %}
-                {% set template_name = error_meta.name %}
-                {% if '$' not in template_name %}
-                  {% set template_slug = 'Template:%s' % template_name %}
-                  {% set edit_url = url('wiki.edit', template_slug) %}
-                  {% set new_url = url('wiki.create') + '?slug=Template:%s' % template_name %}
-                {% endif %}
+                {% set macro_name = error_meta.name %}
+                {% set macro_relpath = macro_sources.get(macro_name.lower()) %}
                 <dt>{{ _('In macro:') }}</dt>
                 <dd>
-                  <code class="kserror-macro">{{ template_name }}</code>
-                  {% if 'status 404' in error.message %}
-                    {% if new_url %}
-                      (<a href="{{ new_url }}">{{ _('Create Template') }}</a>)
-                    {% endif %}
-                  {% elif edit_url  %}
-                    (<a href="{{ edit_url }}">{{ _('Edit Template') }}</a>)
+                  <code class="kserror-macro">{{ macro_name }}</code>
+                  {% if ('unable to load: ' + macro_name) in error.message %}
+                    (<a href="https://github.com/mozilla/kumascript#updating-macros">{{ _('Create Macro') }}</a>)
+                  {% elif macro_relpath %}
+                    (<a href="{{ 'https://github.com/mozilla/kumascript/blob/master/macros/' + macro_relpath }}">{{ _('View Macro') }}</a>)
                   {% endif %}
                 </dd>
                 <dt>{{ _('Parsing macro:') }}</dt>
                 <dd>
-                  <code class="kserror-parse">{{ template_name }}
+                  <code class="kserror-parse">{{ macro_name }}
                     {% if error_meta.token %}
                       ({{ error_meta.token.args }})
                     {% endif %}

--- a/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
@@ -16,8 +16,8 @@
     }}
   </button>
   <div class="kserrors-details hidden">
-      <p>{% trans %}
-        Anyone with an MDN profile can edit a document to fix an error. Use the <a href="/docs/MDN/Contribute/Tools/KumaScript/Troubleshooting">KumaScript troubleshooting guide</a> as a starting point.
+      <p>{% trans troubleshooting_url='/en-US/docs/MDN/Contribute/Tools/KumaScript/Troubleshooting' %}
+        Anyone with an MDN profile can edit a document to fix an error. Use the <a href="{{ troubleshooting_url }}">KumaScript troubleshooting guide</a> as a starting point.
       {% endtrans %}</p>
 
       <ul id="kserrors-list">

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -631,11 +631,6 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 
     Note that these tests really just check whether or not the service was
     used, and are not integration tests meant to exercise the real service.
-
-    REFACTOR NOTES:
-    * The "test_error_reporting" method was moved into "test_views_document.py"
-      as "test_kumascript_error_reporting" and expanded to cover the
-      "wiki.preview" endpoint as well. (escattone, June 20, 2017)
     """
     localizing_client = True
 

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -3,11 +3,13 @@ Tests for kuma/wiki/views/document.py
 
 Legacy tests are in test_views.py.
 """
-
 import mock
 import pytest
+import requests_mock
+from pyquery import PyQuery as pq
 
 from kuma.wiki.models import Document
+from kuma.core.urlresolvers import reverse
 from kuma.wiki.views.document import _apply_content_experiment
 
 
@@ -135,3 +137,63 @@ def test_apply_content_experiment_valid_selection_no_doc(ce_settings, rf):
     assert experiment_doc == doc
     assert params['selected'] is None
     assert not params['selection_is_valid']
+
+
+@pytest.mark.parametrize('endpoint', ['document', 'preview'])
+def test_kumascript_error_reporting(admin_client, root_doc, ks_toolbox,
+                                    endpoint):
+    """
+    Kumascript reports errors in HTTP headers. Kuma should display the errors
+    with appropriate links for both the "wiki.preview" and "wiki.document"
+    endpoints.
+    """
+    ks_settings = dict(
+        KUMASCRIPT_TIMEOUT=1.0,
+        KUMASCRIPT_MAX_AGE=600,
+        KUMA_DOCUMENT_FORCE_DEFERRED_TIMEOUT=10.0,
+        KUMA_DOCUMENT_RENDER_TIMEOUT=180.0
+    )
+    mock_requests = requests_mock.Mocker()
+    mock_ks_config = mock.patch('kuma.wiki.kumascript.config', **ks_settings)
+    with mock_ks_config, mock_requests:
+        if endpoint == 'preview':
+            mock_requests.post(
+                requests_mock.ANY,
+                text='HELLO WORLD',
+                headers=ks_toolbox.errors_as_headers,
+            )
+            mock_requests.get(
+                requests_mock.ANY,
+                **ks_toolbox.macros_response
+            )
+            response = admin_client.post(
+                reverse('wiki.preview', locale=root_doc.locale),
+                dict(content='anything truthy')
+            )
+        else:
+            mock_requests.get(
+                requests_mock.ANY,
+                [
+                    dict(
+                        text='HELLO WORLD',
+                        headers=ks_toolbox.errors_as_headers
+                    ),
+                    ks_toolbox.macros_response,
+                ]
+            )
+            with mock.patch('kuma.wiki.models.config', **ks_settings):
+                response = admin_client.get(root_doc.get_absolute_url())
+
+    assert response.status_code == 200
+
+    response_html = pq(response.content)
+    macro_link = ('#kserrors-list a[href="https://github.com/'
+                  'mozilla/kumascript/blob/master/macros/{}.ejs"]')
+    create_link = ('#kserrors-list a[href="https://github.com/'
+                   'mozilla/kumascript#updating-macros"]')
+    assert len(response_html.find(macro_link.format('SomeMacro'))) == 1
+    assert len(response_html.find(create_link)) == 1
+
+    assert mock_requests.request_history[0].headers['X-FireLogger'] == '1.2'
+    for error in ks_toolbox.errors['logs']:
+        assert error['message'] in response.content

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -728,6 +728,9 @@ def document(request, document_slug, document_locale):
         'has_contributors': has_contributors,
         'fallback_reason': fallback_reason,
         'kumascript_errors': ks_errors,
+        'macro_sources': (kumascript.macro_sources(force_lowercase_keys=True)
+                          if ks_errors else
+                          None),
         'render_raw_fallback': rendering_params['render_raw_fallback'],
         'seo_summary': seo_summary,
         'seo_parent_title': seo_parent_title,

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -66,6 +66,9 @@ def preview(request):
         'content': wiki_content,
         'title': request.POST.get('title', ''),
         'kumascript_errors': kumascript_errors,
+        'macro_sources': (kumascript.macro_sources(force_lowercase_keys=True)
+                          if kumascript_errors else
+                          None),
     }
     return render(request, 'wiki/preview.html', context)
 


### PR DESCRIPTION
See [bugzilla 1324092](https://bugzilla.mozilla.org/show_bug.cgi?id=1324092).

The fix was easy for this PR, but refactoring the tests proved painful. I added a new wiki-level test fixture ``ks_toolbox``. I placed it at the wiki level assuming it will be used by more than one file that we create as we refactor more of the tests within ``kuma/wiki/tests/test_views.py``. It's currently used by both ``test_views.py`` (imported, since the machinery for using fixtures within ``unittest.TestCase`` based classes is worse) and ``test_views_document.py`` .