### PR TITLE
bug 1409894: fix header/footer for dev env

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,5 +1,5 @@
 {% from "includes/common_macros.html" import optimizely_script with context -%}
-{% set untrusted = request.get_host() == settings.ATTACHMENT_HOST %}
+{% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() == settings.ATTACHMENT_HOST) %}
 
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false">


### PR DESCRIPTION
I overlooked conditioning `untrusted` in the `base.html` template with the `ENABLE_RESTRICTIONS_BY_HOST` setting, which broke the default local development environment 😞. This PR fixes that.