### PR TITLE
Bug 1070001: Separate large file into small ones

### DIFF
--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -2,16 +2,83 @@
 
 /*
 Additional formatting for the real page content; i.e. text in the <main> element
-We cannot put these styles in the tags.styl file because they don't apply to the entire layout
+We cannot put these styles in the base/elements/ files because they don't apply to the entire layout
 ********************************************************************** */
-
-$table-blue: #d4dde4;
-$table-cell-border: 2px solid #fff;
 
 .text-content {
 
     /*
-    headings
+    lists
+    ====================================================================== */
+
+    ul,
+    ol,
+    dl {
+        @include restrict-line-length();
+    }
+
+    ul {
+        list-style: disc;
+
+        ul {
+            list-style: circle;
+        }
+    }
+
+    ul ul,
+    ol ol,
+    ul ol,
+    ol ul {
+        margin-bottom: 0;
+        padding-top: $content-vertical-spacing;
+    }
+
+    ul,
+    ol {
+        @include bidi-style(padding-left, ($grid-spacing * 2), padding-right, 0);
+        margin-bottom: $content-block-margin;
+
+        &.no-bullets {
+            list-style-type: none;
+            @include bidi-style(padding-left, 0, padding-right, 0);
+        }
+    }
+
+    ol {
+        list-style-type: decimal;
+    }
+
+    li {
+        margin-bottom: $content-vertical-spacing;
+    }
+    @include prevent-last-child-spacing(li, padding-bottom);
+
+    dt {
+        font-style: normal;
+        font-weight: bold;
+    }
+
+    dd {
+        margin-bottom: $content-block-margin;
+        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+    }
+
+    /*
+    media
+    ====================================================================== */
+
+    img {
+        &.lwrap {
+            padding: 0 20px 10px 0;
+        }
+
+        &.rwrap {
+            padding: 0 0 10px 20px;
+        }
+    }
+
+    /*
+    sectioning
     ====================================================================== */
 
     h2 {
@@ -19,26 +86,14 @@ $table-cell-border: 2px solid #fff;
     }
 
     /*
-    content width restrictions
-    ====================================================================== */
-
-    p,
-    ul,
-    ol,
-    dl {
-        @include restrict-line-length();
-    }
-
-    table,
-    pre {
-        @include full-width-content();
-    }
-
-    /*
     tables
     ====================================================================== */
 
+    $table-blue: #d4dde4;
+    $table-cell-border: 2px solid #fff;
+
     table {
+        @include full-width-content();
         border-collapse: collapse;
         border: solid #e0e0dc;
         border-width: 1px 0 0 1px;
@@ -111,129 +166,22 @@ $table-cell-border: 2px solid #fff;
     }
 
     /*
-    lists and definitions
+    typography
     ====================================================================== */
-    ul {
-        list-style: disc;
 
-        ul {
-            list-style: circle;
-        }
+    p {
+        @include restrict-line-length();
     }
 
-    ul ul,
-    ol ol,
-    ul ol,
-    ol ul {
-        margin-bottom: 0;
-        padding-top: $content-vertical-spacing;
-    }
-
-    ul,
-    ol {
-        @include bidi-style(padding-left, ($grid-spacing * 2), padding-right, 0);
-        margin-bottom: $content-block-margin;
-
-        &.no-bullets {
-            list-style-type: none;
-            @include bidi-style(padding-left, 0, padding-right, 0);
-        }
-    }
-
-    ol {
-        list-style-type: decimal;
-    }
-
-    li {
-        margin-bottom: $content-vertical-spacing;
-    }
-    @include prevent-last-child-spacing(li, padding-bottom);
-
-    dt {
-        font-style: normal;
-        font-weight: bold;
-    }
-
-    dd {
-        margin-bottom: $content-block-margin;
-        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
-    }
-
-    /* =================================================================== */
-
-    span.alllinks {
-        display: block;
-        text-align: right;
-    }
-
-    img {
-        &.lwrap {
-            padding: 0 20px 10px 0;
-        }
-
-        &.rwrap {
-            padding: 0 0 10px 20px;
-        }
-    }
-
-    .licenseblock,
-    .originaldocinfo {
-        @include set-message-base(true);
-        background: $grey-light;
-        border: 2px solid $grey;
-        @include set-font-size($smaller-font-size);
-    }
-
-    .originaldocinfo {
-        h2 {
-            @include set-font-size($body-font-size);
-        }
+    pre {
+        @include full-width-content();
     }
 }
 
-ul.directory-tree {
-    @include bidi-style(padding-left, 0, padding-right, 0);
-
-    &,
-    ul {
-        @include bidi-style(margin-left, 0, margin-right, 0);
-        list-style: none;
-    }
-
-    ul {
-        @include bidi-style(padding-left, ($grid-spacing + $content-horizontal-spacing), padding-right, 0);
-
-        li {
-            position: relative;
-
-            &:before,
-            &:after {
-                content: '';
-                position: absolute;
-                @include bidi-style(left, -15px, right, auto);
-                display: block;
-            }
-
-            &:before {
-                top: 0;
-                height: .75em;
-                width: 10px;
-                border-bottom: 1px solid $grey;
-                @include bidi-style(border-left, 1px solid $grey, border-right, none);
-            }
-
-            &:after {
-                bottom: -7px;
-                height: 100%;
-                @include bidi-style(border-left, 1px solid $grey, border-right, none);
-            }
-
-            &:last-child:after {
-                display: none;
-            }
-        }
-    }
-}
+/*
+  I'm not sure where jquery UI ever appears in article pages, these declarations
+  are here for historical reasons and I'm afraid to move them
+*/
 
 .ui-helper-hidden-accessible {
     display: none;
@@ -277,75 +225,4 @@ ul.directory-tree {
     .ui-state-active {
         background: $light-background-color;
     }
-}
-
-div.bug {
-    font-style: italic;
-    @include prevent-last-child-bottom-spacing();
-    overflow: hidden;
-
-    pre {
-        color: $text-color;
-    }
-}
-
-.callout-box {
-    @include pull-aside();
-    @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing); /* override behaviour of pull-aside */
-    box-sizing: border-box;
-    background: $light-background-color;
-    border: 1px solid #f1f1f1;
-    padding: $grid-spacing;
-    position: relative;
-    text-align: center;
-    min-width: 200px;
-    z-index: 2;
-
-    /* override behaviour of pull-aside */
-    @media #{$mq-small-mobile-and-down} {
-        @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing);
-    }
-}
-
-p.footnote {
-    @include set-font-size($smaller-font-size);
-    font-style: italic;
-    color: $grey;
-}
-
-/*
-Classes created by the WYSIWYG
-====================================================================== */
-.twocolumns {
-    @include vendorize(column-count, 2);
-    @include vendorize(column-gap, $grid-spacing);
-
-    body[contenteditable] & {
-        border: $editor-box-border;
-        column-rule: $editor-box-border;
-    }
-}
-
-.threecolumns {
-    @include vendorize(column-count, 3);
-    @include vendorize(column-gap, $grid-spacing);
-
-    body[contenteditable] & {
-        border: $editor-box-border;
-        column-rule: $editor-box-border;
-    }
-}
-
-@media #{$mq-small-mobile-and-down} {
-    .twocolumns,
-    .threecolumns {
-        @include vendorize(column-count, 1);
-    }
-}
-
-/* =================================================================== */
-
-/* apply to any container to restrict width */
-.readable-line-length {
-    max-width: $max-line-length;
 }

