### PR TITLE
Fix bug 1418010: Fix lazy loading fonts

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -1,7 +1,7 @@
 .quick-links-head {
     @include set-font-size(20px);
+    @include set-heading-font-family();
     display: inline-block;
-    font-family: $heading-font-family;
     margin-bottom: $grid-spacing;
     width: 100%;
 }

--- a/kuma/static/styles/includes-skinny/_mixins.scss
+++ b/kuma/static/styles/includes-skinny/_mixins.scss
@@ -377,20 +377,14 @@ These are not dynamic but serve as mixins
 
 @mixin heading-1() {
     @include set-font-size($h1-font-size);
-    font-family: $heading-font-family;
+    @include set-heading-font-family();
     line-height: 1;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
 }
 
 @mixin heading-2() {
     @include set-font-size($h2-font-size);
-    font-family: $heading-font-family;
+    @include set-heading-font-family();
     line-height: 1;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
 }
 
 @mixin callout() {

--- a/kuma/static/styles/includes-skinny/_vars.scss
+++ b/kuma/static/styles/includes-skinny/_vars.scss
@@ -266,7 +266,7 @@ selectors
 ====================================================================== */
 $selector-icon : 'i[class^="icon-"]';
 $selector-site-font-fallback : 'html[data-ffo-opensans="false"]:not(.no-js) &';
-$selector-heading-font-fallback : 'html[data-zillaslab="false"]:not(.no-js) &';
+$selector-heading-font-fallback : 'html[data-ffo-zillaslab="false"]:not(.no-js) &';
 $selector-prism: 'pre[class*="language-"]';
 
 /*

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -377,20 +377,14 @@ These are not dynamic but serve as mixins
 
 @mixin heading-1() {
     @include set-font-size($h1-font-size);
-    font-family: $heading-font-family;
+    @include set-heading-font-family();
     line-height: 1;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
 }
 
 @mixin heading-2() {
     @include set-font-size($mobile-h2-font-size);
-    font-family: $heading-font-family;
+    @include set-heading-font-family();
     line-height: $heading-line-height;
-    #{$selector-heading-font-fallback} {
-        font-family: $heading-font-family-fallback;
-    }
 
     @media #{$mq-tablet-and-up} {
         @include set-font-size($h2-font-size);


### PR DESCRIPTION
- Copy fix from #4482 into the waffled "skinny" styles files
- Switch to mixin for all header-font-family declarations

The page title should display immediately in the fallback font. Then Zilla should either be swapped in or not in 2 seconds. On the next page load the heading should display in Zilla immediately.

The font-loading script relies on session storage to do this so a hard refresh can confuse it. Empty your session storage before testing.

Fix bug 1418010