### PR TITLE
bug 1402950: Be patient for external links

### DIFF
--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -68,9 +68,11 @@ def test_header_tech_submenu(base_url, selenium):
 @skip_if_maintenance_mode
 def test_header_signin(base_url, selenium):
     page = HomePage(selenium, base_url).open()
+    old_url = selenium.current_url
     # click on sign in widget
     page.header.trigger_signin()
     # assert it's fowarded to github
+    page.wait.until(lambda s: s.current_url != old_url)
     assert 'https://github.com' in str(selenium.current_url)
 
 

--- a/tests/functional/test_report.py
+++ b/tests/functional/test_report.py
@@ -19,6 +19,7 @@ def test_report_content(base_url, selenium):
     page.header.open_report_content()
     # bugzilla loads in new window
     selenium.switch_to_window(selenium.window_handles[1])
+    page.wait.until(lambda s: 'about:blank' not in s.current_url)
     # check form loaded and has reporting URL in query
     assert page.header.is_report_content_url_expected(selenium, report_url)
 


### PR DESCRIPTION
* When opening links in a new tab, wait for the tab to open.
* When opening GitHub in the same window, wait for the URL to change.

This helps address some tests that are flakier in Firefox than Chrome.