### PR TITLE
Set UID=1000 for Jenkins jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,6 +30,8 @@ node {
     sh 'git submodule sync'
     sh 'git submodule update --init --recursive'
     setGitEnvironmentVariables()
+    // Set UID to jenkins
+    env['UID'] = 1000
 
     // When checking in a file exists in another directory start with './' or
     // prepare to fail.


### PR DESCRIPTION
Docker commands that generate files need to run as ``UID=1000`` (jenkins), so that Jenkins can delete them when the branch is deleted.
