### PR TITLE
Fix bug 1389934

### DIFF
--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -44,7 +44,8 @@ Utility classes
     display: none;
 
     html.cke_panel_container &,
-    body[contenteditable] & {
+    body[contenteditable] &,
+    .translate-rendered & {
         position: relative;
         display: block;
         border: 2px dotted #000;


### PR DESCRIPTION
The hidden class is now displayed in the "english" panel when editing a translation of an article.