### PR TITLE
bug 1326384: Remove deprecated protocol filtering

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1466,10 +1466,6 @@ CONSTANCE_CONFIG = dict(
         "Number of days to keep the trashed attachments files before they "
         "are removed from the file storage"
     ),
-    KUMA_WIKI_HREF_BLOCKED_PROTOCOLS=(
-        '(?i)^\s*(data\:?)',
-        '(Deprecated) Regex for protocols that are blocked for A HREFs'
-    ),
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS=(
         ('^https?\:\/\/'
          '(stage-files.mdn.moz.works'               # Staging demos

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -335,12 +335,6 @@ class ContentSectionTool(object):
         return self
 
     @newrelic.agent.function_trace()
-    def filterAHrefProtocols(self, blocked_protocols):
-        # TODO: Remove, deprecated by bleach 1.5.0
-        self.stream = AHrefProtocolFilter(self.stream, blocked_protocols)
-        return self
-
-    @newrelic.agent.function_trace()
     def filterIframeHosts(self, hosts):
         self.stream = IframeHostFilter(self.stream, hosts)
         return self
@@ -1066,27 +1060,4 @@ class IframeHostFilter(html5lib_Filter):
             if token['type'] == 'EndTag' and token['name'] == 'iframe':
                 in_iframe = False
             if not in_iframe:
-                yield token
-
-
-class AHrefProtocolFilter(html5lib_Filter):
-    """
-    Filter which scans through <a> tags and strips the href attribute if
-    it contains a blocked protocol.
-    """
-    def __init__(self, source, blocked_protocols):
-        html5lib_Filter.__init__(self, source)
-        self.blocked_protocols = blocked_protocols
-
-    def __iter__(self):
-        for token in html5lib_Filter.__iter__(self):
-            if token['type'] == 'StartTag' and token['name'] == 'a':
-                attrs = dict(token['data'])
-                for (namespace, name), value in attrs.items():
-                    if name == 'href' and value:
-                        if re.search(self.blocked_protocols, value):
-                            attrs[(namespace, 'href')] = ''
-                    token['data'] = attrs
-                yield token
-            else:
                 yield token


### PR DESCRIPTION
Protocol filtering has been handled by Bleach since 1.5 (Nov 2016). ``AHrefProtocolFilter`` and the associated code hasn't been used since January 2017.

[bug 1326384](https://bugzilla.mozilla.org/show_bug.cgi?id=1326384) was a security bug, with no public pull request. In theory, this PR's change could have been included in the Jan 2017 changes, but we try to minimize changes in security updates, and it was forgotten until now. The relevant commits were:

* https://github.com/mozilla/kuma/commit/020b9ccdc289de85b75f629353fb677dcbcc21cb - Filter iframes after bleach
* https://github.com/mozilla/kuma/commit/729fe608b4a0bb1a67982a63e54ba29470833f67 - Update to Bleach 1.5.0
* https://github.com/mozilla/kuma/commit/5f602dc5937966d326c31c3355d80553bc164945 - Switch to Bleach for protocol filtering
* https://github.com/mozilla/kuma/commit/ec487dac8abd6cfc5ae153b81c18e5a10caf70a2 - Improve redirect detection