### PR TITLE
bug 1370594: Split up translation in redesign notices

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -28,6 +28,8 @@ Switches
 * ``newsletter_article`` - Show newsletter sign-up in article footer (must be
   used in combination with ``newsletter``).
 * ``redesign`` - show design reflecting new Mozilla branding
+* ``redesign_beta`` - show redesign notice for beta period
+* ``redesign_live`` - show redesign notice for launch period
 * ``store_revision_ips`` - Save request data, including the IP address, to
   enable marking revisions as spam.
 * ``welcome_email`` - Send welcome email to new user registrations.

--- a/jinja2/includes/redesign_notice.html
+++ b/jinja2/includes/redesign_notice.html
@@ -28,9 +28,7 @@
   <p>{{ _('Thanks for using MDN!') }} <br> {{ _('The MDN Web Docs Team') }}</p>
 <button id="redesignHide" type="button" class="only-icon transparent redesign-hide"><span>{{ _('Hide redesign announcement') }}</span><i aria-hidden="true" class="icon-times"></i></button>
 </div>
-{% endif %}
-
-{% if waffle.flag('redesign_live') %}
+{% elif waffle.flag('redesign_live') %}
 <div id="redesignNotice" class="redesign-notice hidden">
   <h2>{{ _('Why does MDN look different?') }}</h2>
   <p>{{ _('MDN is changing to focus just on documenting web technologies. All the same great content is still here; we’re just changing some visual elements and navigation, to help you more quickly find the web technology docs you’re looking for.') }}</p>

--- a/jinja2/includes/redesign_notice.html
+++ b/jinja2/includes/redesign_notice.html
@@ -1,37 +1,47 @@
 {% if waffle.flag('redesign_beta') %}
 <div class="redesign-footer">
 <div class="center">
-  {% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/', bug_url='https://bugzilla.mozilla.org/form.mdn#h=detail%7Cbug' %}
-    <h2>Under Construction</h2>
-    <p>Thanks for helping us test the <a href="{{ blog_url }}">new MDN look</a>. Find anything wrong? Please <a href="{{ bug_url }}">file a bug</a>. </p>
-  {% endtrans %}
+  <h2>{{ _('Under Construction') }}</h2>
+  <p>
+    {% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/',
+             bug_url='https://bugzilla.mozilla.org/form.mdn#h=detail%7Cbug' %}
+    Thanks for helping us test the <a href="{{ blog_url }}">new MDN look</a>. Find anything wrong? Please <a href="{{ bug_url }}">file a bug</a>.
+    {% endtrans %}
+  </p>
 </div>
 </div>
 <div id="redesignNotice" class="redesign-notice hidden">
-{% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/', profile_url=url('users.user_edit', username=user.username) %}
-  <h2>Hello Beta Tester!</h2>
-  <p>We’re updating the look and navigation of MDN to more closely reflect our dedication to providing the best (and most platform-agnostic) web docs in the world. As a beta tester, you’re the first to see the new look, and we’d love to hear what you think.</p>
-  <p>You're seeing a preview of our new look. If you find anything wrong please file a bug (the link is in the footer) and you can opt out of being a beta tester on <a href="{{ profile_url }}">your profile page</a>.</p>
-  <p>The changes will roll out to you (as a beta tester) over the next couple weeks, and to the world in mid-July.</p>
-  <p>We hope you love it and find it useful!</p>
-  <p><a href="{{ blog_url }}">Read more about the redesign</a> in our blog post.</p>
-  <p>Thanks for using MDN! <br>The MDN Web Docs Team</p>
-{% endtrans %}
+  <h2>{{ _('Hello Beta Tester!') }}</h2>
+  <p>{{ _('We’re updating the look and navigation of MDN to more closely reflect our dedication to providing the best (and most platform-agnostic) web docs in the world. As a beta tester, you’re the first to see the new look, and we’d love to hear what you think.') }}</p>
+  <p>
+    {% trans profile_url=url('users.user_edit', username=user.username) %}
+    You're seeing a preview of our new look. If you find anything wrong please file a bug (the link is in the footer) and you can opt out of being a beta tester on <a href="{{ profile_url }}">your profile page</a>.
+    {% endtrans %}
+  </p>
+  <p>{{ _('The changes will roll out to you (as a beta tester) over the next couple weeks, and to the world in mid-July.') }}</p>
+  <p>{{ _('We hope you love it and find it useful!') }}</p>
+  <p>
+    {% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/' %}
+    <a href="{{ blog_url }}">Read more about the redesign</a> in our blog post.
+    {% endtrans %}
+  </p>
+  <p>{{ _('Thanks for using MDN!') }} <br> {{ _('The MDN Web Docs Team') }}</p>
 <button id="redesignHide" type="button" class="only-icon transparent redesign-hide"><span>{{ _('Hide redesign announcement') }}</span><i aria-hidden="true" class="icon-times"></i></button>
 </div>
 {% endif %}
 
 {% if waffle.flag('redesign_live') %}
 <div id="redesignNotice" class="redesign-notice hidden">
-  {% trans %}
-    <h2>Why does MDN look different?</h2>
-    <p>MDN is changing to focus just on documenting web technologies. All the same great content is still here; we’re just changing some visual elements and navigation, to help you more quickly find the web technology docs you’re looking for.</p>
-    <p>But don’t worry, MDN and Mozilla are still together! In fact, we're updating MDN’s look to reflect Mozilla's new logo and colors.</p>
-  {% endtrans %}
+  <h2>{{ _('Why does MDN look different?') }}</h2>
+  <p>{{ _('MDN is changing to focus just on documenting web technologies. All the same great content is still here; we’re just changing some visual elements and navigation, to help you more quickly find the web technology docs you’re looking for.') }}</p>
+  <p>{{ _('But don’t worry, MDN and Mozilla are still together! In fact, we\'re updating MDN’s look to reflect Mozilla\'s new logo and colors.') }}</p>
   <p><span class="redesign-old-logo"></span><span class="redesign-new-logo"></span></p>
-  {% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/' %}
-    <p><a href="{{ blog_url }}">Read more about the redesign</a> in our blog post. Thanks for using MDN!</p>
-  {% endtrans %}
+  <p>
+    {% trans blog_url='https://blog.mozilla.org/opendesign/future-mdn-focus-web-docs/' %}
+    <a href="{{ blog_url }}">Read more about the redesign</a> in our blog post.
+    {% endtrans %}
+    {{ _('Thanks for using MDN!') }}
+  </p>
   <button id="redesignHide" type="button" class="only-icon transparent redesign-hide"><span>{{ _('Hide redesign announcement') }}</span><i aria-hidden="true" class="icon-times"></i></button>
 </div>
 {% endif %}


### PR DESCRIPTION
* Split text into smaller translation blocks with less inner HTML.
* Ensure redesign_beta and redesign_live notices aren't displayed at
the same time.