### PR TITLE
bug 1388933: allow MEDIA_ROOT to be overridden from the environment

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -353,7 +353,7 @@ LOCALE_PATHS = (
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
-MEDIA_ROOT = path('media')
+MEDIA_ROOT = config('MEDIA_ROOT', default=path('media'))
 
 # Absolute path to the directory for the humans.txt file.
 HUMANSTXT_ROOT = MEDIA_ROOT


### PR DESCRIPTION
This PR allows the MEDIA_ROOT setting to be overridden from the environment, as a convenience for the MDN->AWS work (see https://github.com/mozmeao/infra/issues/197#issuecomment-321411851). Currently it is hard-wired to the `media` folder under the application-root directory, and that directory within Kubernetes would be ephemeral since it's part of the container. This will allow us to point the MEDIA_ROOT to a location on the shared PVC (EFS).