### PR TITLE
Updates for iframe display behaviour

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1017,6 +1017,7 @@ PIPELINE_JS = {
     'wiki': {
         'source_filenames': (
             'js/wiki.js',
+            'js/interactive.js',
             'js/wiki-samples.js',
             'js/wiki-helpful-survey.js',
         ),

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -1,8 +1,7 @@
 (function() {
     'use strict';
 
-    var mediaQuery = window.matchMedia('(max-width: 1024px)');
-    var iframe = document.querySelector('iframe.interactive');
+    var mediaQuery = window.matchMedia('(min-width: 63.9385em)');
 
     /**
      * A simple wrapper function for the `postMessage`s sent
@@ -11,6 +10,7 @@
      * remove the `small-desktop-and-below` class
      */
     function postToEditor(isSmallViewport) {
+        var iframe = document.querySelector('iframe.interactive');
         iframe.contentWindow.postMessage({ smallViewport: isSmallViewport },
             'https://interactive-examples.mdn.mozilla.net'
         );
@@ -21,15 +21,15 @@
     viewport state to the interactive editor */
     mediaQuery.addListener(function(event) {
         if (event.matches) {
-            postToEditor(true);
-        } else {
             postToEditor(false);
+        } else {
+            postToEditor(true);
         }
     });
 
     window.onload = function() {
-        // if the mediaQuery matches on load
-        if (mediaQuery.matches) {
+        // if the mediaQuery does not match on load
+        if (!mediaQuery.matches) {
             // add the class `small-desktop-and-below`
             postToEditor(true);
         }

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -1,0 +1,38 @@
+(function() {
+    'use strict';
+
+    var mediaQuery = window.matchMedia('(max-width: 1024px)');
+    var iframe = document.querySelector('iframe.interactive');
+
+    /**
+     * A simple wrapper function for the `postMessage`s sent
+     * to the interactive editor iframe
+     * @param {Boolean} isSmallViewport - Boolean indicating whether to add, or
+     * remove the `small-desktop-and-below` class
+     */
+    function postToEditor(isSmallViewport) {
+        iframe.contentWindow.postMessage({ smallViewport: isSmallViewport },
+            'https://interactive-examples.mdn.mozilla.net'
+        );
+    }
+
+    /* As the user sizes the browser or tilts their device,
+    listen for mediaQuery events and communicate the new
+    viewport state to the interactive editor */
+    mediaQuery.addListener(function(event) {
+        if (event.matches) {
+            postToEditor(true);
+        } else {
+            postToEditor(false);
+        }
+    });
+
+    window.onload = function() {
+        // if the mediaQuery matches on load
+        if (mediaQuery.matches) {
+            // add the class `small-desktop-and-below`
+            postToEditor(true);
+        }
+    };
+
+})();

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -708,17 +708,4 @@
         }
     }
 
-    // listens for post message from interactive editor
-    window.addEventListener('message', function(event) {
-        // get the interactive editor iframe
-        var iframe = document.querySelector('iframe.interactive');
-        var isExpectedOrigin = event.origin === 'https://interactive-examples.mdn.mozilla.net';
-
-        /* there may be other post messages so, ensure that the origin is the
-        expected and, that `event.data` contains an `iframeHeight` property */
-        if (isExpectedOrigin && event.data.iframeHeight) {
-            iframe.setAttribute('height', event.data.iframeHeight);
-        }
-    }, false);
-
 })(window, document, jQuery);

--- a/kuma/static/styles/components/wiki/interactive.scss
+++ b/kuma/static/styles/components/wiki/interactive.scss
@@ -1,14 +1,25 @@
+.interactive,
+.interactive-js {
+    box-sizing: border-box;
+}
+
 .interactive {
-    height: 600px;
+    background-color: #f5f9fa;
+    color: #333;
+    padding: .7em;
+    border: 1px solid #eaf2f4;
+    height: 550px;
     width: 100%;
 }
 
-.interactive-js {
-    height: 400px;
+.interactive.interactive-js {
+    height: 490px;
 }
 
-.interactive-large {
-    height: 665px;
+.no-js .interactive {
+    background-color: #f8f8f8;
+    border: 1px solid #eaf2f4;
+    height: 240px;
 }
 
 .interactive-editor-survey {
@@ -19,10 +30,6 @@
 
 @media #{$mq-tablet-and-up} {
     .interactive {
-        height: 420px;
-    }
-
-    .interactive-large {
-        height: 455px;
+        height: 390px;
     }
 }

--- a/kuma/static/styles/components/wiki/interactive.scss
+++ b/kuma/static/styles/components/wiki/interactive.scss
@@ -1,12 +1,8 @@
-.interactive,
-.interactive-js {
-    box-sizing: border-box;
-}
-
 .interactive {
+    box-sizing: border-box;
     background-color: #f5f9fa;
-    color: #333;
-    padding: .7em;
+    color: $text-color;
+    padding: 10px;
     border: 1px solid #eaf2f4;
     height: 550px;
     width: 100%;
@@ -18,7 +14,6 @@
 
 .no-js .interactive {
     background-color: #f8f8f8;
-    border: 1px solid #eaf2f4;
     height: 240px;
 }
 
@@ -28,7 +23,7 @@
     text-align: center;
 }
 
-@media #{$mq-tablet-and-up} {
+@media #{$mq-small-desktop-and-up} {
     .interactive {
         height: 390px;
     }

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -8,11 +8,13 @@ General element over-rides
 ====================================================================== */
 @import 'components/wiki/elements';
 
+
 /*
 Utitlity classes (reused in a variety of contexts)
 ====================================================================== */
 @import 'components/wiki/document-list';
 @import 'components/wiki/external-icon';
+
 
 /*
 Components that may appear on most wiki pages
@@ -37,6 +39,7 @@ Components that may appear on most wiki pages
 @import 'components/wiki/mega';
 @import 'components/wiki/interactive';
 
+
 /*
 Article meta
 - contains breadcrumbs and page buttons.
@@ -44,6 +47,7 @@ Article meta
 @import 'components/wiki/article-head';
 @import 'components/wiki/crumbs';
 @import 'components/wiki/page-buttons';
+
 
 /*
 Styling for article content
@@ -61,6 +65,7 @@ Styling for article content
 @import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';
 
+
 /*
 Delete, move or revert pages.
 ====================================================================== */
@@ -70,6 +75,7 @@ Delete, move or revert pages.
 @import 'components/wiki/doc-source';
 @import 'components/wiki/delete-document';
 @import 'components/wiki/delete-revision';
+
 
 /*
 Promos

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -8,13 +8,11 @@ General element over-rides
 ====================================================================== */
 @import 'components/wiki/elements';
 
-
 /*
 Utitlity classes (reused in a variety of contexts)
 ====================================================================== */
 @import 'components/wiki/document-list';
 @import 'components/wiki/external-icon';
-
 
 /*
 Components that may appear on most wiki pages
@@ -39,7 +37,6 @@ Components that may appear on most wiki pages
 @import 'components/wiki/mega';
 @import 'components/wiki/interactive';
 
-
 /*
 Article meta
 - contains breadcrumbs and page buttons.
@@ -47,7 +44,6 @@ Article meta
 @import 'components/wiki/article-head';
 @import 'components/wiki/crumbs';
 @import 'components/wiki/page-buttons';
-
 
 /*
 Styling for article content
@@ -65,7 +61,6 @@ Styling for article content
 @import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';
 
-
 /*
 Delete, move or revert pages.
 ====================================================================== */
@@ -75,7 +70,6 @@ Delete, move or revert pages.
 @import 'components/wiki/doc-source';
 @import 'components/wiki/delete-document';
 @import 'components/wiki/delete-revision';
-
 
 /*
 Promos


### PR DESCRIPTION
Ok so, I have tried a bunch of different things with regards to the iframe and Kuma trying to get to a happy place where things respond in concert. I have reached that point but, I had to make a call to get to this place.

Basically, while the right sidebar is still visible, the CSS editor will display side-by-side. Once the viewport become narrow enough, and the right sidebar drop to the bottom, it changes to stacked.

This is one part of it. The other side is, to not have to continuously fight with heights, I defined a `max-height`. The maximum height allows for ~6 lines of examples, which is one more than our "rule" of 5. If the specific example goes beyond this, then the examples area aka left side of the editor, will be scrollable to reveal the additional examples.

It ended up requiring a bit more code on the Kuma side, as I kinda flipped the original idea on it's head ;) With that, I am then opening this PR in favour of https://github.com/mozilla/kuma/pull/4369

There is also a PR on the interactive editor side that I will have to open and merge so all the changes, and behaviours are evident.