### PR TITLE
[Bug 1385315] Use 302 not 301 for locale based redirect

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -3,8 +3,7 @@ import urllib
 
 from django.conf import settings
 from django.core import urlresolvers
-from django.http import HttpResponseForbidden, HttpResponsePermanentRedirect
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseForbidden, HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from django.contrib.sessions.middleware import SessionMiddleware

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -4,6 +4,7 @@ import urllib
 from django.conf import settings
 from django.core import urlresolvers
 from django.http import HttpResponseForbidden, HttpResponsePermanentRedirect
+from django.http import HttpResponseRedirect
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -35,7 +36,10 @@ class LocaleURLMiddleware(object):
             new_path = prefixer.fix(prefixer.shortened_path)
             query = dict((smart_str(k), v) for
                          k, v in request.GET.iteritems() if k != 'lang')
-            return HttpResponsePermanentRedirect(urlparams(new_path, **query))
+
+            # Never use HttpResponsePermanentRedirect here.
+            # Its a temporary redirect and should return with http 302, not 301
+            return HttpResponseRedirect(urlparams(new_path, **query))
 
         if full_path != request.path:
             query_string = request.META.get('QUERY_STRING', '')
@@ -44,7 +48,7 @@ class LocaleURLMiddleware(object):
             if query_string:
                 full_path = '%s?%s' % (full_path, query_string)
 
-            response = HttpResponsePermanentRedirect(full_path)
+            response = HttpResponseRedirect(full_path)
 
             # Vary on Accept-Language if we changed the locale
             old_locale = prefixer.locale

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -6,40 +6,40 @@ class TestLocaleMiddleware(KumaTestCase):
         # User wants en-us, we send en-US
         response = self.client.get('/', follow=True,
                                    HTTP_ACCEPT_LANGUAGE='en-us')
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)
 
         # User wants fr-FR, we send fr
         response = self.client.get('/', follow=True,
                                    HTTP_ACCEPT_LANGUAGE='fr-fr')
-        self.assertRedirects(response, '/fr/', status_code=301)
+        self.assertRedirects(response, '/fr/', status_code=302)
 
         # User wants xx, we send en-US
         response = self.client.get('/', follow=True,
                                    HTTP_ACCEPT_LANGUAGE='xx')
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)
 
         # User doesn't know what they want, we send en-US
         response = self.client.get('/', follow=True,
                                    HTTP_ACCEPT_LANGUAGE='')
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)
 
     def test_mixed_case_header(self):
         """Accept-Language is case insensitive."""
         response = self.client.get('/', follow=True,
                                    HTTP_ACCEPT_LANGUAGE='en-US')
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)
 
     def test_specificity(self):
         """Requests for /fr-FR/ should end up on /fr/"""
         reponse = self.client.get('/fr-FR/', follow=True)
-        self.assertRedirects(reponse, '/fr/', status_code=301)
+        self.assertRedirects(reponse, '/fr/', status_code=302)
 
     def test_partial_redirect(self):
         """Ensure that /en/ gets directed to /en-US/."""
         response = self.client.get('/en/', follow=True)
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)
 
     def test_lower_to_upper(self):
         """/en-us should redirect to /en-US."""
         response = self.client.get('/en-us/', follow=True)
-        self.assertRedirects(response, '/en-US/', status_code=301)
+        self.assertRedirects(response, '/en-US/', status_code=302)

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -184,7 +184,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         # canonical one for the default language.
         url = '/Firefox'
         response = self.client.get(url, follow=False)
-        self.assertRedirects(response, '/en-US/Firefox', status_code=301)
+        self.assertRedirects(response, '/en-US/Firefox', status_code=302)
 
     def test_zone_with_default_locale(self):
         # This url is the canonical one for the English zone for this document,
@@ -207,7 +207,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         url = '/docs/Firefox'
         response = self.client.get(url, follow=True)
         self.assertEqual(response.redirect_chain,
-                         [('http://testserver/en-US/docs/Firefox', 301),
+                         [('http://testserver/en-US/docs/Firefox', 302),
                           ('http://testserver/en-US/Firefox', 301)])
 
     def test_docs_zone_with_default_locale(self):
@@ -233,7 +233,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         url = '/docs/Firefox'
         response = self.client.get(url, {'lang': 'fr'}, follow=True)
         self.assertEqual(response.redirect_chain,
-                         [('http://testserver/fr/docs/Firefox', 301),
+                         [('http://testserver/fr/docs/Firefox', 302),
                           ('http://testserver/fr/Firefox', 301)])
 
     def test_zone_document_with_implied_default_locale(self):
@@ -242,7 +242,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         url = '/docs/Mozilla/Firefox'
         response = self.client.get(url, follow=True)
         self.assertEqual(response.redirect_chain,
-                         [('http://testserver/en-US/docs/Mozilla/Firefox', 301),
+                         [('http://testserver/en-US/docs/Mozilla/Firefox', 302),
                           ('http://testserver/en-US/Firefox', 302)])
 
     def test_zone_document_with_default_locale(self):


### PR DESCRIPTION
We should redirect the visitor with 302 redirect rather than 301
@jwhitlock r?