### PR TITLE
bug 1391084: Switch tag names from utf8_distinct_ci to utf8_general_ci 

### DIFF
--- a/kuma/wiki/migrations/0034_utf8_general_ci_tags.py
+++ b/kuma/wiki/migrations/0034_utf8_general_ci_tags.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+import logging
+
+logger = logging.getLogger('django.db.backends.schema')
+
+
+from django.db import migrations
+
+tags_tables = (
+    ('taggit', 'Tag'),
+    ('wiki', 'DocumentTag'),
+    ('wiki', 'LocalizationTag'),
+    ('wiki', 'ReviewTag'),
+)
+
+count_sql_pattern = (
+    "SELECT id, name, COUNT(*) count"
+    "  FROM %(table)s"
+    "  GROUP BY name COLLATE utf8_general_ci"
+    "  HAVING count > 1")
+
+tag_sql_pattern = (
+    "SELECT id, name"
+    "  FROM %(table)s"
+    "  WHERE name = _utf8'%(name)s' COLLATE utf8_general_ci"
+    "  ORDER BY id")
+
+
+def convert_tags_to_utf8_general_ci(apps, schema_editor):
+    models = [apps.get_model(app, model) for app, model in tags_tables]
+    for model in models:
+        assert not model.objects.filter(name__endswith='(2)').exists()
+
+    for Model in models:
+        table = Model._meta.db_table
+        count_sql = count_sql_pattern % {'table': table}
+        named_objs = Model.objects.raw(count_sql)
+        names = [obj.name for obj in named_objs]
+        if names:
+            logger.warn("\nUpdating tags in table %s", table)
+        for name in names:
+            tag_sql = tag_sql_pattern % {'table': table, 'name': name}
+            tag_objs = Model.objects.raw(tag_sql)
+            count = 1
+            for tag in tag_objs:
+                if count == 1:
+                    logger.warn("  Keeping %d: '%s'", tag.id, tag.name)
+                    first = False
+                else:
+                    old_name = tag.name
+                    tag.name += '(%d)' % count
+                    new_name = tag.name
+                    logger.warn("  Changing %d: '%s' to '%s'", tag.id, old_name, new_name)
+                    tag.save()
+                count += 1
+
+
+def revert_tags_to_utf8_distinct_ci(apps, schema_editor):
+    models = [apps.get_model(app, model) for app, model in tags_tables]
+    for Model in models:
+        table = Model._meta.db_table
+        count = 2
+        tag_end = '(%d)' % count
+        tags = Model.objects.filter(name__endswith=tag_end)
+        while tags.exists():
+            if count == 2:
+                logger.warn("\nReverting tags in table %s", table)
+            for tag in tags:
+                old_name = tag.name
+                tag.name = tag.name[:-len(tag_end)]
+                new_name = tag.name
+                logger.warn("  Reverting %d: '%s' to '%s'", tag.id, old_name, new_name)
+                tag.save()
+            count += 1
+            tag_end = '(%d)' % count
+            tags = Model.objects.filter(name__endswith=tag_end)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0033_drop_template_perms'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_tags_to_utf8_general_ci,
+                             revert_tags_to_utf8_distinct_ci)
+    ]

--- a/kuma/wiki/migrations/0035_utf8_general_ci_collation.py
+++ b/kuma/wiki/migrations/0035_utf8_general_ci_collation.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+sql_pattern = """\
+SET FOREIGN_KEY_CHECKS=0;
+ALTER TABLE taggit_tag
+  MODIFY name varchar(100)
+    CHARACTER SET utf8 COLLATE %(collation)s;
+ALTER TABLE wiki_documenttag
+  MODIFY name VARCHAR(100)
+    CHARACTER SET utf8 COLLATE %(collation)s
+    DEFAULT NULL;
+ALTER TABLE wiki_localizationtag
+  MODIFY name VARCHAR(100)
+    CHARACTER SET utf8 COLLATE %(collation)s
+    DEFAULT NULL;
+ALTER TABLE wiki_reviewtag
+  MODIFY name VARCHAR(100)
+   CHARACTER SET utf8 COLLATE %(collation)s
+   DEFAULT NULL;
+SET FOREIGN_KEY_CHECKS=1;
+"""
+
+to_utf8_general_ci = sql_pattern % {'collation': 'utf8_general_ci'}
+to_utf8_distinct_ci = sql_pattern % {'collation': 'utf8_distinct_ci'}
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('wiki', '0034_utf8_general_ci_tags'),
+    ]
+
+    operations = [migrations.RunSQL(to_utf8_general_ci,
+                                    to_utf8_distinct_ci)
+    ]

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -854,26 +854,6 @@ class DocumentListTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(1, len(doc('#document-list ul.document-list li')))
 
-    @pytest.mark.xfail(reason='Requires migrations')
-    @pytest.mark.tags
-    def test_tag_list_duplicates(self):
-        """
-        Verify the tagged documents list view, even for duplicate tags
-
-        http://bugzil.la/871638
-        """
-        en_tag = DocumentTag(name='CSS Reference', slug='css-reference')
-        en_tag.save()
-        fr_tag = DocumentTag(name=u'CSS Référence', slug='css-reference_1')
-        fr_tag.save()
-        self.doc.tags.add(en_tag)
-        self.doc.tags.add(fr_tag)
-        response = self.client.get(reverse('wiki.tag',
-                                   args=[en_tag.name]))
-        eq_(200, response.status_code)
-        doc = pq(response.content)
-        eq_(1, len(doc('#document-list ul.document-list li')))
-
 
 def test_compare_revisions(edit_revision, client):
     """Comparing two valid revisions of the same document works."""


### PR DESCRIPTION
Drops the one test that depends on ``utf8_distinct_ci`` custom collation, and then:

1. Migrates tag names that would collide. The oldest tag retains its name, and the newer tags have  `(2)`, `(3)` appended to their name.
2. Migrates ``name`` columns to use ``utf8_general_ci`` instead of ``utf8_distinct_ci``

This migration runs in 7-10 seconds locally, so I don't think we need to schedule downtime to run it.  I've placed the output of the forwards and reverse migrations in [a gist](https://gist.github.com/jwhitlock/7b18b62fef27fc77a3b71a25d4bf3a71).