### PR TITLE
bug 1407806: add cache-control header to untrusted wiki endpoints

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -201,7 +201,6 @@ def test_edit_attachment_get(admin_client, root_doc):
 
 def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     settings.ATTACHMENT_HOST = 'demos'
-    settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE = 3600
     attachment = file_attachment['attachment']
     created = attachment.current_revision.created
     url = attachment.get_file_url()
@@ -220,13 +219,12 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert response['Last-Modified'] == convert_to_http_date(created)
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
-    assert 'max-age=3600' in response['Cache-Control']
+    assert 'max-age=300' in response['Cache-Control']
     assert 'Vary' not in response
 
 
 def test_raw_file_if_modified_since(client, settings, file_attachment):
     settings.ATTACHMENT_HOST = 'demos'
-    settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE = 3600
     attachment = file_attachment['attachment']
     created = attachment.current_revision.created
     url = attachment.get_file_url()
@@ -241,5 +239,5 @@ def test_raw_file_if_modified_since(client, settings, file_attachment):
     assert response['Last-Modified'] == convert_to_http_date(created)
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
-    assert 'max-age=3600' in response['Cache-Control']
+    assert 'max-age=300' in response['Cache-Control']
     assert 'Vary' not in response

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -45,8 +45,7 @@ def raw_file(request, attachment_id, filename):
         def get_last_modified(*args):
             return convert_to_utc(rev.created)
 
-        @cache_control(public=True,
-                       max_age=settings.ATTACHMENTS_CACHE_CONTROL_MAX_AGE)
+        @cache_control(public=True, max_age=60 * 5)
         @last_modified(get_last_modified)
         def stream_raw_file(*args):
             if settings.DEBUG:

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1241,7 +1241,17 @@ MAX_FILEPATH_LENGTH = 250
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
 ATTACHMENTS_CACHE_CONTROL_MAX_AGE = config(
     'ATTACHMENTS_CACHE_CONTROL_MAX_AGE',
-    default=300,
+    default=60 * 5,
+    cast=int
+)
+CODE_SAMPLES_CACHE_CONTROL_MAX_AGE = config(
+    'CODE_SAMPLES_CACHE_CONTROL_MAX_AGE',
+    default=60 * 60 * 24,
+    cast=int
+)
+CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE = config(
+    'CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE',
+    default=60 * 60 * 24 * 5,
     cast=int
 )
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1239,21 +1239,6 @@ MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
-ATTACHMENTS_CACHE_CONTROL_MAX_AGE = config(
-    'ATTACHMENTS_CACHE_CONTROL_MAX_AGE',
-    default=60 * 5,
-    cast=int
-)
-CODE_SAMPLES_CACHE_CONTROL_MAX_AGE = config(
-    'CODE_SAMPLES_CACHE_CONTROL_MAX_AGE',
-    default=60 * 60 * 24,
-    cast=int
-)
-CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE = config(
-    'CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE',
-    default=60 * 60 * 24 * 5,
-    cast=int
-)
 
 # This should never be false for the production and stage deployments.
 ENABLE_RESTRICTIONS_BY_HOST = config(

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -70,7 +70,6 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
     assert not response.has_header('Vary')
     assert 'Last-Modified' not in response
     assert 'ETag' in response
-    assert response['ETag'] == '"afc6fe6de98e9426818b7779f57c42ed"'
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']
@@ -86,25 +85,19 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
         % settings.STATIC_URL)
     assert normalized == expected
 
+    current_etag = response['ETag']
 
-def test_code_sample_if_none_match(code_sample_doc, constance_config, client,
-                                   settings):
-    """The ETag header is."""
-    Switch.objects.create(name='application_ACAO', active=True)
-    url = reverse('wiki.code_sample', locale='en-US',
-                  args=[code_sample_doc.slug, 'sample1'])
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*testserver'
     response = client.get(
         url,
         HTTP_HOST='testserver',
-        HTTP_IF_NONE_MATCH='"afc6fe6de98e9426818b7779f57c42ed"'
+        HTTP_IF_NONE_MATCH=current_etag
     )
     assert response.status_code == 304
     assert response['Access-Control-Allow-Origin'] == '*'
     assert 'Vary' not in response
     assert 'Last-Modified' not in response
     assert 'ETag' in response
-    assert response['ETag'] == '"afc6fe6de98e9426818b7779f57c42ed"'
+    assert response['ETag'] == current_etag
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']

--- a/kuma/wiki/views/code.py
+++ b/kuma/wiki/views/code.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 import re
+import hashlib
 
