### PR TITLE
bug 1340342: Add make target push-kumascript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,9 @@ push-base:
 push-kuma:
 	docker push ${KUMA_IMAGE}
 
+push-kumascript:
+	docker push ${KUMASCRIPT_IMAGE}
+
 push: push-base push-kuma
 
 deis-create:


### PR DESCRIPTION
Push the kumascript image from the kuma project as well. This should be done when the kumascript master branch is updated, not when the kuma master branch is update, so it is not included in ``make push``.