### PR TITLE
bug 1362026: Add interactive-examples to iframes

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1377,15 +1377,17 @@ CONSTANCE_CONFIG = dict(
         '(Deprecated) Regex for protocols that are blocked for A HREFs'
     ),
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS=(
-        ('^https?\:\/\/('
-         'developer.allizom.org|'  # Staging demos
-         'mdn.mozillademos.org|'   # Production demos
-         'testserver|'             # Unit test demos
-         'localhost\:8000|'        # Docker development demos
-         'rpm.newrelic.com\/public\/charts\/.*|'  # MDN/Kuma/Server_charts
-         '(www.)?youtube.com\/embed\/(\.*)|'  # Embedded videos
-         'jsfiddle.net\/.*embedded.*|'  # Embedded samples
-         'mdn.github.io)'),        # Embedded samples
+        ('^https?\:\/\/'
+         '(developer.allizom.org'                   # Staging demos
+         '|mdn.mozillademos.org'                    # Production demos
+         '|testserver'                              # Unit test demos
+         '|localhost\:8000'                         # Docker development demos
+         '|rpm.newrelic.com\/public\/charts\/.*'    # MDN/Kuma/Server_charts
+         '|(www.)?youtube.com\/embed\/(\.*)'        # Embedded videos
+         '|jsfiddle.net\/.*embedded.*'              # Embedded samples
+         '|mdn.github.io'                           # Embedded samples
+         '|interactive-examples.mdn.mozilla.net'    # Embedded samples
+         ')'),
         'Regex comprised of domain names that are allowed for IFRAME SRCs'
     ),
     GOOGLE_ANALYTICS_ACCOUNT=(

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -856,6 +856,8 @@ FILTERIFRAME_ACCEPTED = {
     'jsfiddle': 'https://jsfiddle.net/78dg25ax/embedded/js,result/',
     'github.io': ('https://mdn.github.io/webgl-examples/'
                   'tutorial/sample6/index.html'),
+    'ie_moz_net': ('https://interactive-examples.mdn.mozilla.net/'
+                   'pages/js/array-push.html'),
 }
 
 FILTERIFRAME_REJECTED = {


### PR DESCRIPTION
Add https://interactive-examples.mdn.mozilla.net to the allowed sources for iframes.  Re-arrange the long regex string so it is easier to add new items at the end.