### PR TITLE
Fix Bug 1414107: Sticky TOC and mobile collapsed

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1075,6 +1075,7 @@ PIPELINE_JS = {
             'js/interactive.js',
             'js/wiki-samples.js',
             'js/wiki-helpful-survey.js',
+            'js/wiki-toc.js',
         ),
         'output_filename': 'build/js/wiki.js',
         'extra_context': {

--- a/kuma/static/js/wiki-toc.js
+++ b/kuma/static/js/wiki-toc.js
@@ -1,0 +1,219 @@
+(function ($, win, doc) {
+    'use strict';
+
+    var breakpoint = '(min-width: 47.9385em)';
+    var $h2s = $('#wikiArticle').find('h2');
+    var tocHeight = 0;
+    var tocItemHeight = 0;
+    var headingMargin = 0;
+
+    function scrollToHeading(id) {
+        /* must use plain JS to get element, IDs contain characters jQuery can't handle */
+        var $heading = $(doc.getElementById(id));
+        var headingTop = $heading.offset().top;
+        var scrollY = headingTop - tocHeight - headingMargin;
+
+        // update hash
+        win.location.hash = '#' + id;
+        // scroll to heading
+        win.scroll(0, scrollY);
+    }
+
+    /* Mobile
+    ************************************************************************ */
+
+    function toggleCollapse(trigger) {
+        var $trigger = $(trigger);
+        var targetId = $trigger.attr('aria-controls');
+        var $target = $('#'+targetId);
+        var expanded = $trigger.attr('aria-expanded') === 'true' ? true : false;
+
+        if(expanded) {
+            $target.attr('aria-hidden', 'true');
+            $trigger.attr('aria-expanded', 'false');
+        } else {
+            $target.attr('aria-hidden', 'false');
+            $trigger.attr('aria-expanded', 'true');
+        }
+    }
+
+    function collapseHeadings() {
+        // don't collapse if just one heading
+        if ($h2s.length < 2) {
+            return;
+        }
+
+        $h2s.each(function(index, h2) {
+            var $h2 = $(h2);
+            var $buttonTemplate = $('<button class="collapse-trigger" aria-expanded="false" aria-controls="collapse-' + index + '"></button>');
+            $buttonTemplate.on('click', function() {
+                toggleCollapse(this);
+            });
+            // add expanded state and buttons to all h2s
+            $h2.find('.section-edit').remove();
+            // remove inline edit buttons
+            $h2.wrapInner($buttonTemplate);
+            // wrap all content in a <div> with aria hidden and ID
+            $h2.nextUntil('h2').wrapAll('<div id="collapse-' + index + '" class="collapsible" aria-hidden="true"></div>');
+        });
+
+        // open by default if user has arrived on specific heading
+        if(window.location.hash) {
+            var thisHash = window.location.hash;
+            var headingId = thisHash.replace(/^#/, '');
+            /* must use plain JS to get element, IDs contain characters jQuery can't handle */
+            var $heading = $(doc.getElementById(headingId));
+            if($heading.length) {
+                var $button = $heading.find('button');
+                $button.click();
+            }
+            scrollToHeading(headingId);
+        }
+    }
+
+
+    /* Desktop & Tablet
+    ************************************************************************ */
+
+    function stickyToc() {
+        // I'm making Table Of Contents lowercase, deal with it
+
+        // detect toc
+        var $toc = $('#toc');
+        var hasToc = $toc.length ? true : false;
+        var underlineTimeOutId;
+        var underlineWait = false;
+        var underlineWaitTime = 100;
+        var wiggleRoom = 20; // vaguely 0.5em, looks right at 100% zoom
+        // detect compat table
+        var $compatTable = $('.htab');
+        var hasCompat = $compatTable.length ? true : false;
+
+        // quit if no #toc on page
+        if(!hasToc) {
+            return;
+        }
+
+        // hide toc if only one heading, unless one is compat link
+        if ($h2s.length < 2 && !hasCompat) {
+            // hide it
+            $toc.addClass('hidden');
+            // stop here
+            return;
+        }
+
+        // set toc height
+        tocHeight = $toc.outerHeight();
+        tocItemHeight = $toc.find('li:first').outerHeight();
+
+
+        // In theory we should not have a TOC without any h2s but it doesn't hurt to be careful
+        if($h2s.length) {
+            // can't use first, it has different margins if it's a :first-child
+            var $lastheading = $h2s.last();
+            // set headingMargin
+            headingMargin = parseInt($lastheading.css('margin-bottom'));
+        }
+
+        function underlineCurrent() {
+            var screenTop = $(win).scrollTop();
+            var screenBottom = screenTop + $(win).height();
+            var screenUsableBottom = screenBottom - wiggleRoom;
+            var screenUsableTop = screenTop + tocHeight + headingMargin + wiggleRoom;
+            var $lastVisible;
+
+            $h2s.each(function(index, h2) {
+                var $h2 = $(h2);
+                var h2Top = $h2.offset().top;
+                var h2Bottom = h2Top + $h2.outerHeight();
+                var $linkToH2 = $toc.find('a[href="#' + $h2.attr('id') + '"]');
+
+                // if it's off the top of the usable screen it might be the current section
+                if(h2Top < screenUsableTop) {
+                    $lastVisible = $linkToH2;
+                }
+
+                // if it's in the usable space it's definately current
+                if((h2Top > screenUsableTop) && ((h2Bottom + headingMargin) < screenUsableBottom)){
+                    // visible
+                    $linkToH2.addClass('toc-current');
+                } else {
+                    $linkToH2.removeClass('toc-current');
+                }
+            });
+            // last visible one is also "current"
+            if($lastVisible) {
+                $lastVisible.addClass('toc-current');
+            }
+        }
+
+        // Throttle and debounce underline
+        function countDownToUnderline () {
+            /* debounce - save underlineWaitTime seconds after scroll stop */
+            // clear old countdown to save
+            clearTimeout(underlineTimeOutId);
+            // begin new countdown to save
+            underlineTimeOutId = setTimeout(underlineCurrent, underlineWaitTime);
+            /* throttle - save every 500ms */
+            if (!underlineWait) {
+                // underline current
+                underlineCurrent();
+                // start wait before saving next time
+                underlineWait = true;
+                setTimeout(function () {
+                    underlineWait = false;
+                }, underlineWaitTime);
+            }
+        }
+
+        function handleTocClick(event) {
+            var $thisTarget = $(event.target);
+            var $thisLink = $thisTarget.closest('a');
+            var linkHref = $thisLink.attr('href');
+            var headingId = linkHref.replace(/^#/, '');
+            var linkData = {
+                category: 'TOC Links',
+                action: $thisLink.text(),
+                label: linkHref
+            };
+
+            // track click
+            mdn.analytics.trackLink(event, linkHref, linkData);
+            scrollToHeading(headingId);
+        }
+
+        // if 3 lines tall or more make it not sticky
+        if (tocHeight > tocItemHeight * 2) {
+            $toc.addClass('toc_tall');
+            mdn.analytics.trackError('TOC Height Warning', 'Reported height:' + tocHeight);
+        }
+
+        // fix scrolling if toc sticky and visible
+        if($toc.css('position') === 'sticky' && $toc.is(':visible')) {
+            $toc.find('a[href]').on('click', function(event) {
+                event.preventDefault();
+                handleTocClick(event);
+            });
+        }
+
+        $(win).on('scroll', function() {
+            // underline current section
+            countDownToUnderline();
+        });
+
+        if(window.location.hash) {
+            var thisHash = window.location.hash;
+            var headingId = thisHash.replace(/^#/, '');
+            scrollToHeading(headingId);
+        }
+    }
+
+    if(win.matchMedia(breakpoint).matches === true) {
+        // don't collapse, possibly make sticky - let stickyToc() figure that out
+        stickyToc();
+    } else {
+        // mobile, collapse
+        collapseHeadings();
+    }
+
+}(jQuery, window, document));

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -213,21 +213,6 @@
         }
     });
 
-    /*
-        Track clicks on TOC links
-    */
-    $('#toc').on('click contextmenu', 'a', function(event) {
-        var $thisLink = $(this);
-        var url = $thisLink.attr('href');
-
-        var linkData = {
-            category: 'TOC Links',
-            action: $thisLink.text(),
-            label: $thisLink.attr('href')
-        };
-
-        mdn.analytics.trackLink(event, url, linkData);
-    });
 
     /*
         Track clicks on main nav links
@@ -256,19 +241,6 @@
 
         mdn.analytics.trackLink(event, url, data);
     });
-
-
-    /*
-        Close the TOC menu by default
-    */
-    (function() {
-        var $toc = $('#toc');
-
-        if ($toc.length) {
-            var $toggler = $toc.find('> .toggler');
-            $toggler.trigger('mdn:click');
-        }
-    })();
 
     /*
         Compat table table setup

--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -1,13 +1,12 @@
 .document-head {
     position: relative;
+    z-index: $document-head-z;
     clear: both;
     background-color: #f5f9fa;
     padding: $first-content-top-padding 0 $last-content-bottom-padding 0;
 }
 
 .document-title {
-    position: relative;
-
     h1 {
         @include set-font-size($mobile-document-title-font-size);
     }
@@ -21,7 +20,7 @@
 
 .document-actions {
     position: relative;
-    z-index: 1; // raise above the h1 in the document-title
+    z-index: $document-actions-z;
     @include bidi-value(float, right, left);
     width: 100%;
     margin-bottom: ($grid-spacing / 2);

--- a/kuma/static/styles/components/structure/main-header.scss
+++ b/kuma/static/styles/components/structure/main-header.scss
@@ -5,13 +5,12 @@ Main header, wraps all components of logo, main, and secondary navigation
 #main-header {
     @include clearfix();
     position: relative;
-    z-index: 1;
+    z-index: $main-header-z;
     padding-top: $mobile-center-spacing;
     border: 5px solid $accent-light;
     border-width: 5px 0 0;
     border-image: linear-gradient(to right, $accent-dark, $accent-light) 10;
     background-color: #fff;
-    box-shadow: 0 0 9px 0 rgba(0, 0, 0, .3);
 
     > .center {
         @include clearfix();
@@ -20,7 +19,7 @@ Main header, wraps all components of logo, main, and secondary navigation
 
 .logo {
     position: relative;
-    z-index: 2; // get above nav-main
+    z-index: $logo-z;
     width: 170px;
     height: 30px;
     background: url($logo-sprite-url) 100% 0 no-repeat;

--- a/kuma/static/styles/components/structure/nav-access.scss
+++ b/kuma/static/styles/components/structure/nav-access.scss
@@ -6,7 +6,7 @@ Keyboard & screen reader skip link menu
     width: 100%;
     position: absolute;
     top: -20em;
-    z-index: 1001;
+    z-index: $nav-access-z;
 
     a {
         @include rgba-fallback(background, #fff, .9);

--- a/kuma/static/styles/components/structure/nav-main.scss
+++ b/kuma/static/styles/components/structure/nav-main.scss
@@ -6,6 +6,7 @@ Main navigation menu
 
 .nav-main {
     position: relative;
+    z-index: $main-nav-z;
 }
 
 html:not(.no-js) .nav-main-item > a {

--- a/kuma/static/styles/components/structure/nav-sec.scss
+++ b/kuma/static/styles/components/structure/nav-sec.scss
@@ -4,6 +4,11 @@
 Secondary navigation, site tools and login info
 ********************************************************************** */
 
+#nav-sec {
+    position: relative;
+    z-index: $nav-sec-z;
+}
+
 @media #{$mq-tablet-and-down} {
     .nav-tools {
         display: none;
@@ -13,9 +18,7 @@ Secondary navigation, site tools and login info
 @media #{$mq-tablet-and-up} {
     #nav-sec {
         @include bidi-value(float, right, left);
-        position: relative;
         @include bidi-style(right, ($gutter-width * -1), left, auto);
-        z-index: 3; /* bring it above search trigger in tablet view */
         background-color: $bg-dark;
 
         > ul > li {

--- a/kuma/static/styles/components/structure/submenu.scss
+++ b/kuma/static/styles/components/structure/submenu.scss
@@ -1,7 +1,7 @@
 .submenu {
     display: none;
     position: absolute;
-    z-index: 3;
+    z-index: $submenu-z;
     top: 100%;
     @include bidi-style(left, 0, right, auto);
     width: 250px; // fallback, IE & Edge

--- a/kuma/static/styles/components/wiki/content/collapsible.scss
+++ b/kuma/static/styles/components/wiki/content/collapsible.scss
@@ -1,0 +1,42 @@
+h2 > .collapse-trigger {
+    /* over-ride button styles */
+    @include set-font-size($mobile-h2-font-size);
+    background-color: inherit;
+    border: inherit;
+    color: inherit;
+    display: block;
+    font-family: inherit;
+    font-weight: normal;
+    letter-spacing: inherit;
+    line-height: inherit;
+    margin: 0;
+    padding: 0;
+    position: relative;
+    text-decoration: inherit;
+    text-align: left;
+    width: 100%;
+
+    /* add toggle symbol */
+    &:before {
+        display: inline-block;
+        color: $link-color;
+        @include bidi-value(content, '\f0da', '\f0d9');
+        cursor: pointer;
+        font-family: FontAwesome;
+        line-height: 39px;
+        padding-right: 10px;
+        vertical-align: top;
+    }
+
+    &[aria-expanded='true']:before {
+        @include bidi-value-vendorize(transform, rotate(90deg), rotate(-90deg));
+    }
+}
+
+.collapsible > :first-child {
+    margin-top: 0;
+}
+
+.collapsible[aria-hidden='true'] {
+    display: none;
+}

--- a/kuma/static/styles/components/wiki/properties.scss
+++ b/kuma/static/styles/components/wiki/properties.scss
@@ -15,7 +15,7 @@ $properties-indent: ($grid-spacing * 2) - $properties-item-spacing;
     .text-content & {
         /* could be defined one level up but that creates duplicate classes in output */
         @include restrict-line-length();
-        width: $max-line-length;
+        width: 100%;
         display: table;
         margin: 0 0 $grid-spacing 0;
         border-style: solid;

--- a/kuma/static/styles/components/wiki/toc.scss
+++ b/kuma/static/styles/components/wiki/toc.scss
@@ -1,58 +1,115 @@
-#toc {
-    @include restrict-line-length();
-    @include reverse-link-decoration();
-    background: $light-background-color;
-    @include bidi-value(padding, ($grid-spacing / 2) $grid-spacing ($grid-spacing / 2) ($grid-spacing - 2px), ($grid-spacing / 2) ($grid-spacing - 2px) ($grid-spacing / 2) $grid-spacing);
-    margin-bottom: $grid-spacing;
+/*
+Sticky TOC
+====================================================================== */
+$padding-vertical: 15px;
+$padding-horizontal: 30px;
 
-    // toggle button
-    .toggler {
-        position: relative;
-        color: $link-color;
 
-        &,
-        &:hover,
-        &:focus,
-        &:active {
-            text-decoration: none;
-        }
+.toc {
+    display: none;
+    background-color: $bg-dark;
+    color: #fff;
+    line-height: 1;
+    top: 0;
+    z-index: $toc-z;
 
-        i {
-            position: static;
-            @include bidi-style(margin-right, $icon-margin, margin-left, 0);
-            display: inline-block;
-            color: $link-color;
-
-            .no-js & {
-                display: none;
-            }
-        }
-    }
-
-    // menu
-    .toggle-container {
-        // hide by default if JS enabled
+    .no-js .toc {
         display: none;
-
-        // display by default if no JS
-        .no-js & {
-            display: block;
-        }
     }
 
+    &.hidden {
+        display: none;
+    }
+}
+
+.toc-head {
+    display: inline-block;
+    font-family: $heading-font-family;
+    @include set-font-size(22px);
+    @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
+}
+
+.toc-links {
+    display: inline;
+
+    /* submenus are still being included in HTML, but we don't want them in TOC */
     ol {
-        margin-bottom: 0;
-        @include bidi-style(padding-left, 0 , padding-right, 0);
-        @include set-smaller-font-size();
-        list-style-type: none;
+        display: none;
     }
 
     li {
-        padding-top: ($grid-spacing / 2);
-        position: relative;
+        display: inline-block;
+        word-wrap: nowrap;
     }
 
-    li li {
-        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+    a {
+        position: relative;
+        color: $accent-light;
+        display: inline-block;
+        @include set-font-size(17px);
+        font-weight: bold;
+        letter-spacing: .02em;
+        @include bidi-value(padding, $padding-vertical $padding-horizontal $padding-vertical 0, $padding-vertical 0 $padding-vertical $padding-horizontal);
+        white-space: nowrap;
+        text-decoration: none;
+
+        &:hover,
+        &:focus {
+            color: #fff;
+        }
+    }
+
+    li:last-child a {
+        @include bidi-value(padding, $padding-vertical 0 $padding-vertical 0, $padding-vertical 0 $padding-vertical 0);
+    }
+}
+
+@media #{$mq-tablet-and-up} {
+    .toc {
+        display: block;
+    }
+}
+
+$emify-tablet-height: (680px / 16px) * 1em;
+@media #{$mq-tablet-and-up} and (min-height: #{$emify-tablet-height}) {
+    .toc {
+        position: sticky;
+    }
+
+    .toc_tall {
+        position: static;
+    }
+
+    .toc-links {
+        li {
+            a {
+                &:after {
+                    content: '';
+                    display: block;
+                    position: absolute;
+                    bottom: 0;
+                    @include bidi-style(left, 0, right, $padding-horizontal);
+                    width: calc(100% - #{$padding-horizontal});
+                    height: 0;
+                    background-color: $accent-light;
+                    transition: height .1s;
+                }
+
+                &.toc-current:after {
+                    height: 3px;
+
+                    /* no underline if it's not sticky because its too tall */
+                    .toc_tall & {
+                        height: 0;
+                    }
+                }
+            }
+
+            &:last-child a {
+                &:after {
+                    width: 100%;
+                }
+            }
+        }
     }
 }

--- a/kuma/static/styles/includes-skinny/_vars.scss
+++ b/kuma/static/styles/includes-skinny/_vars.scss
@@ -133,6 +133,7 @@ $form-font-size: $body-font-size;
 $tiny-font-size: 12px;
 
 $mobile-document-title-font-size: 32px;
+$mobile-h2-font-size: 32px;
 
 /* bumps */
 $larger-font-size: $callout-font-size;

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -280,3 +280,16 @@ $logo-sprite-url: $path-to-images + 'web-docs-sprite.svg';
 edit-mode customizations - applied to blocks only in edit mode
 ====================================================================== */
 $editor-box-border: 2px dotted #adf;
+
+/*
+z-index
+====================================================================== */
+$nav-access-z: 1001;
+$submenu-z: 99;
+$logo-z: 97; /* needs to be above main-nav */
+$nav-sec-z: 97; /* needs to be above main-nav */
+$main-header-z: 96;
+$main-nav-z: 95;
+$document-actions-z: 89;
+$document-head-z: 88;
+$toc-z: 79;

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -56,6 +56,7 @@ Styling for article content
 @import 'components/wiki/content/alllinks';
 @import 'components/wiki/content/bug';
 @import 'components/wiki/content/callout-box';
+@import 'components/wiki/content/collapsible';
 @import 'components/wiki/content/card-grid';
 @import 'components/wiki/content/columnList';
 @import 'components/wiki/content/columns';

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -136,6 +136,16 @@
       </div>
     </div>
   </div>
+  {% if toc_html and waffle.flag('line_length') %}
+  <div id="toc" class="toc">
+    <div class="center">
+      <div class="toc-head">Jump to:</div>
+        <ol class="toc-links">
+          {{ toc_html|safe }}
+        </ol>
+    </div>
+  </div>
+  {% endif %}
 {% endblock%}
 
 {% block content %}
@@ -248,15 +258,6 @@
                   {% if not document_html %}
                     {{ _("This article doesn't have any content yet.") }}
                   {% else %}
-                    {% if toc_html and waffle.flag('line_length') %}
-                    <!-- table of contents -->
-                    <div id="toc" class="toc toggleable">
-                      <a href="#toc" class="title toggler" data-open-icon="icon-caret-right" data-closed-icon="icon-caret-down"><i></i>{{ _('In This Article') }}</a>
-                      <ol class="toggle-container">
-                        {{ toc_html|safe }}
-                      </ol>
-                    </div>
-                    {% endif %}
                     {{ body_html|safe }}
                   {% endif %}
                 {% elif fallback_reason == 'no_translation' %}

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -340,13 +340,12 @@ class Document(NotificationsMixin, models.Model):
     def get_toc_html(self, *args, **kwargs):
         if not self.current_revision:
             return ''
-        toc_depth = self.current_revision.toc_depth
-        if not toc_depth:
+        if not self.current_revision.toc_depth:
             return ''
         html = self.rendered_html and self.rendered_html or self.html
         return (parse_content(html)
                 .injectSectionIDs()
-                .filter(self.TOC_FILTERS[toc_depth])
+                .filter(self.TOC_FILTERS[2])
                 .serialize())
 
     @cache_with_field('summary_html')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -193,9 +193,9 @@ class ViewTests(UserTestCase, WikiTestCase):
         ok_('Access-Control-Allow-Origin' in resp)
         eq_('*', resp['Access-Control-Allow-Origin'])
         self.assertHTMLEqual(
-            resp.content, '<ol><li><a href="#Head_2" rel="internal">Head 2</a>'
-            '<ol><li><a href="#Head_3" rel="internal">Head 3</a>'
-            '</ol></li></ol>')
+            resp.content, '<ol><li>'
+            '<a href="#Head_2" rel="internal">Head 2</a>'
+            '</ol>')
 
     def test_children_view(self):
         """bug 875349"""


### PR DESCRIPTION
- Move TOC to below document title
- Add sticky TOC styles
    - Don't show TOC if the screen is too small
- Add JS to improve TOC user experience
    - Scrolling to anchor links accounts for height of TOC
    - Don't make TOC sticky if it's too big
- Collapse sections by default on mobile
    - open by default if user arrives via an anchor link
- Change code block formatting to avoid FOUT on `<pre>` blocks (the page
  should jump around less when Prism loads now)

Fix bug 1416983