### PR TITLE
Fixes misspelling of relative in CSS rule

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -81,7 +81,7 @@ $see-also-outdent : 6px;
 
         #{$selector-icon} {
             @include set-font-size($body-font-size);
-            position: realtive;
+            position: relative;
             top: 3px;
             min-width: 15px;
             vertical-align: top;


### PR DESCRIPTION
@stephaniehobson Saw the icons did not line up quite correctly on for example:
https://developer.allizom.org/en-US/docs/Web/HTTP

<img width="237" alt="screen shot 2017-06-22 at 13 57 59" src="https://user-images.githubusercontent.com/10350960/27432982-d9cc8df2-5752-11e7-89ed-07ccc0c8150f.png">

Tracked down the problem, and this fixes it.