### PR TITLE
All servers get blue favicon

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -62,14 +62,7 @@
   <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
   <link rel="apple-touch-icon-precomposed" href="{{ static('img/favicon57.png') }}">
   <!-- basic favicon -->
-  {% if request.META.SERVER_NAME in settings.PRODUCTION_URL %}
-    {% set favicon_suffix = '' %}
-  {% elif request.META.SERVER_NAME in settings.STAGING_URL %}
-    {% set favicon_suffix = '-staging' %}
-  {% else %}
-    {% set favicon_suffix = '-local' %}
-  {% endif %}
-  <link rel="shortcut icon" href="{{ static('img/favicon32' + favicon_suffix + '.png') }}">
+  <link rel="shortcut icon" href="{{ static('img/favicon32.png') }}">
   <!--[if IE]>
   <meta http-equiv="imagetoolbar" content="no">
   {% javascript 'html5shiv' %}


### PR DESCRIPTION
Previously we had different coloured favicons for different servers so we could make changes on dev and staging fearlessly. Since the move to AWS the red favicon has been displaying on all servers. This is bad because it's the colour of "it's safe to recklessly make changes". Until https://github.com/mozmeao/infra/issues/585 is fixed all servers should display the "Be careful!" colour.