### PR TITLE
bug 1411098: Remove bare exceptions

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -15,6 +15,7 @@ from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
 
+from .exceptions import DocumentRenderedContentNotAvailable
 from .utils import locale_and_slug_from_path
 
 
@@ -121,7 +122,7 @@ class Extractor(object):
             src, errors = self.document.get_rendered()
             if errors:
                 src = self.document.html
-        except:
+        except DocumentRenderedContentNotAvailable:
             src = self.document.html
 
         if not src:

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -68,16 +68,12 @@ class Extractor(object):
         """
         Extract a unique set of KumaScript macro names used in the content
         """
-        names = set()
-        try:
-            txt = []
-            for token in parse(self.document.html).stream:
-                if token['type'] in ('Characters', 'SpaceCharacters'):
-                    txt.append(token['data'])
-            txt = ''.join(txt)
-            names.update(MACRO_RE.findall(txt))
-        except:
-            pass
+        text_items = []
+        for token in parse(self.document.html).stream:
+            if token['type'] in ('Characters', 'SpaceCharacters'):
+                text_items.append(token['data'])
+        text = ''.join(text_items)
+        names = set(MACRO_RE.findall(text))
         return list(names)
 
     @newrelic.agent.function_trace()
@@ -97,15 +93,12 @@ class Extractor(object):
         """
         Extract the unique set of HTML attributes used in the content
         """
-        try:
-            attribs = []
-            for token in parse(self.document.rendered_html).stream:
-                if token['type'] == 'StartTag':
-                    for (namespace, name), value in token['data'].items():
-                        attribs.append((name, value))
-            return ['%s="%s"' % (k, v) for k, v in attribs]
-        except:
-            return []
+        attribs = []
+        for token in parse(self.document.rendered_html).stream:
+            if token['type'] == 'StartTag':
+                for (namespace, name), value in token['data'].items():
+                    attribs.append((name, value))
+        return ['%s="%s"' % (k, v) for k, v in attribs]
 
     @newrelic.agent.function_trace()
     def code_sample(self, name):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -137,15 +137,15 @@ urllib3==1.22 \
 # flake8
 configparser==3.5.0 \
     --hash=sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a
-mccabe==0.5.2 \
-    --hash=sha256:91cc38b2c7636aaf1903e06d96ee960fb3dff9ca3afc595627c9a638f8e86d2b \
-    --hash=sha256:3473f06c8b757bbb5cdf295099bf64032e5f7d6fe0ec2f97ee9b23cb0a435aff
-pycodestyle==2.1.0 \
-    --hash=sha256:14588a4a51f464b784eb199ade0a04103e93f9ed7d69551f29f295a9e9668030 \
-    --hash=sha256:5b540e4f19b4938c082cfd13f5d778d1ad2308b337abbc687ab9335233f5f3e2
-pyflakes==1.3.0 \
-    --hash=sha256:ad89dafee8ca32282116209a0ca4dff050bdc343af958721d5517d242c1215d5 \
-    --hash=sha256:a4f93317c97a9d9ed71d6ecfe08b68e3de9fea3f4d94dcd1d9d83ccbf929bc31
+mccabe==0.6.1 \
+    --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
+    --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
+pycodestyle==2.3.1 \
+    --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
+    --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766
+pyflakes==1.6.0 \
+    --hash=sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f \
+    --hash=sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805
 
 # google-api-python-client
 httplib2==0.9.2 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,9 +12,9 @@ django-debug-toolbar==1.8 \
     --hash=sha256:0b4d2b1ac49a8bc5604518e8e20f56c1c08c0c4873336107e7c773c42537876b
 
 # Code quality checker
-flake8==3.1.1 \
-    --hash=sha256:898dd353948860c25569cc2298942d20f021021d920dc553dc35f732ee647794 \
-    --hash=sha256:941fa78f61f2524cb7aee4aa4fe9876f4b0dcf5aba9fabd3e780d24918f498b7
+flake8==3.5.0 \
+    --hash=sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37 \
+    --hash=sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
 
 # Calculate hashes for pip 8.x+
 hashin==0.11.2 \

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -1,4 +1,5 @@
 from pypom import Region
+from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -29,9 +30,9 @@ class DashboardPage(BasePage):
     def is_ip_toggle_present(self):
         try:
             self.find_element(*self._ip_toggle_locator)
-            return True
-        except:
+        except NoSuchElementException:
             return False
+        return True
 
     @property
     def first_row(self):
@@ -113,17 +114,17 @@ class DashboardRow(Region):
     def is_ip_ban_present(self):
         try:
             self.find_element(*self._ban_ip_locator)
-            return True
-        except:
+        except NoSuchElementException:
             return False
+        return True
 
     @property
     def is_spam_ham_button_present(self):
         try:
             self.find_element(*self._spam_ham_button_locator)
-            return True
-        except:
+        except NoSuchElementException:
             return False
+        return True
 
 
 class DashboardDetail(Region):


### PR DESCRIPTION
Remove the 3 types of bare exceptions, removing some and making others focused exception handlers:

* In ``kuma/wiki/content.py``, remove some exception handlers that are no longer needed with our current HTML parsing methods. Tested by parsing an empty string, ``None``, and all the current MDN docs.
* In ``kuma/wiki/content.py``, handle the ``DocumentRenderedContentNotAvailable`` that can be raised by ``Document.get_rendered()``
* In ``tests/pages/dashboard.py``, detect that an element isn't present by catching ``NoSuchElementException``, rather than any exception

Update ``flake8`` and dependencies, to reflect the tools that TravisCI is installing.