### PR TITLE
Bug 1370594: Change hit area of header and footer links.

### DIFF
--- a/kuma/static/styles/components/structure/nav-footer.scss
+++ b/kuma/static/styles/components/structure/nav-footer.scss
@@ -41,19 +41,18 @@
     margin-bottom: $mobile-center-spacing;
 
     a {
-        display: block;
-        margin: $content-vertical-spacing 0;
+        display: inline-block;
+        padding: ($grid-spacing / 2) 0;
     }
 }
 
 .footer-social {
     @include set-font-size($h4-font-size);
     display: inline-block;
-    @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+    @include bidi-style(margin-right, ($grid-spacing / 2 ), margin-left, 0);
 
     a {
-        margin-top: 0;
-        margin-bottom: 0;
+        @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
     }
 }
 
@@ -98,22 +97,24 @@
         margin-bottom: $gutter-width;
 
         a {
-            margin: ($grid-spacing / 2) 0;
+            padding: ($grid-spacing / 4) 0;
         }
     }
 
     .footer-social {
         a {
-            margin-top: 0;
-            margin-bottom: 0;
+            @include bidi-style(padding-right, ($grid-spacing / 2 ), padding-left, 0);
         }
     }
-
 
     .languages {
         @include clearfix();
         padding-bottom: $gutter-width;
         margin-bottom: $gutter-width;
+
+        select {
+            max-width: -calc-col-width(3);
+        }
     }
 
     .footer-tos {

--- a/kuma/static/styles/components/structure/submenu.scss
+++ b/kuma/static/styles/components/structure/submenu.scss
@@ -8,6 +8,10 @@
         @include set-heading-font-family;
         @include set-font-size($h4-font-size);
     }
+
+    #{$selector-icon} {
+        @include bidi-style(margin-left, 5px, margin-right, 0);
+    }
 }
 
 .zone #main-header .submenu a {
@@ -65,12 +69,10 @@
             }
         }
 
-        li {
-            margin-top: 15px;
-        }
-
-        #{$selector-icon} {
-            @include bidi-style(margin-left, 5px, margin-right, 0);
+        a {
+            display: block;
+            padding: 5px 0;
+            margin-bottom: 5px;
         }
 
         #nav-sec & {


### PR DESCRIPTION
Footer hit areas are narrower but taller, conforming more to the
shape of the link but being forgiving if you're not exactly on it.

Header hit areas are full width of column and taller.

Bug 1375765 and bug 1375962. Better but not sure they're "fixed".

