### PR TITLE
bug 1402497: /favicon.ico redirect, try #2

### DIFF
--- a/kuma/landing/test_views.py
+++ b/kuma/landing/test_views.py
@@ -30,3 +30,9 @@ def test_robots_enabled(client, db, settings, allowed):
         assert 'Sitemap: ' in content
     else:
         assert 'Disallow: /' in content
+
+
+def test_favicon_ico(client):
+    response = client.get('favicon.ico')
+    assert response.status_code == 302
+    assert response['Location'].endswith('static/img/favicon.ico')

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -25,4 +25,7 @@ urlpatterns = [
     url(r'^robots.txt$',
         views.robots_txt,
         name='robots_txt'),
+    url(r'^favicon.ico$',
+        views.FaviconRedirect.as_view(icon='favicon.ico'),
+        name='favicon_ico'),
 ]

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from django.contrib.staticfiles.storage import staticfiles_storage
 from django.shortcuts import redirect, render
 from django.views import static
+from django.views.generic import RedirectView
 
 from kuma.settings.common import path
 from kuma.core.sections import SECTION_USAGE
@@ -66,3 +68,13 @@ def robots_txt(request):
     else:
         robots = 'robots-go-away.txt'
     return static.serve(request, robots, document_root=path('media'))
+
+
+class FaviconRedirect(RedirectView):
+    """Redirect to the favicon in the static img folder (bug 1402497)"""
+    icon = None
+    permanent = False
+
+    def get_redirect_url(self, *args, **kwargs):
+        assert self.icon
+        return staticfiles_storage.url('img/%s' % self.icon)

--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -1,5 +1,3 @@
-from django.contrib.staticfiles.storage import staticfiles_storage
-
 from redirect_urls import redirect as lib_redirect
 
 
@@ -761,10 +759,5 @@ redirectpatterns = [
 
     # RewriteRule ^es4 http://www.ecma-international.org/memento/TC39.htm [R=302,L]
     redirect(r'^es4', 'http://www.ecma-international.org/memento/TC39.htm',
-             permanent=False),
-
-    # /favicon.ico - requested by some tools
-    redirect(r'^favicon.ico',
-             staticfiles_storage.url('img/favicon.ico'),
              permanent=False),
 ]

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -403,6 +403,7 @@ LANGUAGE_URL_IGNORED_PATHS = (
     '__debug__',
     '.well-known',
     'users/github/login/callback/',
+    'favicon.ico',
     # Legacy files, circa 2008, served in AWS
     'diagrams',
     'presentations',


### PR DESCRIPTION
The redirect pattern fails when hashed assets are enabled, such as building the production Docker images. Instead, wait until runtime to compute the favicon.ico path.