### PR TITLE
bug 1402497: Redirect requests for /favicon.ico

### DIFF
--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -1,3 +1,5 @@
+from django.contrib.staticfiles.storage import staticfiles_storage
+
 from redirect_urls import redirect as lib_redirect
 
 
@@ -759,5 +761,10 @@ redirectpatterns = [
 
     # RewriteRule ^es4 http://www.ecma-international.org/memento/TC39.htm [R=302,L]
     redirect(r'^es4', 'http://www.ecma-international.org/memento/TC39.htm',
+             permanent=False),
+
+    # /favicon.ico - requested by some tools
+    redirect(r'^favicon.ico',
+             staticfiles_storage.url('img/favicon.ico'),
              permanent=False),
 ]


### PR DESCRIPTION
Redirect requests for /favicon.ico to the (current) static file. Cache header is the default of 12 hours.

I thought about a redirect test for this, but the result depends on the static file configuration of the target server, and the current hash of the favicon.ico file in hosted URLs. I'm not sure this is testable that way.