### PR TITLE
bug 1376606: Disable New Relic v1 API call

### DIFF
--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -89,6 +89,7 @@ def restart_celery(ctx):
 # As far as I can tell, Chief does not pass the username to commander,
 # so I can't give a username here: (
 # also doesn't pass ref at this point... we have to backdoor that too!
+# TODO: Update to the v2 API
 @task
 def ping_newrelic(ctx):
     f = open(settings.SRC_DIR + "/media/revision.txt", "r")
@@ -169,7 +170,7 @@ def deploy(ctx):
     restart_web()
     restart_kumascript()
     restart_celery()
-    ping_newrelic()
+    # ping_newrelic()
 
 
 @task


### PR DESCRIPTION
We'll need to update the puppet-controlled configuration settings to include an application ID. Disabling this feature for now so that pushes won't report errors.