--- a/kuma/static/styles/components/wiki/content/alllinks.scss
+++ b/kuma/static/styles/components/wiki/content/alllinks.scss
@@ -1,0 +1,5 @@
+/* "view all" often used with topicpage-table */
+.alllinks {
+    display: block;
+    text-align: right;
+}

--- a/kuma/static/styles/components/wiki/content/bug.scss
+++ b/kuma/static/styles/components/wiki/content/bug.scss
@@ -1,0 +1,9 @@
+div.bug {
+    font-style: italic;
+    @include prevent-last-child-bottom-spacing();
+    overflow: hidden;
+
+    pre {
+        color: $text-color;
+    }
+}

--- a/kuma/static/styles/components/wiki/content/callout-box.scss
+++ b/kuma/static/styles/components/wiki/content/callout-box.scss
@@ -1,0 +1,17 @@
+.callout-box {
+    @include pull-aside();
+    @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing); /* override behaviour of pull-aside */
+    box-sizing: border-box;
+    background: $light-background-color;
+    border: 1px solid #f1f1f1;
+    padding: $grid-spacing;
+    position: relative;
+    text-align: center;
+    min-width: 200px;
+    z-index: 2;
+
+    /* override behaviour of pull-aside */
+    @media #{$mq-small-mobile-and-down} {
+        @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing);
+    }
+}

