### PR TITLE
Removing requirejs from the mix to see how HTTP2 handles the requests

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -204,6 +204,7 @@ console.log(result);
     </div>
 </section>
 
-<script data-main="https://interactive-examples.mdn.mozilla.net/js/codemirrorLoader" src="https://interactive-examples.mdn.mozilla.net/js/require.js"></script>
-<script src="https://interactive-examples.mdn.mozilla.net/js/editor-js.js"></script>
+<script src="https://interactive-examples.mdn.mozilla.net/js/lib/codemirror.js" defer></script>
+<script src="https://interactive-examples.mdn.mozilla.net/js/mode/javascript/javascript.js" defer></script>
+<script src="https://interactive-examples.mdn.mozilla.net/js/editor-js.js" defer></script>
 {%- endmacro %}


### PR DESCRIPTION
Replacing #4519.

Removing requireJS and loading the 2 files directly so we can take advantage of HTTP2.