### PR TITLE
bug 1308630: allow setting MEDIA_URL & STATIC_URL from env

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -370,8 +370,9 @@ HUMANSTXT_ROOT = MEDIA_ROOT
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
 # Examples: "http://media.lawrence.com", "http://example.com/media/"
-MEDIA_URL = '/media/'
-STATIC_URL = '/static/'
+MEDIA_URL = config('MEDIA_URL', default='/media/')
+
+STATIC_URL = config('STATIC_URL', default='/static/')
 STATIC_ROOT = path('static')
 
 SERVE_MEDIA = False

--- a/kuma/settings/prod.py
+++ b/kuma/settings/prod.py
@@ -10,7 +10,7 @@ SERVER_EMAIL = 'mdn-prod-noreply@mozilla.com'
 # Cache
 CACHES['memcache']['TIMEOUT'] = 60 * 60 * 24
 
-MEDIA_URL = 'https://developer.cdn.mozilla.net/media/'
+MEDIA_URL = config('MEDIA_URL', default='https://developer.cdn.mozilla.net/media/')
 DEFAULT_AVATAR = MEDIA_URL + 'img/avatar.png'
 
 CELERY_ALWAYS_EAGER = False


### PR DESCRIPTION
This PR, as part of the AWS work, is another step towards allowing all settings to be configured from the environment, in this case the `MEDIA_URL` and `STATIC_URL` settings.