### PR TITLE
Bug 1370594: Outline sample code

### DIFF
--- a/kuma/static/styles/components/wiki/sample-code.scss
+++ b/kuma/static/styles/components/wiki/sample-code.scss
@@ -1,3 +1,13 @@
+.sample-code-frame {
+    border: 1px solid #9b9b9b;
+    padding: $grid-spacing;
+
+    .sample-code-table & {
+        padding: 0;
+        border: 0;
+    }
+}
+
 .open-in-host {
     @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
 }

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -62,7 +62,7 @@ Styling for article content
 @import 'components/wiki/content/html5ArticleToc';
 @import 'components/wiki/content/fancyTOC';
 @import 'components/wiki/customcss';
-@import 'components/wiki/open-in-host';
+@import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';
 
 


### PR DESCRIPTION
Add a border around live sample code.

- This content looks different from other page content because it is in an iframe, there should be signal  for that
- Borrowed the border colour from the interative-examples
- Renamed .scss file to better indicate what it pertains to