### PR TITLE
[Bug 1331729] Language preference cookie to stop site redirection

### DIFF
--- a/jinja2/includes/lang_switcher.html
+++ b/jinja2/includes/lang_switcher.html
@@ -9,12 +9,12 @@
   {% endfor %}
   <select id="language" class="autosubmit" name="lang">
     {# The default locale should always be in the first choice -#}
-    <option title="{{ get_locale_localized(default_locale) }}" value="{{ default_locale }}">
+    <option title="{{ get_locale_localized(default_locale) }}" data-locale="{{ default_locale }}" value="{{ default_locale }}">
       {{ default_language }} ({{ default_locale }})
     </option>
     {% for code, name in settings.LANGUAGES -%}
       {% if code != default_locale %}
-        <option title="{{ get_locale_localized(code) }}" value="{{ code }}"{% if code == LANG %} selected{% endif %}>
+        <option title="{{ get_locale_localized(code) }}" data-locale="{{ code }}" value="{{ code }}"{% if code == LANG %} selected{% endif %}>
           {{ name }} ({{ code }})
         </option>
       {% endif %}

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -4,11 +4,7 @@ from urlparse import urljoin
 
 from django.conf import settings
 from django.core import urlresolvers
-from django.http import (
-    HttpResponseRedirect,
-    HttpResponseForbidden,
-    HttpResponsePermanentRedirect,
-)
+from django.http import HttpResponseForbidden, HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -33,8 +29,9 @@ class LocaleURLMiddleware(object):
         prefixer = Prefixer(request)
         set_url_prefixer(prefixer)
         full_path = prefixer.fix(prefixer.shortened_path)
+        lang = request.GET.get('lang')
 
-        if 'lang' in request.GET:
+        if lang in dict(settings.LANGUAGES):
             # Blank out the locale so that we can set a new one. Remove lang
             # from the query params so we don't have an infinite loop.
             prefixer.locale = ''

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from kuma.core.tests import KumaTestCase
 
 
@@ -43,3 +44,10 @@ class TestLocaleMiddleware(KumaTestCase):
         """/en-us should redirect to /en-US."""
         response = self.client.get('/en-us/', follow=True)
         self.assertRedirects(response, '/en-US/', status_code=302)
+
+    def test_language_cookie_support(self):
+        """Request with language cookie should redirect to the cookie locale"""
+        # Add appropriate language cookie to the client
+        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
+        response = self.client.get('/')
+        self.assertRedirects(response, '/bn-BD/', status_code=302)

--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -1,10 +1,33 @@
+from django.conf import settings
+from django.http import HttpResponse
 from django.shortcuts import render
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
 from .decorators import never_cache
 
 
 def _error_page(request, status):
     """Render error pages with jinja2."""
     return render(request, '%d.html' % status, status=status)
+
+
+@csrf_exempt
+@require_POST
+def set_language(request):
+    lang_code = request.POST.get("language")
+    response = HttpResponse(status=204)
+
+    if lang_code and lang_code in dict(settings.LANGUAGES):
+
+        response.set_cookie(key=settings.LANGUAGE_COOKIE_NAME,
+                            value=lang_code,
+                            max_age=settings.LANGUAGE_COOKIE_AGE,
+                            path=settings.LANGUAGE_COOKIE_PATH,
+                            domain=settings.LANGUAGE_COOKIE_DOMAIN,
+                            )
+
+    return response
 
 
 handler403 = lambda request: _error_page(request, 403)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -420,7 +420,8 @@ LANGUAGE_URL_IGNORED_PATHS = (
     'index.php',  # Legacy MediaWiki endpoint, return 404
     # Served in AWS
     'sitemap.xml',
-    'sitemaps/'
+    'sitemaps/',
+    'i18n'
 )
 
 # Make this unique, and don't share it with anybody.
@@ -988,6 +989,7 @@ PIPELINE_JS = {
             # FFO lib contains Promise polyfill
             'js/libs/fontfaceobserver/fontfaceobserver.2.0.7.js',
             'js/fonts.js',
+            'js/lang-switcher.js'
         ),
         'output_filename': 'build/js/main.js',
     },

