### PR TITLE
Conditionally adds preload link tag for codemirror and html document

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -67,6 +67,13 @@
   <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
   <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
 
+  {% if doc_abs_url == '/en-US/docs/Experiment:InteractiveEditor/Array.prototype.reduce()' %}
+    <link rel="preload" href="https://interactive-examples.mdn.mozilla.net/js/lib/codemirror.js" as="script" />
+    <link rel="preload" href="https://interactive-examples.mdn.mozilla.net/js/mode/javascript/javascript.js" as="script" />
+    <!-- At the time of writing the below only works in Chrome -->
+    <link rel="preload" href="https://interactive-examples.mdn.mozilla.net/pages/js/array-reduce.html" as="document" />
+  {% endif %}
+
   <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.slug) }}">
   <link rel="canonical" href="{{ canonical }}" >
 


### PR DESCRIPTION
@stephaniehobson So, I am not sure whether this will explicitly add the preloaded files to browser cache seeing that the `Cache-Control` headers are not set at the moment. If not, which I kinda think will be the case, this will not have an impact but, worth getting into production?