### PR TITLE
Set interactive editor iframe height based on postMessage from editor

### DIFF
--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -9,7 +9,7 @@
          * @param {Object} event - The event Object received from the postMessage
          */
         interactiveExamplesEvent: function(event) {
-            if (event.origin !== 'https://mdn.github.io') {
+            if (event.origin !== 'https://interactive-examples.mdn.mozilla.net') {
                 return false;
             }
             mdn.analytics.trackEvent(event.data);

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -883,4 +883,17 @@
         }
     }
 
+    // listens for post message from interactive editor
+    window.addEventListener('message', function(event) {
+        // get the interactive editor iframe
+        var iframe = document.querySelector('iframe.interactive');
+        var isExpectedOrigin = event.origin === 'https://interactive-examples.mdn.mozilla.net';
+
+        /* there may be other post messages so, ensure that the origin is the
+        expected and, that `event.data` contains an `iframeHeight` property */
+        if (isExpectedOrigin && event.data.iframeHeight) {
+            iframe.setAttribute('height', event.data.iframeHeight);
+        }
+    }, false);
+
 })(window, document, jQuery);


### PR DESCRIPTION
This will listen for a `postMessage` event from the interactive editor with the `scrollHeight` of the CSS editor container [1]. 

To ensure arbitrary code is not run, this code checks

1. That the origin match and
2. That the message data contains the property `iFrameHeight`

If this is satisfied, the height of the `iframe` will be updated to the passed value. The editor will send a follow up `postMessage` when a specific `matchMedia` breakpoint[2] is reached.

[1] https://github.com/mdn/interactive-examples/blob/master/js/editor-libs/mce-utils.js#L77
[2] https://github.com/mdn/interactive-examples/blob/master/js/editor-libs/mce-utils.js#L86