### PR TITLE
Fix Bug 1415698: Example classes for non-code blocks

### DIFF
--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -98,7 +98,10 @@ sup {
 mono space elements (pre, code, kbd)
 ====================================================================== */
 
-code {
+/* style <code> but not if it's inside <pre>, the :not() selector doesn't work
+   as :not(pre) code {} so we need to be more specific, this covers common uses */
+:not(pre) > code,
+:not(pre) > * > code {
     /*
       #dcdcdc at 50% on white is roughly $code-block-background-color
       can't blend fallback on white though because text is white in .highlight
@@ -131,26 +134,6 @@ code {
     }
 }
 
-/* pre is a block element so it gets a bit more fancy styling */
-pre {
-    @include set-font-size($body-font-size);
-    line-height: 19px;
-    border: 0;
-    background: $light-background-color;
-    color: $text-color;
-    padding: $code-block-padding;
-    overflow: auto;
-    margin: 0 0 $grid-spacing 0;
-    font-family: $code-block-font-family;
-    font-style: normal;
-}
-
-pre code {
-    font-family: inherit;
-    font-weight: inherit;
-    font-style: normal;
-}
-
 @media #{$mq-mobile-and-down} {
     h1,
     h2,
@@ -162,6 +145,13 @@ pre code {
             word-break: break-all;
         }
     }
+}
+
+/* pre is a block element so it gets a bit more fancy styling.
+   Needs extra specificity because Sass puts the mixins at the top of the file and the
+   resets will over-ride the mixin without the specificity. Thank you Sass. */
+.text-content pre {
+    @extend %code-block;
 }
 
 kbd {

--- a/kuma/static/styles/components-skinny/syntax/base.scss
+++ b/kuma/static/styles/components-skinny/syntax/base.scss
@@ -1,45 +1,53 @@
 /*
 prism.css problem fixing
-This file modifies <pre> and <code> with the class 'language-' which is added by prism.js
-This is complicated by the fact that we don't know the configuration of the HTML
-    - it could be <pre> or <code> or <pre><code> or or <pre><code><code> or
-      <pre><em><code> (just to name a few)
+Prism adds class="lang- to <pre> and <code> by default but we override it
+in syntax-prism.js to just add it to <pre>, it also wraps the contents of the
+<pre> with a <code class="lang- and includes styles for that in its default styles
 ********************************************************************** */
 
-/* prism.css incorrectly double styles code > code, but only with a backround color */
-code[class*='language-'] > code[class*='language-'] {
-    background-color: none;
-}
+.text-content {
 
-/* prism.css overrides our gridspacing with its own margin, override it back */
-pre[class*='language-'] {
-    margin: 0 0 $grid-spacing 0;
+    #{$selector-prism} {
+        @extend %code-block;
 
-    span.comment {
-        display: inherit;
+        /* prism.css overrides our gridspacing with its own margin, override it back */
+        margin: 0 0 $grid-spacing 0;
+
+        /* customCSS contains a conflicting class that hides comments, show comments in prism */
+        span.comment {
+            display: inherit;
+        }
     }
-}
 
-/* prism.css overrides our text-color with black and adds a text-shadow, override it back */
-code[class*='language-'],
-pre[class*='language-'] {
-    color: $text-color;
-    text-shadow: none;
+    /* prism.css incorrectly double styles code > code, but only with a backround color */
+    code[class*='language-'] > code[class*='language-'] {
+        background-color: none;
+    }
+
+    /* prism.css overrides our text-color with black and adds a text-shadow, override it back */
+    #{$selector-prism},
+    code[class*='language-'] {
+        color: $text-color;
+        text-shadow: none;
+    }
+
+    /* %code-block wrecks the padding prisim needs for line numbers, add it back */
+    pre.line-numbers {
+        padding-left: 3.8em;
+    }
 }
 
 /*
 Enhancements!
 ====================================================================== */
 
-:not(pre):not(code) > code[class*='language-'],
-pre[class*='language-'] {
-    @extend %code-block;
-}
-
-/*  we don't want <pre><em><code> to have the code-block styling  */
-pre em code[class*='language-'] {
-    background: none;
-    border-left: 0;
+/* don't give operators, strings, etc a background color */
+.token.operator,
+.token.entity,
+.token.url,
+.language-css .token.string,
+.style .token.string {
+    background-color: transparent;
 }
 
 /*

--- a/kuma/static/styles/components-skinny/syntax/error.scss
+++ b/kuma/static/styles/components-skinny/syntax/error.scss
@@ -1,5 +1,5 @@
 /* styles code that appears in error messages */
-.error pre[class*='language-'] {
+.error #{$selector-prism} {
     margin: 10px 0 0 0;
     background: none;
 }

--- a/kuma/static/styles/components-skinny/syntax/example.scss
+++ b/kuma/static/styles/components-skinny/syntax/example.scss
@@ -1,54 +1,58 @@
-$bg-good : mix($positive, #fff, 5%);
-$bg-bad : mix($negative, #fff, 5%);
+$bg-good: mix($positive, #fff, 5%);
+$bg-bad: mix($negative, #fff, 5%);
 
-/*
-Pseudo element for icons
-====================================================================== */
+.text-content { /* bump specificity to over-ride prism */
 
-:not(pre) > code.example-good[class*='language-'],
-pre.example-good[class*='language-'],
-:not(pre) > code.example-bad[class*='language-'],
-pre.example-bad[class*='language-'] {
-    position: relative;
+    .example,
+    .example-good,
+    .example-bad {
+        @include example-box($code-block-background-color, $grey);
 
-    &:before {
-        border-radius: 100%; /* make it into a circle so bgcolor doesn't show */
-        font-family: FontAwesome;
-        font-size: $larger-font-size;
-        position: absolute;
-        bottom: 2px;
-        right: 2px;
-        z-index: 10;
-        speak: none;
+        &:before {
+            font-family: FontAwesome;
+            font-size: $larger-font-size;
+            line-height: 1;
+            position: absolute;
+            bottom: 2px;
+            @include bidi-style(right, 2px, left, auto);
+            z-index: 10;
+            speak: none;
+        }
     }
-}
 
-:not(pre) > code.example-good[class*='language-']:before,
-pre.example-good[class*='language-']:before {
-    background: $bg-good;
-    color: $positive;
-    content: '\f118';
-}
+    /* code is always LTR
+       Can't combine with above selector because
+       https://github.com/sass/sass/issues/1425 */
+    html[dir='rtl'] & #{$selector-prism}.example,
+    html[dir='rtl'] & #{$selector-prism}.example-good,
+    html[dir='rtl'] & #{$selector-prism}.example-bad {
+        &:before {
+            right: 2px;
+            left: auto;
+        }
+    }
 
-:not(pre) > code.example-bad[class*='language-']:before,
-pre.example-bad[class*='language-']:before {
-    background: $bg-bad;
-    color: $negative;
-    content: '\f119';
-}
+    .example-good,
+    #{$selector-prism}.example-good, {
+        background-color: $bg-good;
+        border-color: $positive;
 
-/*
-Background colouration
--------------------------------------------------------------- */
+        &:before {
+            background: $bg-good;
+            color: $positive;
+            content: '\f118';
+        }
+    }
 
-:not(pre) > code.example-good[class*='language-'],
-pre.example-good[class*='language-'] {
-    background: $bg-good;
-    border-left: $code-block-border-width $code-block-border-style $positive;
-}
+    .example-bad,
+    #{$selector-prism}.example-bad, {
+        background-color: $bg-bad;
+        border-color: $negative;
 
-:not(pre) > code.example-bad[class*='language-'],
-pre.example-bad[class*='language-'] {
-    background: $bg-bad;
-    border-left: $code-block-border-width $code-block-border-style $negative;
+        &:before {
+            background: $bg-bad;
+            color: $negative;
+            content: '\f119';
+        }
+    }
 }

--- a/kuma/static/styles/components-skinny/syntax/syntaxbox.scss
+++ b/kuma/static/styles/components-skinny/syntax/syntaxbox.scss
@@ -4,36 +4,15 @@ Syntax boxes are used for short, non-functional code snippets.
 .twopartsyntaxbox is used for CSS properties
 ********************************************************************** */
 
-$syntaxbox-help-width: 1.1em;
-
 pre.syntaxbox,
 pre.twopartsyntaxbox {
     @extend %code-block;
     background: $code-block-background-alt-color;
+    line-height: 1;
     white-space: pre-wrap;
 }
 
 pre.twopartsyntaxbox {
     border-bottom: 2px solid $code-block-background-color;
     margin-bottom: 0;
-}
-
-.syntaxbox-help {
-    height: 1.2em;
-    float: left;
-    font-size: $larger-font-size;
-    width: $syntaxbox-help-width;
-    margin-left: $syntaxbox-help-width * -1;
-    margin-top: -4px;
-    opacity: 0;
-    overflow: hidden;
-    position: relative;
-    text-align: center;
-
-    /* show on hover and focus, and when triggered by JS adding class */
-    &.isOpaque,
-    &:hover,
-    &:focus {
-        opacity: 1;
-    }
 }

--- a/kuma/static/styles/components/syntax/base.scss
+++ b/kuma/static/styles/components/syntax/base.scss
@@ -1,46 +1,45 @@
 /*
 prism.css problem fixing
-This file modifies <pre> and <code> with the class 'language-' which is added by prism.js
-This is complicated by the fact that we don't know the configuration of the HTML
-    - it could be <pre> or <code> or <pre><code> or or <pre><code><code> or
-      <pre><em><code> (just to name a few)
+Prism adds class="lang- to <pre> and <code> by default but we override it
+in syntax-prism.js to just add it to <pre>, it also wraps the contents of the
+<pre> with a <code class="lang- and includes styles for that in its default styles
 ********************************************************************** */
 
-/* prism.css incorrectly double styles code > code, but only with a backround color */
-code[class*='language-'] > code[class*='language-'] {
-    background-color: none;
-}
+.text-content {
 
-/* prism.css overrides our gridspacing with its own margin, override it back */
-pre[class*='language-'] {
-    margin: 0 0 $grid-spacing 0;
+    #{$selector-prism} {
+        @extend %code-block;
 
-    span.comment {
-        display: inherit;
+        /* prism.css overrides our gridspacing with its own margin, override it back */
+        margin: 0 0 $grid-spacing 0;
+
+        /* customCSS contains a conflicting class that hides comments, show comments in prism */
+        span.comment {
+            display: inherit;
+        }
     }
-}
 
-/* prism.css overrides our text-color with black and adds a text-shadow, override it back */
-code[class*='language-'],
-pre[class*='language-'] {
-    color: $text-color;
-    text-shadow: none;
+    /* prism.css incorrectly double styles code > code, but only with a backround color */
+    code[class*='language-'] > code[class*='language-'] {
+        background-color: none;
+    }
+
+    /* prism.css overrides our text-color with black and adds a text-shadow, override it back */
+    #{$selector-prism},
+    code[class*='language-'] {
+        color: $text-color;
+        text-shadow: none;
+    }
+
+    /* %code-block wrecks the padding prisim needs for line numbers, add it back */
+    pre.line-numbers {
+        padding-left: 3.8em;
+    }
 }
 
 /*
 Enhancements!
 ====================================================================== */
-
-:not(pre):not(code) > code[class*='language-'],
-pre[class*='language-'] {
-    @extend %code-block;
-}
-
-/*  we don't want <pre><em><code> to have the code-block styling  */
-pre em code[class*='language-'] {
-    background: none;
-    border-left: 0;
-}
 
 /* don't give operators, strings, etc a background color */
 .token.operator,

--- a/kuma/static/styles/components/syntax/error.scss
+++ b/kuma/static/styles/components/syntax/error.scss
@@ -1,5 +1,5 @@
 /* styles code that appears in error messages */
-.error pre[class*='language-'] {
+.error #{$selector-prism} {
     margin: 10px 0 0 0;
     background: none;
 }

--- a/kuma/static/styles/components/syntax/example.scss
+++ b/kuma/static/styles/components/syntax/example.scss
@@ -1,54 +1,58 @@
 $bg-good: mix($positive, #fff, 5%);
 $bg-bad: mix($negative, #fff, 5%);
 
-/*
-Pseudo element for icons
-====================================================================== */
+.text-content { /* bump specificity to over-ride prism */
 
-:not(pre) > code.example-good[class*='language-'],
-pre.example-good[class*='language-'],
-:not(pre) > code.example-bad[class*='language-'],
-pre.example-bad[class*='language-'] {
-    position: relative;
+    .example,
+    .example-good,
+    .example-bad {
+        @include example-box($code-block-background-color, $grey);
 
-    &:before {
-        border-radius: 100%; /* make it into a circle so bgcolor doesn't show */
-        font-family: FontAwesome;
-        font-size: $larger-font-size;
-        position: absolute;
-        bottom: 2px;
-        right: 2px;
-        z-index: 10;
-        speak: none;
+        &:after {
+            font-family: FontAwesome;
+            font-size: $larger-font-size;
+            line-height: 1;
+            position: absolute;
+            bottom: 2px;
+            @include bidi-style(right, 2px, left, auto);
+            z-index: 10;
+            speak: none;
+        }
     }
-}
 
-:not(pre) > code.example-good[class*='language-']:before,
-pre.example-good[class*='language-']:before {
-    background: $bg-good;
-    color: $positive;
-    content: '\f118';
-}
+    /* code is always LTR
+       Can't combine with above selector because
+       https://github.com/sass/sass/issues/1425 */
+    html[dir='rtl'] & #{$selector-prism}.example,
+    html[dir='rtl'] & #{$selector-prism}.example-good,
+    html[dir='rtl'] & #{$selector-prism}.example-bad {
+        &:after {
+            right: 2px;
+            left: auto;
+        }
+    }
 
-:not(pre) > code.example-bad[class*='language-']:before,
-pre.example-bad[class*='language-']:before {
-    background: $bg-bad;
-    color: $negative;
-    content: '\f119';
-}
+    .example-good,
+    #{$selector-prism}.example-good, {
+        background-color: $bg-good;
+        border-color: $positive;
 
-/*
-Background colouration
--------------------------------------------------------------- */
+        &:after {
+            background: $bg-good;
+            color: $positive;
+            content: '\f118';
+        }
+    }
 
-:not(pre) > code.example-good[class*='language-'],
-pre.example-good[class*='language-'] {
-    background: $bg-good;
-    border-left: $code-block-border-width $code-block-border-style $positive;
-}
+    .example-bad,
+    #{$selector-prism}.example-bad, {
+        background-color: $bg-bad;
+        border-color: $negative;
 
-:not(pre) > code.example-bad[class*='language-'],
-pre.example-bad[class*='language-'] {
-    background: $bg-bad;
-    border-left: $code-block-border-width $code-block-border-style $negative;
+        &:after {
+            background: $bg-bad;
+            color: $negative;
+            content: '\f119';
+        }
+    }
 }

--- a/kuma/static/styles/components/syntax/syntaxbox.scss
+++ b/kuma/static/styles/components/syntax/syntaxbox.scss
@@ -4,36 +4,14 @@ Syntax boxes are used for short, non-functional code snippets.
 .twopartsyntaxbox is used for CSS properties
 ********************************************************************** */
 
-$syntaxbox-help-width: 1.1em;
-
 pre.syntaxbox,
 pre.twopartsyntaxbox {
     @extend %code-block;
     background: $code-block-background-alt-color;
+    line-height: 1;
     white-space: pre-wrap;
 }
 
 pre.twopartsyntaxbox {
-    border-bottom: 2px solid $code-block-background-color;
     margin-bottom: 0;
-}
-
-.syntaxbox-help {
-    height: 1.2em;
-    float: left;
-    font-size: $larger-font-size;
-    width: $syntaxbox-help-width;
-    margin-left: $syntaxbox-help-width * -1;
-    margin-top: -4px;
-    opacity: 0;
-    overflow: hidden;
-    position: relative;
-    text-align: center;
-
-    /* show on hover and focus, and when triggered by JS adding class */
-    &.isOpaque,
-    &:hover,
-    &:focus {
-        opacity: 1;
-    }
 }

--- a/kuma/static/styles/includes-skinny/_mixins.scss
+++ b/kuma/static/styles/includes-skinny/_mixins.scss
@@ -221,6 +221,20 @@ coloured boxes
     border-color: #{map-get( map-get($colors-lookup, $color), 'medium')};
 }
 
+@mixin example-box($bg-color, $border-color) {
+    @include set-font-size($body-font-size);
+    background: $bg-color;
+    border: 0 $code-block-border-style $border-color;
+    @include bidi-style(border-left-width, $code-block-border-width, border-right-width, 0);
+    color: $text-color;
+    margin-top: 0;
+    margin-bottom: $grid-spacing;
+    padding: 15px;
+    position: relative;
+
+    @include prevent-last-child-bottom-spacing();
+}
+
 
 /* =================================================================== */
 
@@ -474,15 +488,29 @@ Placeholders
 
 /* Styles for code blocks - used for wiki document and WYSIWYG editor */
 %code-block {
-    background: $code-block-background-color;
-    border-left: $code-block-border-width $code-block-border-style $code-block-border-color;
-    background-position: top center;
-    background-repeat: repeat;
-    color: $text-color;
+    @include example-box($code-block-background-color, $code-block-border-color);
     font-family: $code-block-font-family;
+    font-style: normal;
     font-weight: normal;
+    line-height: 1.5;
+    overflow: auto;
+
+    /* code is always LTR */
     direction: ltr;
     text-align: left;
+    @include bidi-value(border-left-width, $code-block-border-width, $code-block-border-width, !important);
+    @include bidi-value(border-right-width, 0, 0, !important);
+
+    p {
+        @include full-width-content();
+    }
+
+    code {
+        background-color: transparent;
+        font-style: normal;
+        font-weight: inherit;
+        padding: 0;
+    }
 
     @include vendorize(tab-size, 4);
     @include vendorize(hyphens, none);

--- a/kuma/static/styles/includes-skinny/_vars.scss
+++ b/kuma/static/styles/includes-skinny/_vars.scss
@@ -267,7 +267,7 @@ selectors
 $selector-icon : 'i[class^="icon-"]';
 $selector-site-font-fallback : 'html[data-ffo-opensans="false"]:not(.no-js) &';
 $selector-heading-font-fallback : 'html[data-zillaslab="false"]:not(.no-js) &';
-
+$selector-prism: 'pre[class*="language-"]';
 
 /*
 paths

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -221,6 +221,19 @@ coloured boxes
     border-color: #{map-get( map-get($colors-lookup, $color), 'medium')};
 }
 
+@mixin example-box($bg-color, $border-color) {
+    @include set-font-size($body-font-size);
+    background: $bg-color;
+    border: 0 $code-block-border-style $border-color;
+    @include bidi-style(border-left-width, $code-block-border-width, border-right-width, 0);
+    color: $text-color;
+    margin-top: 0;
+    margin-bottom: $grid-spacing;
+    padding: 15px;
+    position: relative;
+
+    @include prevent-last-child-bottom-spacing();
+}
 
 /* =================================================================== */
 
@@ -508,18 +521,20 @@ Placeholders
     }
 }
 
-
 /* Styles for code blocks - used for wiki document and WYSIWYG editor */
 %code-block {
-    background: $code-block-background-color;
-    border-left: $code-block-border-width $code-block-border-style $code-block-border-color;
-    background-position: top center;
-    background-repeat: repeat;
-    color: $text-color;
+    @include example-box($code-block-background-color, $code-block-border-color);
     font-family: $code-block-font-family;
+    font-style: normal;
     font-weight: normal;
+    line-height: 1.5;
+    overflow: auto;
+
+    /* code is always LTR */
     direction: ltr;
     text-align: left;
+    @include bidi-value(border-left-width, $code-block-border-width, $code-block-border-width, !important);
+    @include bidi-value(border-right-width, 0, 0, !important);
 
     p {
         @include full-width-content();
@@ -527,6 +542,8 @@ Placeholders
 
     code {
         background-color: transparent;
+        font-style: normal;
+        font-weight: inherit;
         padding: 0;
     }
 

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -263,7 +263,7 @@ selectors
 $selector-icon: 'i[class^="icon-"]';
 $selector-site-font-fallback: 'html[data-ffo-opensans="false"]:not(.no-js) &';
 $selector-heading-font-fallback: 'html[data-ffo-zillaslab="false"]:not(.no-js) &';
-
+$selector-prism: 'pre[class*="language-"]';
 
 /*
 paths


### PR DESCRIPTION
- re-work how backgrounds, borders, and padding are added to prism blocks
  - colours are now added to parent 
  - this means we can use a single class on the parent to target them
  - and that **class can be re-used on other elements** to add the same border background and padding
  - and `example-good` and `example-bad` now show up in CKEditor
- add generic `example` class
- consolidate code block styling in %code-block placeholder
- review prism over-rides
- remove `syntaxbox-help`, the feature this styled has been removed
- changes are added to both waffled and non-waffled files

Some pages to help with testing:
https://developer.mozilla.org/en-US/docs/User:stephaniehobson:code
https://developer.mozilla.org/en-US/docs/User:stephaniehobson:examples

