### PR TITLE
Call trackEvent explicitly on mdn.analytics

### DIFF
--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -12,7 +12,7 @@
             if (event.origin !== 'https://mdn.github.io') {
                 return false;
             }
-            this.trackEvent(event.data);
+            mdn.analytics.trackEvent(event.data);
         },
         /*
             Tracks generic events passed to the method


### PR DESCRIPTION
This resolved the `this.trackEvent` undefined error on staging.