### PR TITLE
Removes siteUrl postMessage to interactive editor

### DIFF
--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -3,8 +3,6 @@
 
     var iframe = document.querySelector('iframe.interactive');
     var mediaQuery = window.matchMedia('(min-width: 63.9385em)');
-    var siteUrl =
-        window.mdn.interactiveEditor.siteUrl || 'https://developer.mozilla.org';
     var targetOrigin =
         window.mdn.interactiveEditor.editorUrl ||
         'https://interactive-examples.mdn.mozilla.net';
@@ -24,18 +22,6 @@
         iframe.contentWindow.postMessage(message, targetOrigin);
     }
 
-    /**
-     * Posts back the current site URL.
-     * @param {Object} event - The event Object received from postMessage
-     */
-    function postSiteUrl(event) {
-        /* only post the site url if the correct property
-        exists on the message object, and its value is true */
-        if (event.data.siteUrl) {
-            postToEditor({ siteUrl: siteUrl });
-        }
-    }
-
     /* As the user sizes the browser or tilts their device,
     listen for mediaQuery events and communicate the new
     viewport state to the interactive editor */
@@ -53,8 +39,5 @@
             // add the class `small-desktop-and-below`
             postToEditor({ smallViewport: true });
         }
-
-        // add event listener for postMessages from the interactive editor
-        window.addEventListener('message', postSiteUrl, false);
     };
 })();


### PR DESCRIPTION
I did not think this one through all the way :-/ So, there is no way to use this functionality from the interactive editor without opening it up with `*` in terms of the `targetOrigin`. We definitely do not want to do that.

Without that, it is basically a loop de loop/catch22[what have you]. The interactive editor needs to know the `targetOrigin` in order to post a message asking for the URL, and should Kuma push the URL down on load, the interactive editor will need to know the trusted origin, before accepting the message.

I am therefore removing this code as it will not be used.

In terms of a solution. I am thinking the biggest challenge is having this work on staging and production. Local development would be great, but there are most likely not going to a lot of instances where all these components are going to be tested running on localhost.

Therefore, adding a conditional inside the interactive editor that accepts either `developer.mozilla.org` or `developer.allizom.org` as the origin will resolve the above.