### PR TITLE
Bug 1370594: Sample output, border and buttons changes

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -57,7 +57,7 @@ other advanced criteria.
 * ``spam_testing_mode`` - Tell Akismet that edits are tests, not real content.
 * ``spam_checks_enabled`` - Toggle spam checks site wide.
 * ``spam_submissions_enabled`` - Toggle Akismet spam/spam submission ability.
-* ``wiki_samples`` - Add button to open samples in Codepen or jsFiddle.
+* ``sample_frame`` - Enable .sample-code-frame width, colour, and button styles
 * ``wiki_spam_exempted`` - Exempt users and user groups from checking.
   submissions for spam.
 * ``wiki_spam_training`` - Call Akismet to check submissions, but don't block

--- a/etc/sample_db.json
+++ b/etc/sample_db.json
@@ -324,12 +324,6 @@
         "superusers": false,
         "created": "2015-02-25"
       }, {
-        "name": "wiki_samples",
-        "note": "Add a button to open wiki doc samples in Codepen and/or jsFiddle",
-        "everyone": true,
-        "staff": true,
-        "created": "2015-07-20"
-      }, {
         "name": "compat_api",
         "created": "2015-10-01"
       }, {

--- a/kuma/static/js/wiki-samples.js
+++ b/kuma/static/js/wiki-samples.js
@@ -1,9 +1,7 @@
 (function(win, doc, $) {
-    "use strict";
+    'use strict';
 
-    if(!win.waffle || !win.waffle.flag_is_active('wiki_samples')) return;
-
-    var sites = ['codepen', 'jsfiddle'];
+    var sites = ['CodePen', 'JSFiddle'];
     var frameLength = 'frame_'.length;
 
     var sourceURL = $('link[rel=canonical]').attr('href') || win.location.href.split('#')[0];
@@ -27,7 +25,7 @@
     });
 
     function openJSFiddle(title, htmlCode, cssCode, jsCode) {
-       var $form = $('<form method="post" action="https://jsfiddle.net/api/mdn/" class="hidden" target="_blank">' +
+        var $form = $('<form method="post" action="https://jsfiddle.net/api/mdn/" class="hidden" target="_blank">' +
             '<input type="hidden" name="html" />' +
             '<input type="hidden" name="css" />' +
             '<input type="hidden" name="js" />' +
@@ -36,27 +34,27 @@
             '<input type="submit" />' +
         '</form>').appendTo(doc.body);
 
-       $form.find('input[name=html]').val(plug + htmlCode);
-       $form.find('input[name=css]').val(cssCode);
-       $form.find('input[name=js]').val(jsCode);
-       $form.find('input[name=title]').val(title);
-       $form.get(0).submit();
+        $form.find('input[name=html]').val(plug + htmlCode);
+        $form.find('input[name=css]').val(cssCode);
+        $form.find('input[name=js]').val(jsCode);
+        $form.find('input[name=title]').val(title);
+        $form.get(0).submit();
     }
 
     function openCodepen(title, htmlCode, cssCode, jsCode) {
-       var $form = $('<form method="post" action="https://codepen.io/pen/define" class="hidden" target="_blank">' +
+        var $form = $('<form method="post" action="https://codepen.io/pen/define" class="hidden" target="_blank">' +
             '<input type="hidden" name="data">' + analytics +
             '<input type="submit" />' +
         '</form>').appendTo(doc.body);
 
-       var data = {'title': title, 'html': plug + htmlCode, 'css': cssCode, 'js': jsCode};
-       $form.find('input[name=data]').val(JSON.stringify(data));
-       $form.get(0).submit();
+        var data = {'title': title, 'html': plug + htmlCode, 'css': cssCode, 'js': jsCode};
+        $form.find('input[name=data]').val(JSON.stringify(data));
+        $form.get(0).submit();
     }
 
     function openSample(sampleCodeHost, section, title, htmlCode, cssCode, jsCode) {
         // replace &nbsp; in CSS Samples to fix bug 1284781
-        var cssCleanCode = cssCode.replace(/\xA0/g, " ");
+        var cssCleanCode = cssCode.replace(/\xA0/g, ' ');
         //track the click and sample code host as event
         mdn.analytics.trackEvent({
             category: 'Samples',
@@ -64,7 +62,9 @@
             label: section
         });
         // add user to segement that has used samples
-        if(win.ga) ga('set', 'dimension8', 'Yes');
+        if(win.ga) {
+            ga('set', 'dimension8', 'Yes');
+        }
 
         if(sampleCodeHost === 'jsfiddle') {
             openJSFiddle(title, htmlCode, cssCleanCode, jsCode);
@@ -107,7 +107,7 @@
                         openSample(sampleCodeHost, section, title, htmlCode, cssCode, jsCode);
                     });
                 });
-            } else if($sample.children().length == 0) {
+            } else if($sample.children().length === 0) {
                 // no content, log error
                 mdn.analytics.trackError('embedLiveSample Error', '$sample was empty', section);
             } else {

--- a/kuma/static/styles/base/elements/forms.scss
+++ b/kuma/static/styles/base/elements/forms.scss
@@ -100,21 +100,7 @@ input[type='button'] {
     }
 
     &.link {
-        @include vendorize(appearance, none);
-        font-size: inherit;
-        font-weight: inherit;
-        letter-spacing: inherit;
-        line-height: inherit;
-        background-color: transparent;
-        text-transform: inherit;
-        border: 0;
-        padding: 0;
-        color: $link-color;
-
-        &:hover,
-        &:focus {
-            text-decoration: underline;
-        }
+        @include button-link();
     }
 
     &::-moz-focus-inner {

--- a/kuma/static/styles/components-skinny/structure/search-form.scss
+++ b/kuma/static/styles/components-skinny/structure/search-form.scss
@@ -53,7 +53,7 @@ Full size form on home and search pages
     .search-form {
 
         &.home-search-form {
-            margin: 0 auto ($grid-spacing * 2) auto;
+            margin: 0 auto 30px auto;
         }
 
         > input#home-q,

--- a/kuma/static/styles/components-skinny/wiki/sample-code.scss
+++ b/kuma/static/styles/components-skinny/wiki/sample-code.scss
@@ -1,5 +1,5 @@
 .sample-code-frame {
-    border: 1px solid #9b9b9b;
+    border: 2px solid #9b9b9b;
     padding: $grid-spacing;
 
     .sample-code-table & {
@@ -10,10 +10,51 @@
 
 .open-in-host {
     @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
+    margin-bottom: $grid-spacing;
 }
 
 @media print {
     .open-in-host-container {
         display: none;
+    }
+}
+
+/* experiment */
+.waffle-sample {
+    .sample-code-frame {
+        border: 1px $code-block-border-style $code-block-border-color;
+        @include bidi-value(border-width, 1px 1px 1px $code-block-border-width, 1px $code-block-border-width 1px 1px);
+        padding: $grid-spacing;
+        width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
+        max-width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
+    }
+
+    .sample-code-table .sample-code-frame {
+        @include bidi-value(border-width, 0, 0);
+        max-width: 100%;
+        padding: 0;
+        width: auto;
+    }
+
+    .open-in-host-container {
+        @include bidi-value(text-align, right, left);
+        margin-bottom: $grid-spacing;
+        width: calc(100% - 5px);
+    }
+
+    .open-in-host {
+        @extend %cta-link;
+        width: 100%;
+    }
+
+    @media #{$mq-mobile-and-up} {
+        .open-in-host {
+            @include bidi-style(margin-right, $grid-spacing * 2, margin-left, 0);
+            width: auto;
+
+            &:last-child {
+                @include bidi-style(margin-right, 0, margin-left, 0);
+            }
+        }
     }
 }

--- a/kuma/static/styles/components/structure/search-form.scss
+++ b/kuma/static/styles/components/structure/search-form.scss
@@ -53,7 +53,7 @@ Full size form on home and search pages
     .search-form {
 
         &.home-search-form {
-            margin: 0 auto ($grid-spacing * 2) auto;
+            margin: 0 auto 30px auto;
         }
 
         > input#home-q,

--- a/kuma/static/styles/components/wiki/sample-code.scss
+++ b/kuma/static/styles/components/wiki/sample-code.scss
@@ -1,5 +1,5 @@
 .sample-code-frame {
-    border: 1px solid #9b9b9b;
+    border: 2px solid #9b9b9b;
     padding: $grid-spacing;
 
     .sample-code-table & {
@@ -16,5 +16,45 @@
 @media print {
     .open-in-host-container {
         display: none;
+    }
+}
+
+/* experiment */
+.waffle-sample {
+    .sample-code-frame {
+        border: 1px $code-block-border-style $code-block-border-color;
+        @include bidi-value(border-width, 1px 1px 1px $code-block-border-width, 1px $code-block-border-width 1px 1px);
+        padding: $grid-spacing;
+        width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
+        max-width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
+    }
+
+    .sample-code-table .sample-code-frame {
+        @include bidi-value(border-width, 0, 0);
+        max-width: 100%;
+        padding: 0;
+        width: auto;
+    }
+
+    .open-in-host-container {
+        @include bidi-value(text-align, right, left);
+        margin-bottom: $grid-spacing;
+        width: calc(100% - 5px);
+    }
+
+    .open-in-host {
+        @extend %cta-link;
+        width: 100%;
+    }
+
+    @media #{$mq-mobile-and-up} {
+        .open-in-host {
+            @include bidi-style(margin-right, $grid-spacing * 2, margin-left, 0);
+            width: auto;
+
+            &:last-child {
+                @include bidi-style(margin-right, 0, margin-left, 0);
+            }
+        }
     }
 }

--- a/kuma/static/styles/includes-skinny/_mixins.scss
+++ b/kuma/static/styles/includes-skinny/_mixins.scss
@@ -126,6 +126,25 @@ Links
     }
 }
 
+// make a button look like a link
+@mixin button-link() {
+    @include vendorize(appearance, none);
+    font-size: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    line-height: inherit;
+    background-color: transparent;
+    text-transform: inherit;
+    border: 0;
+    padding: 0;
+    color: $link-color;
+
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+    }
+}
+
 
 /*
 Colours
@@ -488,12 +507,12 @@ Placeholders
 }
 
 %cta-link {
+    @include button-link();
     position: relative;
     box-sizing: border-box;
     display: inline-block;
     border-bottom: 2px solid;
-    padding-bottom: 10px;
-    @include bidi-style(padding-right, 30px, padding-left, 0);
+    @include bidi-style(padding, 10px 30px 10px 0, padding-left, 10px 0 10px 30px);
     @include bidi-value(text-align, left, right);
 
     &:after {
@@ -512,6 +531,10 @@ Placeholders
         &:after {
             @include bidi-style(margin-right, -4px, margin-left, 0);
         }
+    }
+
+    #{$selector-icon} {
+        margin-top: 4px;
     }
 }
 

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -126,6 +126,25 @@ Links
     }
 }
 
+// make a button look like a link
+@mixin button-link() {
+    @include vendorize(appearance, none);
+    font-size: inherit;
+    font-weight: inherit;
+    letter-spacing: inherit;
+    line-height: inherit;
+    background-color: transparent;
+    text-transform: inherit;
+    border: 0;
+    padding: 0;
+    color: $link-color;
+
+    &:hover,
+    &:focus {
+        text-decoration: underline;
+    }
+}
+
 
 /*
 Colours
@@ -513,12 +532,12 @@ Placeholders
 }
 
 %cta-link {
+    @include button-link();
     position: relative;
     box-sizing: border-box;
     display: inline-block;
     border-bottom: 2px solid;
-    padding-bottom: 10px;
-    @include bidi-style(padding-right, 30px, padding-left, 0);
+    @include bidi-style(padding, 10px 30px 10px 0, padding-left, 10px 0 10px 30px);
     @include bidi-value(text-align, left, right);
 
     &:after {
@@ -537,6 +556,10 @@ Placeholders
         &:after {
             @include bidi-style(margin-right, -4px, margin-left, 0);
         }
+    }
+
+    #{$selector-icon} {
+        margin-top: 4px;
     }
 }
 

--- a/kuma/static/styles/wiki-wysiwyg.scss
+++ b/kuma/static/styles/wiki-wysiwyg.scss
@@ -40,16 +40,6 @@ body {
     }
 }
 
-.summary {
-    background: $light-background-color;
-    font-weight: bold;
-    padding: $grid-spacing;
-    margin-bottom: $grid-spacing;
-
-    p:last-child {
-        margin-bottom: 0;
-    }
-}
 
 /* syntax highlighter update */
 pre {

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -47,7 +47,7 @@
   {%- endif -%}
 {% endblock %}
 
-{% block bodyclass %}document {% if is_zone %}zone{% endif %} {% if is_zone_root %}zone-landing{% endif %}{% endblock %}
+{% block bodyclass %}document {% if is_zone %}zone{% endif %} {% if is_zone_root %}zone-landing{% endif %} {% if waffle.flag('sample_frame') %}waffle-sample{% endif %}{% endblock %}
 {% block body_attributes %}data-slug="{{ document.slug }}" contextmenu="edit-history-menu" data-search-url="{{ search_url }}"{% endblock body_attributes %}
 
 {% block main_content_id %}document-main{% endblock %}


### PR DESCRIPTION
- Remove `wiki_samples` waffle flag, this feature is now permanent.
- Lint wiki-samples.js.
- Capitalize CodePen and JSFiddle names.
- Convert button-link to a mixin and apply to `.open-in` buttons.
- Added top margin to `.cta-link` mixin
    - Decrease margin on homepage search form to account for that.
- Add `sample_frame` waffle
    - Make width 100% by default
    - Make border match code examples by deafult
    - Change buttons to use `.cta-link` styles as recommended by Brigade ages ago.

Also:
- Remove outdated summary styles from wysiqyg style sheet.

Testing notes:
I waffled this feature a little differently. I didn't want to duplicate the styles sheets *again* so I added a class to the body if the `sample_frame` waffle is enabled. This means we can roll this feature into production independent of the `line_length` waffle if we want. All the code  still had to be duplicated between the two sets of .scss files though. I suggest reviewing the code for the one in /components/ and I'll copy any requested changes to the one in /components-skinny/ as well.

