### PR TITLE
Bug 1415969: Waffle typography changes on in editor

### DIFF
--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -23,9 +23,15 @@
         win.mdn.assets = {
             css: {
                 'editor-content': [
-                    {%- stylesheet 'editor-content' %}
-                    {%- stylesheet 'editor-locale-%s' % LANG %}
+                    {%- if waffle.flag('line_length') %}
+                        {%- stylesheet 'editor-content' %}
+                        {%- stylesheet 'editor-locale-%s' % LANG %}
+                    {%- else %}
+                        {%- stylesheet 'editor-content-skinny' %}
+                        {%- stylesheet 'editor-locale-%s' % LANG %}
+                    {%- endif %}
                 ],
+
                 'wiki-compat-tables': [{% stylesheet 'wiki-compat-tables' %}]
             },
             js: {

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -892,13 +892,24 @@ PIPELINE_CSS = {
     },
     'editor-content': {
         'source_filenames': (
+            'styles/main.scss',
+            'styles/wiki.scss',
+            'styles/wiki-wysiwyg.scss',
+            'styles/wiki.scss',
+            'styles/libs/font-awesome/css/font-awesome.min.css',
+        ),
+        'output_filename': 'build/styles/editor-content.css',
+        'template_name': 'pipeline/javascript-array.jinja',
+    },
+    'editor-content-skinny': {
+        'source_filenames': (
             'styles/main-skinny.scss',
             'styles/wiki-skinny.scss',
             'styles/wiki-wysiwyg.scss',
             'styles/wiki-syntax.scss',
             'styles/libs/font-awesome/css/font-awesome.min.css',
         ),
-        'output_filename': 'build/styles/editor-content.css',
+        'output_filename': 'build/styles/editor-content-skinny.css',
         'template_name': 'pipeline/javascript-array.jinja',
     },
     # for maintenance mode page


### PR DESCRIPTION
Testing:
Typography changes should show up in editor only when waffle is enabled. You will have to do a `docker-compose restart web` to pick up the new settings in common.py.

Blue lines are not showing up in editor even when other type changes are displayed. Working on a separate PR for that.