### PR TITLE
Fix Bug 1375947: Add spacing after page content

### DIFF
--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -23,6 +23,7 @@ Utility classes
 
     main > & {
         padding-top: $first-content-top-padding;
+        padding-bottom: $last-content-bottom-padding;
     }
 
     @media #{$mq-tablet-and-up} {

--- a/kuma/static/styles/components/wiki/structure.scss
+++ b/kuma/static/styles/components/wiki/structure.scss
@@ -3,7 +3,6 @@
 .wiki-main-content {
     background: #fff;
     min-height: 300px;
-    padding-bottom: $grid-spacing;
 }
 
 /* the subnav and quick link column of the layout */

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -242,7 +242,8 @@ dimensions
 $gutter-width : 24px;
 $content-block-margin : $gutter-width;
 
-$first-content-top-padding : ($grid-spacing * 1.5);
+$first-content-top-padding: ($grid-spacing * 1.5);
+$last-content-bottom-padding: ($grid-spacing * 1.5);
 $mobile-center-spacing: 15px;
 
 $content-horizontal-spacing : 8px;


### PR DESCRIPTION
Content was sitting too close to the footer on non-article pages (e.g. $history or profile edit page).

Moved the padding from the article wrapper to the content wrapper and increased it a bit because new design has more white space and this mirrors the space on top.