### PR TITLE
bug 1393845: Make revision detail view easier to scrape

### DIFF
--- a/kuma/scrape/tests/test_source_revision.py
+++ b/kuma/scrape/tests/test_source_revision.py
@@ -344,7 +344,7 @@ def test_gather_based_on_is_available(translated_doc, client):
     expected_data = {
         'id': rev.id,
         'based_on_id': rev.based_on.id,
-        'comment': '',
+        'comment': 'Root Racine',
         'content': '<p>Commencer...</p>',
         'created': datetime(2017, 6, 1, 15, 28),
         'creator': {u'username': u'creator'},

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -15,32 +15,34 @@
         <ul>
           <li>
             <mark>{{ _('Revision slug:') }}</mark>
-            <span>{{ revision.slug }}</span>
+            <span data-name="slug">{{ revision.slug }}</span>
           </li>
           <li>
             <mark>{{ _('Revision title:') }}</mark>
-            <span>{{ revision.title }}</span>
+            <span data-name="title">{{ revision.title }}</span>
           </li>
-          <li class="revision-id">
+          <li>
             <mark>{{ _('Revision id:') }}</mark>
-            <span>{{ revision.id }}</span>
+            <span data-name="id">{{ revision.id }}</span>
           </li>
-          <li class="revision-created">
+          <li>
             <mark>{{ _('Created:') }}</mark>
-            <span>{{ datetimeformat(revision.created, format='datetime') }}</span>
+            <span data-name="created">{{ datetimeformat(revision.created, format='datetime') }}</span>
           </li>
           <li>
             <mark>{{ _('Creator:') }}</mark>
-            <span>{{ revision.creator }}</span>
+            <span data-name="creator">{{ revision.creator }}</span>
             {{ ban_links(revision.creator, request.user) }}
           </li>
           <li>
             <mark>{{ _('Is current revision?') }}</mark>
-            <span>{{ (revision == document.current_revision)|yesno }}</span>
+            <span data-name="is-current" data-value="{{ 1 if (revision == document.current_revision) else 0 }}">
+                {{ (revision == document.current_revision)|yesno }}
+            </span>
           </li>
           <li>
             <mark>{{ _('Comment') }}</mark>
-            <span>{{ comment }}</span>
+            <span data-name="comment">{{ comment }}</span>
           </li>
           {#
           {% if user.is_authenticated() %}

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -446,13 +446,18 @@ def test_revision_template(root_doc, client):
     response = client.get(url)
     assert response.status_code == 200
     page = pq(response.content)
-    id_div = page('div.revision-info li.revision-id')
-    assert id_div.text() == 'Revision id: %s' % rev.id
     assert page('h1').text() == 'Revision %s of %s' % (rev.id, root_doc.title)
     assert page('#doc-source pre').text() == rev.content
-    created_div = page('div.revision-info li.revision-created')
+    assert page('span[data-name="slug"]').text() == root_doc.slug
+    assert page('span[data-name="title"]').text() == root_doc.title
+    assert page('span[data-name="id"]').text() == str(rev.id)
     expected_date = 'Apr 14, 2017, 12:15:00 PM'
-    assert created_div.text().strip() == 'Created: ' + expected_date
+    assert page('span[data-name="created"]').text() == expected_date
+    assert page('span[data-name="creator"]').text() == rev.creator.username
+    assert page('span[data-name="comment"]').text() == rev.comment
+    is_current = page('span[data-name="is-current"]')
+    assert is_current.text() == "Yes"
+    assert is_current.attr['data-value'] == "1"
 
 
 class NewDocumentTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import time
 import urllib
-from datetime import datetime
 
 import mock
 import pytest
@@ -440,27 +439,20 @@ class GoogleAnalyticsTests(UserTestCase, WikiTestCase):
         assert self.dim18 in content
 
 
-class RevisionTests(UserTestCase, WikiTestCase):
-    """Tests for the Revision template"""
-    localizing_client = True
-
-    def test_revision_view(self):
-        """Load the revision view page and verify the title and content."""
-        d = _create_document()
-        r = d.current_revision
-        r.created = datetime(2011, 1, 1)
-        r.save()
-        url = reverse('wiki.revision', args=[d.slug, r.id])
-        response = self.client.get(url)
-        eq_(200, response.status_code)
-        doc = pq(response.content)
-        eq_('Revision id: %s' % r.id,
-            doc('div.revision-info li.revision-id').text())
-        eq_('Revision %s of %s' % (r.id, d.title), doc('h1').text())
-        eq_(r.content,
-            doc('#doc-source pre').text())
-        eq_('Created: Jan 1, 2011, 12:00:00 AM',
-            doc('div.revision-info li.revision-created').text().strip())
+def test_revision_template(root_doc, client):
+    """Verify the revision template."""
+    rev = root_doc.current_revision
+    url = reverse('wiki.revision', args=[root_doc.slug, rev.id], locale=root_doc.locale)
+    response = client.get(url)
+    assert response.status_code == 200
+    page = pq(response.content)
+    id_div = page('div.revision-info li.revision-id')
+    assert id_div.text() == 'Revision id: %s' % rev.id
+    assert page('h1').text() == 'Revision %s of %s' % (rev.id, root_doc.title)
+    assert page('#doc-source pre').text() == rev.content
+    created_div = page('div.revision-info li.revision-created')
+    expected_date = 'Apr 14, 2017, 12:15:00 PM'
+    assert created_div.text().strip() == 'Created: ' + expected_date
 
 
 class NewDocumentTests(UserTestCase, WikiTestCase):


### PR DESCRIPTION
* Convert the one revision detail template test to pytest standard.
* Add ``data-name`` attributes to ``<span>`` elements, and use them when  scraping a document revision.
* Add ``data-value`` attribute to the "Is Current" element, so that its  value is the same when translated ([bug 1393845](https://bugzilla.mozilla.org/show_bug.cgi?id=1393845))
* Drop classes used for ease of testing rather than styling.

