### PR TITLE
bug 1406546: enable deploy of Kuma images to AWS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,9 @@
+#!groovy
+
 @Library('github.com/mozmar/jenkins-pipeline@master')
 
 def loadBranch(String branch) {
+  utils = load 'Jenkinsfiles/utils.groovy'
   if (fileExists("./Jenkinsfiles/${branch}.yml")) {
     config = readYaml file: "./Jenkinsfiles/${branch}.yml"
     println "config ==> ${config}"

--- a/Jenkinsfiles/stage-push.groovy
+++ b/Jenkinsfiles/stage-push.groovy
@@ -1,0 +1,24 @@
+stage("Announce") {
+    utils.notify_irc([
+        irc_nick: 'mdnstagepush',
+        status: 'Pushing to Stage',
+        message: "Kuma image ${env.GIT_COMMIT_SHORT}"
+    ])
+}
+
+stage("Prepare Infra") {
+    // Checkout the "mozmeao/infra" repo's "master" branch into the
+    // "infra" sub-directory of the current working directory.
+    utils.checkout_github('mozmeao/infra', 'master', 'infra')
+}
+
+stage('Push') {
+    dir('infra/apps/mdn/mdn-aws/k8s') {
+        // Run the database migrations.
+        utils.migrate_stage_db()
+        // Perform a rolling update of the Kuma-based deployments.
+        utils.rollout_to_stage()
+        // Watch the rollout status until it has completed.
+        utils.monitor_rollout_to_stage()
+    }
+}

--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -1,0 +1,62 @@
+/*
+ * Define utility functions.
+ */
+
+def checkout_github(repo, branch, relative_target_dir) {
+    checkout(
+        [$class: 'GitSCM',
+         userRemoteConfigs: [[url: "https://github.com/${repo}"]],
+         branches: [[name: "refs/heads/${branch}"]],
+         extensions: [[$class: 'RelativeTargetDirectory',
+                       relativeTargetDir: relative_target_dir]],
+         doGenerateSubmoduleConfigurations: false,
+         submoduleCfg: []]
+    )
+}
+
+def notify_irc(Map args) {
+    def command = "${env.WORKSPACE}/scripts/irc-notify.sh"
+    for (arg in args) {
+        command += " --${arg.key} '${arg.value}'"
+    }
+    sh command
+}
+
+def make(setup, cmd) {
+    sh """
+        . ${setup}
+        make ${cmd} KUMA_IMAGE_TAG=${env.GIT_COMMIT_SHORT}
+    """
+}
+
+def make_stage(cmd, cmd_display) {
+    try {
+        make('regions/portland/stage.sh', cmd)
+        notify_irc([
+            irc_nick: 'mdnstagepush',
+            stage: cmd_display,
+            status: 'success'
+        ])
+    } catch(err) {
+        notify_irc([
+            irc_nick: 'mdnstagepush',
+            stage: cmd_display,
+            status: 'failure'
+        ])
+        throw err
+    }
+}
+
+def migrate_stage_db() {
+    make_stage('k8s-db-migration-job', 'Migrate Database')
+}
+
+def rollout_to_stage() {
+    make_stage('k8s-kuma-deployments', 'Start Rollout')
+}
+
+def monitor_rollout_to_stage() {
+    make_stage('k8s-kuma-rollout-status', 'Check Rollout Status')
+}
+
+return this;

--- a/scripts/irc-notify.sh
+++ b/scripts/irc-notify.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+set -eo pipefail
+
+# Required environment variables if using --stage:
+# BRANCH_NAME, BUILD_NUMBER
+
+# defaults and constants
+NICK="jenkins"
+CHANNEL="#mdndev"
+SERVER="irc.mozilla.org:6697"
+BLUE_BUILD_URL="https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_multibranch_pipeline"
+BLUE_BUILD_URL="${BLUE_BUILD_URL}/detail/${BRANCH_NAME/\//%2f}/${BUILD_NUMBER}/pipeline"
+# colors and styles: values from the following links
+# http://www.mirc.com/colors.html
+# http://stackoverflow.com/a/13382032
+RED=$'\x034'
+YELLOW=$'\x038'
+GREEN=$'\x039'
+BLUE=$'\x0311'
+BOLD=$'\x02'
+NORMAL=$'\x0F'
+
+# parse cli args
+while [[ $# -gt 1 ]]; do
+    key="$1"
+    case $key in
+        --stage)
+            STAGE="$2"
+            shift # past argument
+            ;;
+        --status)
+            STATUS="$2"
+            shift # past argument
+            ;;
+        -m|--message)
+            MESSAGE="$2"
+            shift # past argument
+            ;;
+        --irc_nick)
+            NICK="$2"
+            shift # past argument
+            ;;
+        --irc_server)
+            SERVER="$2"
+            shift # past argument
+            ;;
+        --irc_channel)
+            CHANNEL="$2"
+            shift # past argument
+            ;;
+    esac
+    shift # past argument or value
+done
+
+if [[ -n "$STATUS" ]]; then
+    STATUS=$(echo "$STATUS" | tr '[:lower:]' '[:upper:]')
+    case "$STATUS" in
+      'SUCCESS')
+        STATUS_COLOR="🎉 ${BOLD}${GREEN}"
+        ;;
+      'SHIPPED')
+        STATUS_COLOR="🚢 ${BOLD}${GREEN}"
+        ;;
+      'WARNING')
+        STATUS_COLOR="⚠️ ${BOLD}${YELLOW}"
+        ;;
+      'FAILURE')
+        STATUS_COLOR="🚨 ${BOLD}${RED}"
+        ;;
+      *)
+        STATUS_COLOR="✨ $BLUE"
+        ;;
+    esac
+    STATUS="${STATUS_COLOR}${STATUS}${NORMAL}: "
+fi
+
+if [[ -n "$STAGE" ]]; then
+    MESSAGE="${STATUS}${STAGE}:"
+    MESSAGE="$MESSAGE Branch ${BOLD}${BRANCH_NAME}${NORMAL} build #${BUILD_NUMBER}: ${BLUE_BUILD_URL}"
+elif [[ -n "$MESSAGE" ]]; then
+    MESSAGE="${STATUS}${MESSAGE}"
+else
+    echo "Missing required arguments"
+    echo
+    echo "Usage: irc-notify.sh [--stage STAGE]|[-m MESSAGE]"
+    echo "Optional args: --status, --irc_nick, --irc_server, --irc_channel"
+    exit 1
+fi
+
+if [[ -n "$BUILD_NUMBER" ]]; then
+    NICK="${NICK}-${BUILD_NUMBER}"
+fi
+
+(
+  echo "NICK ${NICK}"
+  echo "USER ${NICK} 8 * : ${NICK}"
+  sleep 5
+  echo "JOIN ${CHANNEL}"
+  echo "NOTICE ${CHANNEL} :${MESSAGE}"
+  echo "QUIT"
+) | openssl s_client -connect "$SERVER" > /dev/null 2>&1


### PR DESCRIPTION
This PR is the initial pass at the blueprint for deploying Docker images to K8s. For now, it focuses solely on pushing to stage (stage.mdn.moz.works), and borrows from the Jenkins code and bash scripts used in [bedrock](https://github.com/mozilla/bedrock). The PR https://github.com/mozmeao/infra/pull/629 is a prerequisite for successful operation.