### PR TITLE
bug 1402708: add robots.txt endpoint to untrusted domains

### DIFF
--- a/kuma/urls_untrusted.py
+++ b/kuma/urls_untrusted.py
@@ -1,6 +1,8 @@
+from django.views import static
 from django.conf import settings
 from django.conf.urls import include, url
 
+from kuma.settings.common import path
 from kuma.core import views as core_views
 
 handler403 = core_views.handler403
@@ -10,6 +12,12 @@ handler500 = core_views.handler500
 urlpatterns = [
     url('', include('kuma.attachments.urls')),
     url(r'^docs', include('kuma.wiki.urls_untrusted')),
+    url(
+        r'^robots.txt$',
+        static.serve,
+        {'document_root': path('media'), 'path': 'robots-go-away.txt'},
+        name='robots_txt'
+    ),
 ]
 
 if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):


### PR DESCRIPTION
This PR adds a `/robots.txt` endpoint (which disallows everything) to the untrusted domains:
- `ATTACHMENT_HOST`(e.g., `mdn.mozillademos.org`)
- `ATTACHMENT_ORIGIN` (e.g., `mdn-demos-origin.moz.works`)

This is part of work involved in https://github.com/mozmeao/infra/issues/590.