### PR TITLE
bug 1406546: potential fix for kuma test reliability issue in jenkins

### DIFF
--- a/Jenkinsfiles/default.groovy
+++ b/Jenkinsfiles/default.groovy
@@ -1,14 +1,17 @@
-stage('compose-test') {
-  sh 'make compose-test TEST=noext' // "smoke" tests with no external deps
-  sh 'make compose-test TEST="noext make build-static"' // required for many tests
-  sh 'docker-compose build'
-  sh 'make compose-test'
+stage('Test') {
+    utils.compose_test()
 }
 
 stage('Build & push kuma_base image') {
-  sh 'make build-base push-base'
+    utils.sh_with_notify(
+        'make build-base push-base',
+        'Build and push of commit-tagged Kuma base image'
+    )
 }
 
 stage('Build & push kuma image') {
-  sh 'make build-kuma push-kuma'
+    utils.sh_with_notify(
+        'make build-kuma push-kuma',
+        "Build & push of commit-tagged Kuma image"
+    )
 }

--- a/Jenkinsfiles/master.groovy
+++ b/Jenkinsfiles/master.groovy
@@ -1,15 +1,21 @@
 stage('Build base') {
-  sh 'make build-base VERSION=latest'
+    utils.sh_with_notify(
+        'make build-base VERSION=latest',
+        'Build of latest-tagged Kuma base image'
+    )
 }
 
-stage('compose-test') {
-  sh 'make compose-test TEST=noext' // "smoke" tests with no external deps
-  sh 'make compose-test TEST="noext make build-static"' // required for many tests
-  sh 'docker-compose build'
-  sh 'make compose-test'
+stage('Test') {
+    utils.compose_test()
 }
 
 stage('Build & push images') {
-  sh 'make build-kuma push-kuma'
-  sh 'make push-base VERSION=latest'
+    utils.sh_with_notify(
+        'make build-kuma push-kuma',
+        "Build & push of commit-tagged Kuma image"
+    )
+    utils.sh_with_notify(
+        'make push-base VERSION=latest',
+        'Push of latest-tagged Kuma base image'
+    )
 }

--- a/Makefile
+++ b/Makefile
@@ -181,10 +181,6 @@ bash: up
 shell_plus: up
 	docker-compose exec web ./manage.py shell_plus
 
-compose-test:
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml run $(TEST)
-	docker-compose -f docker-compose.yml -f docker-compose.test.yml stop
-
 create-demo:
 	@ ./Jenkinsfiles/create_demo_instance.sh
 


### PR DESCRIPTION
This PR addresses https://github.com/mozmeao/infra/issues/650 and https://github.com/mozmeao/infra/issues/602, as well as https://github.com/mozmeao/infra/issues/595.

* use `docker-compose down` to ensure a clean context both before and after the Kuma tests (I'm hoping this addresses the symptoms of https://github.com/mozmeao/infra/issues/602)
* notify `#mdndev` in IRC on failure

I also added IRC notification on failure to the `default` case, but I would be happy to remove that if we'd rather not clutter `#mdndev` with failure notifications for random branches.