### PR TITLE
Restrict endpoints (bug 1402708)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - DATABASE_URL=mysql://${DATABASE_USER:-root}:${DATABASE_PASSWORD:-kuma}@mysql:3306/developer_mozilla_org
       - DEBUG=${DEBUG:-True}
       - DOMAIN=localhost
+      - ENABLE_RESTRICTIONS_BY_HOST=${ENABLE_RESTRICTIONS_BY_HOST:-False}
       - ES_URLS=elasticsearch:9200
       - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
       - ALLOWED_HOSTS=*
-      - ATTACHMENT_HOST=localhost:8000
+      - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
       - CSRF_COOKIE_SECURE=False
@@ -32,6 +32,7 @@ services:
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=http://localhost:8000
+      - STATIC_URL=${STATIC_URL:-/static/}
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=True

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -439,6 +439,7 @@ _CONTEXT_PROCESSORS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
+    'kuma.core.middleware.RestrictedWhiteNoiseMiddleware',
     # must come before LocaleURLMiddleware
     'redirect_urls.middleware.RedirectsMiddleware',
     # LocaleURLMiddleware must be before any middleware that uses
@@ -467,6 +468,7 @@ MIDDLEWARE_CLASSES += (
     'kuma.core.anonymous.AnonymousIdentityMiddleware',
     'kuma.users.middleware.BanMiddleware',
     'waffle.middleware.WaffleMiddleware',
+    'kuma.core.middleware.RestrictedEndpointsMiddleware',
 )
 
 # Auth
@@ -1235,6 +1237,13 @@ MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
+
+# This should never be false for the production and stage deployments.
+ENABLE_RESTRICTIONS_BY_HOST = config(
+    'ENABLE_RESTRICTIONS_BY_HOST',
+    default=True,
+    cast=bool
+)
 
 # Video settings, hard coded here for now.
 # TODO: figure out a way that doesn't need these values

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -1,6 +1,7 @@
 from .local import *  # noqa
 
 DEBUG = False
+ENABLE_RESTRICTIONS_BY_HOST = False
 TEMPLATES[0]['OPTIONS']['debug'] = True  # Enable recording of templates
 CELERY_ALWAYS_EAGER = True
 CELERY_EAGER_PROPAGATES_EXCEPTIONS = True

--- a/kuma/urls_untrusted.py
+++ b/kuma/urls_untrusted.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django.conf.urls import include, url
+
+
+urlpatterns = [
+    url('', include('kuma.attachments.urls')),
+    url(r'^docs', include('kuma.wiki.urls_untrusted')),
+]
+
+if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):
+    import debug_toolbar
+    urlpatterns.append(
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    )

--- a/kuma/wiki/urls_untrusted.py
+++ b/kuma/wiki/urls_untrusted.py
@@ -1,0 +1,20 @@
+from django.conf.urls import include, url
+
+from . import views
+from .constants import DOCUMENT_PATH_RE
+
+
+# These patterns inherit (?P<document_path>[^\$]+).
+document_patterns = [
+    url(r'^\$samples/(?P<sample_name>.+)/files/(?P<attachment_id>\d+)/(?P<filename>.+)$',
+        views.code.raw_code_sample_file,
+        name='wiki.raw_code_sample_file'),
+    url(r'^\$samples/(?P<sample_name>.+)$',
+        views.code.code_sample,
+        name='wiki.code_sample'),
+]
+
+urlpatterns = [
+    url(r'^/(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
+        include(document_patterns)),
+]

--- a/kuma/wsgi.py
+++ b/kuma/wsgi.py
@@ -4,7 +4,5 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kuma.settings.local')
 
 # Enable WhiteNoise
 from django.core.wsgi import get_wsgi_application  # noqa
-from whitenoise.django import DjangoWhiteNoise  # noqa
 
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -262,7 +262,8 @@ wheel==0.29.0 \
 
 # Serve static files with compression, etc. from Django
 whitenoise==3.3.1 \
-    --hash=sha256:15f43b2e701821b95c9016cf469d29e2a546cb1c7dead584ba82c36f843995cf
+    --hash=sha256:15f43b2e701821b95c9016cf469d29e2a546cb1c7dead584ba82c36f843995cf \
+    --hash=sha256:9d81515f2b5b27051910996e1e860b1332e354d9e7bcf30c98f21dcb6713e0dd
 
 # Fix gunicorn worker timeout problems with default sync worker
 meinheld==0.6.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -261,9 +261,8 @@ wheel==0.29.0 \
     --hash=sha256:1ebb8ad7e26b448e9caa4773d2357849bf80ff9e313964bcaf79cbf0201a1648
 
 # Serve static files with compression, etc. from Django
-whitenoise==2.0.6 \
-    --hash=sha256:826ffe5d608c9dc8daebef1b0b43d01f7958f17c2fce36e75c80e26160172c4f \
-    --hash=sha256:5aea935dfc09ef2beeb76960b4a808b0bbe65e85fb0b0312434b9c365ca02a41
+whitenoise==3.3.1 \
+    --hash=sha256:15f43b2e701821b95c9016cf469d29e2a546cb1c7dead584ba82c36f843995cf
 
 # Fix gunicorn worker timeout problems with default sync worker
 meinheld==0.6.1 \
@@ -274,4 +273,3 @@ meinheld==0.6.1 \
 django-redirect-urls==0.1 \
     --hash=sha256:cd8499424e4920dc929bf1d64c5563349471353143af8e631033336570c42445 \
     --hash=sha256:267f20cc44de96fc574b5b02e9efcd80f4aab4146539dea1f4228f62f34bb4f5
