### PR TITLE
bug 1395684: persist revision hash in docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,8 @@ target = kuma
 requirements = -r requirements/local.txt
 # set Django settings module if not already set as env var
 export DJANGO_SETTINGS_MODULE ?= kuma.settings.testing
+export KUMA_REVISION_HASH ?= $(shell git rev-parse HEAD)
+export KUMASCRIPT_REVISION_HASH ?= $(shell cd kumascript && git rev-parse HEAD)
 
 # Note: these targets should be run from the kuma vm
 test:
@@ -96,10 +98,12 @@ build-base:
 	docker build -f docker/images/kuma_base/Dockerfile -t ${BASE_IMAGE} .
 
 build-kuma:
-	docker build -f docker/images/kuma/Dockerfile -t ${KUMA_IMAGE} .
+	docker build --build-arg REVISION_HASH=${KUMA_REVISION_HASH} \
+	-f docker/images/kuma/Dockerfile -t ${KUMA_IMAGE} .
 
 build-kumascript:
-	docker build -f docker/images/kumascript/Dockerfile -t ${KUMASCRIPT_IMAGE} .
+	docker build --build-arg REVISION_HASH=${KUMASCRIPT_REVISION_HASH} \
+	-f docker/images/kumascript/Dockerfile -t ${KUMASCRIPT_IMAGE} .
 
 build: build-base build-kuma build-kumascript
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+ifeq ($(shell which git),)
+# git is not available
+VERSION ?= undefined
+KS_VERSION ?= undefined
+export KUMA_REVISION_HASH ?= undefined
+export KUMASCRIPT_REVISION_HASH ?= undefined
+else
+# git is available
 VERSION ?= $(shell git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
 KS_VERSION ?= $(shell cd kumascript && git describe --tags --exact-match 2>/dev/null || git rev-parse --short HEAD)
+export KUMA_REVISION_HASH ?= $(shell git rev-parse HEAD)
+export KUMASCRIPT_REVISION_HASH ?= $(shell cd kumascript && git rev-parse HEAD)
+endif
 BASE_IMAGE_NAME ?= kuma_base
 KUMA_IMAGE_NAME ?= kuma
 KUMASCRIPT_IMAGE_NAME ?= kumascript
@@ -24,8 +35,6 @@ target = kuma
 requirements = -r requirements/local.txt
 # set Django settings module if not already set as env var
 export DJANGO_SETTINGS_MODULE ?= kuma.settings.testing
-export KUMA_REVISION_HASH ?= $(shell git rev-parse HEAD)
-export KUMASCRIPT_REVISION_HASH ?= $(shell cd kumascript && git rev-parse HEAD)
 
 # Note: these targets should be run from the kuma vm
 test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=True
       - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
+      - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
 
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:

--- a/docker/images/kuma/Dockerfile
+++ b/docker/images/kuma/Dockerfile
@@ -1,4 +1,9 @@
 FROM quay.io/mozmar/kuma_base:latest
+
+ARG REVISION_HASH
+# Make the git commit hash permanently available within this image.
+ENV REVISION_HASH $REVISION_HASH
+
 COPY . /app
 # the following is needed until the --user flag is added to COPY
 # see https://github.com/moby/moby/issues/30110

--- a/docker/images/kumascript/Dockerfile
+++ b/docker/images/kumascript/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:jessie
 
+ARG REVISION_HASH
+# Make the git commit hash permanently available within this image.
+ENV REVISION_HASH $REVISION_HASH
+
 # First install curl so we can use it to get the Node.js debian package.
 RUN apt-get update && apt-get install -y curl
 # We need "python" and "build-essential" for building "node-gyp".


### PR DESCRIPTION
Persist the git commit hash for HEAD within the kuma and kumascript Docker images as the environment variable `REVISION_HASH`.

For local development:
- if you use `make up` instead of doing the `docker-compose up -d` directly, the kuma-based containers (`web`, `api`, etc.) will have an accurate `REVISION_HASH`, otherwise its value will be "undefined"
- since the `kumascript` container uses the kumascript Docker image, an accurate `REVISON_HASH` will always be baked into it

Thanks to @safwanrahman  for the idea of using docker build arguments!