### PR TITLE
bug 1411675: fix base.html jinja2 template to check for untrusted-cdn origin

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,5 +1,5 @@
 {% from "includes/common_macros.html" import optimizely_script with context -%}
-{% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() == settings.ATTACHMENT_HOST) %}
+{% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() in (settings.ATTACHMENT_ORIGIN, settings.ATTACHMENT_HOST)) %}
 
 <!DOCTYPE html>
 <html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js" data-ffo-opensans="false" data-ffo-zillaslab="false">


### PR DESCRIPTION
This PR fixes an omission introduced in https://github.com/mozilla/kuma/pull/4479. When I added `ATTACHMENT_ORIGIN` as an untrusted domain, I neglected to add it as well to the `base.html` jinja2 template.

In order to test:
- add `demos` and `demos-origin` to `/etc/hosts` (as aliases to the 127.0.0.1 entry)
- configure your `.env`:
```
ENABLE_RESTRICTIONS_BY_HOST=True
ATTACHMENT_HOST=demos:8000
ATTACHMENT_ORIGIN=demos-origin:8000
STATIC_URL=http://localhost:8000/static/
DEBUG=False
```
- add `ATTACHMENT_ORIGIN` to the `environment` section of the worker
- `docker-compose up -d`
- try loading a missing page both ways, both should show the 404 page without error:
    - http://demos:8000/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started)
    - http://demos-origin:8000/en-US/docs/Learn/HTML/Introduction_to_HTML/Getting_started)
