### PR TITLE
Bug 1414107: New styles for quick-links

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -134,20 +134,31 @@
     });
 
     /*
-        Add intelligent break points to long article titles
+        Add intelligent break points to:
+        - long article titles in document head
+        - left nav
+        - breadcrumbs
+        Don't use this on anything that might have child elements
     */
-    $('.document .document-head h1').each(function() {
-        var $title = $(this);
-        var text = $title.text();
-        // split on . - : ( or capital letter, only if followed by 2 letters
-        var split = text.split(/(?=[\.:\-\(A-Z][\.:\-\(A-Z]{0,}[a-zA-Z]{3})/g);
-        // empty h1
-        $title.empty();
-        // put array back into h1 seperated by <wbr> tags
+    $('.document .document-head h1, .quick-links a code, .crumbs span[property=name]').each(function() {
+        var $wrapper = $(this);
+        var text = $wrapper.text();
+        // don't do anything if there are any child elements, they would be removed
+        if ($wrapper.children().length > 0) {
+            return;
+        }
+        // split on . : - ( [ OR capital letter
+        // IF followed by more than 2 letters or matching characters (including @)
+        var split = text.split(/(?=[\[\.:\-\(A-Z][@\.:\-\(A-Z]{0,}[a-zA-Z]{3})/g);
+        // empty wrapper
+        $wrapper.empty();
+        // put array back into wrapper seperated by <wbr> tags
         $.each(split, function(key, value) {
-            $title.append('<wbr>');
+            if(key > 0) {
+                $wrapper.append('<wbr>');
+            }
             // add text back, make sure it goes back as text, not code to run
-            $title.append(doc.createTextNode(value));
+            $wrapper.append(doc.createTextNode(value));
         });
     });
 

--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -105,6 +105,19 @@ code {
         background-color: transparent;
         padding: 0;
     }
+
+    .toc & {
+        background-color: inherit;
+        color: inherit;
+        font-family: inherit;
+        font-size: inherit;
+        padding: 0;
+    }
+
+    .quick-links & {
+        background-color: transparent;
+        padding: 0;
+    }
 }
 
 /* pre is a block element so it gets a bit more fancy styling */

--- a/kuma/static/styles/components/wiki/customcss.scss
+++ b/kuma/static/styles/components/wiki/customcss.scss
@@ -30,6 +30,12 @@ s.obsoleteElement,
 s.nonStdElement {
     text-decoration: none;
     opacity: .3;
+
+    /* brighten them to be readable if the user hovers or focuses */
+    &:hover,
+    &:focus {
+        opacity: 1;
+    }
 }
 
 /* Add widgeted index, here adding an HTML5 badge as the bullet of the li element if class="html5" */

--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -1,18 +1,22 @@
-$see-also-outdent: 6px;
+.quick-links-head {
+    @include set-font-size(20px);
+    display: inline-block;
+    font-family: $heading-font-family;
+    margin-bottom: $grid-spacing;
+    width: 100%;
+}
 
 .quick-links {
     margin-bottom: $grid-spacing;
     position: relative;
-    background-color: #fff;
-
-    @include set-smaller-font-size();
+    overflow: hidden;
+    @include set-font-size($left-nav-font-size);
 
     a {
-        color: $text-color;
-        display: inline-block;
+        display: inline;
         max-width: 100%;
-        overflow: hidden;
         position: relative;
+        overflow: hidden;
         text-overflow: ellipsis;
 
         /* 404 link */
@@ -21,8 +25,46 @@ $see-also-outdent: 6px;
         }
     }
 
-    /* hides submenus by default */
-    ul ul {
+    li {
+        line-height: 1.2;
+        padding-bottom: $grid-spacing;
+    }
+
+    li li {
+        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+        padding-bottom: $grid-spacing / 2;
+
+        &:first-child {
+            padding-top: $grid-spacing / 2;
+        }
+    }
+
+    /* toggles */
+    .toggleable {
+        margin-top: $grid-spacing * -1 + 5px;
+
+        /* not if it's first in the quicklinks menu */
+        &:first-child {
+            margin-top: 0;
+        }
+
+        > a {
+            @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+            color: $text-color;
+            display: inline-block;
+
+            #{$selector-icon} {
+                @include bidi-style(left, 0, right, auto);
+                @include set-font-size($body-font-size);
+                color: $link-color;
+                position: absolute;
+                top: 1px;
+            }
+        }
+    }
+
+    /* toggled closed by default, not all get the default-state identifier though  */
+    > ol > li > ol {
         display: none;
 
         .no-js & {
@@ -30,45 +72,12 @@ $see-also-outdent: 6px;
         }
     }
 
-    li {
-        padding-top: $content-vertical-spacing;
-        position: relative;
+    /* these will be open once JS runs  */
+    > ol > li[data-default-state='open'] > ol {
+        display: block;
     }
 
-    li li {
-        @include bidi-style(padding-left, $grid-spacing * 1.5, padding-right, 0);
-    }
-
-    li li li {
-        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
-    }
-
-    code {
-        background-color: transparent;
-        color: inherit;
-        padding: 0;
-    }
-
-    /* don't allow empty paragraphs by CKEditor */
-    p:empty,
-    div:empty {
-        display: none;
-    }
-
-    .title {
-        display: inline-block;
-        margin-bottom: 0;
-        width: 100%;
-
-        &.see-also {
-            background: $light-background-color;
-            /* to left align the text in this box with the text above and below */
-            @include bidi-style(margin-left, ($see-also-outdent * -1), margin-right, 0);
-            @include bidi-value(padding, 4px $see-also-outdent 4px 0, 4px 0 4px $see-also-outdent);
-            text-indent: $see-also-outdent;
-        }
-    }
-
+    /* sidebar icons - deprecated, obsolete, experiemental, etc */
     .sidebar-icon {
         @include bidi-value(margin-left, $grid-spacing * -1, 5px);
         @include bidi-value(margin-right, 5px, $grid-spacing * -1);
@@ -82,23 +91,8 @@ $see-also-outdent: 6px;
 
         #{$selector-icon} {
             @include set-font-size($body-font-size);
-            position: relative;
-            top: 3px;
             min-width: 15px;
             vertical-align: top;
         }
-    }
-}
-
-/* items which can be clicked on to toggle */
-.quick-links .toggleable > a {
-    display: inline-block;
-    @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
-
-    #{$selector-icon} {
-        @include set-font-size($body-font-size);
-        position: absolute;
-        top: 1px;
-        @include bidi-style(left, 0, right, auto);
     }
 }

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -129,6 +129,7 @@ $note-font-size: 18px;
 $body-font-size: 16px;
 $form-font-size: $body-font-size;
 $tiny-font-size: 12px;
+$left-nav-font-size: 14px;
 
 $mobile-document-title-font-size: 32px;
 

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -18,7 +18,7 @@
 
 {% macro get_document_quick_links(html) %}
   <div class="quick-links" id="quick-links">
-    <div class="title see-also">{{ _('See also') }}</div>
+    <div class="quick-links-head">{{ _('Related Topics') }}</div>
     {{ html|safe }}
   </div>
 {%- endmacro %}


### PR DESCRIPTION
- tweak function adding intelligent breakpoints to long titles
    - add break before `[`
    - don't add break before first letter of title
    - don't run if there are child elements
- remove background colour from `<code>` elements
- brighten strike through items when hovered (to make them readable)
- change heading to "related topics"
- make links blue
- group headings with their subcategories
- tweak what's hidden while js loads

Test pages:
http://localhost:8000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array
http://localhost:8000/en-US/docs/Learn/HTML/Introduction_to_HTML
http://localhost:8000/en-US/docs/Web/CSS/border-radius
http://localhost:8000/en-US/Add-ons/Firefox_for_Android/API/window.NativeWindow/window.NativeWindow.contextmenus/window.NativeWindow.contextmenus.remove
http://localhost:8000/en-US/Add-ons/WebExtensions/What_are_WebExtensions