--- a/kuma/static/js/lang-switcher.js
+++ b/kuma/static/js/lang-switcher.js
@@ -1,0 +1,27 @@
+(function () {
+    var langSwitcherSelector = document.getElementById('language'),
+        langSwitcherButton = document.getElementById('translations');
+
+    function storeLocaleChange(code, name) {
+        localStorage.setItem('changed-locale-to', JSON.stringify({code: code, name: name}));
+    }
+
+    if (langSwitcherSelector) {
+        langSwitcherSelector.addEventListener('change', function () {
+            var element = this.options[this.options.selectedIndex];
+            storeLocaleChange(element.dataset.locale, element.label);
+        });
+    }
+
+    if (langSwitcherButton) {
+        var transChoices = langSwitcherButton.querySelectorAll('li a');
+
+        for(var i = 0; i < transChoices.length; i++) {
+
+            transChoices[i].addEventListener('click', function () {
+                storeLocaleChange(this.dataset.locale, this.text);
+            });
+        }
+    }
+
+})();

--- a/kuma/static/js/lang-switcher.js
+++ b/kuma/static/js/lang-switcher.js
@@ -1,27 +1,58 @@
-(function () {
-    var langSwitcherSelector = document.getElementById('language'),
-        langSwitcherButton = document.getElementById('translations');
-
+(function (win, doc, $) {
     function storeLocaleChange(code, name) {
         localStorage.setItem('changed-locale-to', JSON.stringify({code: code, name: name}));
     }
 
-    if (langSwitcherSelector) {
-        langSwitcherSelector.addEventListener('change', function () {
-            var element = this.options[this.options.selectedIndex];
-            storeLocaleChange(element.dataset.locale, element.label);
-        });
-    }
+    if(win.mdn.features.localStorage) {
+        var langSwitcherSelector = document.getElementById('language'),
+            langSwitcherButton = document.getElementById('translations');
 
-    if (langSwitcherButton) {
-        var transChoices = langSwitcherButton.querySelectorAll('li a');
-
-        for(var i = 0; i < transChoices.length; i++) {
-
-            transChoices[i].addEventListener('click', function () {
-                storeLocaleChange(this.dataset.locale, this.text);
+        if (langSwitcherSelector) {
+            langSwitcherSelector.addEventListener('change', function () {
+                var element = this.options[this.options.selectedIndex];
+                storeLocaleChange(element.dataset.locale, element.label);
             });
+        }
+
+        if (langSwitcherButton) {
+            var transChoices = langSwitcherButton.querySelectorAll('li a');
+
+            for (var i = 0; i < transChoices.length; i++) {
+
+                transChoices[i].addEventListener('click', function () {
+                    storeLocaleChange(this.dataset.locale, this.text);
+                });
+            }
+        }
+
+        // Insert notice about permanent language switch
+        var changedLocaleTo = localStorage.getItem('changed-locale-to');
+        if (changedLocaleTo) {
+            var locale = JSON.parse(changedLocaleTo),
+                text = gettext('You are now viewing this site in %(localeName)s.' +
+                               ' Do you always want to view this site in %(localeName)s?'),
+                html = interpolate(text +
+                    '<br><button id="locale-permanent-yes" type="button" data-locale="%(localeCode)s">' +
+                    gettext('Yes') + '</button> <button id="locale-permanent-no" type="button">' + gettext('No') +
+                    '</button></p></div>', {localeCode: locale.code, localeName: locale.name}, true),
+                notification = mdn.Notifier.growl(html, {closable: true, duration: 0}).question();
+
+            // Add event listener to the buttons
+            $('#locale-permanent-yes').on('click', function () {
+                $.post('/i18n/setlang/', {language: this.dataset.locale})
+                    .success(function () {
+                        notification.close();
+                        localStorage.removeItem('changed-locale-to');
+                    });
+            }
+            );
+
+            $('#locale-permanent-no').on('click', function () {
+                notification.close();
+                localStorage.removeItem('changed-locale-to');
+            }
+            );
         }
     }
 
-})();
+})(window, document, jQuery);

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -668,48 +668,5 @@
             win.history.replaceState({}, '', location.pathname);
         }
     }
-
-    // listens for post message from interactive editor
-    window.addEventListener('message', function(event) {
-        // get the interactive editor iframe
-        var iframe = document.querySelector('iframe.interactive');
-        var isExpectedOrigin = event.origin === 'https://interactive-examples.mdn.mozilla.net';
-
-        /* there may be other post messages so, ensure that the origin is the
-        expected and, that `event.data` contains an `iframeHeight` property */
-        if (isExpectedOrigin && event.data.iframeHeight) {
-            iframe.setAttribute('height', event.data.iframeHeight);
-        }
-    }, false);
-
-    // Insert notice about permanent language switch
-    var changedLocaleTo = localStorage.getItem('changed-locale-to');
-    if (changedLocaleTo) {
-        var locale = JSON.parse(changedLocaleTo),
-            text = gettext('You are now viewing this article in %(localeName)s.' +
-                           ' Do you always want to view MDN articles in %(locale_name)s?'),
-            html = interpolate('<div id="locale-permanent-banner" class="primary overheadIndicator"><p>' + text +
-                               '<br><button id="locale-permanent-yes" data-locale="%(localeCode)s">' +
-                               gettext('Yes') + '</button> <button id="locale-permanent-no">' +
-                               gettext('No') + '</button></p></div>',
-                {localeCode: locale.code, localeName: locale.name}, true);
-
-        $('#wiki-content').prepend(html);
-
-        // Add event listener to the buttons
-        $('#locale-permanent-yes').on('click', function () {
-            $.post('/i18n/setlang/', {language: this.dataset.locale})
-                .success(function () {
-                    $('#locale-permanent-banner').remove();
-                    localStorage.removeItem('changed-locale-to');
-                });
-        }
-        );
-
-        $('#locale-permanent-no').on('click', function () {
-            $('#locale-permanent-banner').remove();
-            localStorage.removeItem('changed-locale-to');
-        }
-        );
-    }
+    
 })(window, document, jQuery);

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -669,4 +669,47 @@
         }
     }
 
