### PR TITLE
bug 1308630: add ROBOTS_ROOT env override

### DIFF
--- a/kuma/landing/test_views.py
+++ b/kuma/landing/test_views.py
@@ -3,6 +3,20 @@ import pytest
 from kuma.core.urlresolvers import reverse
 
 
+@pytest.fixture()
+def robots(tmpdir):
+    path = tmpdir.realpath()
+    robots_file = tmpdir.join('robots.txt')
+    robots_go_away_file = tmpdir.join('robots-go-away.txt')
+    robots_file.write_text(u'robots: {}'.format(path), 'utf8')
+    robots_go_away_file.write_text(u'robots-go-away: {}'.format(path), 'utf8')
+    return {
+        'tmpdir': tmpdir,
+        'robots': robots_file.read_text('utf8'),
+        'robots-go-away': robots_go_away_file.read_text('utf8'),
+    }
+
+
 def test_contribute_json(client, db):
     response = client.get(reverse('contribute_json'))
     assert response.status_code == 200
@@ -30,3 +44,17 @@ def test_robots_enabled(client, db, settings, allowed):
         assert 'Sitemap: ' in content
     else:
         assert 'Disallow: /' in content
+
+
+@pytest.mark.parametrize('allowed', [True, False])
+def test_robots_root(client, db, settings, robots, allowed):
+    settings.ROBOTS_ROOT = robots['tmpdir'].realpath()
+    settings.ALLOW_ROBOTS = allowed
+    response = client.get(reverse('robots_txt'))
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'text/plain'
+    content = ''.join(response.streaming_content)
+    if allowed:
+        assert robots['robots'] in content
+    else:
+        assert robots['robots-go-away'] in content

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -64,4 +64,4 @@ def robots_txt(request):
         robots = 'robots.txt'
     else:
         robots = 'robots-go-away.txt'
-    return static.serve(request, robots, document_root=settings.MEDIA_ROOT)
+    return static.serve(request, robots, document_root=settings.ROBOTS_ROOT)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -373,6 +373,9 @@ MEDIA_ROOT = config('MEDIA_ROOT', default=path('media'))
 # Absolute path to the directory for the humans.txt file.
 HUMANSTXT_ROOT = MEDIA_ROOT
 
+# Absolute path to the directory for the robots files.
+ROBOTS_ROOT = config('ROBOTS_ROOT', default=MEDIA_ROOT)
+
 # URL that handles the media served from MEDIA_ROOT. Make sure to use a
 # trailing slash if there is a path component (optional in other cases).
 # Examples: "http://media.lawrence.com", "http://example.com/media/"


### PR DESCRIPTION
This PR provides a way to override just the document root for serving the robots files, which in AWS we'll override to `/app/media` instead of using the default value which is the value of `MEDIA_ROOT` (`/mdn/www`). In SCL3, and every other context, we'll continue to use the default value (`MEDIA_ROOT`).