### PR TITLE
Fix bug 1419289 (most minor typo)

### DIFF
--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -153,7 +153,7 @@ class User(AbstractUser):
         validators=[WEBSITE_VALIDATORS['github']],
     )
     is_github_url_public = models.BooleanField(
-        _(u'Public Github URL'),
+        _(u'Public GitHub URL'),
         default=False,
     )
     twitter_url = models.TextField(


### PR DESCRIPTION
GitHub has a capital H (also it is already written like this for every other occurence in the codebase)