### PR TITLE
bug 1362438: Change handling of some legacy paths

### DIFF
--- a/configs/htaccess
+++ b/configs/htaccess
@@ -5,13 +5,6 @@
 ReWriteEngine On
 RewriteBase /
 
-# Old index.php redirects
-RewriteCond %{QUERY_STRING} ^title=http [NC]
-RewriteRule ^index\.php$ / [L,NC]
-
-RewriteCond %{QUERY_STRING} ^title=(.*)$ [NC]
-RewriteRule ^index\.php$ %1 [R=301,L,NC]
-
 # Links to FTP'ed code samples and examples
 RewriteRule ^patches(.*) data/www/patches$1 [L]
 RewriteRule ^presentations(.*) data/www/presentations$1 [L]

--- a/configs/htaccess
+++ b/configs/htaccess
@@ -6,12 +6,9 @@ ReWriteEngine On
 RewriteBase /
 
 # Links to FTP'ed code samples and examples
-RewriteRule ^patches(.*) data/www/patches$1 [L]
 RewriteRule ^presentations(.*) data/www/presentations$1 [L]
 RewriteRule ^samples(.*) data/www/samples$1 [L]
 RewriteRule ^diagrams(.*) data/www/diagrams$1 [L]
-RewriteRule ^web-tech(.*) data/www/web-tech$1 [L]
-RewriteRule ^css(.*) data/www/css$1 [L]
 
 # Disable robots on dev and stage servers
 RewriteCond %{HTTP_HOST} allizom

--- a/configs/htaccess
+++ b/configs/htaccess
@@ -57,7 +57,7 @@ RewriteRule ^(\w{2,3}(?:-\w{2})?/)?demos /$1docs/Web/Demos_of_open_web_technolog
 
 # Legacy off-site redirects (bug 1362438)
 RewriteRule ^contests/ http://www.mozillalabs.com/ [R=302,L]
-RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
+RewriteRule ^es4 http://www.ecma-international.org/memento/TC39.htm [R=302,L]
 
 # HACK: Django will eventually redirect the user to the right spot, but skip a
 # couple of redirects for these known legacy locales

--- a/configs/htaccess
+++ b/configs/htaccess
@@ -55,9 +55,8 @@ RewriteRule ^(\w{2,3}(?:-\w{2})?/)?demos/detail/bananabread/launch$ https://krip
 # All other Demo Studio and Dev Derby paths (bug 1238037)
 RewriteRule ^(\w{2,3}(?:-\w{2})?/)?demos /$1docs/Web/Demos_of_open_web_technologies? [R=301,L]
 
-# Miscellaneous off-site redirects
-RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
-RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]
+# Legacy off-site redirects (bug 1362438)
+RewriteRule ^contests/ http://www.mozillalabs.com/ [R=302,L]
 RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
 
 # HACK: Django will eventually redirect the user to the right spot, but skip a

--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -756,4 +756,8 @@ redirectpatterns = [
     # Legacy off-site redirects (bug 1362438)
     # RewriteRule ^contests/ http://www.mozillalabs.com/ [R=302,L]
     redirect(r'^contests', 'http://www.mozillalabs.com/', permanent=False),
+
+    # RewriteRule ^es4 http://www.ecma-international.org/memento/TC39.htm [R=302,L]
+    redirect(r'^es4', 'http://www.ecma-international.org/memento/TC39.htm',
+             permanent=False),
 ]

--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -752,4 +752,8 @@ redirectpatterns = [
         r'^?demos',
         '/docs/Web/Demos_of_open_web_technologies',
         permanent=True),
+
+    # Legacy off-site redirects (bug 1362438)
+    # RewriteRule ^contests/ http://www.mozillalabs.com/ [R=302,L]
+    redirect(r'^contests', 'http://www.mozillalabs.com/', permanent=False),
 ]

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -387,9 +387,14 @@ LANGUAGE_URL_IGNORED_PATHS = (
     '__debug__',
     '.well-known',
     'users/github/login/callback/',
+    # Legacy files, circa 2008, served in AWS
     'diagrams',
     'presentations',
     'samples',
+    # Legacy files, circa 2008, now return 404
+    'patches',
+    'web-tech',
+    'css',
     'index.php',  # Legacy MediaWiki endpoint, return 404
 )
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -390,6 +390,7 @@ LANGUAGE_URL_IGNORED_PATHS = (
     'diagrams',
     'presentations',
     'samples',
+    'index.php',  # Legacy MediaWiki endpoint, return 404
 )
 
 # Make this unique, and don't share it with anybody.

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -318,4 +318,12 @@ LEGACY_URLS = flatten((
              status_code=404),
     url_test('/index.php?title=En/HTML/Canvas&revision=11',
              status_code=404),
+    url_test('/index.php?title=En/HTML/Canvas&revision=11',
+             status_code=404),
+    url_test('/patches', status_code=404),
+    url_test('/patches/foo', status_code=404),
+    url_test('/web-tech', status_code=404),
+    url_test('/web-tech/feed/atom/', status_code=404),
+    url_test('/css/wiki.css', status_code=404),
+    url_test('/css/base.css', status_code=404),
 ))

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -2,7 +2,7 @@ from utils.urls import flatten, url_test
 
 import requests
 
