### PR TITLE
bug 1392457, 1274874: Improve document list views

### DIFF
--- a/kuma/wiki/jinja2/wiki/list/documents.html
+++ b/kuma/wiki/jinja2/wiki/list/documents.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% set counter = ngettext('Found %(num)s document.', 'Found %(num)s documents', count) %}
+{% set counter = ngettext('Found %(num)s document.', 'Found %(num)s documents', documents.paginator.count) %}
 {% if tag %}
   {% set title = _('Articles tagged: %(tag)s', tag=tag) %}
 {% elif errors %}

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -68,34 +68,35 @@ class BaseDocumentManager(models.Manager):
             docs = docs.filter(parent_topic__isnull=True)
 
         # Only include fields needed for a list of links to docs
-        docs = docs.only('id', 'locale', 'slug', 'deleted', 'summary_text')
+        docs = docs.only('id', 'locale', 'slug', 'deleted', 'title',
+                         'summary_text')
         return docs
 
     def filter_for_review(self, locale=None, tag=None, tag_name=None):
         """Filter for documents with current revision flagged for review"""
-        query = 'current_revision__review_tags__%s'
+        docs = self.filter_for_list(locale=locale)
+        docs = docs.exclude(slug__startswith='Archive/')
+        filter_name = 'current_revision__review_tags__'
         if tag_name:
-            query = {query % 'name': tag_name}
+            docs = docs.filter(**{filter_name + 'name': tag_name})
         elif tag:
-            query = {query % 'in': [tag]}
+            docs = docs.filter(**{filter_name + 'in': [tag]})
         else:
-            query = {query % 'name__isnull': False}
-        if locale:
-            query['locale'] = locale
-        return self.filter(**query).distinct()
+            docs = docs.filter(**{filter_name + 'name__isnull': False})
+        return docs.distinct()
 
     def filter_with_localization_tag(self, locale=None, tag=None, tag_name=None):
         """Filter for documents with a localization tag on current revision"""
-        query = 'current_revision__localization_tags__%s'
+        docs = self.filter_for_list(locale=locale)
+        docs = docs.exclude(slug__startswith='Archive/')
+        filter_name = 'current_revision__localization_tags__'
         if tag_name:
-            query = {query % 'name': tag_name}
+            docs = docs.filter(**{filter_name + 'name': tag_name})
         elif tag:
-            query = {query % 'in': [tag]}
+            docs = docs.filter(**{filter_name + 'in': [tag]})
         else:
-            query = {query % 'name__isnull': False}
-        if locale:
-            query['locale'] = locale
-        return self.filter(**query).distinct()
+            docs = docs.filter(**{filter_name + 'name__isnull': False})
+        return docs.distinct()
 
 
 class DocumentManager(BaseDocumentManager):

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -41,6 +41,10 @@ class BaseDocumentManager(models.Manager):
 
     def filter_for_list(self, locale=None, tag=None, tag_name=None,
                         errors=None, noparent=None, toplevel=None):
