### PR TITLE
bug 1392457, 1274874: Improve document list views

### DIFF
--- a/kuma/wiki/jinja2/wiki/list/documents.html
+++ b/kuma/wiki/jinja2/wiki/list/documents.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% set counter = ngettext('Found %(num)s document.', 'Found %(num)s documents', count) %}
+{% set counter = ngettext('Found %(num)s document.', 'Found %(num)s documents', documents.paginator.count) %}
 {% if tag %}
   {% set title = _('Articles tagged: %(tag)s', tag=tag) %}
 {% elif errors %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -68,34 +68,35 @@ class BaseDocumentManager(models.Manager):
             docs = docs.filter(parent_topic__isnull=True)
 
         # Only include fields needed for a list of links to docs
-        docs = docs.only('id', 'locale', 'slug', 'deleted', 'summary_text')
+        docs = docs.only('id', 'locale', 'slug', 'deleted', 'title',
+                         'summary_text')
         return docs
 
     def filter_for_review(self, locale=None, tag=None, tag_name=None):
         """Filter for documents with current revision flagged for review"""
-        query = 'current_revision__review_tags__%s'
+        docs = self.filter_for_list(locale=locale)
+        docs = docs.exclude(slug__startswith='Archive/')
+        filter_name = 'current_revision__review_tags__'
         if tag_name:
-            query = {query % 'name': tag_name}
+            docs = docs.filter(**{filter_name + 'name': tag_name})
         elif tag:
-            query = {query % 'in': [tag]}
+            docs = docs.filter(**{filter_name + 'in': [tag]})
         else:
-            query = {query % 'name__isnull': False}
-        if locale:
-            query['locale'] = locale
-        return self.filter(**query).distinct()
+            docs = docs.filter(**{filter_name + 'name__isnull': False})
+        return docs.distinct()
 
     def filter_with_localization_tag(self, locale=None, tag=None, tag_name=None):
         """Filter for documents with a localization tag on current revision"""
-        query = 'current_revision__localization_tags__%s'
+        docs = self.filter_for_list(locale=locale)
+        docs = docs.exclude(slug__startswith='Archive/')
+        filter_name = 'current_revision__localization_tags__'
         if tag_name:
-            query = {query % 'name': tag_name}
+            docs = docs.filter(**{filter_name + 'name': tag_name})
         elif tag:
-            query = {query % 'in': [tag]}
+            docs = docs.filter(**{filter_name + 'in': [tag]})
         else:
-            query = {query % 'name__isnull': False}
-        if locale:
-            query['locale'] = locale
-        return self.filter(**query).distinct()
+            docs = docs.filter(**{filter_name + 'name__isnull': False})
+        return docs.distinct()
 
 
 class DocumentManager(BaseDocumentManager):

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -41,6 +41,10 @@ class BaseDocumentManager(models.Manager):
 
     def filter_for_list(self, locale=None, tag=None, tag_name=None,
                         errors=None, noparent=None, toplevel=None):
+        """
+        Returns a filtered queryset for a list of names and urls.
+        """
+
         docs = (self.filter(is_redirect=False)
                     .exclude(slug__startswith='User:')
                     .exclude(slug__startswith='Talk:')
@@ -63,9 +67,8 @@ class BaseDocumentManager(models.Manager):
         if toplevel:
             docs = docs.filter(parent_topic__isnull=True)
 
-        # Leave out the html, since that leads to huge cache objects and we
-        # never use the content in lists.
-        docs = docs.defer('html')
+        # Only include fields needed for a list of links to docs
+        docs = docs.only('id', 'locale', 'slug', 'deleted', 'summary_text')
         return docs
 
     def filter_for_review(self, locale=None, tag=None, tag_name=None):

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -31,7 +31,6 @@ def documents(request, tag=None):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'tag': tag,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -97,7 +96,6 @@ def with_errors(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'errors': True,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -112,7 +110,6 @@ def without_parent(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'noparent': True,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -127,7 +124,6 @@ def top_level(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'toplevel': True,
     }
     return render(request, 'wiki/list/documents.html', context)


### PR DESCRIPTION
Improve special views that return a list of documents:

* Reduce data returned from database to that used in the page
* Eliminate second ``COUNT(*)`` query
* Remove redirects, user pages, and archive pages from the "needs review" and "needs translation" lists.

To Do:
* [ ] Add tests for manager methods

This is not an AWS blocker, so not prioritizing getting this reviewed or merged.