### PR TITLE
bug 1308630: always serve robots files from media dir of repo

### DIFF
--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.shortcuts import redirect, render
 from django.views import static
 
+from kuma.settings.common import path
 from kuma.core.sections import SECTION_USAGE
 from kuma.core.cache import memcache
 from kuma.feeder.models import Bundle
@@ -64,4 +65,4 @@ def robots_txt(request):
         robots = 'robots.txt'
     else:
         robots = 'robots-go-away.txt'
-    return static.serve(request, robots, document_root=settings.MEDIA_ROOT)
+    return static.serve(request, robots, document_root=path('media'))


### PR DESCRIPTION
This PR changes the service of the robot files, such that they're always served, in all contexts (SCL3, AWS, etc.), from where they currently reside, in the `media` sub-directory of the repo. This allows us to override `MEDIA_ROOT` in AWS to something other than the repo's `media` directory, without disturbing the service of these files.