### PR TITLE
Bug 1414107: Move breadcrumbs to left column

### DIFF
--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -6,7 +6,6 @@
 }
 
 .document-title {
-    clear: both;
     position: relative;
 
     h1 {
@@ -21,13 +20,11 @@
 }
 
 .document-actions {
+    position: relative;
+    z-index: 1; // raise above the h1 in the document-title
     @include bidi-value(float, right, left);
     width: 100%;
     margin-bottom: ($grid-spacing / 2);
-
-    .crumbs + & {
-        margin-top: ($grid-spacing / 2);
-    }
 }
 
 @media #{$mq-mobile-and-up} {
@@ -39,11 +36,8 @@
 
     .document-actions {
         width: auto;
-        margin-bottom: $grid-spacing;
-
-        .crumbs + & {
-            margin-top: 0;
-        }
+        @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
+        margin-bottom: 0;
     }
 }
 

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -1,47 +1,73 @@
 /*
-wiki article cookie crumbs
+wiki article bread crumbs
 ********************************************************************** */
 
 .crumbs {
-    @include bidi-value(float, left, right);
-    display: inline-block;
+    border: 1px solid #d7d7d7;
+    border-width: 1px 0;
+    margin: $grid-spacing 0;
+    padding: $grid-spacing 0;
+    @include set-font-size($left-nav-font-size);
 
     li {
-        @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
-        display: none;
+        display: inline;
     }
 
-    li:nth-last-child(2) {
-        display: block;
-    }
+    a { // @include reverse-link-decoration has buggy behaviour in .crumbs for some reason
+        text-decoration: none;
 
-    a {
-        display: block;
-        line-height: 1;
-
-        &:before {
-            @include bidi-style(margin-right, 4px, margin-left, 0, true);
-            @include bidi-style(content, '\f053', content, '\f054');
-            display: inline-block;
-            font-family: FontAwesome;
-            text-decoration: none;
-            color: $text-color;
-            @include set-font-size(70%);
-            vertical-align: middle;
+        &:hover span,
+        &:focus span {
+            text-decoration: underline;
         }
     }
 
-    @include reverse-link-decoration();
+    span {
+        display: inline-block;
+        position: relative;
+        @include bidi-style(padding-right, 5px, padding-left, 0);
+        /* borders increase hit area for mobile without messing with position of arrow */
+        border-top: 15px solid transparent;
+        border-bottom: 15px solid transparent;
+        line-height: 1;
+
+        &:after {
+            @include bidi-style(content, '\00a0\00a0\f054', content, '\00a0\00a0\f053');
+            font-family: FontAwesome;
+            color: $text-color;
+            @include set-font-size(70%);
+        }
+    }
+
+    li:last-child span:after {
+        display: none;
+    }
 }
 
-@media #{$mq-mobile-and-up} {
-    // make them sit inline with .page-actions buttons
-    .crumbs {
-        padding: 5px 0;
+@media #{$mq-tablet-and-up} {
+    $crumb-vertical-spacing: $grid-spacing / 2;
 
-        a {
-            border: $form-border-width solid transparent;
-            padding: 5px 0;
+    .crumbs {
+        border-top-width: 0;
+        margin-top: 0;
+        padding-bottom: $grid-spacing - $crumb-vertical-spacing;
+        padding-top: 0;
+
+        span {
+            border-top: none;
+            border-bottom: $crumb-vertical-spacing solid transparent;
+        }
+    }
+}
+
+@media #{$mq-small-desktop-and-up} {
+    $crumb-vertical-spacing: 5px;
+
+    .crumbs {
+        padding-bottom: $grid-spacing - $crumb-vertical-spacing;
+
+        span {
+            border-bottom: $crumb-vertical-spacing solid transparent;
         }
     }
 }

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -118,11 +118,6 @@
   <!-- heading -->
   <div id="wiki-document-head" class="document-head">
     <div class="center">
-      {% if not is_zone_root %}
-        <!-- crumbs -->
-        {{ crumbs }}
-      {% endif %}
-
       <!-- action buttons -->
       <div class="document-actions">
         {{ buttons }}
@@ -321,6 +316,11 @@
             {% if show_left %}
               <!-- quick links and zone subnav strip -->
               <div id="wiki-left" class="column-strip wiki-column">
+
+                {% if not is_zone_root %}
+                  <!-- crumbs -->
+                  {{ crumbs }}
+                {% endif %}
 
                 {% if zone_subnav_html %}
                   <!-- zone subnav -->

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -1,11 +1,21 @@
 {% macro build_document_crumbs(document) %}
-  <nav class="crumbs" role="navigation"><ol xmlns:v="http://rdf.data-vocabulary.org/#" aria-label="{{ _('breadcrumbs') }}">
-    <li typeof="v:Breadcrumb"><a href="/{{ request.LANGUAGE_CODE }}" rel="v:url" property="v:title">MDN</a></li>
-    {% for doc in document.parents %}
-      <li class="crumb" typeof="v:Breadcrumb"><a href="{{ doc.get_absolute_url() }}" rel="v:url" property="v:title">{{ doc.title }}</a></li>
-    {% endfor %}
-    <li class="crumb" typeof="v:Breadcrumb" property="v:title">{{ document.title }}</li>
-  </ol></nav>
+  {% if document.parents %}
+    <nav class="crumbs" role="navigation">
+      <ol typeof="BreadcrumbList" vocab="https://schema.org/" aria-label="{{ _('breadcrumbs') }}">
+        {% for doc in document.parents %}
+          <li property="itemListElement" typeof="ListItem" class="crumb">
+            <a href="{{ doc.get_absolute_url() }}" property="item" typeof="WebPage">
+              <span property="name">{{ doc.title }}</span>
+            </a>
+            <meta property="position" content="{{ loop.index }}">
+          </li>
+        {% endfor %}
+        <li property="itemListElement" typeof="ListItem" class="crumb">
+          <span property="name">{{ document.title }}</span>
+        </li>
+      </ol>
+    </nav>
+  {% endif %}
 {%- endmacro %}
 
 {% macro get_document_subnav(html) %}

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -211,7 +211,7 @@ def doc_hierarchy_with_zones(settings, wiki_user, wiki_user_2, wiki_user_3):
     Revision.objects.create(
         document=bottom_doc,
         creator=wiki_user,
-        content='<p>Bottom...</p>',
+        content='<p>Bottom...</p><div id="Quick_Links"><p>sidebar</p></div>',
         title='Bottom Document',
         created=datetime(2017, 4, 24, 13, 52)
     )

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -67,7 +67,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         doc = pq(response.content)
         eq_(d2.title, doc('main#content div.document-head h1').text())
-        crumbs = "MDN %s %s" % (d1.title, d2.title)
+        crumbs = " %s %s" % (d1.title, d2.title)
         eq_(crumbs, doc('nav.crumbs').text())
 
     def test_english_document_no_approved_content(self):
@@ -1301,7 +1301,7 @@ def test_zone_styles(client, doc_hierarchy_with_zones, root_doc, doc_name):
     assert (count('.document-title') ==
             one_if('root', 'bottom', 'de', 'fr', 'it'))
     assert count(zone_title) == one_if('bottom')
-    assert count('.crumbs') == one_if('root', 'bottom')
+    assert count('.crumbs') == one_if('bottom')
     assert count(css_link.format('zones')) == one_if('it')
     assert count(css_link.format('zone-bobby')) == one_if('bottom')
     assert count(css_link.format('zone-berlin')) == one_if('de')


### PR DESCRIPTION
- remove crumbs from document-head
- add crumbs to left column
- change from rdf to schema.org encoding on crumbs
- add intelligent break points to long page titles
- tweak flow of document-title and document-actions on mobile and tablet
- update look of crumbs
    - including larger hit area on mobile and tablet