### PR TITLE
Fix issue #242, only run mediaQuery code for CSS examples

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1052,6 +1052,7 @@ PIPELINE_JS = {
     'wiki-skinny': {
         'source_filenames': (
             'js/wiki-skinny.js',
+            'js/interactive.js',
             'js/wiki-samples.js',
             'js/wiki-helpful-survey.js',
         ),

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -1,7 +1,14 @@
 (function() {
     'use strict';
 
+    var iframe = document.querySelector('iframe.interactive');
     var mediaQuery = window.matchMedia('(min-width: 63.9385em)');
+
+    /* The mediaQuery code below is only intended for the CSS
+    example editor so, if this is a JS example, just return. */
+    if (iframe.classList.contains('interactive-js')) {
+        return;
+    }
 
     /**
      * A simple wrapper function for the `postMessage`s sent
@@ -10,8 +17,8 @@
      * remove the `small-desktop-and-below` class
      */
     function postToEditor(isSmallViewport) {
-        var iframe = document.querySelector('iframe.interactive');
-        iframe.contentWindow.postMessage({ smallViewport: isSmallViewport },
+        iframe.contentWindow.postMessage(
+            { smallViewport: isSmallViewport },
             'https://interactive-examples.mdn.mozilla.net'
         );
     }
@@ -34,5 +41,4 @@
             postToEditor(true);
         }
     };
-
 })();


### PR DESCRIPTION
As the title suggests. This ensures that the `mediaQuery` viewport related code only executes for CSS examples.

I also added `interactive.js` to the `wiki-skinny` block on `common.py`. Seems like it was missing from there, or was it left out intentionally? @stephaniehobson 