### PR TITLE
Bug 1414107: Update typography hierarchy

### DIFF
--- a/kuma/static/js/highlight.js
+++ b/kuma/static/js/highlight.js
@@ -9,8 +9,8 @@
         });
     }
 
-    // call on aritcle body with h3 and h4 as targets
-    var $articleSubHeads = $('#wikiArticle h2');
+    // call on aritcle body with targets
+    var $articleSubHeads = $('#wikiArticle h3, #wikiArticle h5');
     highlight($articleSubHeads);
 
 })(jQuery);

--- a/kuma/static/styles/base/elements/sectioning.scss
+++ b/kuma/static/styles/base/elements/sectioning.scss
@@ -67,9 +67,10 @@ summary {
 }
 
 hr {
-    border-top: 1px solid $text-color;
+    border-top: $section-border;
     height: 0;
     margin: $grid-spacing 0;
+    @include restrict-line-length();
 }
 
 @media print {

--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -17,21 +17,31 @@ h2 {
 }
 
 h3 {
-    margin: $grid-spacing 0 ($grid-spacing / 2) 0;
+    margin: $grid-spacing 0;
     @include set-font-size($h3-font-size);
     @include set-heading-font-family();
+    line-height: $heading-line-height;
 }
 
 h4 {
-    margin: $grid-spacing 0 ($grid-spacing / 2) 0;
+    margin: ($grid-spacing * 1.5) 0 $grid-spacing 0;
     @include set-font-size($h4-font-size);
     @include set-heading-font-family();
+    line-height: $heading-line-height;
 }
 
 h5 {
     margin: ($grid-spacing / 2) 0;
+    @include set-font-size($h5-font-size);
+    @include set-heading-font-family();
+    line-height: $heading-line-height;
+}
+
+h6 {
+    margin: ($grid-spacing / 2) 0;
     @include set-font-size($body-font-size);
     @include set-heading-font-family();
+    line-height: $heading-line-height;
 }
 
 /*
@@ -101,6 +111,7 @@ code {
     padding: 0 2px;
     word-wrap: break-word;
 
+    .index &,
     .indexListTerm & {
         background-color: transparent;
         padding: 0;

--- a/kuma/static/styles/components/components.scss
+++ b/kuma/static/styles/components/components.scss
@@ -132,7 +132,7 @@ $notification-button-padding: 2px 5px 3px;
     }
 
     .text-content & {
-        @include restrict-line-length;
+        @include restrict-line-length();
     }
 
     &.closed {

--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -81,9 +81,56 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     sectioning
     ====================================================================== */
 
-    h2 {
+    /* direct decendants h2s get styled like section seperators
+       so do things we think are h2s added by macros */
+    article[id=wikiArticle] > h2,
+    article[id=wikiArticle] > div:not([class]) > h2 {
+        @include heading-2-section();
+    }
+
+    /*  remove top spacing if h2 is effectivly first element in article */
+    article[id=wikiArticle] > h2:first-child,
+    article[id=wikiArticle] > div:first-child:empty + h2,
+    article[id=wikiArticle] > p:first-child:empty + h2,
+    .Quick_links + h2 {
+        margin-top: 0;
+        padding-top: 0;
+
+        &:before {
+            display: none;
+        }
+    }
+
+    /* fix spacing and line if h2 directly follows a hr, summary, or blockquote */
+    article[id=wikiArticle] > hr + h2,
+    article[id=wikiArticle] > .summary + h2,
+    article[id=wikiArticle] > blockquote + h2 {
+        margin-top: ($grid-spacing + $section-border-width) * -1;
+        padding-top: $grid-spacing * 2 + $section-border-width;
+        background-color: #fff;
+
+        &:before {
+            top: 0;
+        }
+    }
+
+    h3,
+    h5 {
         @extend %highlight;
     }
+
+    h3,
+    h3 .highlight-span {
+        @include bidi-value(padding, 0 4px 0 $grid-spacing, 0 $grid-spacing 0 4px);
+    }
+
+    @media #{$mq-tablet-and-up} {
+        h3,
+        h3 .highlight-span {
+            @include bidi-value(padding, 0 4px 0 $grid-spacing * 2, 0 $grid-spacing * 2 0 4px);
+        }
+    }
+
 
     /*
     tables
@@ -168,6 +215,12 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     /*
     typography
     ====================================================================== */
+
+    /* don't allow empty paragraphs by CKEditor */
+    p:empty,
+    div:empty {
+        display: none;
+    }
 
     p {
         @include restrict-line-length();

--- a/kuma/static/styles/components/newsletter.scss
+++ b/kuma/static/styles/components/newsletter.scss
@@ -253,7 +253,7 @@ article page modifications
 -------------------------------------------------------------- */
 .newsletter-box {
     position: relative;
-    border-top: 2px solid $text-color;
+    border-top: $section-border-width solid $text-color;
     padding: $grid-spacing 0;
     margin-top: $grid-spacing * 2;
     background-color: #fff;

--- a/kuma/static/styles/components/structure.scss
+++ b/kuma/static/styles/components/structure.scss
@@ -76,6 +76,11 @@ Misc - needs sorting
     display: none; /* bug 1305178: hide empty first paragraph */
 }
 
+#wikiArticle {
+    padding-bottom: $grid-spacing;
+    border-bottom: $section-border;
+}
+
 p.field-explanation {
     margin-bottom: 0;
 }

--- a/kuma/static/styles/components/wiki/content/card-grid.scss
+++ b/kuma/static/styles/components/wiki/content/card-grid.scss
@@ -11,7 +11,6 @@ side by side calls to action
     > li {
         padding: ($grid-spacing / 2);
         background-color: $light-background-color;
-        @include bidi-value(box-shadow, 3px 3px 0 3px $header-background-color, -3px 3px 0 3px $header-background-color);
 
         > span:first-child,
         > a:first-child {
@@ -28,18 +27,19 @@ side by side calls to action
         display: flex;
         justify-content: center;
         flex-wrap: wrap;
+        margin: 0 0 ($grid-spacing / 2); /* margins on items don't collapse with margin on box, reduce so two together add up to $grid-spacing */
 
         > li {
             flex: 1;
-            min-width: calc(25% - #{($grid-spacing * 2.5)}); /* minus margin and padding */
-            max-width: 200px;
-            margin: 0 ($grid-spacing * .75) $grid-spacing;
-        }
-    }
+            margin: 0 ($grid-spacing / 2) ($grid-spacing / 2);
 
-    @media #{$mq-mobile-and-down} {
-        > li {
-            margin-bottom: $grid-spacing;
+            &:first-child {
+                margin-left: 0;
+            }
+
+            &:last-child {
+                margin-right: 0;
+            }
         }
     }
 }

--- a/kuma/static/styles/components/wiki/content/landingPage.scss
+++ b/kuma/static/styles/components/wiki/content/landingPage.scss
@@ -3,8 +3,8 @@
 .landingPageBox {
     width: 100%;
     padding: 0;
-    border-bottom: 1px solid #bbb;
-    margin-bottom: 3px;
+    border-bottom: $section-border;
+    margin-bottom: $grid-spacing;
 }
 
 .landingPageBox ul {

--- a/kuma/static/styles/components/wiki/content/originaldocinfo.scss
+++ b/kuma/static/styles/components/wiki/content/originaldocinfo.scss
@@ -1,14 +1,16 @@
 /* some documents have different lisences for historic reasons */
 .licenseblock,
 .originaldocinfo {
-    @include set-message-base(true);
+    @include set-font-size($smaller-font-size);
+    @include heading-2-section();
     background: $grey-light;
     border: 2px solid $grey;
-    @include set-font-size($smaller-font-size);
+    padding: $grid-spacing $grid-spacing 0;
 }
 
 .originaldocinfo {
     h2 {
         @include set-font-size($body-font-size);
+        margin-top: 0;
     }
 }

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -110,10 +110,19 @@ inline in a heading
 -------------------------------------------------------------- */
 
 .headingWithIndicator {
+    position: relative;
     @include clearfix();
 
-    h1,
-    h2,
+    h2 {
+        @include heading-2-section();
+
+        & + .indicatorInHeadline {
+            position: absolute;
+            top: 6px;
+            @include bidi-style(right, 0, left, auto);
+        }
+    }
+
     h3,
     h4,
     h5,

--- a/kuma/static/styles/components/wiki/topicpage-table.scss
+++ b/kuma/static/styles/components/wiki/topicpage-table.scss
@@ -12,6 +12,7 @@ body .topicpage-table { // need the extra specificity of body to over-ride .text
     border: none;
     display: block;
     border-collapse: collapse;
+    margin-bottom: $grid-spacing;
 
     tr,
     th,
@@ -27,6 +28,7 @@ body .topicpage-table { // need the extra specificity of body to over-ride .text
 .topicpage-table {
     h2 {
         @include set-heading-font-family();
+        margin-top: 0;
     }
 
     ul {

--- a/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
+++ b/kuma/static/styles/components/wiki/wiki-helpful-survey.scss
@@ -1,6 +1,10 @@
 .helpful-survey {
+    @include heading-2-section();
     float: none;
-    margin: $grid-spacing auto;
+    /* don't specify margin-top to avoid conflict with heeading-2-section() */
+    margin-left: 0;
+    margin-right: 0;
+    margin-bottom: 20px;
     box-sizing: border-box;
     width: 100%;
     border: 0;

--- a/kuma/static/styles/includes-skinny/_mixins.scss
+++ b/kuma/static/styles/includes-skinny/_mixins.scss
@@ -407,6 +407,16 @@ These are not dynamic but serve as mixins
     display: block;
 }
 
+
+@mixin restrict-line-length() {
+    /* empty here but not in waffled version of code */
+}
+
+
+@mixin full-width-content() {
+    /* empty here but not in waffled version of code */
+}
+
 /*
 pull aside
 - assumes content has a bottom margin of its own

--- a/kuma/static/styles/includes-skinny/_vars.scss
+++ b/kuma/static/styles/includes-skinny/_vars.scss
@@ -113,6 +113,7 @@ $site-font-family: 'Open Sans', $site-font-family-fallback;
 $heading-font-family-fallback: 'Palatino', 'Palatino Linotype', x-locale-heading-secondary, serif;
 $heading-font-family: x-locale-heading-primary, zillaslab, $heading-font-family-fallback;
 $tiny-font-family: 'Helvetica', arial, sans-serif;
+$heading-line-height: 1.2;
 $code-block-font-family: consolas, monaco, 'Andale Mono', monospace; /* prism */
 $code-inline-font-family: consolas, 'Liberation Mono', courier, monospace; /* inline */
 $diff-font-family: $code-inline-font-family;
@@ -124,6 +125,7 @@ $h1-font-size: 48px;
 $h2-font-size: 24px;
 $h3-font-size: 22px;
 $h4-font-size: 20px;
+$h5-font-size: 16px;
 $callout-font-size: 22px;
 $note-font-size: 18px;
 $body-font-size: 16px;
@@ -249,6 +251,9 @@ $list-item-spacing : $content-horizontal-spacing;
 $icon-margin : ($grid-spacing / 2);
 
 $logo-height: 48px;
+
+$section-border-width: 1px;
+$section-border: $section-border-width solid #000;
 
 /*
 forms

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -372,24 +372,50 @@ These are not dynamic but serve as mixins
 }
 
 @mixin heading-2() {
-    @include set-font-size($h2-font-size);
+    @include set-font-size($mobile-h2-font-size);
     font-family: $heading-font-family;
-    line-height: 1;
+    line-height: $heading-line-height;
     #{$selector-heading-font-fallback} {
         font-family: $heading-font-family-fallback;
+    }
+
+    @media #{$mq-tablet-and-up} {
+        @include set-font-size($h2-font-size);
+    }
+}
+
+@mixin heading-2-section() {
+    position: relative;
+    margin-top: $grid-spacing * 5 + $section-border-width;
+
+    &:before {
+        @include bidi-style(left, 0, right, auto);
+        border-top: $section-border;
+        content: '';
+        display: block;
+        position: absolute;
+        top: $grid-spacing * 2.5 * -1;
+        width: 100%;
     }
 }
 
 @mixin callout() {
     @include restrict-line-length();
-    @include set-font-size(22px);
-    border: 5px solid $accent-light;
-    border-width: 5px 0;
+    @include set-font-size(20px);
+    border: $section-border-width solid $accent-light;
+    border-width: $section-border-width 0;
     border-image: linear-gradient(to right, $accent-dark, $accent-light) 10;
     padding: $grid-spacing 0;
     margin-bottom: $grid-spacing;
 
     @include prevent-last-child-spacing(p, margin-bottom);
+
+    article > &:first-child,
+    article > div:first-child:empty + &,
+    article > p:first-child:empty + & {
+        border-top-width: 0;
+        padding-top: 0;
+    }
 }
 
 @mixin clearfix() {
@@ -522,15 +548,20 @@ Placeholders
 
     &,
     & .highlight-span {
-        padding: 0 4px;
         background-color: $text-color;
         color: #fff;
         font-weight: normal;
         line-height: 1.25;
+        padding: 0 4px;
         @include vendorize(box-decoration-break, clone);
 
         a {
             color: $accent-light;
+        }
+
+        code {
+            background-color: rgba(255, 255, 255, .4) !important; /* stylelint-disable-line declaration-no-important */
+            color: #fff !important; /* stylelint-disable-line declaration-no-important */
         }
     }
 }
@@ -541,7 +572,7 @@ Placeholders
     box-sizing: border-box;
     display: inline-block;
     border-bottom: 2px solid;
-    @include bidi-style(padding, 10px 30px 10px 0, padding-left, 10px 0 10px 30px);
+    @include bidi-value(padding, 10px 30px 10px 0, 10px 0 10px 30px);
     @include bidi-value(text-align, left, right);
 
     &:after {

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -84,7 +84,7 @@ $neutral: $blue;
 $default: $grey;
 
 $text-color: #333;
-$link-color: darken($blue, 5);
+$link-color: #3f87a6;
 $menu-link-color: $text-color;
 $blue-background-text-color: #fff;
 $light-background-color: #{map-get( map-get($colors-lookup, 'default'), 'light')};
@@ -113,6 +113,7 @@ $site-font-family-fallback: arial, x-locale-body, sans-serif;
 $site-font-family: 'Open Sans', $site-font-family-fallback;
 $heading-font-family-fallback: 'Palatino', 'Palatino Linotype', x-locale-heading-secondary, serif;
 $heading-font-family: x-locale-heading-primary, zillaslab, $heading-font-family-fallback;
+$heading-line-height: 1.2;
 $tiny-font-family: 'Helvetica', arial, sans-serif;
 $code-block-font-family: consolas, monaco, 'Andale Mono', monospace; /* prism */
 $code-inline-font-family: consolas, 'Liberation Mono', courier, monospace; /* inline */
@@ -122,9 +123,10 @@ $diff-font-family: $code-inline-font-family;
 sizes
 ====================================================================== */
 $h1-font-size: 48px;
-$h2-font-size: 24px;
-$h3-font-size: 22px;
-$h4-font-size: 20px;
+$h2-font-size: 40px;
+$h3-font-size: 24px;
+$h4-font-size: 22px;
+$h5-font-size: 16px;
 $callout-font-size: 22px;
 $note-font-size: 18px;
 $body-font-size: 16px;
@@ -132,6 +134,7 @@ $form-font-size: $body-font-size;
 $tiny-font-size: 12px;
 
 $mobile-document-title-font-size: 32px;
+$mobile-h2-font-size: 32px;
 
 /* bumps */
 $larger-font-size: $callout-font-size;
@@ -243,6 +246,9 @@ $list-item-spacing: $content-horizontal-spacing;
 $icon-margin: ($grid-spacing / 2);
 
 $logo-height: 48px;
+
+$section-border-width: 3px;
+$section-border: $section-border-width solid $blue;
 
 /*
 forms


### PR DESCRIPTION
- add separator variables
- add separator to h2s
- add separator to end of articles
- make hr match separator
- collapse separator lines when appearing next to each other:
  - summaries, blockquotes, top of the page, hrs
- move highlight to h3 and h5
- font size and margin changes to all headings
- remove empty p and div tags from article bodies
- adjust card-grid to appear better as full-width-content
- tweaks to components that use headings in them to accommodate new
  margins and typography on headings