### PR TITLE
bug 1316610: temporarily remove nofollow from user-profile pages

### DIFF
--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -8,7 +8,7 @@
 {% block bodyclass %}user user-display{% endblock %}
 
 {% block title %}{{ page_title(detail_user) }}{% endblock %}
-{% block robots_value %}noindex, nofollow{% endblock %}
+{% block robots_value %}noindex{% endblock %}
 
 {% block site_css %}
   {{ super() }}


### PR DESCRIPTION
This is my understanding of the first step to removing user-profile pages from search indices. Is this all there is to the first step?