### PR TITLE
bug 1301102: Fix default cleancss binary

### DIFF
--- a/kuma/core/pipeline/cleancss.py
+++ b/kuma/core/pipeline/cleancss.py
@@ -4,8 +4,7 @@ from pipeline.compressors import SubProcessCompressor
 
 class CleanCSSCompressor(SubProcessCompressor):
     def compress_css(self, css):
-        binary = settings.PIPELINE.get('CLEANCSS_BINARY',
-                                       '/usr/bin/env cleancss')
+        binary = settings.PIPELINE.get('CLEANCSS_BINARY', 'cleancss')
         args = settings.PIPELINE.get('CLEANCSS_ARGUMENTS', '')
         command = (binary, args) if args else (binary,)
         return self.execute_command(command, css)


### PR DESCRIPTION
Default SCL3 to ``'cleancss'`` as the binary, and assume it is in the executable path.

Using ``'/usr/bin/env cleancss'`` doesn't work, because it looks for an executable with a space in the name. This can wait for the django-pipeline PR, where the string is split by whitespace.