### PR TITLE
Added the wordcount plugin to display current article length

### DIFF
--- a/kuma/static/js/libs/ckeditor/source/build-config.js
+++ b/kuma/static/js/libs/ckeditor/source/build-config.js
@@ -84,6 +84,7 @@ var CKBUILDER_CONFIG = {
 		'mdn-youtube': 1,
 		descriptionlist: 1,
 		tablesort: 1,
-		texzilla: 1
+		texzilla: 1,
+		wordcount: 1
 	}
 };

--- a/kuma/static/js/libs/ckeditor/source/build.sh
+++ b/kuma/static/js/libs/ckeditor/source/build.sh
@@ -14,7 +14,7 @@ CKBUILDER_URL="http://download.cksource.com/CKBuilder/$CKBUILDER_VERSION/ckbuild
 DESCRIPTION_LIST_VERSION="e365ac622a995d535266c22f0c44b743f8fffa14"
 SCAYT_VERSION="release.4.8.4.0"
 WSC_VERSION="release.4.8.4.0"
-
+WORDCOUNT_VERSION="v1.16"
 
 set -e
 
@@ -60,6 +60,14 @@ function download_plugin
 	git checkout $2
 	cd -
 	rm -rf plugins/$1/.git
+
+	# For plugins whose packages have them in a subdirectory,
+	# move them
+
+	if [[ "$1" == "wordcount" ]]; then
+	  mv plugins/wordcount/wordcount/* plugins/wordcount
+	  rm -r plugins/wordcount/wordcount
+  fi
 }
 
 # Move to the script directory.
@@ -95,6 +103,8 @@ download_plugin "descriptionlist" $DESCRIPTION_LIST_VERSION "https://github.com/
 download_plugin "scayt" $SCAYT_VERSION "https://github.com/WebSpellChecker/ckeditor-plugin-scayt.git"
 
 download_plugin "wsc" $WSC_VERSION "https://github.com/WebSpellChecker/ckeditor-plugin-wsc.git"
+
+download_plugin "wordcount" $WORDCOUNT_VERSION "https://github.com/w8tcha/CKEditor-WordCount-Plugin.git"
 
 cp -R plugins/* ckeditor/plugins/
 

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/README.md
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/README.md
@@ -1,0 +1,92 @@
+CKEditor-WordCount-Plugin
+=========================
+
+WordCount Plugin for CKEditor v4 (or above) that counts the words/characters an shows the word count and/or char count in the footer of the editor.
+
+![Screenshot]
+(http://www.watchersnet.de/Portals/0/screenshots/dnn/CKEditorWordCountPlugin.png)
+
+####Demo
+
+http://w8tcha.github.com/CKEditor-WordCount-Plugin/
+
+DISCLAIMER: This is a forked Version, i can not find the original Author anymore if anyone knows the original Author please contact me and i can include the Author in the Copyright Notices. 
+
+####License
+
+Licensed under the terms of the MIT License.
+
+####Installation
+
+ If building a new editor using the CKBuilder from http://ckeditor.com/, there is no need to follow numbers steps below. If adding the Word Count & Char Count plugin to an already established CKEditor, follow the numbered steps below.
+
+1.	Download the Word Count &  Char Count plugin from http://ckeditor.com/addon/wordcount or https://github.com/w8tcha/CKEditor-WordCount-Plugin. This will download a folder named **wordcount_*version*.zip** or **CKEditor-WordCount-Plugin-master.zip** to your Downloads folder.
+2.	Download the Notification plugin from http://ckeditor.com/addon/notification. This will download a folder named **notification_*version*.zip** to your Downloads folder.
+3.	Extract the .zip folders for both the Word Count & Char Count and Notification plugin. After extraction, you should have a folder named **wordcount** and a folder named **notification**.
+4.	Move the wordcount folder to /web/server/root/ckeditor/plugins/.  Move the notification folder to /web/server/root/ckeditor/plugins/.
+5.	Add the following line of text to the config.js file, which is located at /web/server/root/ckeditor/.
+
+```javascript
+config.extraPlugins = 'wordcount,notification'; 
+```
+
+Below is an example of what your config.js file might look like after adding config.extraPlugins = 'wordcount,notification';
+
+```javascript
+CKEDITOR.editorConfig = function( config ) {
+  config.extraPlugins = 'wordcount,notification';
+  config.toolbar [
+  et cetera . . .
+  ];
+};
+```
+
+There now should be text in the bottom right-hand corner of your CKEditor which counts the number of Paragraphs and number of Words in your CKEditor.
+
+![plugin example](http://www.trojanbot.com/uploads/ckeditor_paragraph_words.png)
+
+To modify the behavior of the Word Count & Char Count text at the bottom right-hand corner of your CKEditor, add the following text to your config.js file located at /web/server/root/ckeditor/config.js.
+
+````js
+config.wordcount = {
+
+    // Whether or not you want to show the Paragraphs Count
+    showParagraphs: true,
+
+    // Whether or not you want to show the Word Count
+    showWordCount: true,
+
+    // Whether or not you want to show the Char Count
+    showCharCount: false,
+
+    // Whether or not you want to count Spaces as Chars
+    countSpacesAsChars: false,
+
+    // Whether or not to include Html chars in the Char Count
+    countHTML: false,
+    
+    // Maximum allowed Word Count, -1 is default for unlimited
+    maxWordCount: -1,
+
+    // Maximum allowed Char Count, -1 is default for unlimited
+    maxCharCount: -1,
+
+    // How long to show the 'paste' warning, 0 is default for not auto-closing the notification
+    pasteWarningDuration: 0,
+    
+
+    // Add filter to add or remove element before counting (see CKEDITOR.htmlParser.filter), Default value : null (no filter)
+    filter: new CKEDITOR.htmlParser.filter({
+        elements: {
+            div: function( element ) {
+                if(element.attributes.class == 'mediaembed') {
+                    return false;
+                }
+            }
+        }
+    })
+};
+````
+
+**Note:** If you plan to change some of the JavaScript, you probably will not want to use the CKBuilder, because this will place the JavaScript of the Word Count & Char Count plugin in the ckeditor.js file located at /web/server/root/ckeditor/ckeditor.js. The JavaScript for the Word Count & Char Count plugin in the ckeditor.js file is different than the JavaScript used when manually adding the Word Count & Char Count plugin.  When manually adding the Word Count & Char Count plugin, the JavaScript will be in the plugin.js file located at 
+

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/css/wordcount.css
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/css/wordcount.css
@@ -1,0 +1,3 @@
+.cke_wordcount {display:block;float:right;margin-top:-2px;margin-right:3px;color:black;}
+
+.cke_wordcountLimitReached {color:red! important}

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ar.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ar.js
@@ -1,0 +1,11 @@
+// Arabic Translation by Amine BENHAMIDA
+
+CKEDITOR.plugins.setLang('wordcount', 'ar', {
+    WordCount: 'كلمات:',
+    CharCount: 'حروف:',
+    CharCountWithHTML: 'حروف مع إتش تي إم إل',
+    Paragraphs: 'فقرات',
+    pasteWarning: 'لا يمكن اضافة هذا المحتوى لانه تجاوز الحد الاقصى',
+    Selected: 'محدد: ',
+    title: 'احصائيات'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ca.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ca.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'ca', {
+    WordCount: 'Paraules:',
+    CharCount: 'Caràcters:',
+    CharCountWithHTML: 'Caràcters (including HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Estadístiques'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/da.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/da.js
@@ -1,0 +1,13 @@
+/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'da', {
+    WordCount: 'Ord:',
+    CharCount: 'Karakterer:',
+    CharCountWithHTML: 'Karakterer (med HTML):',
+    Paragraphs: 'Afsnit:',
+    pasteWarning: 'Indholdet kan ikke indsættes da det er længere end den tilladte grænse.',
+    Selected: 'Markeret: ',
+    title: 'Statistik'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/de.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/de.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'de', {
+    WordCount: 'Wörter:',
+    CharCount: 'Zeichen:',
+    CharCountWithHTML: 'Zeichen (inkl. HTML):',
+    Paragraphs: 'Absätze:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Statistik'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/el.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/el.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'el', {
+    WordCount: 'Λέξεις:',
+    CharCount: 'Χαρακτήρες:',
+    CharCountWithHTML: 'Χαρακτήρες (μαζί με HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Στατιστικά'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/en.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/en.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'en', {
+    WordCount: 'Words:',
+    CharCount: 'Characters:',
+    CharCountWithHTML: 'Characters (with HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Statistics'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/es.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/es.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'es', {
+    WordCount: 'Palabras:',
+    CharCount: 'Carácteres:',
+    CharCountWithHTML: 'Carácteres (con HTML):',
+    Paragraphs: 'Párrafos:',
+    pasteWarning: 'El contenido no se puede pegar, ya que se encuentra fuera del límite permitido',
+    Selected: 'Seleccionado: ',
+    title: 'Estadísticas'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/eu.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/eu.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'eu', {
+    WordCount: 'Hitzak:',
+    CharCount: 'Karaktereak:',
+    CharCountWithHTML: 'Karaktereak (HTMLarekin):',
+    Paragraphs: 'Paragrafoak:',
+    pasteWarning: 'Ezin da edukia itsatsi, onartutako muga gainditu duelako',
+    Selected: 'Hautatuta: ',
+    title: 'Estatistikak'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fa.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fa.js
@@ -1,0 +1,12 @@
+﻿/*
+Its The Persian (Farsi) Language Translate For Iranian By "Mohsen Esmaili"
+*/
+CKEDITOR.plugins.setLang('wordcount', 'fa', {
+    WordCount: 'لغت:',
+    CharCount: 'کاراکتر:',
+    CharCountWithHTML: 'کاراکترها (با HTML):',
+    Paragraphs: 'پاراگراف:',
+    pasteWarning: 'محتوای مورد نظر را نمی توان چسباند. زیرا این بیشتر از حد مجاز است.',
+    Selected: 'انتخاب شده: ',
+    title: 'آمار'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fi.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fi.js
@@ -1,0 +1,14 @@
+/**
+ * Finnish localisation.
+ *
+ * @author Joel Posti / Response200.pro
+ */
+CKEDITOR.plugins.setLang('wordcount', 'fi', {
+    WordCount: 'Sanoja:',
+    CharCount: 'Merkkejä:',
+    CharCountWithHTML: 'Merkkejä (ml. HTML):',
+    Paragraphs: 'Kappaleita:',
+    pasteWarning: 'Sisältöä ei voida liittää, koska se ylittää sallitun rajan.',
+    Selected: 'Valittuna: ',
+    title: 'Statistiikkaa'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fr.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/fr.js
@@ -1,0 +1,11 @@
+﻿// French Translation by Nicolas M. et Pierre-Luc Auclair
+
+CKEDITOR.plugins.setLang('wordcount', 'fr', {
+    WordCount: 'Mots :',
+    CharCount: 'Caractères :',
+    CharCountWithHTML: 'Caractères (incluant HTML) :',
+    Paragraphs: 'Paragraphes :',
+    pasteWarning: 'Le contenu ne peut pas être collé car il dépasse la limite autorisée',
+    Selected: 'Sélectionné :',
+    title: 'Statistiques'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/he.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/he.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'he', {
+    WordCount: 'מילים:',
+    CharCount: 'תווים:',
+    CharCountWithHTML: 'תווים (כולל HTML):',
+    Paragraphs: 'פסקאות:',
+    pasteWarning: 'לא ניתן להדביק תוכן בשל עודף תווים',
+    Selected: 'נבחר: ',
+    title: 'סטטיסטיקות'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/hr.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/hr.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'hr', {
+    WordCount: 'Riječi:',
+    CharCount: 'Znakova:',
+    CharCountWithHTML: 'Znakova (uključujući HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Statistika'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/hu.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/hu.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'hu', {
+    WordCount: 'Szavak:',
+    CharCount: 'Karakaterek:',
+    CharCountWithHTML: 'Karakterek (HTML tagekkel):',
+    Paragraphs: 'Bekezdések:',
+    pasteWarning: 'A szöveget nem lehet beilleszteni, mert a megadott limit felett van',
+    Selected: 'Kiválasztva: ',
+    title: 'Statisztika'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/it.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/it.js
@@ -1,0 +1,14 @@
+/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+@author translation: Davide Montorio
+*/
+CKEDITOR.plugins.setLang('wordcount', 'it', {
+    WordCount: 'Parole:',
+    CharCount: 'Caratteri:',
+    CharCountWithHTML: 'Caratteri (HTML incluso):',
+    Paragraphs: 'Paragrafi:',
+    pasteWarning: 'Il contenuto non può essere incollato poiché supera il limite massimo di caratteri disponibili',
+    Selected: 'Selezionato: ',
+    title: 'Statistiche'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ja.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ja.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'ja', {
+    WordCount: '単語数:',
+    CharCount: '文字数:',
+    CharCountWithHTML: '文字数 (with HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'ワードカウント'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/nl.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/nl.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'nl', {
+    WordCount: 'Woorden:',
+    CharCount: 'Tekens:',
+    CharCountWithHTML: 'Tekens (inclusief HTML):',
+    Paragraphs: 'Paragraven:',
+    pasteWarning: 'De tekst kan niet worden geplakt omdat de limiet is overschreden',
+    Selected: 'Selected: ',
+    title: 'Statistieken'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/no.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/no.js
@@ -1,0 +1,10 @@
+﻿// Norwegian translation by Vegard S.
+CKEDITOR.plugins.setLang('wordcount', 'no', {
+    WordCount: 'Ord:',
+    CharCount: 'Tegn:',
+    CharCountWithHTML: 'Tegn (including HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Statistikk'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pl.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pl.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'pl', {
+    WordCount: 'Słów:',
+    CharCount: 'Znaków:',
+    CharCountWithHTML: 'Znaków (wraz z kodem HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Zawartość nie może zostać wklejona, ponieważ przekracza dozwolony limit',
+    Selected: 'Selected: ',
+    title: 'Statystyka'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pt-br.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pt-br.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'pt-br', {
+    WordCount: 'Contagem de palavras:',
+    CharCount: 'Contagem de carateres:',
+    CharCountWithHTML: 'Carateres (incluindo HTML):',
+    Paragraphs: 'Parágrafos:',
+    pasteWarning: 'Conteúdo não pode ser colado porque ultrapassa o limite permitido',
+    Selected: 'Selecionado: ',
+    title: 'Estatísticas'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pt.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/pt.js
@@ -1,0 +1,9 @@
+CKEDITOR.plugins.setLang('wordcount', 'pt', {
+    WordCount: 'Palavras:',
+    CharCount: 'Caracteres:',
+    CharCountWithHTML: 'Carateres (incluindo HTML):',
+    Paragraphs: 'Parágrafos:',
+    pasteWarning: 'O conteúdo não pode ser colado porque ultrapassa o limite permitido',
+    Selected: 'Selecionado: ',
+    title: 'Estatísticas'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ru.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/ru.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2013, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'ru', {
+    WordCount: 'Слов:',
+    CharCount: 'Символов:',
+    CharCountWithHTML: ' (включая HTML разметку):',
+    Paragraphs: 'Параграфов:',
+    pasteWarning: 'Контент не может быть вставлен, т.к. привышает допустимый лимит',
+    Selected: 'Выделено: ',
+    title: 'Статистика'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/sk.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/sk.js
@@ -1,0 +1,14 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'sk', {
+      WordCount: 'Slov:',
+      CharCount: 'Znakov:',
+      CharCountWithHTML: 'Znakov (vrátane HTML):',
+      Paragraphs: 'Odstavcov:',
+      pasteWarning: 'Obsah sa nedá prilepiť.',
+      Selected: 'Výber: ',
+      title: 'Štatistika'
+});
+

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/sv.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/sv.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'sv', {
+    WordCount: 'Ord:',
+    CharCount: 'Tecken:',
+    CharCountWithHTML: 'Tecken (inklusive HTML):',
+    Paragraphs: 'Paragraphs:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'Statistik'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/tr.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/tr.js
@@ -1,0 +1,13 @@
+﻿/*
+Mesut ÇAKIR
+mesut.cakir@hotmail.com.tr
+*/
+CKEDITOR.plugins.setLang('wordcount', 'tr', {
+    WordCount: 'Kelime:',
+    CharCount: 'Karakter:',
+    CharCountWithHTML: 'Karakter (HTML dahil):',
+    Paragraphs: 'Paragraf:',
+    pasteWarning: 'Content can not be pasted because it is above the allowed limit',
+    Selected: 'Selected: ',
+    title: 'İstatistik'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/zh-cn.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/lang/zh-cn.js
@@ -1,0 +1,13 @@
+﻿/*
+Copyright (c) 2003-2012, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.html or http://ckeditor.com/license
+*/
+CKEDITOR.plugins.setLang('wordcount', 'zh-cn', {
+    WordCount: '词数:',
+    CharCount: '字符:',
+    CharCountWithHTML: '字符 (含HTML)',
+    Paragraphs: '段落:',
+    pasteWarning: '由于上限允许,内容不能粘贴',
+    Selected: '已选择: ',
+    title: '统计'
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/plugin.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/plugin.js
@@ -1,0 +1,430 @@
+/**
+ * @license Copyright (c) CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.html or http://ckeditor.com/license
+ */
+
+CKEDITOR.plugins.add("wordcount", {
+    lang: "ar,ca,da,de,el,en,es,eu,fa,fi,fr,he,hr,hu,it,ja,nl,no,pl,pt,pt-br,ru,sk,sv,tr,zh-cn", // %REMOVE_LINE_CORE%
+    version: 1.15,
+    requires: 'htmlwriter,notification,undo',
+    bbcodePluginLoaded: false,
+    onLoad: function(editor) {
+        CKEDITOR.document.appendStyleSheet(this.path + "css/wordcount.css");
+    },
+    init: function (editor) {
+        var defaultFormat = "",
+            intervalId,
+            lastWordCount = -1,
+            lastCharCount = -1,
+            limitReachedNotified = false,
+            limitRestoredNotified = false,
+            snapShot = editor.getSnapshot(),
+            notification = null;
+
+
+        var dispatchEvent = function (type, currentLength, maxLength) {
+            if (typeof document.dispatchEvent == 'undefined') {
+                return;
+            }
+
+            type = 'ckeditor.wordcount.' + type;
+
+            var cEvent;
+            var eventInitDict = {
+                bubbles: false,
+                cancelable: true,
+                detail: {
+                    currentLength: currentLength,
+                    maxLength: maxLength
+                }
+            };
+
+            try {
+                cEvent = new CustomEvent(type, eventInitDict);
+            } catch (o_O) {
+                cEvent = document.createEvent('CustomEvent');
+                cEvent.initCustomEvent(
+                    type,
+                    eventInitDict.bubbles,
+                    eventInitDict.cancelable,
+                    eventInitDict.detail
+                );
+            }
+
+            document.dispatchEvent(cEvent);
+        };
+
+        // Default Config
+        var defaultConfig = {
+            showParagraphs: true,
+            showWordCount: true,
+            showCharCount: false,
+            countSpacesAsChars: false,
+            countHTML: false,
+            hardLimit: true,
+
+            //MAXLENGTH Properties
+            maxWordCount: -1,
+            maxCharCount: -1,
+
+            // Filter
+            filter: null,
+
+            // How long to show the 'paste' warning
+            pasteWarningDuration: 0,
+
+            //DisAllowed functions
+            wordCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+                dispatchEvent('wordCountGreaterThanMaxLengthEvent', currentLength, maxLength);
+            },
+            charCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+                dispatchEvent('charCountGreaterThanMaxLengthEvent', currentLength, maxLength);
+            },
+
+            //Allowed Functions
+            wordCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+                dispatchEvent('wordCountLessThanMaxLengthEvent', currentLength, maxLength);
+            },
+            charCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+                dispatchEvent('charCountLessThanMaxLengthEvent', currentLength, maxLength);
+            }
+        };
+
+        // Get Config & Lang
+        var config = CKEDITOR.tools.extend(defaultConfig, editor.config.wordcount || {}, true);
+
+        if (config.showParagraphs) {
+            defaultFormat += editor.lang.wordcount.Paragraphs + " %paragraphs%";
+        }
+
+        if (config.showParagraphs && (config.showWordCount || config.showCharCount)) {
+            defaultFormat += ", ";
+        }
+
+        if (config.showWordCount) {
+            defaultFormat += editor.lang.wordcount.WordCount + " %wordCount%";
+            if (config.maxWordCount > -1) {
+                defaultFormat += "/" + config.maxWordCount;
+            }
+        }
+
+        if (config.showCharCount && config.showWordCount) {
+            defaultFormat += ", ";
+        }
+
+        if (config.showCharCount) {
+            var charLabel = editor.lang.wordcount[config.countHTML ? "CharCountWithHTML" : "CharCount"];
+
+            defaultFormat += charLabel + " %charCount%";
+            if (config.maxCharCount > -1) {
+                defaultFormat += "/" + config.maxCharCount;
+            }
+        }
+
+        var format = defaultFormat;
+
+        bbcodePluginLoaded = typeof editor.plugins.bbcode != 'undefined';
+
+       function counterId(editorInstance) {
+            return "cke_wordcount_" + editorInstance.name;
+        }
+
+        function counterElement(editorInstance) {
+            return document.getElementById(counterId(editorInstance));
+        }
+
+        function strip(html) {
+            if (bbcodePluginLoaded) {
+                // stripping out BBCode tags [...][/...]
+                return html.replace(/\[.*?\]/gi, '');
+            }
+
+            var tmp = document.createElement("div");
+
+            // Add filter before strip
+            html = filter(html);
+
+            tmp.innerHTML = html;
+
+            if (tmp.textContent == "" && typeof tmp.innerText == "undefined") {
+                return "";
+            }
+
+            return tmp.textContent || tmp.innerText;
+        }
+
+        /**
+         * Implement filter to add or remove before counting
+         * @param html
+         * @returns string
+         */
+        function filter(html) {
+            if(config.filter instanceof CKEDITOR.htmlParser.filter) {
+                var fragment = CKEDITOR.htmlParser.fragment.fromHtml(html),
+                    writer = new CKEDITOR.htmlParser.basicWriter();
+                config.filter.applyTo( fragment );
+                fragment.writeHtml( writer );
+                return writer.getHtml();
+            }
+            return html;
+        }
+
+        function countCharacters(text, editorInstance) {
+            if (config.countHTML) {
+                return (filter(text).length);
+            } else {
+                var normalizedText;
+
+                // strip body tags
+                if (editor.config.fullPage) {
+                    var i = text.search(new RegExp("<body>", "i"));
+                    if (i != -1) {
+                        var j = text.search(new RegExp("</body>", "i"));
+                        text = text.substring(i + 6, j);
+                    }
+
+                }
+
+                normalizedText = text;
+
+                if (!config.countSpacesAsChars) {
+                    normalizedText = text.
+                        replace(/\s/g, "").
+                        replace(/&nbsp;/g, "");
+                }
+
+                normalizedText = normalizedText.
+                    replace(/(\r\n|\n|\r)/gm, "").
+                    replace(/&nbsp;/gi, " ");
+
+                normalizedText = strip(normalizedText).replace(/^([\t\r\n]*)$/, "");
+
+                return(normalizedText.length);
+            }
+        }
+
+        function countParagraphs(text) {
+            return (text.replace(/&nbsp;/g, " ").replace(/(<([^>]+)>)/ig, "").replace(/^\s*$[\n\r]{1,}/gm, "++").split("++").length);
+        }
+
+        function countWords(text) {
+            var normalizedText = text.
+                replace(/(\r\n|\n|\r)/gm, " ").
+                replace(/^\s+|\s+$/g, "").
+                replace("&nbsp;", " ");
+
+            normalizedText = strip(normalizedText);
+
+            var words = normalizedText.split(/\s+/);
+
+            for (var wordIndex = words.length - 1; wordIndex >= 0; wordIndex--) {
+                if (words[wordIndex].match(/^([\s\t\r\n]*)$/)) {
+                    words.splice(wordIndex, 1);
+                }
+            }
+
+            return (words.length);
+        }
+
+        function limitReached(editorInstance, notify) {
+            limitReachedNotified = true;
+            limitRestoredNotified = false;
+
+            if (config.hardLimit) {
+                editorInstance.loadSnapshot(snapShot);
+                // lock editor
+                editorInstance.config.Locked = 1;
+            }
+
+            if (!notify) {
+                counterElement(editorInstance).className = "cke_path_item cke_wordcountLimitReached";
+                editorInstance.fire("limitReached", {}, editor);
+            }
+        }
+
+        function limitRestored(editorInstance) {
+            limitRestoredNotified = true;
+            limitReachedNotified = false;
+            editorInstance.config.Locked = 0;
+            snapShot = editor.getSnapshot();
+
+            counterElement(editorInstance).className = "cke_path_item";
+        }
+
+        function updateCounter(editorInstance) {
+            var paragraphs = 0,
+                wordCount = 0,
+                charCount = 0,
+                text;
+
+            if (text = editorInstance.getData()) {
+                if (config.showCharCount) {
+                    charCount = countCharacters(text, editorInstance);
+                }
+
+                if (config.showParagraphs) {
+                    paragraphs = countParagraphs(text);
+                }
+
+                if (config.showWordCount) {
+                    wordCount = countWords(text);
+                }
+            }
+
+            var html = format.replace("%wordCount%", wordCount).replace("%charCount%", charCount).replace("%paragraphs%", paragraphs);
+
+            (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).wordCount = wordCount;
+            (editorInstance.config.wordcount || (editorInstance.config.wordcount = {})).charCount = charCount;
+
+            if (CKEDITOR.env.gecko) {
+                counterElement(editorInstance).innerHTML = html;
+            } else {
+                counterElement(editorInstance).innerText = html;
+            }
+
+            if (charCount == lastCharCount && wordCount == lastWordCount) {
+                return true;
+            }
+
+            //If the limit is already over, allow the deletion of characters/words. Otherwise,
+            //the user would have to delete at one go the number of offending characters
+            var deltaWord = wordCount - lastWordCount;
+            var deltaChar = charCount - lastCharCount;
+
+            lastWordCount = wordCount;
+            lastCharCount = charCount;
+
+            if (lastWordCount == -1) {
+                lastWordCount = wordCount;
+            }
+            if (lastCharCount == -1) {
+                lastCharCount = charCount;
+            }
+
+            // Check for word limit and/or char limit
+            if ((config.maxWordCount > -1 && wordCount > config.maxWordCount && deltaWord > 0) ||
+                (config.maxCharCount > -1 && charCount > config.maxCharCount && deltaChar > 0)) {
+
+                limitReached(editorInstance, limitReachedNotified);
+            } else if ((config.maxWordCount == -1 || wordCount < config.maxWordCount) &&
+            (config.maxCharCount == -1 || charCount < config.maxCharCount)) {
+
+                limitRestored(editorInstance);
+            } else {
+                snapShot = editorInstance.getSnapshot();
+            }
+
+            // Fire Custom Events
+            if (config.charCountGreaterThanMaxLengthEvent && config.charCountLessThanMaxLengthEvent) {
+                if (charCount > config.maxCharCount && config.maxCharCount > -1) {
+                    config.charCountGreaterThanMaxLengthEvent(charCount, config.maxCharCount);
+                } else {
+                    config.charCountLessThanMaxLengthEvent(charCount, config.maxCharCount);
+                }
+            }
+
+            if (config.wordCountGreaterThanMaxLengthEvent && config.wordCountLessThanMaxLengthEvent) {
+                if (wordCount > config.maxWordCount && config.maxWordCount > -1) {
+                    config.wordCountGreaterThanMaxLengthEvent(wordCount, config.maxWordCount);
+
+                } else {
+                    config.wordCountLessThanMaxLengthEvent(wordCount, config.maxWordCount);
+                }
+            }
+
+            return true;
+        }
+
+        editor.on("key", function (event) {
+            if (editor.mode === "source") {
+                updateCounter(event.editor);
+            }
+        }, editor, null, 100);
+
+        editor.on("change", function (event) {
+            updateCounter(event.editor);
+        }, editor, null, 100);
+
+        editor.on("uiSpace", function (event) {
+            if (editor.elementMode === CKEDITOR.ELEMENT_MODE_INLINE) {
+                if (event.data.space == "top") {
+                    event.data.html += "<div class=\"cke_wordcount\" style=\"\"" +
+                        " title=\"" +
+                        editor.lang.wordcount.title +
+                        "\"" +
+                        "><span id=\"" +
+                        counterId(event.editor) +
+                        "\" class=\"cke_path_item\">&nbsp;</span></div>";
+                }
+            } else {
+                if (event.data.space == "bottom") {
+                    event.data.html += "<div class=\"cke_wordcount\" style=\"\"" +
+                        " title=\"" +
+                        editor.lang.wordcount.title +
+                        "\"" +
+                        "><span id=\"" +
+                        counterId(event.editor) +
+                        "\" class=\"cke_path_item\">&nbsp;</span></div>";
+                }
+            }
+
+        }, editor, null, 100);
+
+        editor.on("dataReady", function (event) {
+            updateCounter(event.editor);
+        }, editor, null, 100);
+
+        editor.on("paste", function(event) {
+            if (config.maxWordCount > 0 || config.maxCharCount > 0) {
+
+                // Check if pasted content is above the limits
+                var wordCount = -1,
+                    charCount = -1,
+                    text = event.editor.getData() + event.data.dataValue;
+
+
+                if (config.showCharCount) {
+                    charCount = countCharacters(text, event.editor);
+                }
+
+                if (config.showWordCount) {
+                    wordCount = countWords(text);
+                }
+
+
+                // Instantiate the notification when needed and only have one instance
+                if(notification === null) {
+                    notification = new CKEDITOR.plugins.notification(event.editor, {
+                        message: event.editor.lang.wordcount.pasteWarning,
+                        type: 'warning',
+                        duration: config.pasteWarningDuration
+                    });
+                }
+
+                if (config.maxCharCount > 0 && charCount > config.maxCharCount && config.hardLimit) {
+                    if(!notification.isVisible()) {
+                        notification.show();
+                    }
+                    event.cancel();
+                }
+
+                if (config.maxWordCount > 0 && wordCount > config.maxWordCount && config.hardLimit) {
+                    if(!notification.isVisible()) {
+                        notification.show();
+                    }
+                    event.cancel();
+                }
+            }
+        }, editor, null, 100);
+
+        editor.on("afterPaste", function (event) {
+            updateCounter(event.editor);
+        }, editor, null, 100);
+
+        editor.on("blur", function () {
+            if (intervalId) {
+                window.clearInterval(intervalId);
+            }
+        }, editor, null, 300);
+    }
+});

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/samples/wordcount.html
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/samples/wordcount.html
@@ -1,0 +1,61 @@
+﻿<!DOCTYPE html>
+<!--
+Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+-->
+<html>
+<head>
+	<meta charset="utf-8">
+        <title>WordCount &mdash; CKEditor Sample</title>
+        <script src="../../../ckeditor.js"></script>
+	<link href="../../../samples/sample.css" rel="stylesheet">
+	<meta name="ckeditor-sample-name" content="WordCount plugin">
+	<meta name="ckeditor-sample-group" content="Plugins">
+    <meta name="ckeditor-sample-description" content="Counts the words an shows the word count in the footer of the editor.">
+	<meta name="ckeditor-sample-isnew" content="1">
+	<script>
+		CKEDITOR.disableAutoInline = true;
+	</script>
+</head>
+<body>
+	<h1 class="samples">
+		<a href="../../../samples/index.html">CKEditor Samples</a> &raquo; WordCount Plugin
+	</h1>
+
+	<div class="description">
+		<p>
+            WordCount Plugin for CKEditor that counts the words an shows the word count in the footer of the editor.</a>.
+		</p>
+		<p>
+			In order to use the new plugin, include it in the <code><a class="samples" href="http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-extraPlugins">config.extraPlugins</a></code> configuration setting.
+		</p>
+<pre class="samples">
+CKEDITOR.replace( '<em>textarea_id</em>', {
+	<strong>extraPlugins: 'wordcount'</strong>
+} );
+</pre>
+	</div>
+
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+    This is some <strong>sample text</strong>. You are using <a href="http://ckeditor.com/">CKEditor</a>.
+</textarea>
+    <script>
+
+	    CKEDITOR.replace('editor1', {
+	        extraPlugins: 'wordcount'
+	    });
+
+	</script>
+
+	<div id="footer">
+		<hr>
+		<p>
+			CKEditor - The text editor for the Internet - <a class="samples" href="http://ckeditor.com/">http://ckeditor.com</a>
+		</p>
+		<p id="copy">
+			Copyright &copy; 2003-2015, <a class="samples" href="http://cksource.com/">CKSource</a> - Frederico
+			Knabben. All rights reserved.
+		</p>
+	</div>
+</body>
+</html>

--- a/kuma/static/js/libs/ckeditor/source/plugins/wordcount/samples/wordcountWithMaxCount.html
+++ b/kuma/static/js/libs/ckeditor/source/plugins/wordcount/samples/wordcountWithMaxCount.html
@@ -1,0 +1,110 @@
+﻿<!DOCTYPE html>
+<!--
+Copyright (c) 2003-2015, CKSource - Frederico Knabben. All rights reserved.
+For licensing, see LICENSE.md or http://ckeditor.com/license
+-->
+<html>
+<head>
+	<meta charset="utf-8">
+        <title>WordCount &mdash; CKEditor Sample</title>
+        <script src="http://code.jquery.com/jquery-1.11.2.min.js"></script>
+        <script src="../../../ckeditor.js"></script>
+	<link href="../../../samples/sample.css" rel="stylesheet">
+	<meta name="ckeditor-sample-name" content="WordCount plugin">
+	<meta name="ckeditor-sample-group" content="Plugins">
+    <meta name="ckeditor-sample-description" content="Counts the words an shows the word count in the footer of the editor.">
+	<meta name="ckeditor-sample-isnew" content="1">
+	<script>
+		CKEDITOR.disableAutoInline = true;
+	</script>
+</head>
+<body>
+	<h1 class="samples">
+		<a href="../../../samples/index.html">CKEditor Samples</a> &raquo; WordCount Plugin
+	</h1>
+
+	<div class="description">
+		<p>
+            WordCount Plugin for CKEditor that counts the words an shows the word count in the footer of the editor.</a>.
+		</p>
+		<p>
+			In order to use the new plugin, include it in the <code><a class="samples" href="http://docs.ckeditor.com/#!/api/CKEDITOR.config-cfg-extraPlugins">config.extraPlugins</a></code> configuration setting.
+		</p>
+<pre class="samples">
+CKEDITOR.replace( '<em>textarea_id</em>', {
+	<strong>extraPlugins: 'wordcount', 
+                maxWordCount: 4,
+	        maxCharCount: 10,
+                // optional events
+	        paragraphsCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationparagraphs").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - paragraphs").show();
+	        },
+	        wordCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationword").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - word").show();
+	        },
+	        charCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationchar").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - char").show();
+	        },
+	        charCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationchar").css("background-color", "white").css("color", "black").hide();
+	        },
+	        paragraphsCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationparagraphs").css("background-color", "white").css("color", "black").hide();
+	        },
+	        wordCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationword").css("background-color", "white").css("color", "black").hide();
+	        }</strong>
+} );
+</pre>
+	</div>
+
+<textarea cols="80" id="editor1" name="editor1" rows="10">
+    This is some <strong>sample text</strong>. You are using <a href="http://ckeditor.com/">CKEditor</a>.
+</textarea>
+    <div id="informationchar"></div>
+    <div id="informationword"></div>
+    <div id="informationparagraphs"></div>
+	<script>
+
+	    CKEDITOR.replace('editor1', {
+	        extraPlugins: 'wordcount',
+	        wordcount: {
+	            showWordCount: true, 
+                    showCharCount: true,
+	            maxWordCount: 4,
+	            maxCharCount: 10,
+	            paragraphsCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationparagraphs").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - paragraphs").show();
+	            },
+	            wordCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationword").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - word").show();
+	            },
+	            charCountGreaterThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationchar").css("background-color", "crimson").css("color", "white").text(currentLength + "/" + maxLength + " - char").show();
+	            },
+	            charCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationchar").css("background-color", "white").css("color", "black").hide();
+	            },
+	            paragraphsCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationparagraphs").css("background-color", "white").css("color", "black").hide();
+	            },
+	            wordCountLessThanMaxLengthEvent: function (currentLength, maxLength) {
+	                $("#informationword").css("background-color", "white").css("color", "black").hide();
+	            }
+	        }
+	    });
+
+	</script>
+
+	<div id="footer">
+		<hr>
+		<p>
+			CKEditor - The text editor for the Internet - <a class="samples" href="http://ckeditor.com/">http://ckeditor.com</a>
+		</p>
+		<p id="copy">
+			Copyright &copy; 2003-2015, <a class="samples" href="http://cksource.com/">CKSource</a> - Frederico
+			Knabben. All rights reserved.
+		</p>
+	</div>
+</body>
+</html>

--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -54,7 +54,7 @@
       'mdn-redirect,mdn-sample-finder,mdn-sampler,mdn-syntaxhighlighter,mdn-system-integration,mdn-table-customization,' +
       'mdn-toggle-block,mdn-wrapstyle,mdn-youtube,' +
       // Other plugins.
-      'descriptionlist,tablesort,texzilla';
+      'descriptionlist,tablesort,texzilla,wordcount';
 
     config.removeButtons = 'Cut,Copy,PasteFromWord,Language';
     config.toolbarGroups = [
@@ -157,6 +157,7 @@
         { name: 'Hidden When Reading', element: 'div', attributes: { 'class': 'hidden' }, type: 'wrap' }
       ]);
     }
+
     config.keystrokes = [
       // CTRL+0
       [ CKEDITOR.CTRL + 48, 'removeFormat' ],
@@ -190,6 +191,41 @@
       // CTRL+P
       CKEDITOR.CTRL + 80
     ] );
