### PR TITLE
bug 1407806: increase caching max-age for file attachments

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -247,7 +247,7 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert response['Last-Modified'] == convert_to_http_date(created)
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
-    assert 'max-age=300' in response['Cache-Control']
+    assert 'max-age=900' in response['Cache-Control']
     assert 'Vary' not in response
 
 
@@ -267,5 +267,5 @@ def test_raw_file_if_modified_since(client, settings, file_attachment):
     assert response['Last-Modified'] == convert_to_http_date(created)
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
-    assert 'max-age=300' in response['Cache-Control']
+    assert 'max-age=900' in response['Cache-Control']
     assert 'Vary' not in response

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -46,7 +46,7 @@ def raw_file(request, attachment_id, filename):
         def get_last_modified(*args):
             return convert_to_utc(rev.created)
 
-        @cache_control(public=True, max_age=60 * 5)
+        @cache_control(public=True, max_age=60 * 15)
         @last_modified(get_last_modified)
         def stream_raw_file(*args):
             if settings.DEBUG:


### PR DESCRIPTION
This PR simply increases the `max-age` portion of the `Cache-Control` header for the file-attachment endpoints from 5 minutes to 15 minutes. The [cache-hit rate for the most popular file-attachment endpoints](https://console.aws.amazon.com/cloudfront/home?region=us-west-2#popular_urls:) is currently hovering roughly around 50%. The goal is to significantly increase that, and this should give us more data we can use to find the sweet spot.