### PR TITLE
Fixes layout of get involved card on landing page

### DIFF
--- a/kuma/static/styles/components-skinny/home/home-hacks.scss
+++ b/kuma/static/styles/components-skinny/home/home-hacks.scss
@@ -2,7 +2,7 @@
 hacks blog row, wrapper, entries, and get involved teaser
 ********************************************************************** */
 
-$home-involved-background-y : 50px;
+$home-involved-background-y: 50px;
 
 .home-hacks {
     padding: $first-content-top-padding 0;
@@ -42,10 +42,9 @@ $home-involved-background-y : 50px;
 
     h2 {
         @include set-larger-font-size();
-        padding-bottom: ($grid-spacing / 2);
+        padding: $grid-spacing $grid-spacing 12px;
         border-bottom: 1px solid #e0e2e4;
-        margin-bottom: 110px;
-        @include bidi-style(margin-right, -($grid-spacing), margin-left, 0);
+        margin: 0 0 110px;
         font-weight: bold;
     }
 
@@ -58,7 +57,7 @@ $home-involved-background-y : 50px;
     a {
         color: #fff;
         text-decoration: none;
-        padding: $grid-spacing;
+        padding: 0 0 $grid-spacing;
         display: block;
     }
 
@@ -80,17 +79,12 @@ $home-involved-background-y : 50px;
 }
 
 @media #{$mq-mobile-and-down} {
-    .column-hacks,
-    .column-involved {
+    .column-hacks {
         float: none;
         width: auto;
     }
 
     .column-involved {
-        margin-top: ($grid-spacing * 2);
-    }
-
-    .home-involved-card {
-        background-position: center $home-involved-background-y;
+        display: none;
     }
 }

--- a/kuma/static/styles/components/home/home-hacks.scss
+++ b/kuma/static/styles/components/home/home-hacks.scss
@@ -42,10 +42,9 @@ $home-involved-background-y: 50px;
 
     h2 {
         @include set-larger-font-size();
-        padding-bottom: ($grid-spacing / 2);
+        padding: $grid-spacing $grid-spacing 12px;
         border-bottom: 1px solid #e0e2e4;
-        margin-bottom: 110px;
-        @include bidi-style(margin-right, -($grid-spacing), margin-left, 0);
+        margin: 0 0 110px;
         font-weight: bold;
     }
 
@@ -58,7 +57,7 @@ $home-involved-background-y: 50px;
     a {
         color: #fff;
         text-decoration: none;
-        padding: $grid-spacing;
+        padding: 0 0 $grid-spacing;
         display: block;
     }
 
@@ -80,17 +79,12 @@ $home-involved-background-y: 50px;
 }
 
 @media #{$mq-mobile-and-down} {
-    .column-hacks,
-    .column-involved {
+    .column-hacks {
         float: none;
         width: auto;
     }
 
     .column-involved {
-        margin-top: ($grid-spacing * 2);
-    }
-
-    .home-involved-card {
-        background-position: center $home-involved-background-y;
+        display: none;
     }
 }


### PR DESCRIPTION
@stephaniehobson So, this fixes the layout problem with the header section of the "Get Involved" card on the landing page. Also, when it break to `$mq-mobile-and-down` I did some experiments but:

1. Seeing we only have a `jpeg`
2. And even if we get a high-res `png` or even SVG

Sizing and placement of the globe becomes a real fight to ensure, it looks good, and the copy does not flow out of the bound rendering it unreadable.

Seeing that right below this card, there is the "Help improve MDN" section with links on how to get involved:

<img width="708" alt="screen shot 2017-08-30 at 16 40 36" src="https://user-images.githubusercontent.com/10350960/29878145-089765c8-8da2-11e7-9028-26672e9927aa.png">

 I thought it best to not fight with the card, and simply completely hide it.