### PR TITLE
bug 1391092: add ability to serve legacy files from Django (for AWS)

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -367,6 +367,9 @@ STATIC_ROOT = path('static')
 
 SERVE_MEDIA = False
 
+SERVE_LEGACY = config('SERVE_LEGACY', default=False)
+LEGACY_ROOT = config('LEGACY_ROOT', default=None)
+
 # Paths that don't require a locale prefix.
 LANGUAGE_URL_IGNORED_PATHS = (
     'healthz',
@@ -383,6 +386,9 @@ LANGUAGE_URL_IGNORED_PATHS = (
     '__debug__',
     '.well-known',
     'users/github/login/callback/',
+    'diagrams',
+    'presentations',
+    'samples',
 )
 
 # Make this unique, and don't share it with anybody.

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -91,6 +91,15 @@ if settings.SERVE_MEDIA:
             {'document_root': settings.MEDIA_ROOT}),
     ]
 
+if settings.SERVE_LEGACY and settings.LEGACY_ROOT:
+    urlpatterns.append(
+        url(
+            r'^(?P<path>(diagrams|presentations|samples)/.+)$',
+            serve,
+            {'document_root': settings.LEGACY_ROOT}
+        )
+    )
+
 # Legacy MindTouch redirects. These go last so that they don't mess
 # with local instances' ability to serve media.
 urlpatterns += [


### PR DESCRIPTION
This PR gives Kuma the ability to serve the legacy diagrams, presentations, and samples, and it's target use is for MDN in AWS. By default it is not enabled, so it will not affect the SCL3 deployment which already serves these legacy files via Apache. The legacy files are so rarely requested, and hopefully will be removed from MDN altogether in the future, so it doesn't seem worth the effort to serve these files in a more production-like manner.

For the AWS work, this feature can be enabled by setting two environment variables:
```
SERVE_LEGACY=True
LEGACY_ROOT=/mdn/www
```