### PR TITLE
bug 1409119: do not use cached layers when building ks image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,8 @@ build-kuma:
 	-f docker/images/kuma/Dockerfile -t ${KUMA_IMAGE} .
 
 build-kumascript:
-	docker build --build-arg REVISION_HASH=${KUMASCRIPT_REVISION_HASH} \
+	docker build --no-cache \
+	--build-arg REVISION_HASH=${KUMASCRIPT_REVISION_HASH} \
 	-f docker/images/kumascript/Dockerfile -t ${KUMASCRIPT_IMAGE} .
 
 build: build-base build-kuma build-kumascript


### PR DESCRIPTION
This PR ensures that the "npm update" command is always freshly run when building the Kumascript Docker image.