### PR TITLE
Fix bug 1400331: Rename WebExtensions link in main nav.

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -148,7 +148,7 @@
             <li><a href="{{ wiki_url('Web/Guide/Graphics') }}">{{ _('Graphics') }}</a></li>
             <li><a href="{{ wiki_url('Web/HTTP') }}">{{ _('HTTP') }}</a></li>
             <li><a href="{{ wiki_url('Web/API') }}">{{ _('APIs / DOM') }}</a></li>
-            <li><a href="{{ wiki_url('Mozilla/Add-ons/WebExtensions') }}">{{ _('WebExtensions') }}</a></li>
+            <li><a href="{{ wiki_url('Mozilla/Add-ons/WebExtensions') }}">{{ _('Browser Extensions') }}</a></li>
             <li><a href="{{ wiki_url('Web/MathML') }}">{{ _('MathML') }}</a></li>
           </ul>
         </div></div><li class="nav-main-item"><a href="{{ wiki_url('Learn') }}">{{ _('References & Guides') }}<i aria-hidden="true" class="icon-caret-down"></i></a>


### PR DESCRIPTION
I've tested this in a local Kuma instance and it looks all right.

One thing I wasn't sure about was case: I've used "Browser Extensions" here, to match the name in the standard: https://browserext.github.io/browserext/, but the title of the linked page is actually "Browser extensions". I think probably the title of the page should be changed to match the name of the standard.