### PR TITLE
bug 1411675: add setting for ATTACHMENT_ORIGIN

### DIFF
--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -8,6 +8,7 @@ from django.views.decorators.http import last_modified
 from django.views.decorators.cache import cache_control
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 
+from kuma.core.utils import is_untrusted
 from kuma.core.decorators import login_required
 from kuma.wiki.models import Document
 from kuma.wiki.decorators import process_document_path
@@ -39,7 +40,7 @@ def raw_file(request, attachment_id, filename):
     if attachment.current_revision is None:
         raise Http404
 
-    if request.get_host() == settings.ATTACHMENT_HOST:
+    if is_untrusted(request):
         rev = attachment.current_revision
 
         def get_last_modified(*args):

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -10,7 +10,7 @@ from django.contrib.sessions.middleware import SessionMiddleware
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 from .urlresolvers import Prefixer, set_url_prefixer, split_path
-from .utils import urlparams
+from .utils import urlparams, is_untrusted
 from .views import handler403
 
 
@@ -175,8 +175,7 @@ class RestrictedEndpointsMiddleware(object):
         """
         Restricts the accessible endpoints based on the host.
         """
-        if (settings.ENABLE_RESTRICTIONS_BY_HOST and
-                (request.get_host() == settings.ATTACHMENT_HOST)):
+        if settings.ENABLE_RESTRICTIONS_BY_HOST and is_untrusted(request):
             request.urlconf = 'kuma.urls_untrusted'
 
 
@@ -186,8 +185,7 @@ class RestrictedWhiteNoiseMiddleware(WhiteNoiseMiddleware):
         """
         Restricts the use of WhiteNoiseMiddleware based on the host.
         """
-        if (settings.ENABLE_RESTRICTIONS_BY_HOST and
-                (request.get_host() == settings.ATTACHMENT_HOST)):
+        if settings.ENABLE_RESTRICTIONS_BY_HOST and is_untrusted(request):
             return None
         return super(RestrictedWhiteNoiseMiddleware, self).process_request(
             request

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -33,6 +33,13 @@ from .jobs import IPBanJob
 log = logging.getLogger('kuma.core.utils')
 
 
+def is_untrusted(request):
+    return request.get_host() in (
+        settings.ATTACHMENT_ORIGIN,
+        settings.ATTACHMENT_HOST,
+    )
+
+
 def paginate(request, queryset, per_page=20):
     """Get a Paginator, abstracting some common paging actions."""
     paginator = Paginator(queryset, per_page)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1239,6 +1239,7 @@ MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
+ATTACHMENT_ORIGIN = config('ATTACHMENT_ORIGIN', default=ATTACHMENT_HOST)
 
 # This should never be false for the production and stage deployments.
 ENABLE_RESTRICTIONS_BY_HOST = config(


### PR DESCRIPTION
This PR adds a new setting that allows the use of a CDN for the untrusted-domain endpoints. Companion to https://github.com/mozmeao/infra/pull/623.