### PR TITLE
Bug 1407806 - Remove Vary: Cookie header

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -184,7 +184,7 @@ def test_legacy_redirect(client, file_attachment):
     assert response.status_code == 301
     assert 'Location' in response
     assert response['Location'] == file_attachment['attachment'].get_file_url()
-    assert response['Vary'] == 'Cookie'
+    assert 'Vary' not in response
 
 
 def test_edit_attachment_get(admin_client, root_doc):

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -184,6 +184,7 @@ def test_legacy_redirect(client, file_attachment):
     assert response.status_code == 301
     assert 'Location' in response
     assert response['Location'] == file_attachment['attachment'].get_file_url()
+    assert response['Vary'] == 'Cookie'
 
 
 def test_edit_attachment_get(admin_client, root_doc):

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -34,10 +34,6 @@ def raw_file(request, attachment_id, filename):
     """
     Serve up an attachment's file.
     """
-
-    # Stop SessionMiddleware from adding "Cookie" to the "Vary" header.
-    request.session.accessed = False
-
     qs = Attachment.objects.select_related('current_revision')
     attachment = get_object_or_404(qs, pk=attachment_id)
     if attachment.current_revision is None:

--- a/kuma/users/tests/test_middleware.py
+++ b/kuma/users/tests/test_middleware.py
@@ -1,27 +1,48 @@
 from email.utils import parsedate
 from time import gmtime
 
-from . import UserTestCase
-from ..models import UserBan
+from ..models import User, UserBan
+
+import pytest
 
 
-class BanTestCase(UserTestCase):
-    localizing_client = True
+@pytest.fixture()
+def test_user(db):
+    return User.objects.create(username='user', email='user@example.com')
 
-    def test_ban_middleware(self):
-        """Ban middleware functions correctly."""
-        self.client.login(username='testuser', password='testpass')
 
-        resp = self.client.get('/')
-        self.assertTemplateNotUsed(resp, 'users/user_banned.html')
+@pytest.fixture()
+def user_client(test_user, client):
+    test_user.set_password('password')
+    test_user.save()
+    client.login(username='user', password='password')
+    return client
 
-        admin = self.user_model.objects.get(username='admin')
-        testuser = self.user_model.objects.get(username='testuser')
-        ban = UserBan(user=testuser, by=admin,
-                      reason='Banned by unit test.',
-                      is_active=True)
-        ban.save()
 
-        resp = self.client.get('/')
-        self.assertTemplateUsed(resp, 'users/user_banned.html')
-        assert parsedate(resp['Expires']) <= gmtime()
+def test_ban_middleware_anon_user(db, client):
+    resp = client.get('/en-US/')
+    assert resp.status_code == 200
+    templates = [template.name for template in resp.templates]
+    assert 'users/user_banned.html' not in templates
+    assert resp['Vary'] == 'Cookie'
+
+
+def test_ban_middleware_unbanned_user(user_client):
+    resp = user_client.get('/en-US/')
+    assert resp.status_code == 200
+    templates = [template.name for template in resp.templates]
+    assert 'users/user_banned.html' not in templates
+    assert resp['Vary'] == 'Cookie'
+
+
+def test_ban_middleware_banned_user(test_user, user_client, admin_user):
+    UserBan.objects.create(user=test_user, by=admin_user,
+                           reason='Banned by unit test.', is_active=True)
+    resp = user_client.get('/en-US/')
+    assert resp.status_code == 200
+    templates = [template.name for template in resp.templates]
+    assert 'users/user_banned.html' in templates
+    assert parsedate(resp['Expires']) <= gmtime()
+    assert not resp.has_header('Vary')
+    never_cache = 'no-cache, no-store, must-revalidate, max-age=0'
+    assert resp['Cache-Control'] == never_cache

--- a/kuma/users/tests/test_middleware.py
+++ b/kuma/users/tests/test_middleware.py
@@ -24,7 +24,7 @@ def test_ban_middleware_anon_user(db, client):
     assert resp.status_code == 200
     templates = [template.name for template in resp.templates]
     assert 'users/user_banned.html' not in templates
-    assert resp['Vary'] == 'Cookie'
+    assert not resp.has_header('Vary')
 
 
 def test_ban_middleware_unbanned_user(user_client):


### PR DESCRIPTION
The ``BanMiddleware`` calls ``request.user.is_authenticated`` to check if a user is a banned user. However, this accesses the session, and the ``SessionMiddleware`` adds a ``Vary: Cookie`` header to all requests.  @escattone discovered and fixed this in PR #4461 by clearing ``request.session.accessed``.  This PR fixes the root cause, and confirms the ``/files/`` and ``@api`` methods both exclude a ``Vary: Cookie`` header.