### PR TITLE
Bug 1370594: More stuff is narrow by default

### DIFF
--- a/kuma/static/styles/components/components.scss
+++ b/kuma/static/styles/components/components.scss
@@ -132,7 +132,7 @@ $notification-button-padding: 2px 5px 3px;
     }
 
     .text-content & {
-        @include full-width-content;
+        @include restrict-line-length;
     }
 
     &.closed {

--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -30,8 +30,7 @@ $table-cell-border: 2px solid #fff;
     }
 
     table,
-    pre,
-    table {
+    pre {
         @include full-width-content();
     }
 

--- a/kuma/static/styles/components/wiki/communitybox.scss
+++ b/kuma/static/styles/components/wiki/communitybox.scss
@@ -8,7 +8,7 @@
 $communitybox-spacing: 13px;
 
 .communitybox {
-    @include full-width-content();
+    @include restrict-line-length();
     padding: $communitybox-spacing;
     background-color: $blue-light;
     @include bidi-value(border, 0, 0);

--- a/kuma/static/styles/components/wiki/content/moreinfo.scss
+++ b/kuma/static/styles/components/wiki/content/moreinfo.scss
@@ -3,7 +3,7 @@ moreinfo styling
 ********************************************************************** */
 
 .moreinfo {
-    @include full-width-content();
+    @include restrict-line-length();
     position: relative;
     padding: ($grid-spacing / 2) $grid-spacing $grid-spacing 30px;
     margin-bottom: $grid-spacing;

--- a/kuma/static/styles/components/wiki/properties.scss
+++ b/kuma/static/styles/components/wiki/properties.scss
@@ -14,7 +14,8 @@ $properties-indent: ($grid-spacing * 2) - $properties-item-spacing;
 .summary-box-events {
     .text-content & {
         /* could be defined one level up but that creates duplicate classes in output */
-        @include full-width-content();
+        @include restrict-line-length();
+        width: $max-line-length;
         display: table;
         margin: 0 0 $grid-spacing 0;
         border-style: solid;

--- a/kuma/static/styles/components/wiki/toc.scss
+++ b/kuma/static/styles/components/wiki/toc.scss
@@ -1,4 +1,5 @@
 #toc {
+    @include restrict-line-length();
     @include reverse-link-decoration();
     background: $light-background-color;
     @include bidi-value(padding, ($grid-spacing / 2) $grid-spacing ($grid-spacing / 2) ($grid-spacing - 2px), ($grid-spacing / 2) ($grid-spacing - 2px) ($grid-spacing / 2) $grid-spacing);

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -239,6 +239,7 @@ coloured boxes
 
 /* sets the base styles for messages (review, warning, error, notice, etc.) */
 @mixin set-message-base($remove-last-spacing: true) {
+    @include restrict-line-length();
     overflow: hidden;
     margin-bottom: $grid-spacing;
     @include bidi-style(border-left-width, $border-width, border-right-width, 0);
@@ -361,6 +362,7 @@ These are not dynamic but serve as mixins
 }
 
 @mixin callout() {
+    @include restrict-line-length();
     @include set-font-size(22px);
     border: 5px solid $accent-light;
     border-width: 5px 0;
@@ -369,11 +371,6 @@ These are not dynamic but serve as mixins
     margin-bottom: $grid-spacing;
 
     @include prevent-last-child-spacing(p, margin-bottom);
-
-    .text-content &,
-    .text-content & p {
-        @include full-width-content();
-    }
 }
 
 @mixin clearfix() {
@@ -431,19 +428,6 @@ Placeholders
 @mixin restrict-line-length {
     box-sizing: border-box;
     max-width: $max-line-length;
-
-    /* This makes the restricted line length about 50% of the screen. It becomes
-       practical to do that on large desktops. The vw units mean we can't keep
-       using this technique after the width of the site is frozen at 1400px.
-       I expected that we would need to define a new value to make it 50% of
-       the max width but as it turns out the $max-line-length of 42rem is about
-       half of 1400px so we just have to restrict this enhancement to the
-       narrow range where it makes sense */
-    @media all and (min-width: #{$small-desktop-ends}) and (max-width: #{$max-width-default}) {
-        .wiki-left-none & {
-            max-width: calc(50vw - #{$grid-spacing});
-        }
-    }
 }
 
 

--- a/kuma/static/styles/includes/_mixins_indicators.scss
+++ b/kuma/static/styles/includes/_mixins_indicators.scss
@@ -10,7 +10,6 @@ block indicators aka banners
 ====================================================================== */
 
 %indicator-block {
-    @include full-width-content();
     @include set-message-base(true);
     @include clearfix();
     clear: none; // over-rides default value assigned in clearfix
@@ -42,7 +41,7 @@ block indicators aka banners
 }
 
 %indicator-system {
-    @include full-width-content();
+    @include restrict-line-length();
     /* need to specifically declare RTL to over-ride RTL inherited from set-message-base */
     @include bidi-value(border-width, 2px, 2px);
     @include bidi-value(border-style, solid, solid);


### PR DESCRIPTION
Changed notes, indicators, ect to be narrow. The only things that should
be wide now are code samples and tables.