### PR TITLE
bug 1360294: Add user.is_github_url_public

### DIFF
--- a/kuma/users/migrations/0007_user_is_github_url_public.py
+++ b/kuma/users/migrations/0007_user_is_github_url_public.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('users', '0006_stackoverflow_validator'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='user',
+            name='is_github_url_public',
+            field=models.BooleanField(default=False, verbose_name='Public Github URL'),
+        ),
+    ]


### PR DESCRIPTION
Add the column ``User.is_github_url_public``. We'll need to deploy and run migrations before merging the rest of #4346.