### PR TITLE
bug 1397786: Update welcome email

### DIFF
--- a/kuma/users/jinja2/users/email/welcome/html.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/html.ltxt
@@ -9,7 +9,7 @@
         <p>{{ _('Hi %(username)s!', username=username) }}</p>
         <p>
           {% trans mdn_link=add_utm('https://developer.mozilla.org', 'welcome') %}
-            Thanks for creating a profile on <a href="{{ mdn_link }}">Mozilla Developer Network (MDN)</a> - a community making great resources for developers like you.
+            Thanks for creating a profile on <a href="{{ mdn_link }}">MDN Web Docs</a> - a community making great resources for developers like you.
           {% endtrans %}
         </p>
         <p>
@@ -44,14 +44,7 @@
                 channel_link='irc://irc.mozilla.org/mdn',
                 irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome')
               %}
-                Real-time chat: <a href="{{ channel_link }}">#mdn channel on irc.mozilla.org</a>. (Get more info about <a href="{{ irc_link }}">IRC</a>.) You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jms), MDN's community manager.
-              {% endtrans %}
-            </li>
-            <li>
-              {% trans
-                blog_link=add_utm('https://blog.mozilla.org/community', 'welcome'),
-                tagged_link=add_utm('https://blog.mozilla.org/community/category/developer-engagement/', 'welcome')
-              %}Blog: On the <a href="{{ blog_link }}">about:community</a> blog, look for the posts tagged with <a href="{{ tagged_link }}">Developer Engagement</a>.
+                Real-time chat: <a href="{{ channel_link }}">#mdn channel on irc.mozilla.org</a>.  (Get more info about <a href="{{ irc_link }}">IRC</a>.) You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jswisher), MDN's community manager.
               {% endtrans %}
             </li>
         </ul>

--- a/kuma/users/jinja2/users/email/welcome/plain.ltxt
+++ b/kuma/users/jinja2/users/email/welcome/plain.ltxt
@@ -4,7 +4,7 @@
 {{ _('Hi %(username)s', username=username) }}
 
 {# L10n: This is an email. Whitespace matters! #}
-{{ _('Thanks for creating a profile on Mozilla Developer Network (MDN) -- a community making great resources for developers like you.') }}
+{{ _('Thanks for creating a profile on MDN Web Docs -- a community making great resources for developers like you.') }}
 
 {# L10n: This is an email. Whitespace matters! #}
 {{ _("You've completed the first step of Getting Started on MDN by creating a profile. Now, keep going by picking a task on MDN, and doing it! We have a bunch of intro tasks you can choose based on your interests.") }}
@@ -42,10 +42,7 @@
     ({{ _('See %(irc_link)s for more info about IRC.', irc_link=add_utm('https://wiki.mozilla.org/IRC', 'welcome')) }})
 
 {# L10n: This is an email. Whitespace matters! #}
-    {{ _("You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Jean-Yves Perrier (teoli), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jms), MDN's community manager.") }}
-
-{# L10n: This is an email. Whitespace matters! #}
-* {{ _('Blog: %(blog_link)s', blog_link=add_utm('https://blog.mozilla.org/community/category/developer-engagement', 'welcome')) }}
+    {{ _("You can find the MDN writing staff admins there: Eric Shepherd (sheppy), Will Bamberg (wbamberg), Florian Scholz (fscholz), Chris Mills (chrismills), and me (jswisher), MDN's community manager.") }}
 
 {# L10n: This is an email. Whitespace matters! #}
 {{ _("Don't be shy, if you have any doubt, problems, questions: contact us! We are here to help.") }}


### PR DESCRIPTION
As specified on [bug 1397786](https://bugzilla.mozilla.org/show_bug.cgi?id=1397786#c9)

- Mozilla Developer Network -> MDN Web Docs
- Drop link to unused blog
- Remove Jean-Yves
- Update Janet's IRC handle