### PR TITLE
Adds post message listener for interactive examples

### DIFF
--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -1,7 +1,6 @@
 (function(win, doc, $) {
     'use strict';
 
-    // prettier-ignore
     // Adding to globally available mdn object
     var analytics = mdn.analytics = {
         /**
@@ -42,8 +41,8 @@
             var ga = win.ga;
             var data = {
                 hitType: 'event',
-                eventCategory: eventObject.category || '', // Required.
-                eventAction: eventObject.action || '', // Required.
+                eventCategory: eventObject.category || '',    // Required.
+                eventAction: eventObject.action || '',             // Required.
                 eventLabel: eventObject.label || '',
                 eventValue: eventObject.value || 0,
                 hitCallback: callback || null
@@ -51,20 +50,22 @@
 
             // If Analytics has loaded, go ahead with tracking
             // Checking for ".create" due to Ghostery mocking of ga
-            if (ga && ga.create) {
+            if(ga && ga.create) {
                 // Send event to GA
                 ga('send', data);
-            } else if (ga && !ga.create) {
+            }
+            else if(ga && !ga.create) {
                 // GA blocked or not yet initialized
                 // strip callback from data
                 data.hitCallback = null;
                 // add to queue without callback
                 ga('send', data);
                 // execute callback now
-                if (callback) {
+                if(callback) {
                     callback();
                 }
-            } else if (callback) {
+            }
+            else if(callback) {
                 // GA disabled or blocked or something, make sure we still
                 // call the caller's callback:
                 callback();
@@ -77,7 +78,7 @@
         trackOutboundLinks: function(target) {
             target = target || document.body;
 
-            $(target).on('click', 'a', function(e) {
+            $(target).on('click', 'a', function (e) {
                 var $this = $(this);
 
                 // bug 1222864 - prevent links to data: uris
@@ -88,14 +89,13 @@
                 }
 
                 // If we explicitly say not to track something, don't
-                if ($this.hasClass('no-track')) {
+                if($this.hasClass('no-track')) {
                     return;
                 }
 
                 var host = this.hostname;
-                if (host && host !== location.hostname) {
-                    var newTab =
-                        this.target === '_blank' || e.metaKey || e.ctrlKey;
+                if(host && host !== location.hostname) {
+                    var newTab = (this.target === '_blank' || e.metaKey || e.ctrlKey);
                     var href = this.href;
                     var callback = function() {
                         win.location = href;
@@ -105,7 +105,7 @@
                         action: href
                     };
 
-                    if (newTab) {
+                    if(newTab) {
                         analytics.trackEvent(data);
                     } else {
                         e.preventDefault();
@@ -118,16 +118,16 @@
 
         trackLink: function(event, url, data) {
             // ctrl or cmd click or context menu
-            // prettier-ignore
-            var newTab = event.metaKey || event.ctrlKey || event.type === 'contextmenu';
+            var newTab = (event.metaKey || event.ctrlKey || event.type == 'contextmenu');
             // is a same page anchor
-            var isAnchor = url.indexOf('#') === 0;
+            var isAnchor = (url.indexOf("#") == 0);
             // isBlank
             var isBlank = $(event.target).attr('target') === '_blank';
 
-            if (newTab || isAnchor || isBlank) {
+            if(newTab || isAnchor || isBlank) {
                 mdn.analytics.trackEvent(data);
-            } else {
+            }
+            else {
                 event.preventDefault();
                 mdn.analytics.trackEvent(data, function() {
                     window.location = url;
@@ -140,24 +140,17 @@
             this article was a lot of help: http://blog.gospodarets.com/track_javascript_angularjs_and_jquery_errors_with_google_analytics/
         */
         trackClientErrors: function() {
+
             // javascript & jQuery errors
             $(win).on('error', function(e) {
                 // probably javascript
-                if (e.originalEvent) {
+                if(e.originalEvent) {
                     var originalEvent = e.originalEvent;
-                    var lineAndColumnInfo = ' line:' + originalEvent.lineno;
-
-                    if (originalEvent.colno) {
-                        lineAndColumnInfo = ' line:' + originalEvent.lineno + ', column:' + originalEvent.colno;
-                    }
-
-                    analytics.trackError(
-                        'JavaScript Error',
-                        originalEvent.message,
-                        originalEvent.filename + ':' + lineAndColumnInfo
-                    );
-                } else {
-                    // no originalEvent means probably jQuery
+                    var lineAndColumnInfo = originalEvent.colno ? ' line:' + originalEvent.lineno +', column:'+ originalEvent.colno : ' line:' + originalEvent.lineno;
+                    analytics.trackError('JavaScript Error', originalEvent.message , originalEvent.filename + ':' + lineAndColumnInfo);
+                }
+                // no originalEvent means probably jQuery
+                else {
                     var message = e.message ? e.message : '';
                     analytics.trackError('jQuery Error', message);
                 }
@@ -165,15 +158,12 @@
 
             // jQuery ajax errors
             $(doc).ajaxError(function(e, request, settings) {
-                analytics.trackError(
-                    'AJAX Error',
-                    settings.url,
-                    JSON.stringify({
-                        result: e.result,
-                        status: request.status,
-                        statusText: request.statusText,
-                        crossDomain: settings.crossDomain,
-                        dataType: settings.dataType
+                analytics.trackError('AJAX Error', settings.url , JSON.stringify({
+                    result: e.result,
+                    status: request.status,
+                    statusText: request.statusText,
+                    crossDomain: settings.crossDomain,
+                    dataType: settings.dataType
                     })
                 );
             });
@@ -186,13 +176,12 @@
             // label is optional, give it a default value if it's not passed
             label = typeof label !== 'undefined' ? label : '';
             return analytics.trackEvent({
-                category: category,
-                action: action,
-                label: label
+                'category': category,
+                'action': action,
+                'label': label
             });
         }
     };
-
     // add event listener for postMessages from the interactive editor
     win.addEventListener('message', analytics.interactiveExamplesEvent, false);
 })(window, document, jQuery);

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -1,8 +1,20 @@
 (function(win, doc, $) {
     'use strict';
 
+    // prettier-ignore
     // Adding to globally available mdn object
     var analytics = mdn.analytics = {
+        /**
+         * Handles postMessage events from the interactive editor, passing of
+         * the data to `trackEvent` if the origin of the message is what we expect.
+         * @param {Object} event - The event Object received from the postMessage
+         */
+        interactiveExamplesEvent: function(event) {
+            if (event.origin !== 'https://mdn.github.io') {
+                return false;
+            }
+            this.trackEvent(event.data);
+        },
         /*
             Tracks generic events passed to the method
         */
@@ -30,8 +42,8 @@
             var ga = win.ga;
             var data = {
                 hitType: 'event',
-                eventCategory: eventObject.category || '',    // Required.
-                eventAction: eventObject.action || '',             // Required.
+                eventCategory: eventObject.category || '', // Required.
+                eventAction: eventObject.action || '', // Required.
                 eventLabel: eventObject.label || '',
                 eventValue: eventObject.value || 0,
                 hitCallback: callback || null
@@ -39,22 +51,20 @@
 
             // If Analytics has loaded, go ahead with tracking
             // Checking for ".create" due to Ghostery mocking of ga
-            if(ga && ga.create) {
+            if (ga && ga.create) {
                 // Send event to GA
                 ga('send', data);
-            }
-            else if(ga && !ga.create) {
+            } else if (ga && !ga.create) {
                 // GA blocked or not yet initialized
                 // strip callback from data
                 data.hitCallback = null;
                 // add to queue without callback
                 ga('send', data);
                 // execute callback now
-                if(callback) {
+                if (callback) {
                     callback();
                 }
-            }
-            else if(callback) {
+            } else if (callback) {
                 // GA disabled or blocked or something, make sure we still
                 // call the caller's callback:
                 callback();
@@ -67,7 +77,7 @@
         trackOutboundLinks: function(target) {
             target = target || document.body;
 
-            $(target).on('click', 'a', function (e) {
+            $(target).on('click', 'a', function(e) {
                 var $this = $(this);
 
                 // bug 1222864 - prevent links to data: uris
@@ -78,13 +88,14 @@
                 }
 
                 // If we explicitly say not to track something, don't
-                if($this.hasClass('no-track')) {
+                if ($this.hasClass('no-track')) {
                     return;
                 }
 
                 var host = this.hostname;
-                if(host && host !== location.hostname) {
-                    var newTab = (this.target === '_blank' || e.metaKey || e.ctrlKey);
+                if (host && host !== location.hostname) {
+                    var newTab =
+                        this.target === '_blank' || e.metaKey || e.ctrlKey;
                     var href = this.href;
                     var callback = function() {
                         win.location = href;
@@ -94,7 +105,7 @@
                         action: href
                     };
 
-                    if(newTab) {
+                    if (newTab) {
                         analytics.trackEvent(data);
                     } else {
                         e.preventDefault();
@@ -107,16 +118,16 @@
 
         trackLink: function(event, url, data) {
             // ctrl or cmd click or context menu
-            var newTab = (event.metaKey || event.ctrlKey || event.type == 'contextmenu');
+            var newTab =
+                event.metaKey || event.ctrlKey || event.type == 'contextmenu';
             // is a same page anchor
-            var isAnchor = (url.indexOf("#") == 0);
+            var isAnchor = url.indexOf('#') == 0;
             // isBlank
             var isBlank = $(event.target).attr('target') === '_blank';
 
-            if(newTab || isAnchor || isBlank) {
+            if (newTab || isAnchor || isBlank) {
                 mdn.analytics.trackEvent(data);
-            }
-            else {
+            } else {
                 event.preventDefault();
                 mdn.analytics.trackEvent(data, function() {
                     window.location = url;
@@ -129,17 +140,24 @@
             this article was a lot of help: http://blog.gospodarets.com/track_javascript_angularjs_and_jquery_errors_with_google_analytics/
         */
         trackClientErrors: function() {
-
             // javascript & jQuery errors
             $(win).on('error', function(e) {
                 // probably javascript
-                if(e.originalEvent) {
+                if (e.originalEvent) {
                     var originalEvent = e.originalEvent;
-                    var lineAndColumnInfo = originalEvent.colno ? ' line:' + originalEvent.lineno +', column:'+ originalEvent.colno : ' line:' + originalEvent.lineno;
-                    analytics.trackError('JavaScript Error', originalEvent.message , originalEvent.filename + ':' + lineAndColumnInfo);
-                }
-                // no originalEvent means probably jQuery
-                else {
+                    var lineAndColumnInfo = originalEvent.colno
+                        ? ' line:' +
+                          originalEvent.lineno +
+                          ', column:' +
+                          originalEvent.colno
+                        : ' line:' + originalEvent.lineno;
+                    analytics.trackError(
+                        'JavaScript Error',
+                        originalEvent.message,
+                        originalEvent.filename + ':' + lineAndColumnInfo
+                    );
+                } else {
+                    // no originalEvent means probably jQuery
                     var message = e.message ? e.message : '';
                     analytics.trackError('jQuery Error', message);
                 }
@@ -147,12 +165,15 @@
 
             // jQuery ajax errors
             $(doc).ajaxError(function(e, request, settings) {
-                analytics.trackError('AJAX Error', settings.url , JSON.stringify({
-                    result: e.result,
-                    status: request.status,
-                    statusText: request.statusText,
-                    crossDomain: settings.crossDomain,
-                    dataType: settings.dataType
+                analytics.trackError(
+                    'AJAX Error',
+                    settings.url,
+                    JSON.stringify({
+                        result: e.result,
+                        status: request.status,
+                        statusText: request.statusText,
+                        crossDomain: settings.crossDomain,
+                        dataType: settings.dataType
                     })
                 );
             });
@@ -165,10 +186,13 @@
             // label is optional, give it a default value if it's not passed
             label = typeof label !== 'undefined' ? label : '';
             return analytics.trackEvent({
-                'category': category,
-                'action': action,
-                'label': label
+                category: category,
+                action: action,
+                label: label
             });
         }
     };
+
+    // add event listener for postMessages from the interactive editor
+    win.addEventListener('message', analytics.interactiveExamplesEvent, false);
 })(window, document, jQuery);

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -118,10 +118,10 @@
 
         trackLink: function(event, url, data) {
             // ctrl or cmd click or context menu
-            var newTab =
-                event.metaKey || event.ctrlKey || event.type == 'contextmenu';
+            // prettier-ignore
+            var newTab = event.metaKey || event.ctrlKey || event.type === 'contextmenu';
             // is a same page anchor
-            var isAnchor = url.indexOf('#') == 0;
+            var isAnchor = url.indexOf('#') === 0;
             // isBlank
             var isBlank = $(event.target).attr('target') === '_blank';
 
@@ -145,12 +145,12 @@
                 // probably javascript
                 if (e.originalEvent) {
                     var originalEvent = e.originalEvent;
-                    var lineAndColumnInfo = originalEvent.colno
-                        ? ' line:' +
-                          originalEvent.lineno +
-                          ', column:' +
-                          originalEvent.colno
-                        : ' line:' + originalEvent.lineno;
+                    var lineAndColumnInfo = ' line:' + originalEvent.lineno;
+
+                    if (originalEvent.colno) {
+                        lineAndColumnInfo = ' line:' + originalEvent.lineno + ', column:' + originalEvent.colno;
+                    }
+
                     analytics.trackError(
                         'JavaScript Error',
                         originalEvent.message,


### PR DESCRIPTION
Adds a `message` event listener for `postMessage` messages from the interactive code examples.

The `event` object passed to the `interactiveExamplesEvent` function will contain the following:

`event.origin` ~ Origin of the window that sent the message (here it is the iframe)
`event.data` ~ The data sent via `postMessage`. This will contain a category, action and label associated with the event that is then passed to `trackEvent`

For example:

```
{
  category: 'js-examples',
  action: 'Clicked run',
  label: 'Interaction Events'
}
```