### PR TITLE
bug 1409523: add gzip compression + BREACH-attack mitigation

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -239,7 +239,11 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert response['Location'] == url
     assert 'Vary' not in response
 
-    response = client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
+    response = client.get(
+        url,
+        HTTP_ACCEPT_ENCODING='gzip',
+        HTTP_HOST=settings.ATTACHMENT_HOST
+    )
     assert response.status_code == 200
     assert response.streaming
     assert response['x-frame-options'] == 'ALLOW-FROM %s' % settings.DOMAIN
@@ -248,7 +252,8 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']
-    assert 'Vary' not in response
+    assert response['Content-Encoding'] == 'gzip'
+    assert response['Vary'] == 'Accept-Encoding'
 
 
 def test_raw_file_if_modified_since(client, settings, file_attachment):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -430,7 +430,8 @@ _CONTEXT_PROCESSORS = (
     'django.core.context_processors.media',
     'django.core.context_processors.static',
     'django.core.context_processors.request',
-    'django.core.context_processors.csrf',
+    # todo: re-enable with Django 1.11
+    # 'django.core.context_processors.csrf',
     'django.contrib.messages.context_processors.messages',
 
     'kuma.core.context_processors.global_settings',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -438,6 +438,7 @@ _CONTEXT_PROCESSORS = (
     'kuma.core.context_processors.next_url',
 
     'constance.context_processors.config',
+    'debreach.context_processors.csrf',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -448,6 +449,7 @@ MIDDLEWARE_CLASSES = (
     # LocaleURLMiddleware must be before any middleware that uses
     # kuma.core.urlresolvers.reverse() to add locale prefixes to URLs:
     'kuma.core.middleware.SetRemoteAddrFromForwardedFor',
+    'django.middleware.gzip.GZipMiddleware',
     ('kuma.core.middleware.ForceAnonymousSessionMiddleware'
      if MAINTENANCE_MODE else
      'django.contrib.sessions.middleware.SessionMiddleware'),
@@ -463,7 +465,10 @@ MIDDLEWARE_CLASSES = (
 if not MAINTENANCE_MODE:
     # We don't want this in maintence mode, as it adds "Cookie"
     # to the Vary header, which in turn, kills caching.
-    MIDDLEWARE_CLASSES += ('django.middleware.csrf.CsrfViewMiddleware',)
+    MIDDLEWARE_CLASSES += (
+        'debreach.middleware.CSRFCryptMiddleware',
+        'django.middleware.csrf.CsrfViewMiddleware',
+    )
 
 MIDDLEWARE_CLASSES += (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -524,6 +529,7 @@ INSTALLED_APPS = (
     'django.contrib.sitemaps',
     'django.contrib.staticfiles',
     'soapbox',  # must be before kuma.wiki, or RemovedInDjango19Warning
+    'debreach',
 
     # MDN
     'kuma.core',

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -67,7 +67,7 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
     )
     assert response.status_code == 200
     assert response['Access-Control-Allow-Origin'] == '*'
-    assert not response.has_header('Vary')
+    assert response['Vary'] == 'Accept-Encoding'
     assert 'Last-Modified' not in response
     assert 'ETag' in response
     assert 'Cache-Control' in response


### PR DESCRIPTION
This PR adds GZIP compression handling to all requests that can accept GZIP encoding, and all endpoints with a response greater than 200 bytes that are not already content-encoded. It also adds BREACH attack mitigation via `django-debreach` and rate-limiting (the search page only). It does not add Brotli compression handling, which can be in another PR.