### PR TITLE
bug 1399639: Upgrade urllib3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -130,9 +130,9 @@ elasticsearch==1.9.0 \
 python-dateutil==2.4.2 \
     --hash=sha256:3e95445c1db500a344079a47b171c45ef18f57d188dffdb0e4165c71bea8eb3d \
     --hash=sha256:2ae63cf475f0bd049b722fac20813d62aedc14957dd5a3bf00d120d2b5404460
-urllib3==1.14 \
-    --hash=sha256:ffe8859ca4fdfb021c2e8e0d3033f6c5eb372f8d4c3fd5455523055a2806a437 \
-    --hash=sha256:dd4fb13a4ce50b18338c7e4d665b21fd38632c5d4b1d9f1a1379276bd3c08d37
+urllib3==1.22 \
+    --hash=sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b \
+    --hash=sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f
 
 # flake8
 configparser==3.5.0 \


### PR DESCRIPTION
This library is used by our ElasticSearch libraries. We're currently not using SSL for ES connections inside of SCL3, but we're going to start using it for AWS (https://github.com/mozmeao/infra/issues/383).

[urllib3 1.17](https://github.com/shazow/urllib3/blob/master/CHANGES.rst#117-2016-09-06) added checking the SSL certificate against the OS certificate chain. There was an issue that required a security release in [urllib3 1.18.1](https://github.com/shazow/urllib3/blob/master/CHANGES.rst#1181-2016-10-27), where validation was silently skipped. I believe this is why requires.io is showing us as [insecure](https://requires.io/github/mozilla/kuma/requirements/?branch=master) for being on urllib3 1.14, which is why it came up in my inbox today.

Now is a good time to upgrade, and make sure that 1) our SSL connection is checked, and 2) we can see if it is broken before the production switch.