--- a/kuma/static/styles/components/wiki/content/columns.scss
+++ b/kuma/static/styles/components/wiki/content/columns.scss
@@ -1,0 +1,29 @@
+/*
+Classes created by the WYSIWYG
+====================================================================== */
+.twocolumns {
+    @include vendorize(column-count, 2);
+    @include vendorize(column-gap, $grid-spacing);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
+}
+
+.threecolumns {
+    @include vendorize(column-count, 3);
+    @include vendorize(column-gap, $grid-spacing);
+
+    body[contenteditable] & {
+        border: $editor-box-border;
+        column-rule: $editor-box-border;
+    }
+}
+
+@media #{$mq-small-mobile-and-down} {
+    .twocolumns,
+    .threecolumns {
+        @include vendorize(column-count, 1);
+    }
+}

--- a/kuma/static/styles/components/wiki/content/directory-tree.scss
+++ b/kuma/static/styles/components/wiki/content/directory-tree.scss
@@ -1,0 +1,43 @@
+ul.directory-tree {
+    @include bidi-style(padding-left, 0, padding-right, 0);
+
+    &,
+    ul {
+        @include bidi-style(margin-left, 0, margin-right, 0);
+        list-style: none;
+    }
+
+    ul {
+        @include bidi-style(padding-left, ($grid-spacing + $content-horizontal-spacing), padding-right, 0);
+
+        li {
+            position: relative;
+
+            &:before,
+            &:after {
+                content: '';
+                position: absolute;
+                @include bidi-style(left, -15px, right, auto);
+                display: block;
+            }
+
+            &:before {
+                top: 0;
+                height: .75em;
+                width: 10px;
+                border-bottom: 1px solid $grey;
+                @include bidi-style(border-left, 1px solid $grey, border-right, none);
+            }
+
+            &:after {
+                bottom: -7px;
+                height: 100%;
+                @include bidi-style(border-left, 1px solid $grey, border-right, none);
+            }
+
+            &:last-child:after {
+                display: none;
+            }
+        }
+    }
+}

--- a/kuma/static/styles/components/wiki/content/footnote.scss
+++ b/kuma/static/styles/components/wiki/content/footnote.scss
@@ -1,0 +1,5 @@
+p.footnote {
+    @include set-font-size($smaller-font-size);
+    font-style: italic;
+    color: $grey;
+}

--- a/kuma/static/styles/components/wiki/content/originaldocinfo.scss
+++ b/kuma/static/styles/components/wiki/content/originaldocinfo.scss
@@ -1,0 +1,14 @@
+/* some documents have different lisences for historic reasons */
+.licenseblock,
+.originaldocinfo {
+    @include set-message-base(true);
+    background: $grey-light;
+    border: 2px solid $grey;
+    @include set-font-size($smaller-font-size);
+}
+
+.originaldocinfo {
+    h2 {
+        @include set-font-size($body-font-size);
+    }
+}

--- a/kuma/static/styles/components/wiki/content/readable-line-length.scss
+++ b/kuma/static/styles/components/wiki/content/readable-line-length.scss
@@ -1,0 +1,4 @@
+/* apply to any container to restrict width */
+.readable-line-length {
+    max-width: $max-line-length;
+}

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -53,14 +53,22 @@ Article meta
 Styling for article content
 ====================================================================== */
 
-@import 'components/wiki/content/moreinfo';
-@import 'components/wiki/content/summary';
+@import 'components/wiki/content/alllinks';
+@import 'components/wiki/content/bug';
+@import 'components/wiki/content/callout-box';
 @import 'components/wiki/content/card-grid';
-@import 'components/wiki/content/pull-aside';
-@import 'components/wiki/content/landingPage';
 @import 'components/wiki/content/columnList';
-@import 'components/wiki/content/html5ArticleToc';
+@import 'components/wiki/content/columns';
+@import 'components/wiki/content/directory-tree';
 @import 'components/wiki/content/fancyTOC';
+@import 'components/wiki/content/footnote';
+@import 'components/wiki/content/html5ArticleToc';
+@import 'components/wiki/content/landingPage';
+@import 'components/wiki/content/moreinfo';
+@import 'components/wiki/content/originaldocinfo';
+@import 'components/wiki/content/pull-aside';
+@import 'components/wiki/content/readable-line-length';
+@import 'components/wiki/content/summary';
 @import 'components/wiki/customcss';
 @import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';


### PR DESCRIPTION
Separating the large content.scss into smaller files.
Re-ordered includes to be alphabetical.

Testing:
- I have not changed any of the code, please do not comment on the code.
- look for: 
  - stuff I have deleted from content.scss and not included somewhere else
  - stuff that doesn't work in its new location
- no need for cross-browser testing, it should work or be broken in all of them

You can edit this URL to search for pages that uses specific classes on MDN (example uses `callout-box` as search term):
https://developer.mozilla.org/en-US/search?locale=*&topic=none&css_classnames=callout-box