### PR TITLE
Add gradient background to status colours

### DIFF
--- a/kuma/static/styles/components/compat-tables/_vars.scss
+++ b/kuma/static/styles/components/compat-tables/_vars.scss
@@ -17,14 +17,14 @@ $safari-desktop: 'safari_desktop';
 $safari-ios: 'safari_ios';
 
 $bc-colors: (
-    yes: #ebf8e1,
-    no: #ffe7e8,
-    partial: #fff3d4,
-    unknown: #eee
+    yes: $green-light,
+    no: $red-light,
+    partial: $yellow-light,
+    unknown: $grey-light
 );
 
-$bc-color-text: #000;
-$bc-border-color: #000;
+$bc-color-text: $bg-dark;
+$bc-border-color: $bg-dark;
 $bc-border-width-thin: 1px;
 $bc-border-width-thick: 2px;
 $bc-support: yes, no, partial, unknown;

--- a/kuma/static/styles/components/compat-tables/bc-supports.scss
+++ b/kuma/static/styles/components/compat-tables/bc-supports.scss
@@ -26,11 +26,53 @@ Supports colouring
 .bc-supports-partial,
 .bc-supports-partial .bc-history {
     background: map-get($bc-colors, partial);
+    background-image: linear-gradient(to bottom right,
+        rgba($yellow, .3) 0,
+        rgba($yellow, .3) 1px,
+        transparent 1px,
+        transparent 67px,
+        rgba($yellow, .3) 67px,
+        rgba($yellow, .3) 73px,
+        transparent 73px,
+        transparent 138px,
+        rgba($yellow, .3) 138px,
+        rgba($yellow, .3) 144px,
+        transparent 144px);
+    background-size: 100px 100px;
+    background-position: 50% 50%;
+    background-repeat: no-repeat;
 }
 
 .bc-supports-no,
 .bc-supports-no .bc-history {
     background-color: map-get($bc-colors, no);
+    background-image: linear-gradient(to bottom right,
+        rgba($red, .2) 0,
+        rgba($red, .2) 1px,
+        transparent 1px,
+        transparent 67px,
+        rgba($red, .2) 67px,
+        rgba($red, .2) 73px,
+        transparent 73px,
+        transparent 138px,
+        rgba($red, .2) 138px,
+        rgba($red, .2) 144px,
+        transparent 144px),
+    linear-gradient(to bottom left,
+        rgba($red, .2) 0,
+        rgba($red, .2) 1px,
+        transparent 1px,
+        transparent 67px,
+        rgba($red, .2) 67px,
+        rgba($red, .2) 73px,
+        transparent 73px,
+        transparent 138px,
+        rgba($red, .2) 138px,
+        rgba($red, .2) 144px,
+        transparent 144px);
+    background-size: 100px 100px, 100px 100px;
+    background-position: 50% 50%, 50% 50%;
+    background-repeat: no-repeat;
 }
 
 .bc-supports-unknown,


### PR DESCRIPTION
- Add gradient background to colours to give them a pattern for colour
  blind users to tell them apart
- change colours to reference global variables