### PR TITLE
Fix issue #283, add dns-prefetch, preconnect for editor iframe

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -64,6 +64,9 @@
 {% endblock %}
 
 {% block extrahead %}
+  <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+  <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+
   <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.slug) }}">
   <link rel="canonical" href="{{ canonical }}" >
 


### PR DESCRIPTION
Adds `dns-prefetch` and `preconnect` for the editor `iframe` to test the performance impact.