### PR TITLE
Fixing a minor typo (s/Github/GitHub)

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -260,7 +260,7 @@
                 <li><a href="/docs/MDN/About">{{ _('About MDN') }}</a></li>
                 <li><a href="{{ wiki_url('MDN/Feedback') }}">{{ _('Feedback') }}</a></li>
                 <li class="footer-social"><a href="https://twitter.com/mozdevnet" class="only-icon"><i aria-hidden="true" class="icon-twitter"></i> <span>{{ _('Twitter') }}</span></a></li>
-                <li class="footer-social"><a href="https://github.com/mdn/" class="only-icon"><i aria-hidden="true" class="icon-github"></i> <span>{{ _('Github') }}</span></a></li>
+                <li class="footer-social"><a href="https://github.com/mdn/" class="only-icon"><i aria-hidden="true" class="icon-github"></i> <span>{{ _('GitHub') }}</span></a></li>
               </ul>
             </div>
 


### PR DESCRIPTION
Just fixing a case typo in 'GitHub' (since I can't stand FireFox… ;))

Note: This PR  does not follow the contribution rule since this is a really minor issue. I can file a bug and reword this if necessary.