+        """
+        Returns a filtered queryset for a list of names and urls.
+        """
+
         docs = (self.filter(is_redirect=False)
                     .exclude(slug__startswith='User:')
                     .exclude(slug__startswith='Talk:')
@@ -63,9 +67,8 @@ class BaseDocumentManager(models.Manager):
         if toplevel:
             docs = docs.filter(parent_topic__isnull=True)
 
-        # Leave out the html, since that leads to huge cache objects and we
-        # never use the content in lists.
-        docs = docs.defer('html')
+        # Only include fields needed for a list of links to docs
+        docs = docs.only('id', 'locale', 'slug', 'deleted', 'summary_text')
         return docs
 
     def filter_for_review(self, locale=None, tag=None, tag_name=None):

--- a/kuma/wiki/tests/test_managers.py
+++ b/kuma/wiki/tests/test_managers.py
@@ -1,0 +1,251 @@
+from datetime import datetime
+import pytest
+
+from kuma.wiki.constants import REDIRECT_CONTENT
+from kuma.wiki.models import (Document, DocumentTag, LocalizationTag,
+                              ReviewTag, Revision)
+
+
+@pytest.fixture
+def redirect_doc(root_doc, wiki_user):
+    """A redirect document."""
+    html = REDIRECT_CONTENT % {'href': root_doc.get_absolute_url(),
+                               'title': root_doc.title}
+    doc = Document.objects.create(locale='en-US', slug='OldRoot', html=html)
+    doc.current_revision = Revision.objects.create(
+        document=doc,
+        creator=wiki_user,
+        content=html,
+        created=datetime(2017, 10, 27, 17, 4))
+    doc.save()
+    return doc
+
+
+@pytest.fixture
+def archive_doc(wiki_user):
+    """An archived document."""
+    archive = Document.objects.create(locale='en-US', slug='Archive',
+                                      title='Archive of obsolete content')
+    doc = Document.objects.create(locale='en-US', slug='Archive/Doc',
+                                  title='Archived document',
+                                  parent_topic=archive)
+    doc.current_revision = Revision.objects.create(
+        document=doc,
+        creator=wiki_user,
+        content='<p>Obsolete content.</p>',
+        comment='Obsolete content',
+        created=datetime(2017, 10, 27, 15, 48))
+    doc.save()
+    return doc
+
+
+def test_get_queryset(root_doc):
+    """Managers are customized for including / excluding deleted documents."""
+    deleted_doc = Document.objects.create(locale='en-US', slug='Deleted',
+                                          title='Deleted Document',
+                                          deleted=True)
+    assert Document.admin_objects.all().count() == 2
+    assert list(Document.objects.all()) == [root_doc]
+    assert list(Document.deleted_objects.all()) == [deleted_doc]
+
+
+def test_get_natural_key(root_doc):
+    """The locale + slug is the natural key for Documents."""
+    assert root_doc.natural_key() == (root_doc.locale, root_doc.slug)
+    assert root_doc == Document.objects.get_by_natural_key(root_doc.locale,
+                                                           root_doc.slug)
+
+
+@pytest.mark.parametrize(
+    'legacy_slug',
+    ('User:ethertank',
+     'Talk:Developer_Guide/Build_Instructions/Windows_Prerequisites',
+     'User_talk:ethertank',
+     'Template_talk:anch'))
+def test_documents_filter_for_list_exclude_slug_prefixes(root_doc, legacy_slug):
+    """filter_for_list excludes some slug prefixes."""
+    Document.objects.create(locale='en-US', slug=legacy_slug)
+    results = Document.objects.filter_for_list()
+    assert len(results) == 1
+    assert results[0] == root_doc
+
+
+def test_documents_filter_for_list_exclude_redirects(root_doc, redirect_doc):
+    """filter_for_list excludes redirects"""
+    assert list(Document.objects.filter_for_list()) == [root_doc]
+
+
+def test_documents_filter_for_list_by_locale(root_doc, trans_doc):
+    """filter_for_list can filter by locale."""
+    results = Document.objects.filter_for_list(locale=trans_doc.locale)
+    assert list(results) == [trans_doc]
+
+
+def test_documents_filter_for_list_by_tag(root_doc):
+    """filter_for_list can filter by a DocumentTag."""
+    tag_foo = DocumentTag.objects.create(name='foo')
+    tag_bar = DocumentTag.objects.create(name='bar')
+    root_doc.tags.add(tag_foo)
+    assert list(Document.objects.filter_for_list(tag=tag_foo)) == [root_doc]
+    assert len(Document.objects.filter_for_list(tag=tag_bar)) == 0
+
+
+def test_documents_filter_for_list_by_tag_name(root_doc):
+    """filter_for_list can filter by a DocumentTag name."""
+    tag_foo = DocumentTag.objects.create(name='foo')
+    root_doc.tags.add(tag_foo)
+    assert list(Document.objects.filter_for_list(tag_name='foo')) == [root_doc]
+    assert len(Document.objects.filter_for_list(tag_name='bar')) == 0
+
+
+def test_documents_filter_for_list_by_errors(root_doc):
+    """filter_for_list can filter by Documents with render errors."""
+    assert root_doc.rendered_errors is None
+    assert len(Document.objects.filter_for_list(errors=True)) == 0
+    root_doc.rendered_errors = '[]'
+    root_doc.save()
+    assert len(Document.objects.filter_for_list(errors=True)) == 0
+    root_doc.rendered_errors = '[{"name": "kumascript", "level": "error"}]'
+    root_doc.save()
+    assert list(Document.objects.filter_for_list(errors=True)) == [root_doc]
+
+
+def test_documents_filter_for_list_by_noparent(root_doc, trans_doc):
+    """filter_for_list can filter by Documents with no parent."""
+    assert list(Document.objects.filter_for_list(noparent=True)) == [root_doc]
+    result = Document.objects.filter_for_list(locale=trans_doc.locale,
+                                              noparent=True)
+    assert len(result) == 0
+    trans_doc.parent = None
+    trans_doc.save()
+    result = Document.objects.filter_for_list(locale=trans_doc.locale,
+                                              noparent=True)
+    assert list(result) == [trans_doc]
+
+
+def test_documents_filter_for_list_by_toplevel(root_doc):
+    """filter_for_list can filter by top-level Documents (no parent topic)."""
+    Document.objects.create(locale=root_doc.locale,
+                            parent_topic=root_doc,
+                            slug=root_doc.slug + '/Child',
+                            title='Child Document')
+    assert len(Document.objects.filter_for_list()) == 2
+    assert list(Document.objects.filter_for_list(toplevel=True)) == [root_doc]
+
+
+def test_documents_filter_for_review(create_revision):
+    """filter_for_review can filter all documents with a review tag."""
+    assert len(Document.objects.filter_for_review()) == 0
+
+    create_revision.review_tags.set('tag')
+    doc = create_revision.document
+    assert list(Document.objects.filter_for_review()) == [doc]
+
+
+def test_documents_filter_for_review_by_locale(create_revision, trans_revision):
+    """filter_for_review can filter by locale."""
+    create_revision.review_tags.set('tag')
+    trans_revision.review_tags.set('other_tag')
+    assert len(Document.objects.filter_for_review()) == 2
+
+    doc = create_revision.document
+    resp = list(Document.objects.filter_for_review(locale=doc.locale))
+    assert resp == [doc]
+
+
+def test_documents_filter_for_review_by_tag_name(create_revision):
+    """filter_for_review can filter by ReviewTtag name."""
+    assert len(Document.objects.filter_for_review(tag_name='editorial')) == 0
+    assert len(Document.objects.filter_for_review(tag_name='technical')) == 0
+
+    create_revision.review_tags.set('editorial')
+    resp = list(Document.objects.filter_for_review(tag_name='editorial'))
+    assert resp == [create_revision.document]
+    assert len(Document.objects.filter_for_review(tag_name='technical')) == 0
+
+
+def test_documents_filter_for_review_by_tag(create_revision):
+    """filter_for_review can filter by ReviewTag instance."""
+    editorial, _ = ReviewTag.objects.get_or_create(name='editorial')
+    technical, _ = ReviewTag.objects.get_or_create(name='technical')
+    assert len(Document.objects.filter_for_review(tag=editorial)) == 0
+    assert len(Document.objects.filter_for_review(tag=technical)) == 0
+
+    create_revision.review_tags.add(technical)
+    assert len(Document.objects.filter_for_review(tag=editorial)) == 0
+    resp = list(Document.objects.filter_for_review(tag=technical))
+    assert resp == [create_revision.document]
+
+
+def test_documents_filter_for_review_includes_redirects(redirect_doc):
+    """bug 1274874: filter_for_review includes redirects."""
+    redirect_doc.current_revision.review_tags.set('editorial')
+    resp = Document.objects.filter_for_review(tag_name='editorial')
+    assert list(resp) == [redirect_doc]
+
+
+def test_documents_filter_for_review_includes_archive(archive_doc):
+    """bug 1274874: filter_for_review includes archive documents."""
+    archive_doc.current_revision.review_tags.set('editorial')
+    resp = Document.objects.filter_for_review(tag_name='editorial')
+    assert list(resp) == [archive_doc]
+
+
+def test_documents_filter_with_localization_tag(create_revision):
+    """filter_with_localization_tag can filter all documents."""
+    assert len(Document.objects.filter_with_localization_tag()) == 0
+
+    create_revision.localization_tags.set('tag')
+    doc = create_revision.document
+    assert list(Document.objects.filter_with_localization_tag()) == [doc]
+
+
+def test_documents_filter_with_localization_tag_by_locale(create_revision,
+                                                          trans_revision):
+    """filter_with_localization_tag can filter by locale."""
+    create_revision.localization_tags.set('tag')
+    trans_revision.localization_tags.set('other_tag')
+    assert len(Document.objects.filter_with_localization_tag()) == 2
+
+    doc = create_revision.document
+    resp = Document.objects.filter_with_localization_tag(locale=doc.locale)
+    assert list(resp) == [doc]
+
+
+def test_documents_filter_with_localization_tag_by_tag_name(create_revision):
+    """filter_with_localization_tag can filter by LocalizationTag name."""
+    tag = 'inprogress'
+    resp = Document.objects.filter_with_localization_tag(tag_name=tag)
+    assert len(resp) == 0
+
+    create_revision.localization_tags.set('inprogress')
+    resp = Document.objects.filter_with_localization_tag(tag_name=tag)
+    assert list(resp) == [create_revision.document]
+
+
+def test_documents_filter_with_localization_tag_by_tag(create_revision):
+    """filter_with_localization_tag can filter by the instance."""
+    inprogress = LocalizationTag.objects.create(name='inprogress')
+    resp = Document.objects.filter_with_localization_tag(tag=inprogress)
+    assert len(resp) == 0
+
+    create_revision.localization_tags.add(inprogress)
+    resp = Document.objects.filter_with_localization_tag(tag=inprogress)
+    assert list(resp) == [create_revision.document]
+
+
+def test_documents_filter_with_localization_tag_includes_redirects(
+        redirect_doc):
+    """bug 1274874: filter_with_localization_tag includes redirects."""
+    tag = 'inprogress'
+    redirect_doc.current_revision.localization_tags.set(tag)
+    resp = Document.objects.filter_with_localization_tag(tag_name=tag)
+    assert list(resp) == [redirect_doc]
+
+
+def test_documents_filter_with_localization_tag_includes_archive(archive_doc):
+    """bug 1274874: filter_with_localization_tag includes archive docs."""
+    tag = 'inprogress'
+    archive_doc.current_revision.localization_tags.set(tag)
+    resp = Document.objects.filter_with_localization_tag(tag_name=tag)
+    assert list(resp) == [archive_doc]

--- a/kuma/wiki/tests/test_managers.py
+++ b/kuma/wiki/tests/test_managers.py
@@ -177,18 +177,18 @@ def test_documents_filter_for_review_by_tag(create_revision):
     assert resp == [create_revision.document]
 
 
-def test_documents_filter_for_review_includes_redirects(redirect_doc):
-    """bug 1274874: filter_for_review includes redirects."""
+def test_documents_filter_for_review_excludes_redirects(redirect_doc):
+    """bug 1274874: filter_for_review excludes redirects."""
     redirect_doc.current_revision.review_tags.set('editorial')
     resp = Document.objects.filter_for_review(tag_name='editorial')
-    assert list(resp) == [redirect_doc]
+    assert len(resp) == 0
 
 
-def test_documents_filter_for_review_includes_archive(archive_doc):
-    """bug 1274874: filter_for_review includes archive documents."""
+def test_documents_filter_for_review_excludes_archive(archive_doc):
+    """bug 1274874: filter_for_review excludes archive documents."""
     archive_doc.current_revision.review_tags.set('editorial')
     resp = Document.objects.filter_for_review(tag_name='editorial')
-    assert list(resp) == [archive_doc]
+    assert len(resp) == 0
 
 
 def test_documents_filter_with_localization_tag(create_revision):
@@ -234,18 +234,18 @@ def test_documents_filter_with_localization_tag_by_tag(create_revision):
     assert list(resp) == [create_revision.document]
 
 
-def test_documents_filter_with_localization_tag_includes_redirects(
+def test_documents_filter_with_localization_tag_excludes_redirects(
         redirect_doc):
-    """bug 1274874: filter_with_localization_tag includes redirects."""
+    """bug 1274874: filter_with_localization_tag excludes redirects."""
     tag = 'inprogress'
     redirect_doc.current_revision.localization_tags.set(tag)
     resp = Document.objects.filter_with_localization_tag(tag_name=tag)
-    assert list(resp) == [redirect_doc]
+    assert len(resp) == 0
 
 
-def test_documents_filter_with_localization_tag_includes_archive(archive_doc):
-    """bug 1274874: filter_with_localization_tag includes archive docs."""
+def test_documents_filter_with_localization_tag_excludes_archive(archive_doc):
+    """bug 1274874: filter_with_localization_tag excludes archive docs."""
     tag = 'inprogress'
     archive_doc.current_revision.localization_tags.set(tag)
     resp = Document.objects.filter_with_localization_tag(tag_name=tag)
-    assert list(resp) == [archive_doc]
+    assert len(resp) == 0

--- a/kuma/wiki/tests/test_managers.py
+++ b/kuma/wiki/tests/test_managers.py
@@ -61,7 +61,9 @@ def test_get_natural_key(root_doc):
     ('User:ethertank',
      'Talk:Developer_Guide/Build_Instructions/Windows_Prerequisites',
      'User_talk:ethertank',
-     'Template_talk:anch'))
+     'Template_talk:anch',
+     'Project_talk:To-do_list',
+     ))
 def test_documents_filter_for_list_exclude_slug_prefixes(root_doc, legacy_slug):
     """filter_for_list excludes some slug prefixes."""
     Document.objects.create(locale='en-US', slug=legacy_slug)

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -31,7 +31,6 @@ def documents(request, tag=None):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'tag': tag,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -97,7 +96,6 @@ def with_errors(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'errors': True,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -112,7 +110,6 @@ def without_parent(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'noparent': True,
     }
     return render(request, 'wiki/list/documents.html', context)
@@ -127,7 +124,6 @@ def top_level(request):
     paginated_docs = paginate(request, docs, per_page=DOCUMENTS_PER_PAGE)
     context = {
         'documents': paginated_docs,
-        'count': docs.count(),
         'toplevel': True,
     }
     return render(request, 'wiki/list/documents.html', context)


### PR DESCRIPTION
Improve special views that return a list of documents:

* Reduce data returned from database to that used in the page
* Eliminate second ``COUNT(*)`` query
* Remove redirects, user pages, and archive pages from the "needs review" and "needs translation" lists.

To Do:
* [x] Add tests for manager methods

This was originally PR #4378. These views are even slower post-AWS.