### PR TITLE
bug 1301102: Switch from cssmin to clean-css

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ env:
         - DOCKER_COMPOSE_VERSION=1.9.0
         - ES_VERSION=2.4.5
         - ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz
-        - PIPELINE_CSSMIN_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/cssmin
-        - PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor
+        - PIPELINE_CLEANCSS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/cleancss
+        - PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor
         - PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor
         - PIPELINE_SASS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/node-sass
         - PIPELINE_UGLIFYJS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/uglifyjs

--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -34,15 +34,14 @@ RUN update-alternatives --install /usr/bin/node node /usr/bin/nodejs 10
 
 RUN npm install -g \
     fibers@1.0.15 \
-    cssmin@0.4.3 \
     csslint@0.10.0 \
     jshint@2.7.0 \
     node-sass@4.3.0 \
     uglify-js@2.4.13 \
     clean-css@3.4.23 \
     stylelint@7.10.1
-ENV PIPELINE_CSS_COMPRESSOR=pipeline.compressors.cssmin.CSSMinCompressor \
-    PIPELINE_CSSMIN_BINARY=/usr/bin/cssmin \
+ENV PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
+    PIPELINE_CLEANCSS_BINARY=/usr/bin/cleancss \
     PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor \
     PIPELINE_UGLIFYJS_BINARY=/usr/bin/uglifyjs
 

--- a/kuma/core/pipeline/cleancss.py
+++ b/kuma/core/pipeline/cleancss.py
@@ -1,6 +1,11 @@
+from django.conf import settings
 from pipeline.compressors import SubProcessCompressor
 
 
 class CleanCSSCompressor(SubProcessCompressor):
     def compress_css(self, css):
-        return self.execute_command(['cleancss'], css)
+        binary = settings.PIPELINE.get('CLEANCSS_BINARY',
+                                       '/usr/bin/env cleancss')
+        args = settings.PIPELINE.get('CLEANCSS_ARGUMENTS', '')
+        command = (binary, args) if args else (binary,)
+        return self.execute_command(command, css)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1208,6 +1208,8 @@ pipeline_overrides = (
     'CSSTIDY_ARGUMENTS',
     'CSSMIN_BINARY',
     'CSSMIN_ARGUMENTS',
+    'CLEANCSS_BINARY',
+    'CLEANCSS_ARGUMENTS',
 )
 for override in pipeline_overrides:
     env_value = config('PIPELINE_' + override, default=None)

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -30,12 +30,12 @@ fi
 if [ ${INSTALL_PIPELINE:-0} -ne 0 ]
 then
     npm install
-    npm install cssmin@0.4.3
+    npm install clean-css@3.4.23
     npm install uglify-js@2.4.13
 fi
 
 # Install docker-compose
-if [ ${INSTALL_DOCKER_COMPOSE:--} -ne 0 ]
+if [ ${INSTALL_DOCKER_COMPOSE:-0} -ne 0 ]
 then
     if [ -x $(command -v docker-compose) ]
     then


### PR DESCRIPTION
SCL3 uses ``clean-css`` 3.4.23. This changes from ``cssmin`` to ``clean-css`` 3.4.23
for Docker and TravisCI as well.

**Update**: ``clean-css`` in SCL3 is 3.4.23, not 2.2.16 as I previously reported.