### PR TITLE
bug 1367098: Remove more DevRel Survey CSS

### DIFF
--- a/kuma/static/styles/components-blue/home/column-callout.scss
+++ b/kuma/static/styles/components-blue/home/column-callout.scss
@@ -162,32 +162,12 @@ Media queries
         background-image: url($path-to-embedded-images + 'promos/sauce-labs-home-high-res.png');
         background-size: 129px 140px;
     }
-
-    .callout-devrel a:after {
-        background-image: url($path-to-embedded-images + 'promos/devrel-survey-icon-high-res.png');
-        background-size: 129px 140px;
-    }
 }
 
 @media #{$mq-small-desktop-and-down} {
     .callout-saucelabs a:after {
         @include bidi-style(right, -20px, right, auto);
         @include bidi-style(left, auto, left, -20px);
-    }
-
-    .callout-devrel {
-        a {
-            @include set-font-size(12px);
-
-            &:after {
-                @include bidi-style(right, 0, right, auto);
-                @include bidi-style(left, auto, left, 0);
-            }
-        }
-
-        span {
-            @include bidi-value(padding, 0 50px ($grid-spacing * 2) $grid-spacing, 0 $grid-spacing ($grid-spacing * 2) 50px);
-        }
     }
 }
 
@@ -197,8 +177,7 @@ Media queries
         @include bidi-style(right, $grid-spacing, left, auto);
     }
 
-    .callout-saucelabs,
-    .callout-devrel {
+    .callout-saucelabs {
         a {
             @include set-font-size(12px);
 
@@ -210,17 +189,6 @@ Media queries
 
         span {
             width: 90%;
-        }
-    }
-
-    .callout-devrel {
-        a:after {
-            @include bidi-style(right, -50px, right, auto);
-            @include bidi-style(left, auto, left, -50px);
-        }
-
-        span {
-            @include bidi-value(padding, ($grid-spacing / 2) 50px ($grid-spacing + 10) $grid-spacing, ($grid-spacing / 2) $grid-spacing ($grid-spacing + 10) 50px);
         }
     }
 }
@@ -235,8 +203,7 @@ Media queries
         @include bidi-style(right, $callout-icon-spacing + $grid-spacing, left, auto);
     }
 
-    .callout-saucelabs,
-    .callout-devrel {
+    .callout-saucelabs {
         a {
             @include set-font-size(14px);
 
@@ -248,12 +215,6 @@ Media queries
 
         span {
             max-width: 300px;
-        }
-    }
-
-    .callout-devrel {
-        a:after {
-            top: 15px;
         }
     }
 }
@@ -274,15 +235,6 @@ Media queries
 
         span {
             max-width: 250px;
-        }
-    }
-
-    .callout-devrel a {
-        &:after {
-            background-repeat: no-repeat;
-            background-size: 109px auto;
-            @include bidi-style(right, -25px, right, auto);
-            @include bidi-style(left, auto, left, 5px);
         }
     }
 }


### PR DESCRIPTION
Remove more ``.callout-devel`` CSS styles, to eliminate unused style and reference to ``promos/sauce-labs-home-high-res.png``.