### PR TITLE
bug 1110799: Update raven, expand configuration

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1681,6 +1681,25 @@ REST_FRAMEWORK = {
 SENTRY_DSN = config('SENTRY_DSN', default=None)
 
 if SENTRY_DSN:
+    from raven.transport.requests import RequestsHTTPTransport
+    RAVEN_CONFIG = {
+        'dsn': SENTRY_DSN,
+        'transport': RequestsHTTPTransport,  # Sync transport
+        'repos': {
+            'kuma': {
+                'name': 'mozilla/kuma',
+            },
+            'kumascript': {
+                'name': 'mdn/kumascript',
+            },
+        },
+        'ignore_exception': [
+            'django.core.exceptions.DisallowedHost',
+        ],
+    }
+    release = config('REVISION_HASH', default='')
+    if release:
+        RAVEN_CONFIG['release'] = release
     INSTALLED_APPS = INSTALLED_APPS + (
         'raven.contrib.django.raven_compat',
     )

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -226,9 +226,9 @@ pytidylib==0.2.4 \
     --hash=sha256:0af07bd8ebd256af70ca925ada9337faf16d85b3072624f975136a5134150ab6
 
 # Send tracebacks to Sentry instead of emailing admins
-raven==5.10.2 \
-    --hash=sha256:f17269486e9f64ccd5a38a859e8191a8d8f5609e8f0efee6f1881e8a0fb20ed8 \
-    --hash=sha256:58d52e16c834f70046f07d53795cafbf2709aef87afa9ca2a9d21be28a6ed92c
+raven==6.2.1 \
+    --hash=sha256:f58ead6842c02d427617e827f4c0a97cfd3f8b648a52e53ef12182002a8663cb \
+    --hash=sha256:c0a30bcc3e3206059f79656d80362ce080b1c991c95d867edce559a7294570fe
 
 # Modern caching server, to replace memcached in AWS
 redis==2.10.5 \


### PR DESCRIPTION
``raven`` is the Python Sentry client.  This PR:

* Updates raven from 5.10.2 → 6.2.1 (no gotchas in the [changelog](https://github.com/getsentry/raven-python/blob/master/CHANGES))
* Sends the revision hash, for release tracking
* Sets a syncronous transport, which may be more compatible with meinheld
* Sets the repos name, which may make tracebacks more useful
* Ignores DisallowedHost exceptions, which happen in AWS

This extra config won't happen in AWS. It will just get ``SENTRY_DSN`` set by the local settings override file, which [continues to work as a way to specify the dsn](https://github.com/getsentry/raven-python/blob/24c0ecd44617d9fc916bf4c9c4a0ce4ef18ea05e/raven/utils/conf.py#L49).