+
+    // Configure the word count plugin. It will ignore the following:
+    //
+    // * <div> and <p> blocks with the class "hidden" applied
+    // * <div> blocks with the class "prevnext" (that is, Previous and
+    //   Next buttons at the top and/or bottom of pages)
+    //
+    // NOTE: The docs for the wordcount plugin say that the notification
+    //       plugin is required; that is only true if you set maximum
+    //       character, word, or paragraph counts, which we do not.
+
+    config.wordcount = {
+        showParagraphs: true,
+        showWordCount: true,
+/*--- For more on filters:
+ *        https://github.com/w8tcha/CKEditor-WordCount-Plugin
+ *        http://docs.ckeditor.com/#!/api/CKEDITOR.htmlParser.filter
+ *        https://github.com/w8tcha/CKEditor-WordCount-Plugin/blob/master/wordcount/plugin.js#L58
+*/
+        filter: new CKEDITOR.htmlParser.filter({
+            elements: {
+                div: function(element) {
+                    if (element.hasClass("hidden") ||
+                        element.hasClass("prevnext")) {
+                        element.setHtml("");
+                    }
+                },
+                p: function(element) {
+                    if (element.hasClass("hidden")) {
+                        element.setHtml("");
+                    }
+                }
+            }
+        })
+    };
 
     {{ editor_config|safe }}
   };


### PR DESCRIPTION
The information is placed in the editor's status bar. Currently configured to show words and paragraphs, and to ignore content marked with class "hidden" and such.

This will help with the SEO project, some of which is focused on the length of pages.