### PR TITLE
bug 1391986

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     command: ./manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
     user: ${UID:-33}
     volumes:
-      - ./:/app
+      - ./:/app:z
     depends_on:
       - memcached
       - mysql


### PR DESCRIPTION
Adding `:z` so that SELinux labels are properly updated and docker-compose succeeds for systems based on Fedora/RHEL.