### PR TITLE
Fix obscured drop down menu on game dev page

### DIFF
--- a/kuma/static/styles/zones/components/subnav.scss
+++ b/kuma/static/styles/zones/components/subnav.scss
@@ -6,5 +6,4 @@ Zone subnav styling
     background: #fff;
     margin-bottom: $grid-spacing;
     position: relative;
-    z-index: 10;
 }


### PR DESCRIPTION
This was happening on `docs/Games`

## Before

<img width="425" alt="screen shot 2017-08-31 at 17 50 53" src="https://user-images.githubusercontent.com/10350960/29932754-6ef6d910-8e75-11e7-91aa-8777b94b92d3.png">

## After

<img width="440" alt="screen shot 2017-08-31 at 17 51 16" src="https://user-images.githubusercontent.com/10350960/29932758-767b6c46-8e75-11e7-82e1-715f866c5287.png">
