### PR TITLE
bug 1407806: improve caching for file attachments

### DIFF
--- a/kuma/attachments/tests/conftest.py
+++ b/kuma/attachments/tests/conftest.py
@@ -1,0 +1,31 @@
+import datetime
+
+import pytest
+from django.core.files.base import ContentFile
+
+from kuma.attachments.models import Attachment, AttachmentRevision
+
+
+@pytest.fixture
+def file_attachment(db, wiki_user):
+    file_id = 97
+    filename = 'test.txt'
+    title = 'Test text file'
+
+    attachment = Attachment(title=title, mindtouch_attachment_id=file_id)
+    attachment.save()
+    revision = AttachmentRevision(
+        title=title,
+        is_approved=True,
+        attachment=attachment,
+        mime_type='text/plain',
+        description='Initial upload',
+        created=datetime.datetime.now(),
+    )
+    revision.creator = wiki_user
+    revision.file.save(filename, ContentFile('This is only a test.'))
+    revision.make_current()
+    return dict(
+        attachment=attachment,
+        file=dict(id=file_id, name=filename),
+    )

--- a/kuma/attachments/utils.py
+++ b/kuma/attachments/utils.py
@@ -37,21 +37,29 @@ def full_attachment_url(attachment_id, filename):
     return '%s%s%s' % (settings.PROTOCOL, settings.ATTACHMENT_HOST, path)
 
 
-def convert_to_http_date(dt):
+def convert_to_utc(dt):
     """
-    Given a timezone naive or aware datetime return the HTTP date
-    formatted string to be used in HTTP response headers.
+    Given a timezone naive or aware datetime return it converted to UTC.
     """
-    # first check if the given dt is timezone aware and if not make it aware
+    # Check if the given dt is timezone aware and if not make it aware.
     if timezone.is_naive(dt):
         default_timezone = timezone.get_default_timezone()
         dt = timezone.make_aware(dt, default_timezone)
 
-    # then convert the datetime to UTC (which epoch time is based on)
-    utc_dt = dt.astimezone(timezone.utc)
-    # convert the UTC time to the seconds since the epch
+    # Convert the datetime to UTC.
+    return dt.astimezone(timezone.utc)
+
+
+def convert_to_http_date(dt):
+    """
+    Given a timezone naive or aware datetime return the HTTP date-formatted
+    string to be used in HTTP response headers.
+    """
+    # Convert the datetime to UTC.
+    utc_dt = convert_to_utc(dt)
+    # Convert the UTC datetime to seconds since the epoch.
     epoch_dt = calendar.timegm(utc_dt.utctimetuple())
-    # format the thing as a RFC1123 datetime
+    # Format the thing as a RFC1123 datetime.
     return http_date(epoch_dt)
 
 

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -1,8 +1,85 @@
+from datetime import datetime
+from collections import namedtuple
+
 import pytest
 from django.conf import settings
 from django.core.cache import caches
+
+from kuma.wiki.models import Document, Revision
+
+
+BannedUser = namedtuple('BannedUser', 'user ban')
 
 
 @pytest.fixture()
 def cleared_cacheback_cache():
     caches[settings.CACHEBACK_CACHE_ALIAS].clear()
