### PR TITLE
bug 1269104: Fix issues when comparing first translation to English revision

### DIFF
--- a/kuma/wiki/jinja2/wiki/compare_revisions.html
+++ b/kuma/wiki/jinja2/wiki/compare_revisions.html
@@ -13,7 +13,7 @@
     <h1>{{ _('Compare Revisions') }}</h1>
     <h2><a href="{{ document.get_absolute_url() }}">{{ document.title }}</a></h2>
 
-    {{ revision_diff(revision_from, revision_to) }}
+    {{ revision_diff(revision_from, revision_to, 'compare') }}
 
     <p><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow, noindex">{{ _('Back to History') }}</a></p>
 

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -26,7 +26,7 @@
 {% macro revision_diff(revision_from, revision_to, origin) -%}
   {% if revision_from and revision_to %}
     <section class="revision-diff">
-      <a class="change-revisions" href="{{ url('wiki.document_revisions', revision_from.document.slug)|urlparams(locale=revision_from.document.locale, origin=origin) }}">{{ _('Change Revisions') }}</a>
+      <a class="change-revisions" href="{{ url('wiki.document_revisions', revision_to.document.slug)|urlparams(locale=revision_to.document.locale, origin=origin) }}">{{ _('Change Revisions') }}</a>
       <header>
         <div class="rev-from">
           <h3>

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -23,10 +23,10 @@
   </div>
 {%- endmacro %}
 
-{% macro revision_diff(revision_from, revision_to) -%}
+{% macro revision_diff(revision_from, revision_to, origin) -%}
   {% if revision_from and revision_to %}
     <section class="revision-diff">
-      <a class="change-revisions" href="{{ url('wiki.document_revisions', revision_from.document.slug)|urlparams(locale=revision_from.document.locale, origin='translate') }}">{{ _('Change Revisions') }}</a>
+      <a class="change-revisions" href="{{ url('wiki.document_revisions', revision_from.document.slug)|urlparams(locale=revision_from.document.locale, origin=origin) }}">{{ _('Change Revisions') }}</a>
       <header>
         <div class="rev-from">
           <h3>

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -67,13 +67,13 @@
             </ul>
             #}
             {% if revision_from and revision_to %}
-                {{ revision_diff(revision_from, revision_to) }}
+                {{ revision_diff(revision_from, revision_to, 'translate') }}
             {% elif document.current_revision and document.current_revision.based_on %}
               {% if parent.current_revision != document.current_revision.based_on %}
                 {# Diff between the English version the current translation is based on and the current English version. #}
                 {% set revision_from = document.current_revision.based_on %}
                 {% set revision_to = parent.current_revision %}
-                {{ revision_diff(revision_from, revision_to) }}
+                {{ revision_diff(revision_from, revision_to, 'translate') }}
               {% endif %}
             {% endif %}
 


### PR DESCRIPTION
This fixes three issues you can see on https://developer.mozilla.org/fr/docs/user:jwhitlock$compare?locale=fr&to=1269259&from=1249101

* When clicking on "Changer de révision", you see the history page for the **English** document with a French UI. You should see the history for the **French** document with a French UI.
* When clicking on "Changer de révision", and then select "Comparer les révisions sélectionnées" (Compare selected revisions), you start **translating the document**. Instead, you should be back at **the revision comparison interface**.
* When clicking on "Révision 1249101" (the left-side English revision), you are taken to [fr/docs/user:jwhitlock$revision/1249101](https://developer.mozilla.org/fr/docs/user:jwhitlock$revision/1249101), the **French page**. You should be taken to [en-US/docs/user:jwhitlock$revision/1249101](https://developer.mozilla.org/en-US/docs/user:jwhitlock$revision/1249101), the **English page**.

You can get these pages in the development environment with:
```
./manage.py scrape_document https://developer.mozilla.org/en-US/docs/user:jwhitlock --translations --revisions=5
```