### PR TITLE
bug 1405690: Move overflow to own xfail test

### DIFF
--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -29,8 +29,6 @@ def test_dashboard(base_url, selenium):
     assert page.is_first_details_displayed
     # contains a diff
     assert page.is_first_details_diff_displayed
-    # does not overflow page
-    assert page.dashboard_not_overflowing
     # save id of first revision on page one
     first_row_id = page.first_row_id
     # click on page two link
@@ -39,6 +37,20 @@ def test_dashboard(base_url, selenium):
     new_first_row_id = page.first_row_id
     # check first revison on page one is not on page two
     assert first_row_id is not new_first_row_id
+
+
+@pytest.mark.xfail(reason='bug 1405690: fails for some revision diffs')
+@pytest.mark.smoke
+@pytest.mark.nondestructive
+def test_dashboard_overflow(base_url, selenium):
+    """
+    The revision detail diff stays in page boundaries
+
+    bug 1405690 - some content causes overflows
+    """
+    page = DashboardPage(selenium, base_url).open()
+    page.open_first_details()
+    assert page.scrollWidth < page.clientWidth
 
 
 @pytest.mark.nondestructive

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -89,9 +89,14 @@ class DashboardPage(BasePage):
         self.wait.until(lambda s: 'opacity' not in self.find_element(*self._parent_locator).get_attribute('style'))
 
     @property
-    def dashboard_not_overflowing(self):
-        crawlBar = self.selenium.execute_script("return document.documentElement.scrollWidth>document.documentElement.clientWidth;")
-        return not crawlBar
+    def scroll_width(self):
+        script = "return document.documentElement.scrollWidth;"
+        return int(self.selenium.execute_script(script))
+
+    @property
+    def client_width(self):
+        script = "return document.documentElement.clientWidth;"
+        return int(self.selenium.execute_script(script))
 
 
 class DashboardRow(Region):


### PR DESCRIPTION
Move the sometimes-failing check for details overflow on the search dashboard to its own test. Rewrite the assertion so that the traceback will be better someday (although the traceback is skipped for xfailed tests...). 

Discussed on https://github.com/mozmeao/infra/issues/527. [bug 1405690](https://bugzilla.mozilla.org/show_bug.cgi?id=1405690) is unlikely to be fixed by staff, because of low priority of layout bugs that only affect wiki moderators.