### PR TITLE
bug 1380045: Change Project:MDN links

### DIFF
--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -162,7 +162,7 @@
     {{ newsfeed(updates) }}
   </div>
   <div class="column-involved">
-    <div class="home-involved-card"><a href="{{ wiki_url('Project:MDN/Contributing') }}">
+    <div class="home-involved-card"><a href="{{ wiki_url('MDN/Contribute') }}">
       <h2 class="title">{{ _('Get Involved') }}</h2>
 
       {% trans contributors=stats.contributors, locales=stats.locales %}

--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -63,7 +63,7 @@
                 <tr>
                     <th scope="row">
                     {% if is_me %}
-                        {% trans docs_url=wiki_url('Project:MDN/Contributing/Creating_and_editing_pages') %}
+                        {% trans docs_url=wiki_url('MDN/Contribute/Howto/Create_and_edit_pages') %}
                         <p class="none">You haven't contributed to any MDN docs. <a href="{{ docs_url }}">Pitch in!</a></p>
                         {% endtrans %}
                     {% else %}

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -160,7 +160,7 @@
           <section class="first-contrib-welcome">
             <h2>{{ _('Thank you for taking the time to improve MDN!') }}</h2>
             <p>
-              {% trans url=wiki_url('Project:MDN/Contributing/Editor_guide/') %}
+              {% trans url=wiki_url('MDN/Contribute/Editor') %}
                 It looks like this is your first contribution to MDN. You can find answers to common editing questions within our <a target="_blank" href="{{ url }}">Editor Guide</a>.
               {% endtrans %}
             </p>
@@ -183,7 +183,7 @@
             <section id="page-tags" class="page-tags wiki-block">
               <h3><i aria-hidden="true" class="icon-tags"></i>{{ _('Tags') }} <a href="{{ wiki_url('MDN/Contribute/Editor/Basics#The_tags_box') }}"><i aria-hidden="true" title="{{ _('Learn how to tag an article') }}" class="icon-question-sign editor-help-icon"></i></a></h3>
               <p>
-              {% trans url=wiki_url('Project:MDN/Contributing/Tagging_standards') %}
+              {% trans url=wiki_url('MDN/Contribute/Howto/Tag') %}
                 Categorize the article. It will make the article findable under the right filters in the search engine. <a target="_blank" href="{{ url }}">Read the Tagging Guide</a>.
               {% endtrans %}
               </p>

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -111,7 +111,7 @@
             <summary><h2>{{ _('Translate Tags') }}</h2></summary>
             <div class="wiki-block">
               <p>
-                {% trans url=wiki_url('Project:MDN/Contributing/Tagging_standards') %}
+                {% trans url=wiki_url('MDN/Contribute/Howto/Tag') %}
                 Categorize the article. It will make the article findable under the right filters in the search engine. <a target="_blank" href="{{ url }}">Read the Tagging Guide</a>.
                 {% endtrans %}
               </p>

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -254,8 +254,12 @@ def wiki_url(path):
     Create a URL pointing to Kuma.
     Look for a wiki page in the current locale, or default to given path
     """
-    parts = urlparse.urlsplit(path)
-    new_path = reverse('wiki.document', args=[parts.path])
-    new_parts = list(parts)
-    new_parts[2] = new_path
-    return urlparse.urlunsplit(new_parts)
+    if '#' in path:
+        slug, fragment = path.split('#', 1)
+    else:
+        slug = path
+        fragment = ''
+    new_path = reverse('wiki.document', args=[slug])
+    if fragment:
+        new_path += '#' + fragment
+    return new_path


### PR DESCRIPTION
A recent ``wiki_url`` change by me is causing some links to Project:MDN to break (see [bug 1380045](https://bugzilla.mozilla.org/show_bug.cgi?id=1380045)).  This fixes ``wiki_url`` so they will work. 

However, all of these pages have been moved, such as Project:MDN/Contributing moving to [MDN/Contribute](https://developer.mozilla.org/en-US/docs/MDN/Contribute). Updating the templates to point to the new location.