### PR TITLE
bug 1399639: Configure python for node-gyp

### DIFF
--- a/docker/images/kumascript/Dockerfile
+++ b/docker/images/kumascript/Dockerfile
@@ -22,6 +22,7 @@ WORKDIR /
 # install the Node.js dependencies, but only the versions
 # specified in "npm-shrinkwrap.json" (if it exists)
 COPY kumascript/package.json kumascript/npm-shrinkwrap.json /
+RUN npm config set python /usr/bin/python2.7
 RUN npm install
 # update any top-level npm packages listed in package.json,
 # as allowed by each package's given "semver".


### PR DESCRIPTION
node-gyp is the compiler for binary node.js packages, needed to compile the optional New Relic native-metrics package. node-gyp requires Python, and looks for it at /usr/bin/python by default. This location doesn't exists, because Ubuntu is transitioning to Python 3 and wants users to be explicit about Python 2 versus Python 3. This PR sets the Python path to the installed Python 2.7 binary.