### PR TITLE
bug 1308630: fix some env overrides

### DIFF
--- a/kuma/settings/prod.py
+++ b/kuma/settings/prod.py
@@ -1,7 +1,7 @@
 from .common import *  # noqa
 
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
-ALLOW_ROBOTS = True
+ALLOW_ROBOTS = config('ALLOW_ROBOTS', default=True, cast=bool)
 
 # Email
 DEFAULT_FROM_EMAIL = config(
@@ -18,8 +18,12 @@ CACHES['memcache']['TIMEOUT'] = 60 * 60 * 24
 
 MEDIA_URL = config('MEDIA_URL', default='https://developer.cdn.mozilla.net/media/')
 
-CELERY_ALWAYS_EAGER = False
-CELERYD_MAX_TASKS_PER_CHILD = 500
+CELERY_ALWAYS_EAGER = config('CELERY_ALWAYS_EAGER', False, cast=bool)
+CELERYD_MAX_TASKS_PER_CHILD = config(
+    'CELERYD_MAX_TASKS_PER_CHILD',
+    default=500,
+    cast=int
+) or None
 
 ES_INDEX_PREFIX = config('ES_INDEX_PREFIX', default='mdnprod')
 ES_LIVE_INDEX = config('ES_LIVE_INDEX', default=True, cast=bool)

--- a/kuma/settings/stage.py
+++ b/kuma/settings/stage.py
@@ -15,11 +15,15 @@ SERVER_EMAIL = config(
     default='server-error@developer-dev.allizom.org'
 )
 
-DOMAIN = STAGING_DOMAIN
-SITE_URL = STAGING_URL
+DOMAIN = config('DOMAIN', default=STAGING_DOMAIN)
+SITE_URL = config('SITE_URL', default=STAGING_URL)
 
-CELERY_ALWAYS_EAGER = False
-CELERYD_MAX_TASKS_PER_CHILD = 3000
+CELERY_ALWAYS_EAGER = config('CELERY_ALWAYS_EAGER', False, cast=bool)
+CELERYD_MAX_TASKS_PER_CHILD = config(
+    'CELERYD_MAX_TASKS_PER_CHILD',
+    default=3000,
+    cast=int
+) or None
 
 ES_INDEX_PREFIX = config('ES_INDEX_PREFIX', default='mdnstage')
 ES_LIVE_INDEX = config('ES_LIVE_INDEX', default=True, cast=bool)


### PR DESCRIPTION
This PR fixes some env overrides for AWS where the `config()` calls were not carried into the `kuma/settings/prod.py` file. I carried the `config()` calls into the `kuma/settings/stage.py` file as well.