### PR TITLE
bug 1405519: handle 403/404/500 errors when domain is untrusted

### DIFF
--- a/jinja2/403.html
+++ b/jinja2/403.html
@@ -43,6 +43,7 @@
       {% endtrans %}
     {% endif %}
 
+    {%- if not untrusted %}
       <ul class="prose">
       {% if user.username %}
         {% trans logout_url=url('account_logout') %}
@@ -54,6 +55,7 @@
         {% endtrans %}
       {% endif %}
       </ul>
+    {%- endif %} {# if not untrusted #}
     {% endblock %}
 
     {% block tumbeast_attribution -%}

--- a/jinja2/404.html
+++ b/jinja2/404.html
@@ -21,6 +21,7 @@
           We're sorry, we couldn't find what you were looking for.
           {% endtrans %}</p>
 
+        {%- if not untrusted %}
         <p>{% trans homepage_url=url('home') %}
           You can try a search or start over on the <a href="{{ homepage_url }}">home page</a>.
           {% endtrans %}</p>
@@ -29,13 +30,14 @@
             If you were following a documentation link, you can sign in and create the page. Otherwise, please <a
                 href="{{ bug_form_url }}" rel="nofollow">file a bug</a>. Thanks!
             {% endtrans %}</p>
+        {%- endif %}
 
       {% elif reason=="banneduser" %}
 
         <p class="notice">{{ _("This user's profile has been banned.") }}</p>
       {% endif %}
 
-      {% if not user.is_authenticated() %}
+      {% if not untrusted and not user.is_authenticated() %}
       {% include "socialaccount/snippets/provider_list.html" %}
       {% endif %}
 

--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -14,7 +14,7 @@
   <section id="content-main" class="full" role="main">
 
     <h1 class="page-title">Internal Server Error</h1>
-    
+
     <img src="{{ static('img/beast-500.png') }}" alt="" class="beast 500">
 
     {% if error_message %}
@@ -27,14 +27,16 @@
       <p>An unhandled error occurred in the application. The error has been logged
       and an administrator was notified. We apologize for the inconvenience!</p>
 
+      {%- if not untrusted %}
       <p>Please start over on the <a href="{{ url('home') }}">home page</a>.</p>
+      {%- endif %}
     {% endif %}
     <p>If you have additional information how to reproduce this problem, please
     <a href="https://bugzilla.mozilla.org/form.mdn" rel="nofollow">file a bug.</a>
     Thanks!</p>
-    
+
     <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>
-    
+
   </section>
 
 </div>

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,20 +1,21 @@
 {% from "includes/common_macros.html" import optimizely_script with context -%}
+{% set untrusted = request.get_host() == settings.ATTACHMENT_HOST %}
 
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false">
-<head {%- if not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
+<head {%- if not untrusted and not is_sphinx %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
-  {% if not is_sphinx %}
+  {% if not untrusted and not is_sphinx %}
     {{ optimizely_script() }}
   {% endif %}
   <title>{% block title %}{{ _('MDN Web Docs') }}{% endblock %}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content="{% block robots_value%}index, follow{% endblock %}">
-  {%- if not is_sphinx %}
+  {%- if not untrusted and not is_sphinx %}
     <link rel="home" href="{{ url('home') }}">
     <link rel="copyright" href="#copyright">
   {% endif %}
@@ -39,7 +40,7 @@
   {#- If the stylesheet exists, include it. Otherwise, does nothing. #}
   {% stylesheet 'locale-%s' % LANG %}
 
-  {%- if not is_sphinx %}
+  {%- if not untrusted and not is_sphinx %}
     <!-- common social tags -->
     {% set social_logo = request.build_absolute_uri(static('img/opengraph-logo.png')) %}
     <meta property="og:type" content="website">
@@ -92,7 +93,9 @@
         <p>
           <bdi>
             {{ _('MDN is currently in read-only maintenance mode.') }}
+            {%- if not untrusted %}
             <a href="{{ url('maintenance_mode') }}">{{ _('Learn more') }}</a>.
+            {%- endif %}
           </bdi>
         </p>
       </div>
@@ -101,6 +104,7 @@
     {{ soapbox_messages(get_soapbox_messages(request.path)) }}
   {%- endif %}
 
+  {%- if not untrusted %}
   <ul id="nav-access">
     <li><a href="#{% block main_content_id %}content{% endblock %}" id="skip-main">{{ _('Skip to main content') }}</a></li>
     {%- if not is_sphinx %}
@@ -188,6 +192,7 @@
         </div>
       </form></li>{% endif %}</ul></nav>
   </div></header>
+  {%- endif %} {# if not untrusted #}
 
   <!-- Content will go here -->
   <main id="content">
@@ -201,6 +206,7 @@
   {% include "includes/redesign_notice.html" %}
 
 
+  {%- if not untrusted %}
   <!-- Footer -->
     <footer id="nav-footer" class="nav-footer">
       <div class="center">
@@ -253,6 +259,7 @@
           {% endblock %}
       </div>
     </footer>
+    {%- endif %} {# if not untrusted #}
 
   <!-- site js -->
   {% block site_js %}

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -18,7 +18,9 @@
         win.mdn.staticPath = '{{ STATIC_URL }}';
         win.mdn.optimizely = win['optimizely'] || [];
         win.mdn.wiki = {
+            {%- if not untrusted %}
             autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
+            {%- endif %}
         };
         win.mdn.assets = {
             css: {

--- a/kuma/urls_untrusted.py
+++ b/kuma/urls_untrusted.py
@@ -1,6 +1,11 @@
 from django.conf import settings
 from django.conf.urls import include, url
 
+from kuma.core import views as core_views
+
+handler403 = core_views.handler403
+handler404 = core_views.handler404
+handler500 = core_views.handler500
 
 urlpatterns = [
     url('', include('kuma.attachments.urls')),


### PR DESCRIPTION
This PR addresses [bug 1405519](https://bugzilla.mozilla.org/show_bug.cgi?id=1405519 ) and, at least partially, https://github.com/mozmeao/infra/issues/558. I decided to keep going with a common set of handlers, selectively avoiding specific parts of the current `jinja2/base.html`, `jinja2/403.html`, `jinja2/404.html`, `jinja2/500.html`, and `jinja2/includes/config.html` templates depending upon whether the **untrusted** domain (used for file attachments and code samples, e.g., `mdn.mozillademos.org`) is used. Here's a screenshot of what the 404 would look like:

<img width="1280" alt="404" src="https://user-images.githubusercontent.com/3743693/31204861-b960c638-a922-11e7-8477-1a27e8af055d.png">

I did the following in order to test this in my local Docker development environment:
- changed `/etc/hosts` by adding a `demos` alias to `127.0.0.1`
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos
255.255.255.255	broadcasthost
::1             localhost
```
- added the following to my `.env` file:
```
ENABLE_RESTRICTIONS_BY_HOST=True
ATTACHMENT_HOST=demos:8000
STATIC_URL=http://localhost:8000/static/
DEBUG=False
```
- `docker-compose up -d`
- re-compiled the static assets (with DEBUG=False):
```
docker-compose exec web bash
$ make localecompile
$ ./manage.py compilejsi18n
$ ./manage.py collectstatic
$ exit
docker-compose restart web
```
- paste `http://demos:8000/files/123456/junk.png` into your browser