+    // listens for post message from interactive editor
+    window.addEventListener('message', function(event) {
+        // get the interactive editor iframe
+        var iframe = document.querySelector('iframe.interactive');
+        var isExpectedOrigin = event.origin === 'https://interactive-examples.mdn.mozilla.net';
+
+        /* there may be other post messages so, ensure that the origin is the
+        expected and, that `event.data` contains an `iframeHeight` property */
+        if (isExpectedOrigin && event.data.iframeHeight) {
+            iframe.setAttribute('height', event.data.iframeHeight);
+        }
+    }, false);
+
+    // Insert notice about permanent language switch
+    var changedLocaleTo = localStorage.getItem('changed-locale-to');
+    if (changedLocaleTo) {
+        var locale = JSON.parse(changedLocaleTo),
+            text = gettext('You are now viewing this article in %(localeName)s.' +
+                           ' Do you always want to view MDN articles in %(locale_name)s?'),
+            html = interpolate('<div id="locale-permanent-banner" class="primary overheadIndicator"><p>' + text +
+                               '<br><button id="locale-permanent-yes" data-locale="%(localeCode)s">' +
+                               gettext('Yes') + '</button> <button id="locale-permanent-no">' +
+                               gettext('No') + '</button></p></div>',
+                {localeCode: locale.code, localeName: locale.name}, true);
+
+        $('#wiki-content').prepend(html);
+
+        // Add event listener to the buttons
+        $('#locale-permanent-yes').on('click', function () {
+            $.post('/i18n/setlang/', {language: this.dataset.locale})
+                .success(function () {
+                    $('#locale-permanent-banner').remove();
+                    localStorage.removeItem('changed-locale-to');
+                });
+        }
+        );
+
+        $('#locale-permanent-no').on('click', function () {
+            $('#locale-permanent-banner').remove();
+            localStorage.removeItem('changed-locale-to');
+        }
+        );
+    }
 })(window, document, jQuery);

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -668,5 +668,4 @@
             win.history.replaceState({}, '', location.pathname);
         }
     }
