### PR TITLE
Implements fallback for IE9 and older

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -6,7 +6,9 @@
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <!--[if lte IE 9]>
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
+  <![endif]-->
   <title>{% block title %}{{ _('MDN Web Docs') }}{% endblock %}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -17,19 +19,22 @@
   {% endif %}
 
   {% block site_css %}
-
     {% stylesheet 'mdn' %}
 
     {% for style in styles %}
       {% stylesheet style %}
     {% endfor %}
+
+    <!--[if lte IE 9]>
+      {% stylesheet 'fallback' %}
+    <![endif]-->
   {% endblock %}
 
   {%- if settings.MAINTENANCE_MODE %}
     {% stylesheet 'maintenance-mode-global' %}
   {%- endif %}
 
-  {#- If the stylesheet exists, include it. Otherwise, does nothing. #}
+  {#- If the stylesheet exists, include it. Otherwise, do nothing. #}
   {% stylesheet 'locale-%s' % LANG %}
 
   {% block site_analytics %}
@@ -58,11 +63,11 @@
   <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ static('img/favicon72.png') }}">
   <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
   <link rel="apple-touch-icon-precomposed" href="{{ static('img/favicon57.png') }}">
+
   <!-- basic favicon -->
   <link rel="shortcut icon" href="{{ static('img/favicon32.png') }}">
   <!--[if IE]>
-  <meta http-equiv="imagetoolbar" content="no">
-  {% javascript 'html5shiv' %}
+    {% javascript 'html5shiv' %}
   <![endif]-->
 
   {% javascript 'font-check' %}
@@ -240,21 +245,28 @@
     {%- endif %} {# if not untrusted #}
 
   <!-- site js -->
+  <![if !lte IE 9]>
   {% block site_js %}
-    <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
-
     {{ providers_media_js() }}
-    <script type="text/javascript" src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+
+    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+
     {% javascript 'main' %}
+
     <script>
-      if(window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
+      if (window.mdn && mdn.analytics) {
+        mdn.analytics.trackOutboundLinks();
+      }
     </script>
+
     {% for script in scripts %}
       {% javascript script %}
     {% endfor %}
-
   {% endblock %}
+  <![endif]>
 
-  {% block js %}{% endblock %}
+  <![if !lte IE 9]>
+    {% block js %}{% endblock %}
+  <![endif]>
 </body>
 </html>

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -4,8 +4,9 @@
 
 {% block site_css %}
   {{ super() }}
-
-  {% stylesheet 'home' %}
+  <![if !lte IE 9]>
+    {% stylesheet 'home' %}
+  <![endif]>
 {% endblock %}
 
 {% block extrahead %}
@@ -142,8 +143,10 @@
 {% endblock %}
 
 {% block js %}
+<![if !lte IE 9]>
   {{ super() }}
   {% if settings.NEWSLETTER %}
     {% javascript 'newsletter' %}
   {% endif %}
+<![endif]>
 {% endblock %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -673,6 +673,12 @@ def pipeline_one_scss(slug, **kwargs):
 
 
 PIPELINE_CSS = {
+    'fallback': {
+        'source_filenames': (
+            'styles/fallback.scss',
+        ),
+        'output_filename': 'build/styles/fallback.css',
+    },
     'mdn': {
         'source_filenames': (
             'styles/font-awesome.scss',

--- a/kuma/static/styles/fallback.scss
+++ b/kuma/static/styles/fallback.scss
@@ -1,0 +1,9 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+@import 'base/elements/reset';
+@import 'base/elements/document';
+@import 'base/elements/typography';
+@import 'base/elements/tables';
+
+@import 'fallback/overrides';

--- a/kuma/static/styles/fallback/overrides.scss
+++ b/kuma/static/styles/fallback/overrides.scss
@@ -1,0 +1,129 @@
+body {
+    margin: 10px 20px;
+}
+
+pre {
+    margin-top: 20px;
+    max-height: 250px;
+    overflow: scroll;
+}
+
+.logo {
+    position: relative;
+    z-index: 2; // get above nav-main
+    width: 219px;
+    height: 50px;
+    background: url($logo-sprite-url) 100% 0 no-repeat;
+    background-size: 219px auto;
+    display: block;
+    direction: ltr; // ltr should be set with negative text indent
+    text-indent: -9999px;
+    overflow: hidden;
+}
+
+.nav-main {
+    margin: 20px 0;
+}
+
+.home-masthead {
+    h1 {
+        margin-bottom: 20px;
+    }
+}
+
+.crumbs {
+    float: none;
+    display: block;
+    margin: 20px 0;
+}
+
+.toc,
+.quick-links {
+    margin-top: 20px;
+}
+
+.quick-links {
+    .title {
+        margin-bottom: 20px;
+        font-size: $note-font-size;
+        font-weight: bold;
+    }
+}
+
+.summary {
+    margin-top: 20px;
+    padding: 10px 0;
+    border-top: 5px solid #83d0f2;
+    border-bottom: 5px solid #83d0f2;
+}
+
+.topicpage-table {
+    dd {
+        margin-bottom: 20px;
+    }
+
+    ul > li {
+        margin-bottom: 10px;
+    }
+
+    li > ul {
+        margin-top: 20px;
+    }
+
+    ul > li li {
+        margin-left: 20px;
+        list-style-type: disc;
+    }
+}
+
+.search-results-filters {
+    legend {
+        margin: 20px 0;
+    }
+
+    label {
+        display: block;
+    }
+}
+
+.newsletter-group-submit {
+    margin-top: 20px;
+}
+
+table.properties {
+    th {
+        vertical-align: top;
+    }
+}
+
+.compat-table {
+    width: 95%;
+
+    tbody tr:nth-child(2n) {
+        background-color: #eaeef2;
+    }
+}
+
+.contributors-sub {
+    margin-top: 20px;
+}
+
+/* hidden elements */
+#nav-access {
+    width: 100%;
+    position: absolute;
+    top: -20em;
+    z-index: 1001;
+}
+
+#nav-sec,
+.bc-data,
+.document-actions,
+.helpful-survey,
+.home-masthead form,
+.nav-footer-logo,
+.newsletter-thanks,
+.newsletter-hide,
+.zone-parent {
+    display: none;
+}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -51,6 +51,7 @@
 
 {% block site_css %}
     {{ super() }}
+    <![if !lte IE 9]>
     {% if nearest_zone %}
       {% if nearest_zone.css_slug %}
         {% stylesheet 'zone-' + nearest_zone.css_slug %}
@@ -58,6 +59,7 @@
         {% stylesheet 'zones' %}
       {% endif %}
     {% endif %}
+    <![endif]>
 {% endblock %}
 
 {% block extrahead %}


### PR DESCRIPTION
Implements fallback styles for IE9 and older. No javascript is served to these browser either, except for GA but, we can probably remove that as well, unless we create a tiny bundle of JS that collects stats.

The aim here is to make the pages as light as possible while ensuring pages and content are readable.