### PR TITLE
bug 1385405: Remove transitional deploy step

### DIFF
--- a/scripts/chief_deploy.py
+++ b/scripts/chief_deploy.py
@@ -36,7 +36,6 @@ os.environ['PATH'] = os.pathsep.join([
 def update_code(ctx, tag):
     with ctx.lcd(settings.SRC_DIR):
         ctx.local("git fetch")
-        ctx.local("find locale -name '*.mo' -delete")  # bug 1385405
         ctx.local("git checkout -f %s" % tag)
         ctx.local("git submodule sync")
         ctx.local("git submodule update --init --recursive")


### PR DESCRIPTION
This worked locally for being able to checkout the repository after switching to locales in a subfolder. It did not work on the SCL3 deployment server. Instead, manually replacing ``locales/`` with an empty folder, and then running deployment script, for the one-time transition.