### PR TITLE
bug 1399639: Update to bleach 2.1.1, deps

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -38,9 +38,9 @@ setuptools==26.1.1 \
     --hash=sha256:475ce28993d7cb75335942525b9fac79f7431a7f6e8a0079c0f2680641379481 \
     --hash=sha256:02a06e1a547b16c25143d2bb898008286a3cbd600a7dbe47234ce57dc51abbf6
 # bleach, django-appconf, django-cacheback, django-extensions, mock, etc.
-six==1.10.0 \
-    --hash=sha256:0ff78c403d9bccf5a425a6d31a12aa6b47f1c21ca4dc2573a7e2f32a97335eb1 \
-    --hash=sha256:105f8d68616f8248e24bf0e9372ef04d3cc10104f1980f54d57b2ce73a5ad56a
+six==1.11.0 \
+    --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
+    --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
 # cryptography, flake8
 enum34==1.1.6 \
     --hash=sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -4,9 +4,9 @@
 -c constraints.txt
 
 # Sanitize HTML with a whitelist
-bleach==2.0.0 \
-    --hash=sha256:a6d9d5f5b7368c1689ad7f128af8e792beea23393688872b576c0271e6564a16 \
-    --hash=sha256:b9522130003e4caedf4f00a39c120a906dcd4242329c1c8f621f5370203cbc30
+bleach==2.1.1 \
+    --hash=sha256:7a316eac1eef1e98b9813636ebe05878aab1a658d2708047fb00fe2bcbc49f84 \
+    --hash=sha256:760a9368002180fb8a0f4ea48dc6275378e6f311c39d0236d7b904fca1f5ea0d
 
 # Process tasks in the background
 celery==3.1.20 \


### PR DESCRIPTION
* bleach 2.0.0 → 2.1.1: Convert control characters to entities, restrict clean and linkify to unicode or utf8-encoded strings.
* six 1.10.0 → 1.11.0: with_metaclass fixes, more moves