### PR TITLE
bug 1408460: Use stage.mdn.moz.works as stage site

### DIFF
--- a/Jenkinsfiles/stage-integration-tests.yml
+++ b/Jenkinsfiles/stage-integration-tests.yml
@@ -5,6 +5,6 @@ job:
   dockerfile: "docker/images/integration-tests/Dockerfile"
   selenium: "2.48.2"
   selenium_nodes: 5
-  base_url: 'https://developer.allizom.org'
+  base_url: 'https://stage.mdn.moz.works'
   tests: "not login"
   maintenance_mode: false

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ coveragetesthtml: coveragetest
 	coverage html
 
 locust:
-	locust -f tests/performance/smoke.py --host=https://developer.allizom.org
+	locust -f tests/performance/smoke.py --host=https://stage.mdn.moz.works
 
 compilejsi18n:
 	@ echo "## Generating JavaScript translation catalogs ##"

--- a/README.rst
+++ b/README.rst
@@ -38,12 +38,12 @@ Development
                 http://logs.glob.uno/?c=mozilla%23mdndev (logs)
 :Servers:       `What's Deployed on MDN?`_
 
-                https://developer.allizom.org/ (stage)
+                https://stage.mdn.moz.works/ (stage)
 
                 https://developer.mozilla.org/ (prod)
 
 .. _`Pull Request Queues`: http://prs.mozilla.io/mozilla:kuma,kuma-lib,kumascript,mozhacks
-.. _`What's Deployed on MDN?`: https://whatsdeployed.io/?owner=mozilla&repo=kuma&name[]=Stage&url[]=https://developer.allizom.org/media/revision.txt&name[]=Prod&url[]=https://developer.mozilla.org/media/revision.txt
+.. _`What's Deployed on MDN?`: https://whatsdeployed.io/s-NyD
 
 
 Getting started

--- a/contribute.json
+++ b/contribute.json
@@ -27,7 +27,7 @@
     },
     "urls": {
         "prod": "https://developer.mozilla.org/",
-        "stage": "https://developer.allizom.org/"
+        "stage": "https://stage.mdn.moz.works/"
     },
     "keywords": [
         "python",

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -269,4 +269,4 @@ We suspect that a clever user could de-anonymize the data in the full
 anonymized database, so we do not distribute it, and try to limit our own use
 of the database.
 
-.. _`staging site`: https://developer.allizom.org
+.. _`staging site`: https://stage.mdn.moz.works

--- a/docs/deploy-scl3.rst
+++ b/docs/deploy-scl3.rst
@@ -2,7 +2,10 @@
 Deploying to SCL3
 =================
 
-MDN is served from SLC3, a data center in Santa Clara, California.  It is
+.. warning:: MDN is now deployed to AWS, and this process is no longer used.
+   We are still working on the process and docs for deploying to AWS
+
+MDN was served from SLC3, a data center in Santa Clara, California.  It is
 deployed on several persistent virtual machines, managed by Mozilla WebOps.
 Deploying new code to SCL3 takes several steps.  It takes a couple of hours to
 deploy, and the deployer is responsible for emergency issues for the next 24
@@ -87,7 +90,7 @@ Pre-Deployment: Update Submodules
 
 Deploy to Staging
 -----------------
-The staging site is located at https://developer.allizom.org.  It runs on the
+The staging site was located at https://developer.allizom.org.  It runs on the
 same Kuma code as production, but against a different database, other backing
 services, and with less resources. It is used for verifying code changes before
 pushing to production.

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -187,7 +187,7 @@ Add a new locale to Pontoon
 The process for getting a new locale on MDN is documented at
 `Starting a new MDN localization`_. One step is to enable translation of the
 UI strings. This will also enable the locale in development environments and
-on https://developer.allizom.org.
+on https://stage.mdn.moz.works.
 
 .. Note::
 

--- a/docs/tests-ui.rst
+++ b/docs/tests-ui.rst
@@ -148,7 +148,7 @@ Run tests on MDN's Continuous Integration (CI) infrastructure
 If you have commit rights on the `mozilla/kuma GitHub repository`_
 you can run the UI tests using the `MDN CI Infrastructure`_. Just force push
 to `mozilla/kuma@stage-integration-tests`_ to run the tests
-against https://developer.allizom.org.
+against https://stage.mdn.moz.works.
 
 You can check the status, progress, and logs of the
 test runs at `MDN's Jenkins-based multi-branch pipeline`_.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -45,7 +45,7 @@ PROTOCOL = config('PROTOCOL', default='https://')
 DOMAIN = config('DOMAIN', default='developer.mozilla.org')
 SITE_URL = config('SITE_URL', default=PROTOCOL + DOMAIN)
 PRODUCTION_URL = SITE_URL
-STAGING_DOMAIN = 'developer.allizom.org'
+STAGING_DOMAIN = 'stage.mdn.moz.works'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
 INTERACTIVE_EXAMPLES_BASE = config(
@@ -1477,7 +1477,8 @@ CONSTANCE_CONFIG = dict(
     ),
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS=(
         ('^https?\:\/\/'
-         '(developer.allizom.org'                   # Staging demos
+         '(stage-files.mdn.moz.works'               # Staging demos
+         '|developer.allizom.org'                   # Staging demos (SCL3)
          '|mdn.mozillademos.org'                    # Production demos
          '|testserver'                              # Unit test demos
          '|localhost\:8000'                         # Docker development demos

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -835,8 +835,10 @@ def test_filteriframe_empty_contents():
 
 
 FILTERIFRAME_ACCEPTED = {
-    'stage': ('https://developer.allizom.org/'
+    'stage': ('https://stage-files.mdn.moz.works/'
               'fr/docs/Test$samples/sample2?revision=234'),
+    'scl3-stage': ('https://developer.allizom.org/'
+                   'fr/docs/Test$samples/sample2?revision=234'),
     'test': 'http://testserver/en-US/docs/Test$samples/test?revision=567',
     'docker': 'http://localhost:8000/de/docs/Test$samples/test?revision=678',
     'youtube_http': ('http://www.youtube.com/embed/'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def pytest_addoption(parser):
 
 @pytest.fixture(scope='session')
 def base_url(base_url, request):
-    return base_url or 'https://developer.allizom.org'
+    return base_url or 'https://stage.mdn.moz.works'
 
 
 @pytest.fixture

--- a/tests/performance/smoke.py
+++ b/tests/performance/smoke.py
@@ -12,7 +12,7 @@ class SmokeBehavior(TaskSet):
     """
 
     def on_start(self):
-        locust_host = os.environ.get('LOCUST_HOST', 'developer.allizom.org')
+        locust_host = os.environ.get('LOCUST_HOST', 'stage.mdn.moz.works')
         self.client.headers['Host'] = locust_host
 
     @task(weight=265)


### PR DESCRIPTION
Replace developer.allizom.org with stage.mdn.moz.works in various places, including the default domain for integration and performance tests and in the documentation.

I'm not disabling the SCL3 sites yet. When I do, I'd like it in one PR / commit, so that we can revert if we  need SCL3 back in the next few weeks.