-


### PR DESCRIPTION
This PR address at least part of [bugzilla 1402708](https://bugzilla.mozilla.org/show_bug.cgi?id=1402708) and https://github.com/mozmeao/infra/issues/529. Currently in SCL3, there are three domains in use: **main** (developer.mozilla.org), **untrusted** (mdn.mozillademos.org), and **cdn** (developer.cdn.mozilla.net). Here's a sample of what each of the domains in SCL3  returns for specific endpoints:

### **main** (developer.mozilla.org):
- should NOT serve sample endpoints (https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color) and should redirect on file-attachment endpoints (https://developer.mozilla.org/files/12984/web-font-example.png)
- no new code needed since these endpoints already check for the proper HOST header and redirect if necessary (must be `ATTACHMENT_HOST` for file attachments and the constance setting `KUMA_WIKI_IFRAME_ALLOWED_HOSTS` for samples)
- currently does serve static/media files (via WhiteNoise)

https://developer.mozilla.org/admin/login/ --> 200
https://developer.mozilla.org/en-US/docs/Web/JavaScript --> 200
https://developer.mozilla.org/media/sitemap.xml --> 200
https://developer.mozilla.org/static/build/js/wiki-skinny.2187d581918b.js --> 200
https://developer.mozilla.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color --> 403
https://developer.mozilla.org/files/12984/web-font-example.png --> 301 to https://mdn.mozillademos.org/files/12984/web-font-example.png
https://developer.mozilla.org/@api/deki/files/2926/=AudioTest_(1).ogg --> 301 to https://mdn.mozillademos.org/files/2587/AudioTest%20(1).ogg
https://developer.mozilla.org/diagrams/workflow/workflow.svg --> 200
https://developer.mozilla.org/presentations/javascript2/images/big-cake.jpg --> 200
https://developer.mozilla.org/samples/svg/swarm-of-motes.xhtml --> 200

### **untrusted** (mdn.mozillademos.org):
- should only serve the file attachment and code sample endpoints
- should not serve any other endpoints, like static, media, or document endpoints

https://mdn.mozillademos.org/admin/login/ --> 404
https://mdn.mozillademos.org/en-US/docs/Web/JavaScript --> 404
https://mdn.mozillademos.org/media/sitemap.xml --> 404
https://mdn.mozillademos.org/static/build/js/wiki-skinny.2187d581918b.js --> 404
https://mdn.mozillademos.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color --> 200
https://mdn.mozillademos.org/files/12984/web-font-example.png --> 200
https://mdn.mozillademos.org/@api/deki/files/2926/=AudioTest_(1).ogg --> 404
https://mdn.mozillademos.org/diagrams/workflow/workflow.svg --> 404
https://mdn.mozillademos.org/presentations/javascript2/images/big-cake.jpg --> 404
https://mdn.mozillademos.org/samples/svg/swarm-of-motes.xhtml --> 404

### **cdn** (developer.cdn.mozilla.net):
- currently in SCL3 serves all endpoints including static, media, admin, and documents

https://developer.cdn.mozilla.net/admin/login/ --> 200
https://developer.cdn.mozilla.net/en-US/docs/Web/JavaScript --> 200
https://developer.cdn.mozilla.net/media/sitemap.xml --> 200
https://developer.cdn.mozilla.net/static/build/js/wiki-skinny.2187d581918b.js --> 200
https://developer.cdn.mozilla.net/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color --> 403
https://developer.cdn.mozilla.net/files/12984/web-font-example.png --> 301 to https://mdn.mozillademos.org/files/12984/web-font-example.png
https://developer.cdn.mozilla.net/@api/deki/files/2926/=AudioTest_(1).ogg --> 301 to https://mdn.mozillademos.org/files/2587/AudioTest%20(1).ogg
https://developer.cdn.mozilla.net/diagrams/workflow/workflow.svg --> 200
https://developer.cdn.mozilla.net/presentations/javascript2/images/big-cake.jpg --> 200
https://developer.cdn.mozilla.net/samples/svg/swarm-of-motes.xhtml --> 200

So this PR effectively makes the Kuma-based code in AWS match SCL3 (the results above). In brief, it blocks the **untrusted** domain from serving anything other than code samples and file attachments. It does NOT restrict the **cdn** domain, which goes beyond what we currently do in SCL3. I can do that in this PR or another if that is what we want. If we do want to restrict the **cdn** domain, do we want to restrict it to just serve static files?

I did the following in order to test this in my local Docker development environment:
- changed `/etc/hosts` by adding a `demos` alias to `127.0.0.1`
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos
255.255.255.255	broadcasthost
::1             localhost
```
- added `ENABLE_RESTRICTIONS_BY_HOST=True` to my `.env` file
- set `ATTACHMENT_HOST=demos:8000` in my `docker-compose.yml` file
- built a new `kuma_base` Docker image: `make build-base` (This is required due to the upgrade of the whitenoise package to version 3.3.1)
- changed line 4 of my `docker-compose.yml` to use the Docker image hash (e.g., `6c7af4df819c`) from the `make build-base` command above rather than `quay.io/mozmar/kuma_base`
- logged into  the Django admin (`localhost:8000/admin/login`) and added `demos:8000` to the constance regex setting `KUMA_WIKI_IFRAME_ALLOWED_HOSTS`
