### PR TITLE
Bug 1150118: Fix lazy loading fonts

### DIFF
--- a/kuma/static/styles/components-skinny/tagit.scss
+++ b/kuma/static/styles/components-skinny/tagit.scss
@@ -6,7 +6,7 @@ overrides for tagit widget
 .tagit.ui-widget-content { /* over-ride the jQuery plugin */
     @extend ul.tags;
     background-image: none;
-    font-family: $site-font-family;
+    @include set-site-font-family();
     font-size: 1em;
 
     .close {

--- a/kuma/static/styles/components-skinny/wiki/wiki-helpful-survey.scss
+++ b/kuma/static/styles/components-skinny/wiki/wiki-helpful-survey.scss
@@ -13,11 +13,8 @@
 
     > p {
         @include set-font-size(30px);
-        font-family: $heading-font-family;
+        @include set-heading-font-family();
         line-height: 1;
-        #{$selector-heading-font-fallback} {
-            font-family: $heading-font-family-fallback;
-        }
     }
 
     .zone & {

--- a/kuma/static/styles/components/tagit.scss
+++ b/kuma/static/styles/components/tagit.scss
@@ -6,7 +6,7 @@ overrides for tagit widget
 .tagit.ui-widget-content { /* over-ride the jQuery plugin */
     @extend ul.tags;
     background-image: none;
-    font-family: $site-font-family;
+    @include set-site-font-family();
     font-size: 1em;
 
     .close {

--- a/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
+++ b/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
@@ -13,11 +13,8 @@
 
     > p {
         @include set-font-size(30px);
-        font-family: $heading-font-family;
+        @include set-heading-font-family();
         line-height: 1;
-        #{$selector-heading-font-fallback} {
-            font-family: $heading-font-family-fallback;
-        }
     }
 
     .zone & {

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -254,7 +254,7 @@ selectors
 ====================================================================== */
 $selector-icon: 'i[class^="icon-"]';
 $selector-site-font-fallback: 'html[data-ffo-opensans="false"]:not(.no-js) &';
-$selector-heading-font-fallback: 'html[data-zillaslab="false"]:not(.no-js) &';
+$selector-heading-font-fallback: 'html[data-ffo-zillaslab="false"]:not(.no-js) &';
 
 
 /*

--- a/kuma/static/styles/zones/components/promo10.scss
+++ b/kuma/static/styles/zones/components/promo10.scss
@@ -9,12 +9,8 @@ Blue "join us!" promo in MDN 10 zone
     color: #fff;
     text-align: center;
 
-
-    font-family: $heading-font-family;
+    @include set-heading-font-family();
     font-size: $larger-font-size;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
 
     h3 {
         color: #fff;

--- a/kuma/static/styles/zones/components/quote.scss
+++ b/kuma/static/styles/zones/components/quote.scss
@@ -15,12 +15,9 @@ fancy quotes in MDN 10 zone
         padding: 0;
         background-color: inherit;
 
-        font-family: $heading-font-family;
+        @include set-heading-font-family();
         font-style: italic;
         font-size: $larger-font-size;
-        #{$selector-heading-font-fallback} {
-            font-family: $heading-font-family-fallback;
-        }
     }
 
     blockquote:before,


### PR DESCRIPTION
- repair zilla fallback font declaration
- switch to mixin for all font-family declarations

Looking into this after @schalkneethling noted fonts were loading before other stuff, and they should be async.

The Zilla fallback font declaration was broken :( It should work now.

Our font loading system needs the fonts to be declared in a specific way. In a perfect world this would be enforced by something like Post-CSS but we don't have a perfect world. There used to be two ways to do this but this PR switches to the mixin only.