### PR TITLE
Update to styling for code blocks with line numbers in documentation

### DIFF
--- a/kuma/static/styles/sphinx.scss
+++ b/kuma/static/styles/sphinx.scss
@@ -21,3 +21,12 @@ div.admonition {
         }
     }
 }
+
+/* styling for code blocks with line numbers */
+.highlighttable {
+    width: 100%;
+}
+
+.highlighttable pre {
+    margin: 0;
+}


### PR DESCRIPTION
Applies to code blocks marked with:

```
.. code-block:: javascript
    :linenos:
```