### PR TITLE
Use current STATIC_URL setting in test

### DIFF
--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -295,7 +295,8 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
 
     # src attribute of the content experiment <script> tag
     # Can't use pyquery for <head> elements
-    script_src = 'src="/static/build/js/experiment-framework-test.js"'
+    script_src = ('src="%sbuild/js/experiment-framework-test.js"' %
+                  settings.STATIC_URL)
 
     # Googla Analytics custom dimension calls
     expected_15 = "ga('set', 'dimension15', 'experiment-test:test')"


### PR DESCRIPTION
The path of the experiment JS can change due to STATIC_URL, which can now be set from the environment.