-from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.clickjacking import xframe_options_exempt
-from django.views.decorators.http import require_GET
+from django.views.decorators.http import require_GET, etag
 from django.views.decorators.cache import cache_control
 
 from constance import config
@@ -20,10 +20,6 @@ from ..models import Document
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
-@cache_control(
-    public=True,
-    max_age=settings.CODE_SAMPLES_CACHE_CONTROL_MAX_AGE
-)
 def code_sample(request, document_slug, document_locale, sample_name):
     """
     Extract a code sample from a document and render it as a standalone
@@ -39,17 +35,24 @@ def code_sample(request, document_slug, document_locale, sample_name):
     job = DocumentCodeSampleJob(generation_args=[document.pk])
     data = job.get(document.pk, sample_name)
     data['document'] = document
-    return render(request, 'wiki/code_sample.html', data)
+    response = render(request, 'wiki/code_sample.html', data)
+
+    def get_etag(*args):
+        return '{}'.format(hashlib.md5(response.content).hexdigest())
+
+    @cache_control(public=True, max_age=60 * 60 * 24)
+    @etag(get_etag)
+    def render_code_sample(request, *args):
+        return response
+
+    return render_code_sample(request)
 
 
 @require_GET
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
-@cache_control(
-    public=True,
-    max_age=settings.CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE
-)
+@cache_control(public=True, max_age=60 * 60 * 24 * 5)
 def raw_code_sample_file(request, document_slug, document_locale,
                          sample_name, attachment_id, filename):
     """

--- a/kuma/wiki/views/code.py
+++ b/kuma/wiki/views/code.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 import re
 
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_GET
+from django.views.decorators.cache import cache_control
 
 from constance import config
 
@@ -18,6 +20,10 @@ from ..models import Document
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
+@cache_control(
+    public=True,
+    max_age=settings.CODE_SAMPLES_CACHE_CONTROL_MAX_AGE
+)
 def code_sample(request, document_slug, document_locale, sample_name):
     """
     Extract a code sample from a document and render it as a standalone
@@ -40,6 +46,10 @@ def code_sample(request, document_slug, document_locale, sample_name):
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
+@cache_control(
+    public=True,
+    max_age=settings.CODE_SAMPLE_FILE_REDIRECT_CACHE_CONTROL_MAX_AGE
+)
 def raw_code_sample_file(request, document_slug, document_locale,
                          sample_name, attachment_id, filename):
     """


### PR DESCRIPTION
This PR ensures that all of the remaining untrusted-domain endpoints appropriately set (or not) the `Cache-Control` header:

1. `attachments.raw_file` (e.g., https://mdn.mozillademos.org/files/12984/web-font-example.png)
    - The appropriate cache-control headers (public, 5-minute default max age that can be modified from settings) and handling (last-modified) have already been applied.
1. `attachments.mindtouch_file_redirect` (e.g., https://developer.mozilla.org/@api/deki/files/2926/=AudioTest_(1).ogg)
    - The response is always a permanent redirect (to the `attachments.raw_file` endpoint). There is no need for cache-control headers since the response will always be permanently cached.
1. `wiki.code_sample`(e.g., https://mdn.mozillademos.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color):
    - The response is dynamically-rendered HTML that depends on two things: the `wiki/code-sample.html` template, and the code sample extracted from the document.
    - We can add `public` and some `max-age` to the cache-control header, but I'm not sure what the best approach (`ETag` or `Last-Modified`), if any, is in terms of handling validation.
        - It seems to me we can't use the `Last-Modified` approach unless we cheat. We'd have to use the `max` of the two dates, one for the document and one for the template, but I don't think there's a fast and reliable way to get the last-modified date of a template. We could cheat and just use the last-modified date of the document, assuming that the template will rarely change, but we'd need a way to invalidate the cache in the rare event of a template change.
        - If we use the `ETag` approach, we'd have to select a way to generate its value. We could generate a SHA1 (or other) hash of the rendered HTML and use that, but that doesn't save much (if any) since we still must perform a complete render on validation requests and we're adding the hash computation as well.
    - This PR chooses, for now, to exclude the `ETag` and/or `Last-Modified` headers, and simply sets a max-age setting for code samples, using `Cache-Control: public, max-age=X` (where X defaults to 24 hours and can be modified from the settings).
1. `wiki.raw_code_sample_file` (e.g., `https://mdn.mozillademos.org/en-US/docs/Learn/CSS/Styling_text/Fundamentals$samples/Color/files/<id>/<filename>`)
    - The response is a temporary redirect (to the `attachments.raw_file` endpoint), so this PR sets the cache-control header to `public` with a default `max-age` of 5 days (which can be modified from the settings).

I've submitted this PR without tests in order to start the discussion of this approach right away.