### PR TITLE
Fixes link colors on search results page

### DIFF
--- a/kuma/static/styles/search.scss
+++ b/kuma/static/styles/search.scss
@@ -87,10 +87,6 @@ fieldset #{$selector-icon} {
 
 .search-meta {
     margin-top: ($grid-spacing / 4);
-
-    a {
-        color: lighten($link-color, 50);
-    }
 }
 
 .result-list-link {


### PR DESCRIPTION
Noticed that the links on the search results page are very light, making them almost impossible to read.

<img width="938" alt="screen shot 2017-08-03 at 14 53 00" src="https://user-images.githubusercontent.com/10350960/28922817-edb3b7ee-785b-11e7-831c-bfd7be87a7b5.png">
