### PR TITLE
Bug 1362025: Add classes to resize interactive examples

### DIFF
--- a/kuma/static/styles/components/wiki/interactive.scss
+++ b/kuma/static/styles/components/wiki/interactive.scss
@@ -1,0 +1,27 @@
+.interactive {
+    height: 430px;
+    width: 100%;
+    margin-bottom: $grid-spacing;
+}
+
+.interactive-js {
+    height: 330px;
+}
+
+.interactive-large {
+    height: 630px;
+}
+
+@media #{$mq-tablet-and-up} {
+    .interactive {
+        height: 280px;
+    }
+
+    .interactive-js {
+        height: 330px;
+    }
+
+    .interactive-large {
+        height: 455px;
+    }
+}

--- a/kuma/static/styles/wiki-blue.scss
+++ b/kuma/static/styles/wiki-blue.scss
@@ -37,6 +37,7 @@ Components that may appear on most wiki pages
 @import 'components-blue/wiki/glossaryLink';
 @import 'components-blue/wiki/communitybox';
 @import 'components-blue/wiki/mega';
+@import 'components/wiki/interactive';
 
 
 /*

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -37,6 +37,7 @@ Components that may appear on most wiki pages
 @import 'components/wiki/glossaryLink';
 @import 'components/wiki/communitybox';
 @import 'components/wiki/mega';
+@import 'components/wiki/interactive';
 
 
 /*


### PR DESCRIPTION
Resizes the interactive example iframe based on classes passed through to the macro.

Macro changes are in: https://github.com/mozilla/kumascript/pull/239 (but this PR is not dependent on that)