### PR TITLE
return unused fixtures from root to wiki conftest

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -1,14 +1,10 @@
 from datetime import datetime
-from collections import namedtuple
 
 import pytest
 from django.conf import settings
 from django.core.cache import caches
 
 from kuma.wiki.models import Document, Revision
-
-
-BannedUser = namedtuple('BannedUser', 'user ban')
 
 
 @pytest.fixture()
@@ -26,46 +22,6 @@ def wiki_user(db, django_user_model):
 
 
 @pytest.fixture
-def wiki_user_2(db, django_user_model):
-    """A second test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_2',
-        email='wiki_user_2@example.com',
-        date_joined=datetime(2017, 4, 17, 10, 30))
-
-
-@pytest.fixture
-def wiki_user_3(db, django_user_model):
-    """A third test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_3',
-        email='wiki_user_3@example.com',
-        date_joined=datetime(2017, 4, 23, 11, 45))
-
-
-@pytest.fixture
-def inactive_wiki_user(db, django_user_model):
-    """An inactive test user."""
-    return django_user_model.objects.create(
-        is_active=False,
-        username='wiki_user_slacker',
-        email='wiki_user_slacker@example.com',
-        date_joined=datetime(2017, 4, 19, 10, 58))
-
-
-@pytest.fixture
-def banned_wiki_user(db, django_user_model, wiki_user):
-    """A banned test user."""
-    user = django_user_model.objects.create(
-        username='bad_wiki_user',
-        email='bad_wiki_user@example.com',
-        date_joined=datetime(2017, 4, 18, 9, 15)
-    )
-    ban = user.bans.create(by=wiki_user, reason='because')
-    return BannedUser(user=user, ban=ban)
-
-
-@pytest.fixture
 def root_doc(wiki_user):
     """A newly-created top-level English document."""
     root_doc = Document.objects.create(
@@ -77,9 +33,3 @@ def root_doc(wiki_user):
         title='Root Document',
         created=datetime(2017, 4, 14, 12, 15))
     return root_doc
-
-
-@pytest.fixture
-def create_revision(root_doc):
-    """A revision that created an English document."""
-    return root_doc.revisions.first()

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -10,6 +10,7 @@ import pytest
 from ..models import Document, DocumentZone, Revision
 
 
+BannedUser = namedtuple('BannedUser', 'user ban')
 Contributors = namedtuple('Contributors', 'valid banned inactive')
 DocWithContributors = namedtuple('DocWithContributors', 'doc contributors')
 DocHierarchy = namedtuple('DocHierarchy', 'top middle_top middle_bottom bottom')
@@ -17,6 +18,52 @@ KumaScriptToolbox = namedtuple(
     'KumaScriptToolbox',
     'errors errors_as_headers macros_response'
 )
+
+
+@pytest.fixture
+def wiki_user_2(db, django_user_model):
+    """A second test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_2',
+        email='wiki_user_2@example.com',
+        date_joined=datetime(2017, 4, 17, 10, 30))
+
+
+@pytest.fixture
+def wiki_user_3(db, django_user_model):
+    """A third test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_3',
+        email='wiki_user_3@example.com',
+        date_joined=datetime(2017, 4, 23, 11, 45))
+
+
+@pytest.fixture
+def inactive_wiki_user(db, django_user_model):
+    """An inactive test user."""
+    return django_user_model.objects.create(
+        is_active=False,
+        username='wiki_user_slacker',
+        email='wiki_user_slacker@example.com',
+        date_joined=datetime(2017, 4, 19, 10, 58))
+
+
+@pytest.fixture
+def banned_wiki_user(db, django_user_model, wiki_user):
+    """A banned test user."""
+    user = django_user_model.objects.create(
+        username='bad_wiki_user',
+        email='bad_wiki_user@example.com',
+        date_joined=datetime(2017, 4, 18, 9, 15)
+    )
+    ban = user.bans.create(by=wiki_user, reason='because')
+    return BannedUser(user=user, ban=ban)
+
+
+@pytest.fixture
+def create_revision(root_doc):
+    """A revision that created an English document."""
+    return root_doc.revisions.first()
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR is meant to be a follow-on to https://github.com/mozilla/kuma/pull/4461 to address the review comments. Without getting into the details, all of the requested changes were problematic except for the change in this PR (limit root-level `conftest.py` to fixtures that are actually needed at that level).