-    
 })(window, document, jQuery);

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -86,6 +86,11 @@ modifications for 'system' indicators
     }
 }
 
+.primary {
+    color: #004085;
+    background-color: #cce5ff;
+    border-color: #b8daff;
+}
 
 /*
 inline indicators aka badges

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -86,11 +86,6 @@ modifications for 'system' indicators
     }
 }
 
-.primary {
-    color: #004085;
-    background-color: #cce5ff;
-    border-color: #b8daff;
-}
 
 /*
 inline indicators aka badges

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -102,6 +102,8 @@ urlpatterns += [
     url(r'^miel$',
         handler500,
         name='users.honeypot'),
+    # We use our own views for setting language in cookies. But to just align with django, set it like this.
+    url(r'^i18n/setlang/', core_views.set_language, name='set-language-cookie'),
 ]
 
 if settings.SERVE_MEDIA:

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -93,11 +93,11 @@
     <form class="languages go" method="get" action="{{ wiki_url('Web') }}">
       <label for="language">{{ _('Other languages:') }}</label>
       <select id="language" class="wiki-l10n" name="next" dir="ltr">
-        <option title="{{ get_locale_localized(document.locale) }}" value="{{ doc_abs_url }}" selected>
+        <option title="{{ get_locale_localized(document.locale) }}" data-locale="{{ document.locale }}" value="{{ doc_abs_url }}" selected>
           {{ document.language }} ({{ document.locale }})
         </option>
         {% for translation in other_translations %}
-          <option title="{{ get_locale_localized(translation.locale) }}" value="{{ translation.get_absolute_url() }}">
+          <option title="{{ get_locale_localized(translation.locale) }}" data-locale="{{ document.locale }}" value="{{ translation.get_absolute_url() }}">
             {{ translation.language }} ({{ translation.locale }})
           </option>
         {%- endfor %}

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -23,10 +23,10 @@
               {% if document.other_translations or fallback_reason %}
                 {# show the parent locale in choices if fall back to parent for any reason #}
                 {% if fallback_reason=='no_translation' %}
-                  <li><bdi><a rel="internal" href="{{ document.get_absolute_url() }}" title="{{ get_locale_localized(document.locale) }}">{{ document.language }} ({{ document.locale }})</a></bdi></li>
+                  <li><bdi><a rel="internal" href="{{ document.get_absolute_url() }}" data-locale="{{ document.locale }}" title="{{ get_locale_localized(document.locale) }}">{{ document.language }} ({{ document.locale }})</a></bdi></li>
                 {% endif %}
                 {% for translation in document.other_translations %}
-                  <li><bdi><a rel="internal" href="{{ url('wiki.document', translation.slug, locale=translation.locale) }}" title="{{ get_locale_localized(translation.locale) }}">{{ translation.language }} ({{ translation.locale }})</a></bdi></li>
+                  <li><bdi><a rel="internal" href="{{ url('wiki.document', translation.slug, locale=translation.locale) }}" data-locale="{{ translation.locale }}" title="{{ get_locale_localized(translation.locale) }}">{{ translation.language }} ({{ translation.locale }})</a></bdi></li>
                 {% endfor %}
               {% else %}
                 <li class="smaller">{{ _('No translations exist for this article.') }}</li>


### PR DESCRIPTION
**You need to clear your browser cache or using private browsing before testing this**

As the past code was redirecting permanently with http `301` status code, It should be return with temporary redirect with http `302`

It was fixed in kitsune long ago by James, But was not ported back to kuma.

The Implementation is based on kitsune, refactored some part of the code to increase readability. 

@jwhitlock @escattone r?

Need to be done:
- [x] Pass all the unittests
- [x] Write tests for the functionality 