### PR TITLE
bug 1375869: fix ISE when KumaScript returns DocumentParsingError

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
@@ -30,9 +30,9 @@
               <dd class="kserror-type">
                 {{ error_type }}
               </dd>
-              {% set error_meta = error.args[2] %}
-              {% if error_meta %}
-                {% set macro_name = error_meta.name %}
+              {% set error_meta = error.args[2] if error.args|count > 2 else None %}
+              {% set macro_name = error_meta.get('name') if error_meta else None %}
+              {% if macro_name %}
                 {% set macro_relpath = macro_sources.get(macro_name.lower()) %}
                 <dt>{{ _('In macro:') }}</dt>
                 <dd>
@@ -46,7 +46,7 @@
                 <dt>{{ _('Parsing macro:') }}</dt>
                 <dd>
                   <code class="kserror-parse">{{ macro_name }}
-                    {% if error_meta.token %}
+                    {% if error_meta.get('token') %}
                       ({{ error_meta.token.args }})
                     {% endif %}
                   </code>

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -348,6 +348,15 @@ def ks_toolbox():
              "args": ['TestError', {}, {'name': 'SomeMacro2'}],
              "time": "12:33:58 GMT-0400 (EDT)",
              "timestamp": "1331829238052000"},
+            {"level": "error",
+             "message": "Syntax error at line 88...",
+             "args": [
+                 'DocumentParsingError',
+                 'Syntax error at line 88...',
+                 {'error': {'line': 88, 'column': 65}}
+             ],
+             "time": "12:33:59 GMT-0400 (EDT)",
+             "timestamp": "1331829238053000"},
             {"level": "info",
              "message": "Message #3",
              "args": ['TestError'],


### PR DESCRIPTION
* add case to the "ks_toolbox" fixture that mimics a DocumentParsingError (adds regression test for this case going forward)
* fix "kumascript_errors.html" such that it tries to get the information it needs from "error_meta" in a safer manner

It turns out that this issue is caused by a combination of two things:

1. The document actually contains an error that causes KumaScript to report a `DocumentParsingError` (e.g., https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics is missing a double quote at line 88 column 65, which should be `htmlelement("head")` instead of `htmlelement(head")`)
2. The `kumascript_errors.html` template contained a bug such that `DocumentParsingError` errors raised an exception.

So in addition to this fix, all of the following documents have syntax errors that have to be fixed as well:
- https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web/HTML_basics
- https://developer.mozilla.org/en-US/docs/Archive/Apps/Tools_and_frameworks/Web_components
- https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/%3Cinput_type=_tel_%3E
- https://developer.mozilla.org/en-US/docs/Web/HTML/Index
