### PR TITLE
Bug 1414107: Display tweaks for zone-parent

### DIFF
--- a/kuma/static/styles/zones/components/parent.scss
+++ b/kuma/static/styles/zones/components/parent.scss
@@ -3,14 +3,10 @@ Custom images which appear in zone headers
 ********************************************************************** */
 
 .zone-parent {
-    @include heading-1();
+    @include set-font-size($mobile-document-title-font-size);
     background-repeat: no-repeat;
     background-size: contain;
     border: 0 solid #d7d7d7;
-    @include bidi-style(border-right-width, 1px, border-left-width, 0);
-    @include bidi-value(float, left, right);
-    @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
-    @include bidi-style(padding-right, ($grid-spacing / 2), padding-left, 0);
 
     .zone-landing & {
         // Don't display by default, it will look like duplicate text
@@ -20,6 +16,9 @@ Custom images which appear in zone headers
 
 @media #{$mq-tablet-and-up} {
     .zone-parent {
+        @include heading-1();
+        @include bidi-style(border-right-width, 1px, border-left-width, 0);
+        @include bidi-value(float, left, right);
         @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
         @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
     }
@@ -28,12 +27,13 @@ Custom images which appear in zone headers
 @mixin zone-image($img, $width, $height) {
     $image-small-size: $mobile-document-title-font-size;
     $image-big-size: $h1-font-size;
-    $image-landing-size: 90px;
     $image-small-width: round($width * $image-small-size / $height);
     $image-big-width: round($width * $image-big-size / $height);
-    $image-landing-width: round($width * $image-landing-size / $height);
 
     .zone-parent {
+        @include bidi-value(float, left, right);
+        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+        display: block;
         background-image: url($path-to-images + 'zones/' + $img);
         direction: ltr; // ltr should be set with negative text indent
         height: $image-small-size;
@@ -46,8 +46,6 @@ Custom images which appear in zone headers
             display: block;
             // but grey it out so it doesn't look like a link
             filter: saturate(0);
-            @include bidi-style(margin-right, 0, margin-left, 0);
-            border: none;
         }
     }
 
@@ -55,12 +53,6 @@ Custom images which appear in zone headers
         .zone-parent {
             height: $image-big-size;
             width: $image-big-width;
-
-            .zone-landing & {
-                height: $image-landing-size;
-                width: $image-landing-width;
-                margin-top: $image-big-size - $image-landing-size - 7px;
-            }
         }
     }
 }


### PR DESCRIPTION
- make landing page icon same size as sub page icons (in preparation for breadcrumbs to be removed and document head to shrink)
- keep zone parent text on separate line from document title until tablet breakpoint
- make zone parent font size match document title font size

Testing notes:
- some zones have an icon ([Learn](https://developer.mozilla.org/en-US/docs/Learn)) and some have text ([Extensions](https://developer.mozilla.org/en-US/Add-ons/WebExtensions))
- the zone landing page and the interior pages used to have different size icons but this PR changes that