### PR TITLE
bug 1390267: allow ATTACHMENT_HOST to be set from env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
       - ALLOWED_HOSTS=*
+      - ATTACHMENT_HOST=localhost:8000
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
       - CSRF_COOKIE_SECURE=False

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1153,7 +1153,7 @@ ALLOWED_HOSTS = config('ALLOWED_HOSTS',
 MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
-ATTACHMENT_HOST = 'mdn.mozillademos.org'
+ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
 
 # Video settings, hard coded here for now.
 # TODO: figure out a way that doesn't need these values

--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -7,7 +7,8 @@ from .common import *  # noqa
 DEFAULT_FILE_STORAGE = 'kuma.core.storage.KumaHttpStorage'
 LOCALDEVSTORAGE_HTTP_FALLBACK_DOMAIN = PRODUCTION_URL + '/media/'
 
-ATTACHMENT_HOST = 'mdn-local.mozillademos.org'
+ATTACHMENT_HOST = config('ATTACHMENT_HOST',
+                         default='mdn-local.mozillademos.org')
 
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1', '172.18.0.1')
 

--- a/kuma/settings/prod.py
+++ b/kuma/settings/prod.py
@@ -1,6 +1,6 @@
 from .common import *  # noqa
 
-ATTACHMENT_HOST = 'mdn.mozillademos.org'
+ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
 ALLOW_ROBOTS = True
 
 # Email

--- a/kuma/settings/stage.py
+++ b/kuma/settings/stage.py
@@ -1,6 +1,7 @@
 from .common import *  # noqa
 
-ATTACHMENT_HOST = 'developer-samples.allizom.org'
+ATTACHMENT_HOST = config('ATTACHMENT_HOST',
+                         default='developer-samples.allizom.org')
 
 EMAIL_SUBJECT_PREFIX = '[mdn stage] '
 


### PR DESCRIPTION
Allow the ATTACHMENT_HOST to be set from the environment, which helps with MDN->AWS development.