### PR TITLE
Fix issue #255, exposes site url and editor url to JS and editor

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,7 +1,7 @@
 {% from "includes/common_macros.html" import optimizely_script with context -%}
 
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false">
+<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false" data-site-url="{{ settings.SITE_URL }}" data-editor-url="{{ settings.INTERACTIVE_EXAMPLES_BASE }}">
 <head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,7 +1,7 @@
 {% from "includes/common_macros.html" import optimizely_script with context -%}
 
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false" data-site-url="{{ settings.SITE_URL }}" data-editor-url="{{ settings.INTERACTIVE_EXAMPLES_BASE }}">
+<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false">
 <head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -45,5 +45,12 @@
                 {% endif %}
             {% endfor %}
         {% endif %}
+
+        // interactive editor config
+        win.mdn.interactiveEditor = {
+            siteUrl: "{{ settings.SITE_URL }}",
+            editorUrl: "{{ settings.INTERACTIVE_EXAMPLES_BASE }}"
+        };
+
     })(this);
 </script>

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -45,7 +45,9 @@ PRODUCTION_URL = SITE_URL
 STAGING_DOMAIN = 'developer.allizom.org'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
-INTERACTIVE_EXAMPLES_BASE = 'https://interactive-examples.mdn.mozilla.net'
+INTERACTIVE_EXAMPLES_BASE = config(
+    'https://interactive-examples.mdn.mozilla.net',
+    default='https://interactive-examples.mdn.mozilla.net')
 
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', default=False, cast=bool)
 ALLOW_ROBOTS = config('ALLOW_ROBOTS', default=False, cast=bool)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -45,6 +45,8 @@ PRODUCTION_URL = SITE_URL
 STAGING_DOMAIN = 'developer.allizom.org'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
+INTERACTIVE_EXAMPLES_BASE = 'https://interactive-examples.mdn.mozilla.net'
+
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', default=False, cast=bool)
 ALLOW_ROBOTS = config('ALLOW_ROBOTS', default=False, cast=bool)
 

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -9,7 +9,8 @@
          * @param {Object} event - The event Object received from the postMessage
          */
         interactiveExamplesEvent: function(event) {
-            if (event.origin !== 'https://interactive-examples.mdn.mozilla.net') {
+            var allowedOrigin = document.documentElement.dataset['editorUrl'];
+            if (event.origin !== allowedOrigin) {
                 return false;
             }
             mdn.analytics.trackEvent(event.data);

--- a/kuma/static/js/analytics.js
+++ b/kuma/static/js/analytics.js
@@ -9,7 +9,7 @@
          * @param {Object} event - The event Object received from the postMessage
          */
         interactiveExamplesEvent: function(event) {
-            var allowedOrigin = document.documentElement.dataset['editorUrl'];
+            var allowedOrigin = win.mdn.interactiveEditor.editorUrl || 'https://interactive-examples.mdn.mozilla.net';
             if (event.origin !== allowedOrigin) {
                 return false;
             }

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -3,8 +3,11 @@
 
     var iframe = document.querySelector('iframe.interactive');
     var mediaQuery = window.matchMedia('(min-width: 63.9385em)');
-    var siteUrl = document.documentElement.dataset['siteUrl'];
-    var targetOrigin = document.documentElement.dataset['editorUrl'];
+    var siteUrl =
+        window.mdn.interactiveEditor.siteUrl || 'https://developer.mozilla.org';
+    var targetOrigin =
+        window.mdn.interactiveEditor.editorUrl ||
+        'https://interactive-examples.mdn.mozilla.net';
 
     /* If there is no `iframe`, or if this is a JS example,
     simply return */

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -3,6 +3,8 @@
 
     var iframe = document.querySelector('iframe.interactive');
     var mediaQuery = window.matchMedia('(min-width: 63.9385em)');
+    var siteUrl = document.documentElement.dataset['siteUrl'];
+    var targetOrigin = document.documentElement.dataset['editorUrl'];
 
     /* If there is no `iframe`, or if this is a JS example,
     simply return */
@@ -13,14 +15,22 @@
     /**
      * A simple wrapper function for the `postMessage`s sent
      * to the interactive editor iframe
-     * @param {Boolean} isSmallViewport - Boolean indicating whether to add, or
-     * remove the `small-desktop-and-below` class
+     * @param {Object} message - The message object sent to the interactive editor
      */
-    function postToEditor(isSmallViewport) {
-        iframe.contentWindow.postMessage(
-            { smallViewport: isSmallViewport },
-            'https://interactive-examples.mdn.mozilla.net'
-        );
+    function postToEditor(message) {
+        iframe.contentWindow.postMessage(message, targetOrigin);
+    }
+
+    /**
+     * Posts back the current site URL.
+     * @param {Object} event - The event Object received from postMessage
+     */
+    function postSiteUrl(event) {
+        /* only post the site url if the correct property
+        exists on the message object, and its value is true */
+        if (event.data.siteUrl) {
+            postToEditor({ siteUrl: siteUrl });
+        }
     }
 
     /* As the user sizes the browser or tilts their device,
@@ -28,9 +38,9 @@
     viewport state to the interactive editor */
     mediaQuery.addListener(function(event) {
         if (event.matches) {
-            postToEditor(false);
+            postToEditor({ smallViewport: false });
         } else {
-            postToEditor(true);
+            postToEditor({ smallViewport: true });
         }
     });
 
@@ -38,7 +48,10 @@
         // if the mediaQuery does not match on load
         if (!mediaQuery.matches) {
             // add the class `small-desktop-and-below`
-            postToEditor(true);
+            postToEditor({ smallViewport: true });
         }
+
+        // add event listener for postMessages from the interactive editor
+        window.addEventListener('message', postSiteUrl, false);
     };
 })();


### PR DESCRIPTION
@jwhitlock This should be sufficient to expose the needed URLs to the JS in kuma and, make available a `postMessage` target call for the editor to get its parent URL.

Anything here that concern you security wise? Anything you would do different? Thanks!