### PR TITLE
bug 1397786: Update mailing list links to Discourse

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,14 +5,14 @@ Things to know when contributing code
 =====================================
 
   * You agree to license your contributions under [MPL 2][MPL2].
-  * Discuss large changes on the [dev-mdn mailing list][dev-mdn]
+  * Discuss large changes in [Discourse][discourse]
     or on a [bugzilla bug][mdn-backlog] before coding.
   * Python code style should follow [PEP8 standards][pep8] whenever possible.
   * We don't accept pull requests for translated strings (i.e. anything under locale/).
     Please use [Pontoon][pontoon] instead.
 
 [MPL2]: http://www.mozilla.org/MPL/2.0/
-[dev-mdn]: https://lists.mozilla.org/listinfo/dev-mdn
+[discourse]: https://discourse.mozilla.org/c/mdn
 [mdn-backlog]: http://mzl.la/mdn_backlog
 [pep8]: http://www.python.org/dev/peps/pep-0008/
 [pontoon]: https://pontoon.mozilla.org/projects/mdn/

--- a/README.rst
+++ b/README.rst
@@ -32,7 +32,7 @@ Development
                 `Pull Request Queues`_
 :Dev Docs:      https://kuma.readthedocs.io/en/latest/installation.html
 :CI Server:     https://travis-ci.org/mozilla/kuma
-:Mailing list:  https://lists.mozilla.org/listinfo/dev-mdn
+:Forum:         https://discourse.mozilla.org/c/mdn
 :IRC:           irc://irc.mozilla.org/mdndev
 
                 http://logs.glob.uno/?c=mozilla%23mdndev (logs)

--- a/contribute.json
+++ b/contribute.json
@@ -9,7 +9,7 @@
     "participate": {
         "home": "https://wiki.mozilla.org/MDN",
         "docs": "https://kuma.readthedocs.io/",
-        "mailing-list": "https://www.mozilla.org/about/forums/#dev-mdn",
+        "mailing-list": "https://discourse.mozilla.org/c/mdn",
         "irc": "irc://irc.mozilla.org/#mdndev",
         "irc-contacts": [
             "jgmize",

--- a/contribute.json
+++ b/contribute.json
@@ -13,7 +13,6 @@
         "irc": "irc://irc.mozilla.org/#mdndev",
         "irc-contacts": [
             "jgmize",
-            "jpetto",
             "jwhitlock",
             "metadave",
             "rjohnson",
@@ -38,7 +37,6 @@
         "jquery",
         "ckeditor",
         "docker",
-        "ansible",
         "mysql",
         "elasticsearch"
     ]

--- a/docker/images/mysql/Dockerfile
+++ b/docker/images/mysql/Dockerfile
@@ -1,6 +1,5 @@
 FROM mysql:5.6
 
-MAINTAINER MDN Developer <dev-mdn@lists.mozilla.org>
 ENV MYSQL_ROOT_PASSWORD kuma
 COPY kuma.cnf /etc/mysql/conf.d/
 COPY Index.xml /usr/share/mysql/charsets/

--- a/docs/troubleshooting.rst
+++ b/docs/troubleshooting.rst
@@ -82,9 +82,9 @@ Getting more help
 If you have more problems running Kuma, please:
 
 #. Paste errors to `pastebin`_.
-#. Email the `dev-mdn`_ list.
+#. Start a thread on `Discourse`_.
 #. After you email dev-mdn, you can also ask in `IRC`_.
 
 .. _pastebin: https://pastebin.mozilla.org/
-.. _dev-mdn: https://lists.mozilla.org/listinfo/dev-mdn
+.. _Discourse: https://discourse.mozilla.org/c/mdn
 .. _IRC: irc://irc.mozilla.org:6697/#mdndev

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -34,9 +34,11 @@ DEBUG = config('DEBUG', default=False, cast=bool)
 
 ROOT = dirname(dirname(dirname(os.path.abspath(__file__))))
 
+ADMIN_EMAILS = config('ADMIN_EMAILS', default='mdn-dev@mozilla.com',
+                      cast=Csv())
 ADMINS = zip(
     config('ADMIN_NAMES', default='MDN devs', cast=Csv()),
-    config('ADMIN_EMAILS', default='mdn-dev@mozilla.com', cast=Csv())
+    ADMIN_EMAILS
 )
 
 PROTOCOL = config('PROTOCOL', default='https://')
@@ -636,7 +638,7 @@ PUENTE = {
         ],
     },
     'PROJECT': 'MDN',
-    'MSGID_BUGS_ADDRESS': 'dev-mdn@lists.mozilla.org',
+    'MSGID_BUGS_ADDRESS': ADMIN_EMAILS[0],
 }
 
 STATICI18N_ROOT = 'build/locale'

--- a/kuma/users/jinja2/users/email/welcome/html.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/html.ltxt
@@ -35,8 +35,8 @@
         <p>{{ _('Want to talk to someone about MDN? There are a few ways you can do that:') }}</p>
         <ul>
             <li>
-              {% trans list_link=add_utm('https://lists.mozilla.org/listinfo/dev-mdc', 'welcome') %}
-                Mailing list: <a href="{{ list_link }}">subscribe</a> to tell us about what you're interested in on MDN and ask questions about the site.
+              {% trans list_link=add_utm('https://discourse.mozilla.org/c/mdn', 'welcome') %}
+                Discussion forum: <a href="{{ list_link }}">join</a> to tell us about what you're interested in on MDN and ask questions about the site.
               {% endtrans %}
             </li>
             <li>

--- a/kuma/users/jinja2/users/email/welcome/plain.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/plain.ltxt
@@ -30,10 +30,10 @@
 {{ _('Want to talk to someone about MDN? There are a few ways you can do that:') }}
 
 {# L10n: This is an email. Whitespace matters! #}
-* {{ _('Mailing list: %(list_link)s', list_link=add_utm('https://lists.mozilla.org/listinfo/dev-mdc', 'welcome')) }}
+* {{ _('Discussion forum: %(list_link)s', list_link=add_utm('https://discourse.mozilla.org/c/mdn', 'welcome')) }}
 
 {# L10n: This is an email. Whitespace matters! #}
-    {{ _("Subscribe to tell us about what you're interested in on MDN and ask questions about the site.") }}
+    {{ _("Join to tell us about what you're interested in on MDN and ask questions about the site.") }}
 
 {# L10n: This is an email. Whitespace matters! #}
 * {{ _('Real-time chat: #mdn channel on irc.mozilla.org') }}


### PR DESCRIPTION
* Change dev-mdc and dev-mdn links to Discourse
* Change dev-mdn email gateway to admin email
* Fix some other keywords in [contribute.json](https://github.com/mozilla/contribute.json)