-URLS = flatten((
+REDIRECT_URLS = flatten((
     url_test("/media/redesign/css/foo-min.css",
              "/static/build/styles/foo.css"),
     url_test("/media/css/foo-min.css", "/static/build/styles/foo.css"),
@@ -309,4 +309,13 @@ MOZILLADEMOS_URLS = flatten((
              "https://mdn.mozillademos.org/files/5397/rhino.jpg"),
     url_test("/samples/canvas-tutorial/images/wallpaper.png",
              "https://mdn.mozillademos.org/files/222/Canvas_createpattern.png"),
+))
+
+LEGACY_URLS = flatten((
+    # bug 1362438
+    url_test('/index.php', status_code=404),
+    url_test('/index.php?title=Special:Recentchanges&feed=atom',
+             status_code=404),
+    url_test('/index.php?title=En/HTML/Canvas&revision=11',
+             status_code=404),
 ))

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -330,4 +330,11 @@ LEGACY_URLS = flatten((
     url_test('/contests/', 'http://www.mozillalabs.com/', status_code=302),
     url_test('/contests/extendfirefox/faq.php', 'http://www.mozillalabs.com/',
              status_code=302),
+    url_test('/es4', 'http://www.ecma-international.org/memento/TC39.htm',
+             status_code=302),
+    url_test('/es4/', 'http://www.ecma-international.org/memento/TC39.htm',
+             status_code=302),
+    url_test('/es4/proposals/slice_syntax.html',
+             'http://www.ecma-international.org/memento/TC39.htm',
+             status_code=302),
 ))

--- a/tests/redirects/map_301.py
+++ b/tests/redirects/map_301.py
@@ -326,4 +326,8 @@ LEGACY_URLS = flatten((
     url_test('/web-tech/feed/atom/', status_code=404),
     url_test('/css/wiki.css', status_code=404),
     url_test('/css/base.css', status_code=404),
+    url_test('/contests', 'http://www.mozillalabs.com/', status_code=302),
+    url_test('/contests/', 'http://www.mozillalabs.com/', status_code=302),
+    url_test('/contests/extendfirefox/faq.php', 'http://www.mozillalabs.com/',
+             status_code=302),
 ))

--- a/tests/redirects/test_redirects.py
+++ b/tests/redirects/test_redirects.py
@@ -3,9 +3,8 @@ from __future__ import absolute_import
 import pytest
 
 from utils.urls import assert_valid_url
-from .map_301 import URLS as REDIRECT_URLS
-from .map_301 import GITHUB_IO_URLS
-from .map_301 import MOZILLADEMOS_URLS
+from .map_301 import (REDIRECT_URLS, GITHUB_IO_URLS, MOZILLADEMOS_URLS,
+                      LEGACY_URLS)
 
 # while these test methods are similar, they're each testing a
 # subset of redirects, and it was easier to work with them separately.
@@ -31,5 +30,13 @@ def test_github_redirects(url, base_url):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize('url', MOZILLADEMOS_URLS)
 def test_mozillademos_redirects(url, base_url):
+    url['base_url'] = base_url
+    assert_valid_url(**url)
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('url', LEGACY_URLS)
+def test_legacy_urls(url, base_url):
     url['base_url'] = base_url
     assert_valid_url(**url)


### PR DESCRIPTION
Apache in SCL3 handles some legacy paths from earlier versions of MDN, and many of these are incorrect. This PR updates the Apache rules, and creates Django-based redirects for some.

A fuller analysis of these URLs is on [PR 4231](https://github.com/mozilla/kuma/pull/4231#issuecomment-324359728).

AWS blocker, tracked in https://github.com/mozmeao/infra/issues/436