### PR TITLE
bug 1391084: Upgrade sqlparse and related reqs

### DIFF
--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -37,3 +37,10 @@ if DEBUG:
     WHITENOISE_MAX_AGE = 0
     if DEBUG_TOOLBAR:
         INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
+        MIDDLEWARE_CLASSES = list(MIDDLEWARE_CLASSES)
+        common_index = MIDDLEWARE_CLASSES.index(
+            'django.middleware.common.CommonMiddleware')
+        MIDDLEWARE_CLASSES.insert(
+            common_index + 1,
+            'debug_toolbar.middleware.DebugToolbarMiddleware')
+        DEBUG_TOOLBAR_INSTALLED = 1

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -100,6 +100,12 @@ if settings.SERVE_LEGACY and settings.LEGACY_ROOT:
         )
     )
 
+if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):
+    import debug_toolbar
+    urlpatterns.append(
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )
+
 # Legacy MindTouch redirects. These go last so that they don't mess
 # with local instances' ability to serve media.
 urlpatterns += [

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -104,9 +104,6 @@ requests-oauthlib==0.6.1 \
     --hash=sha256:905306080ec0cc6b3c65c8101f471fccfdb9994c16dd116524fd3fc0790d46d7 \
     --hash=sha256:7c708e8e2a4aa6a905cf91f28420d75db37270e0ec8fc951915c098dd8bde53e
 
-# django-debug-toolbar
-sqlparse==0.1.19 \
-    --hash=sha256:d896be1a1c7f24bffe08d7a64e6f0176b260e281c5f3685afe7826f8bada4ee8
 
 # django-statici18n
 django-appconf==1.0.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -246,6 +246,11 @@ requests-mock==0.7.0 \
     --hash=sha256:ee2816992d4505596ec3c98c7b4ab57475539ac037d08dd3a81370b1e3cdd568 \
     --hash=sha256:e61056cdb809fcc6ed47771b74054fe3ab4c3659d7f66c32a5256e8cf013e0af
 
+# Parse SQL statements, needed for RunSQL migrations
+sqlparse==0.2.3 \
+    --hash=sha256:740a023ef38ce11bbb99a9d143856f56ef4ec5b0d7a853f58c02c65b035114c4 \
+    --hash=sha256:becd7cc7cebbdf311de8ceedfcf2bd2403297024418801947f8c953025beeff8
+
 # Utility class for manipulating URLs, used in util functions
 URLObject==2.4.0 \
     --hash=sha256:f51272b12846db98af530b0a64f6593d2b1e8405f0aa580285b37ce8009b8d9c

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -7,9 +7,9 @@ django-babel==0.4.0 \
 --hash=sha256:b328dae0e594031d7b0ffded51fd6df60677d4509aee3677013a3a2f76da4e70
 
 # Analyze Django performance during request
-django-debug-toolbar==1.4 \
---hash=sha256:0cbae8760f4851d480a70b72ace5b075f8191ecf899bc97427715e50fb0e90b9 \
---hash=sha256:852a37b80df9597048591ebc87d0ce85a4edceaef015dc5360ad89cc5960c27b
+django-debug-toolbar==1.8 \
+    --hash=sha256:e9f08b94f9423ac76cfc287151182bbaddbe7521ae32bef9f9863e2ac58018d3 \
+    --hash=sha256:0b4d2b1ac49a8bc5604518e8e20f56c1c08c0c4873336107e7c773c42537876b
 
 # Code quality checker
 flake8==3.1.1 \
@@ -17,9 +17,9 @@ flake8==3.1.1 \
     --hash=sha256:941fa78f61f2524cb7aee4aa4fe9876f4b0dcf5aba9fabd3e780d24918f498b7
 
 # Calculate hashes for pip 8.x+
-hashin==0.9.0 \
-    --hash=sha256:814eb85c3cede62e85b11572bfef3f86ff955e89a172e73ef52fe63ca5c95168 \
-    --hash=sha256:e07bb03a35dc6d973a61196cd6d11442649f8faf6085159e7bf4f9d521eec160
+hashin==0.11.2 \
+    --hash=sha256:a52b094dc7b1603a2f65617502f2de61123a268bab01c2079249c1c506480395 \
+    --hash=sha256:aaf11abf155830b7c2b868bb6dbc5dfde49cd0b17a4c0dc1b8b67ca9f31ec490
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
Move sqlparse from contraints to default, because it is needed for RunSQL data migrations. Also update it and some other requirements:

* sqlparse 0.1.19 → 0.2.3 - Cleanup, refactoring, bug fixes
* django-debug-toolbar 1.4 → 1.8 - sqlparse 0.2 compat, Django 1.11 compatibility, manual setup required (with code changes)
* hashin 0.9.0 → 0.11.2 - Update how latest version is determined