### PR TITLE
bug 1399154: Fix ES_DOWNLOAD_URL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ env:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma
         - DJANGO_SETTINGS_MODULE=kuma.settings.travis
         - DOCKER_COMPOSE_VERSION=1.9.0
-          # ES_VERSION must come before ES_DOWNLOAD_URL
         - ES_VERSION=2.4.5
-        - ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/$ES_VERSION/elasticsearch-$ES_VERSION.tar.gz
+        - ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz
         - PIPELINE_CSSMIN_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/cssmin
         - PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor
         - PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor


### PR DESCRIPTION
The env variable ``ES_VERSION`` was used to define the env variable ``ES_DOWNLOAD_URL``. It appears TravisCI has changed the way it processes environment variables, and this method can't be used anymore.