### PR TITLE
bug 1308630: Set Interactive Examples URL from env

### DIFF
--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -10,3 +10,13 @@
 # Enable the Django Debug Toolbar
 # Provides useful troubleshooting data, but adds 3+ seconds to response time
 #DEBUG_TOOLBAR=False
+
+# Enable Maintenance Mode
+# https://kuma.readthedocs.io/en/latest/development.html#maintenance-mode
+#MAINTENANCE_MODE=True
+#DATABASE_USER=kuma_ro
+
+# Local development of Interactive Examples
+# See https://github.com/mdn/interactive-examples/
+# Constance KUMA_WIKI_IFRAME_ALLOWED_HOSTS will need to allow this iframe src
+#INTERACTIVE_EXAMPLES_BASE=http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - DEBUG=${DEBUG:-True}
       - DOMAIN=localhost
       - ES_URLS=elasticsearch:9200
+      - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
       - MEMCACHE_SERVERS=memcached:11211
       - PROD_DETAILS_DIR=/app/product_details_json
@@ -90,6 +91,7 @@ services:
       - api
       - memcached
     environment:
+      - interactive_examples__base_url=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - log__console=true
       - log__file=
       - server__template_root_dir=macros

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1442,6 +1442,7 @@ CONSTANCE_CONFIG = dict(
          '|mdn.mozillademos.org'                    # Production demos
          '|testserver'                              # Unit test demos
          '|localhost\:8000'                         # Docker development demos
+         '|localhost\:8080'                         # Embedded samples server
          '|rpm.newrelic.com\/public\/charts\/.*'    # MDN/Kuma/Server_charts
          '|(www.)?youtube.com\/embed\/(\.*)'        # Embedded videos
          '|jsfiddle.net\/.*embedded.*'              # Embedded samples


### PR DESCRIPTION
Pass ``INTERACTIVE_EXAMPLES_BASE`` to both the kuma and kumascript containers.  Whitelist the interactive examples host used for local development. Builds on #4404.

This requires the changes in https://github.com/mdn/kumascript/pull/306 to work. Local development of interactive examples on MDN pages will be:

1. Clone and ``npm install`` https://github.com/mdn/interactive-examples
2. Change ``https://developer.mozilla.org`` to ``http://localhost:8080`` in ``analytics.js`` and ``events.js``
3. ``npm run build`` and ``npm start`` to run it, such as http://localhost:8080/pages/js/array-filter.html
3. Add ``INTERACTIVE_EXAMPLES_BASE=http://localhost:8080`` in ``.env``
4. ``make up`` to restart containers with the new environment, and maybe ``docker-compose restart memcache`` to clear the KumaScript render cache.
5. Grab a page with the embeded sample, such as ``make bash`` then ``./manage scrape_links https://developer.mozilla.org/en-US/docs/Experiment:InteractiveEditor``
6. Load up a page like http://localhost:8000/en-US/docs/Experiment:InteractiveEditor/background-color, and log-in and force-refresh as needed to regenerate the iframe.
7. Inspect and see that the iframe src is http://localhost:8080, and that there are no debugger messages about the ``postMessage`` failing.

These are the lines that need to be changed in interactive-examples:

https://github.com/mdn/interactive-examples/blob/b05330eac3bb104ff23022220f132c477f558c1d/js/editor-libs/analytics.js#L12

https://github.com/mdn/interactive-examples/blob/b05330eac3bb104ff23022220f132c477f558c1d/js/editor-libs/events.js#L92

There may be a way to make it easier to make this change for local development, such as passing the MDN URL to the iframe, like: http://localhost:8080/pages/js/array-filter.html?site_url=http://localhost:8000.