+
+
+@pytest.fixture
+def wiki_user(db, django_user_model):
+    """A test user."""
+    return django_user_model.objects.create(
+        username='wiki_user',
+        email='wiki_user@example.com',
+        date_joined=datetime(2017, 4, 14, 12, 0))
+
+
+@pytest.fixture
+def wiki_user_2(db, django_user_model):
+    """A second test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_2',
+        email='wiki_user_2@example.com',
+        date_joined=datetime(2017, 4, 17, 10, 30))
+
+
+@pytest.fixture
+def wiki_user_3(db, django_user_model):
+    """A third test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_3',
+        email='wiki_user_3@example.com',
+        date_joined=datetime(2017, 4, 23, 11, 45))
+
+
+@pytest.fixture
+def inactive_wiki_user(db, django_user_model):
+    """An inactive test user."""
+    return django_user_model.objects.create(
+        is_active=False,
+        username='wiki_user_slacker',
+        email='wiki_user_slacker@example.com',
+        date_joined=datetime(2017, 4, 19, 10, 58))
+
+
+@pytest.fixture
+def banned_wiki_user(db, django_user_model, wiki_user):
+    """A banned test user."""
+    user = django_user_model.objects.create(
+        username='bad_wiki_user',
+        email='bad_wiki_user@example.com',
+        date_joined=datetime(2017, 4, 18, 9, 15)
+    )
+    ban = user.bans.create(by=wiki_user, reason='because')
+    return BannedUser(user=user, ban=ban)
+
+
+@pytest.fixture
+def root_doc(wiki_user):
+    """A newly-created top-level English document."""
+    root_doc = Document.objects.create(
+        locale='en-US', slug='Root', title='Root Document')
+    Revision.objects.create(
+        document=root_doc,
+        creator=wiki_user,
+        content='<p>Getting started...</p>',
+        title='Root Document',
+        created=datetime(2017, 4, 14, 12, 15))
+    return root_doc
+
+
+@pytest.fixture
+def create_revision(root_doc):
+    """A revision that created an English document."""
+    return root_doc.revisions.first()

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1238,6 +1238,11 @@ MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
+ATTACHMENTS_CACHE_CONTROL_MAX_AGE = config(
+    'ATTACHMENTS_CACHE_CONTROL_MAX_AGE',
+    default=300,
+    cast=int
+)
 
 # This should never be false for the production and stage deployments.
 ENABLE_RESTRICTIONS_BY_HOST = config(

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -10,7 +10,6 @@ import pytest
 from ..models import Document, DocumentZone, Revision
 
 
-BannedUser = namedtuple('BannedUser', 'user ban')
 Contributors = namedtuple('Contributors', 'valid banned inactive')
 DocWithContributors = namedtuple('DocWithContributors', 'doc contributors')
 DocHierarchy = namedtuple('DocHierarchy', 'top middle_top middle_bottom bottom')
@@ -18,75 +17,6 @@ KumaScriptToolbox = namedtuple(
     'KumaScriptToolbox',
     'errors errors_as_headers macros_response'
 )
-
-
-@pytest.fixture
-def wiki_user(db, django_user_model):
-    """A test user."""
-    return django_user_model.objects.create(
-        username='wiki_user',
-        email='wiki_user@example.com',
-        date_joined=datetime(2017, 4, 14, 12, 0))
-
-
-@pytest.fixture
-def wiki_user_2(db, django_user_model):
-    """A second test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_2',
-        email='wiki_user_2@example.com',
-        date_joined=datetime(2017, 4, 17, 10, 30))
-
-
-@pytest.fixture
-def wiki_user_3(db, django_user_model):
-    """A third test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_3',
-        email='wiki_user_3@example.com',
-        date_joined=datetime(2017, 4, 23, 11, 45))
-
-
-@pytest.fixture
-def inactive_wiki_user(db, django_user_model):
-    """An inactive test user."""
-    return django_user_model.objects.create(
-        is_active=False,
-        username='wiki_user_slacker',
-        email='wiki_user_slacker@example.com',
-        date_joined=datetime(2017, 4, 19, 10, 58))
-
-
-@pytest.fixture
-def banned_wiki_user(db, django_user_model, wiki_user):
-    """A banned test user."""
-    user = django_user_model.objects.create(
-        username='bad_wiki_user',
-        email='bad_wiki_user@example.com',
-        date_joined=datetime(2017, 4, 18, 9, 15)
-    )
-    ban = user.bans.create(by=wiki_user, reason='because')
-    return BannedUser(user=user, ban=ban)
-
-
-@pytest.fixture
-def root_doc(wiki_user):
-    """A newly-created top-level English document."""
-    root_doc = Document.objects.create(
-        locale='en-US', slug='Root', title='Root Document')
-    Revision.objects.create(
-        document=root_doc,
-        creator=wiki_user,
-        content='<p>Getting started...</p>',
-        title='Root Document',
-        created=datetime(2017, 4, 14, 12, 15))
-    return root_doc
-
-
-@pytest.fixture
-def create_revision(root_doc):
-    """A revision that created an English document."""
-    return root_doc.revisions.first()
 
 
 @pytest.fixture


### PR DESCRIPTION
* use Django-supplied decorators to add "Cache-Control" header as well as handle "Last-Modified" and its related request headers like "If-Modified-Since"
* allow the "max-age" caching-header value for file attachments to be configured from the environment via `ATTACHMENTS_CACHE_CONTROL_MAX_AGE`
* block Django's `SessionMiddleware` from adding the "Vary: Cookie" header
* move some generally-useful pytest fixtures from `kuma/wiki/tests/conftest.py` to the top level
  `kuma/conftest.py`
* add `file_attachment` fixture to `kuma/attachments/tests/conftest.py`
* convert/modify some of the old-style tests in `kuma/attachments/tests/test_views.py` to the
  pytest style and add one new test for the file-attachments endpoint
* add `convert_to_utc()` function to `kuma/attachments/utils.py`