### PR TITLE
Typography tweaks for kbd and code in indicators

### DIFF
--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -89,7 +89,12 @@ mono space elements (pre, code, kbd)
 ====================================================================== */
 
 code {
+    background-color: $code-block-background-color;
+    border-radius: 2px;
+    box-decoration-break: clone;
+    color: $text-color;
     font-family: $code-inline-font-family;
+    padding: 2px 5px;
     word-wrap: break-word;
 }
 

--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -131,6 +131,7 @@ kbd {
     border-radius: 3px;
     border: 1px solid #b4b4b4;
     box-shadow: 0 1px 1px rgba(0, 0, 0, .2), 0 2px 0 0 rgba(255, 255, 255, .7) inset;
+    color: $text-color;
     display: inline-block;
     font-family: $code-inline-font-family;
     font-size: .85em;

--- a/kuma/static/styles/components-skinny/wiki/indicators.scss
+++ b/kuma/static/styles/components-skinny/wiki/indicators.scss
@@ -25,6 +25,10 @@ block indicators aka banners
 .geckoVersionNote {
     @extend %indicator-block;
 
+    code {
+        @include set-font-size($body-font-size);
+    }
+
     /* heading */
     p > strong {
         @extend %indicator-block-heading;

--- a/kuma/static/styles/components-skinny/wiki/quick-links.scss
+++ b/kuma/static/styles/components-skinny/wiki/quick-links.scss
@@ -43,6 +43,11 @@ $see-also-outdent : 6px;
         @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
     }
 
+    code {
+        background-color: transparent;
+        padding: 0;
+    }
+
     /* don't allow empty paragraphs by CKEditor */
     p:empty,
     div:empty {

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -25,6 +25,10 @@ block indicators aka banners
 .geckoVersionNote {
     @extend %indicator-block;
 
+    code {
+        @include set-font-size($body-font-size);
+    }
+
     /* heading */
     p > strong {
         @extend %indicator-block-heading;

--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -43,6 +43,11 @@ $see-also-outdent: 6px;
         @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
     }
 
+    code {
+        background-color: transparent;
+        padding: 0;
+    }
+
     /* don't allow empty paragraphs by CKEditor */
     p:empty,
     div:empty {

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -497,6 +497,11 @@ Placeholders
         @include full-width-content();
     }
 
+    code {
+        background-color: transparent;
+        padding: 0;
+    }
+
     @include vendorize(tab-size, 4);
     @include vendorize(hyphens, none);
 }


### PR DESCRIPTION
Fix bug 1376770.

Testing notes:
`kbd` in a heading on [this page](https://developer.mozilla.org/en-US/docs/User:stephaniehobson:code#This_is_a_heading_with_a_code_tag_in_it_%3Chtml%3E._Lorem_codeipsum_kbd_dollar_sit_amet)

Code problem reported on [this page](https://developer.mozilla.org/en-US/docs/Learn/JavaScript/Objects/Object_prototypes#A_prototype-based_language).

Code looks a lot like the serif font in the notes now. Not sure how I feel about that. I'm wondering if we should add a background colour `like github does`.