### PR TITLE
Bug 1040595: Add padding to top of English

### DIFF
--- a/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
+++ b/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
@@ -25,6 +25,21 @@
         .approved-title {
             display: inline-block;
             float: left;
+            margin-top: 0;
+        }
+    }
+
+    .translate-rendered,
+    .translate-source {
+        padding-top: 223px; /* approximate height of tool bar on translation side */
+    }
+}
+
+@media #{$mq-max-width-and-up} {
+    #translate-document {
+        .translate-rendered,
+        .translate-source {
+            padding-top: 155px; /* approximate height of tool bar on translation side */
         }
     }
 }

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -84,7 +84,7 @@
             {% endif %}
 
             <div id="content-fields">
-              <article class="approved text-content">
+              <article class="approved">
                 <header>
                     <h3 class="approved-title">{{ _('Approved %(locale)s version:', locale=default_locale) }}</h3>
                     <div class="translate-buttons">
@@ -92,7 +92,7 @@
                         <button class="hide-original-btn" data-alternate-message="{{ _('Show %(locale)s', locale=default_locale) }}">{{ _('Hide %(locale)s', locale=default_locale) }}</button>
                     </div>
                 </header>
-                <div class="boxed translate-rendered">
+                <div class="boxed translate-rendered text-content">
                   {{ based_on.content_cleaned|safe }}
                 </div>
                 <div class="boxed translate-source hidden">


### PR DESCRIPTION
- add padding to the top of the English display matching approximate
  height of the toolbar on the translation side
- move `.text-content` to different element so headings identifying
  English and French translations match style