### PR TITLE
[Bug 962148] URL with 'en' locale don't redirect to 'en-US'

### DIFF
--- a/configs/htaccess
+++ b/configs/htaccess
@@ -70,13 +70,6 @@ RewriteRule ^contests/$ http://labs.mozilla.com/contests/extendfirefox/ [R=302]
 RewriteRule ^contests/extendfirefox(/.*)? http://labs.mozilla.com/contests/extendfirefox$1 [R=302]
 RewriteRule ^es4(/.*)?$ http://wiki.ecmascript.org/ [R]
 
-# HACK: Django will eventually redirect the user to the right spot, but skip a
-# couple of redirects for these known legacy locales
-RewriteRule ^en/(.*)$     /mwsgi/en-US/$1 [L,QSA,NE,NC]
-RewriteRule ^cn/(.*)$     /mwsgi/zh-CN/$1 [L,QSA,NE,NC]
-RewriteRule ^zh_cn/(.*)$  /mwsgi/zh-CN/$1 [L,QSA,NE,NC]
-RewriteRule ^zh_tw/(.*)$  /mwsgi/zh-TW/$1 [L,QSA,NE,NC]
-
 # These are some known static files
 RewriteCond %{REQUEST_URI} !/favicon.ico
 # TODO: Should Django handle robots.txt?

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -226,6 +226,7 @@ LOCALE_ALIASES = {
     'pt': 'pt-PT',
     'sr': 'sr-Cyrl',
     'zh': 'zh-CN',
+    'cn': 'zh-CN',
 
     # Create aliases for locales which do not share a prefix.
     'nb-NO': 'no',
@@ -234,6 +235,10 @@ LOCALE_ALIASES = {
     # Create aliases for locales which use region subtags to assume scripts.
     'zh-Hans': 'zh-CN',
     'zh-Hant': 'zh-TW',
+
+    # Map locale whose region subtag is separated by `_`(underscore)
+    'zh_cn': 'zh-CN',
+    'zh_tw': 'zh-TW',
 }
 
 LANGUAGE_URL_MAP = dict([(i.lower(), i) for i in MDN_LANGUAGES])

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -213,6 +213,7 @@ LOCALE_ALIASES = {
 
     # Create aliases for over-specific locales.
     'bn': 'bn-BD',
+    'cn': 'zh-CN',
     'fy': 'fy-NL',
     'ga': 'ga-IE',
     'gu': 'gu-IN',
@@ -226,7 +227,6 @@ LOCALE_ALIASES = {
     'pt': 'pt-PT',
     'sr': 'sr-Cyrl',
     'zh': 'zh-CN',
-    'cn': 'zh-CN',
 
     # Create aliases for locales which do not share a prefix.
     'nb-NO': 'no',

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -3390,7 +3390,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
          'expected': '/zh-CN/docs/XHTML'},
         {'title': 'JavaScript', 'mt_locale': 'zh_cn', 'kuma_locale': 'zh-CN',
          'expected': '/zh-CN/docs/JavaScript'},
-        {'title': 'XHTML6', 'mt_locale': 'zh_tw', 'kuma_locale': 'zh-CN',
+        {'title': 'XHTML6', 'mt_locale': 'zh_tw', 'kuma_locale': 'zh-TW',
          'expected': '/zh-TW/docs/XHTML6'},
         {'title': 'HTML7', 'mt_locale': 'fr', 'kuma_locale': 'fr',
          'expected': '/fr/docs/HTML7'},
@@ -3413,9 +3413,10 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         d.title = 'FooFoo'
         d.save()
         mt_url = '/cn/%s/' % (d.slug,)
-        resp = self.client.get(mt_url)
-        eq_(301, resp.status_code)
-        eq_('http://testserver%s' % d.get_absolute_url(), resp['Location'])
+        resp = self.client.get(mt_url, follow=True)
+        eq_(200, resp.status_code)
+        # Check the last redirect chain url is the expected url
+        eq_('http://testserver%s' % d.get_absolute_url(), resp.redirect_chain[-1][0])
 
     def test_document_urls(self):
         for doc in self.documents:
@@ -3425,9 +3426,11 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
             d.locale = doc['kuma_locale']
             d.save()
             mt_url = '/%s' % '/'.join([doc['mt_locale'], doc['title']])
-            resp = self.client.get(mt_url)
-            eq_(301, resp.status_code)
-            eq_('http://testserver%s' % doc['expected'], resp['Location'])
+            resp = self.client.get(mt_url, follow=True)
+            eq_(200, resp.status_code)
+
+            # Check the last redirect chain url is the expected url
+            eq_('http://testserver%s' % doc['expected'], resp.redirect_chain[-1][0])
 
     def test_view_param(self):
         d = document()

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -3385,17 +3385,6 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
          'kuma': '%s/User:Foo' % server_prefix},
     )
 
-    documents = (
-        {'title': 'XHTML', 'mt_locale': 'cn', 'kuma_locale': 'zh-CN',
-         'expected': '/zh-CN/docs/XHTML'},
-        {'title': 'JavaScript', 'mt_locale': 'zh_cn', 'kuma_locale': 'zh-CN',
-         'expected': '/zh-CN/docs/JavaScript'},
-        {'title': 'XHTML6', 'mt_locale': 'zh_tw', 'kuma_locale': 'zh-TW',
-         'expected': '/zh-TW/docs/XHTML6'},
-        {'title': 'HTML7', 'mt_locale': 'fr', 'kuma_locale': 'fr',
-         'expected': '/fr/docs/HTML7'},
-    )
-
     def test_namespace_urls(self):
         new_doc = document()
         new_doc.title = 'User:Foo'
@@ -3406,31 +3395,17 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
             eq_(301, resp.status_code)
             eq_(namespace_test['kuma'], resp['Location'])
 
-    def test_trailing_slash(self):
-        d = document()
-        d.locale = 'zh-CN'
-        d.slug = 'foofoo'
-        d.title = 'FooFoo'
-        d.save()
-        mt_url = '/cn/%s/' % (d.slug,)
-        resp = self.client.get(mt_url, follow=True)
-        eq_(200, resp.status_code)
-        # Check the last redirect chain url is the expected url
-        eq_('http://testserver%s' % d.get_absolute_url(), resp.redirect_chain[-1][0])
-
     def test_document_urls(self):
-        for doc in self.documents:
-            d = document()
-            d.title = doc['title']
-            d.slug = doc['title']
-            d.locale = doc['kuma_locale']
-            d.save()
-            mt_url = '/%s' % '/'.join([doc['mt_locale'], doc['title']])
-            resp = self.client.get(mt_url, follow=True)
-            eq_(200, resp.status_code)
+        """Check the url redirect to proper document when the url like
+         /<locale>/<document_slug>"""
+        d = document(locale='zh-CN')
+        d.save()
+        mt_url = '{locale}/{slug}'.format(locale=d.locale, slug=d.slug)
+        resp = self.client.get(mt_url, follow=True)
+        assert resp.status_code == 200
 
-            # Check the last redirect chain url is the expected url
-            eq_('http://testserver%s' % doc['expected'], resp.redirect_chain[-1][0])
+        # Check the last redirect chain url is correct document url
+        eq_('http://testserver' + d.get_absolute_url(), resp.redirect_chain[-1][0])
 
     def test_view_param(self):
         d = document()


### PR DESCRIPTION
There could be more generic fix for the locale with underscore. Like `bn_BD` should redirect to `bn-BD`. But for avoiding the complexity, I think this patch is good enough to fix the burning issue.

As we handle the language redirect already from settings, I believe we do not need to add this rule to `kuma/redirects/redirects.py`

@jwhitlock r?