### PR TITLE
bug 1402708: Speed up tests w/ whitenoise 3.3.1

### DIFF
--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -56,3 +56,9 @@ PIPELINE['COMPILERS'] = ('pipeline.compilers.sass.SASSCompiler',)
 # Enabled=T, Collector=F -   535s
 # Enabled=F, Collector=T - 18262s
 # Enabled=F, Collector=F -  2043s
+
+# Defer to django-pipeline's finders for testing
+# This avoids reading the static folder for each test client request, for
+# a 10x speedup on Docker on MacOS.
+WHITENOISE_AUTOREFRESH = True
+WHITENOISE_USE_FINDERS = True


### PR DESCRIPTION
Set two config options in test that default to DEBUG (True in tests):

* ``WHITENOISE_AUTOREFRESH`` - When ``True``, it stores the ``STATIC_ROOT`` path without further processing (fast). When ``False``, it reads and processes all the files in the ``STATIC_ROOT`` with each call to the Django test client (very slow).
* ``WHITENOISE_USE_FINDERS`` - When ``True``, it uses Django's static finders, which uses django-pipeline's test-optimized finder. When ``False``, it scans the ``STATIC_ROOT`` path itself (slow).

This is a 10x speed-up for Docker for MacOS for me.