### PR TITLE
Update strings 2017.16

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -613,7 +613,7 @@ TEMPLATES = [
 ]
 
 PUENTE = {
-    'VERSION': '2017.15',
+    'VERSION': '2017.16',
     'BASE_DIR': ROOT,
     'TEXT_DOMAIN': 'django',
     # Tells the extract script what files to look for l10n in and what function


### PR DESCRIPTION
Update copyright statement, add task completion survey.

There's nothing much to review here (the new strings have been sent to https://github.com/mozilla-l10n/mdn-l10n and Pontoon), but we've prevented merging to master without a PR. This should be merged before the next production push.