### PR TITLE
Bug 1414107: Remove empty Quick_Links section

### DIFF
--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -81,36 +81,41 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     sectioning
     ====================================================================== */
 
-    /* direct decendants h2s get styled like section seperators
-       so do things we think are h2s added by macros */
-    article[id='wikiArticle'] > h2,
-    article[id='wikiArticle'] > div:not([class]) > h2 {
-        @include heading-2-section();
-    }
-
-    /*  remove top spacing if h2 is effectivly first element in article */
-    article[id='wikiArticle'] > h2:first-child,
-    article[id='wikiArticle'] > div:first-child:empty + h2,
-    article[id='wikiArticle'] > p:first-child:empty + h2,
-    .Quick_links + h2 {
-        margin-top: 0;
-        padding-top: 0;
-
-        &:before {
-            display: none;
+    article[id='wikiArticle'] {
+        /* direct decendants h2s get styled like section seperators
+           so do things we think are h2s added by macros */
+        > h2,
+        > div:not([class]) > h2 {
+            @include heading-2-section();
         }
-    }
 
-    /* fix spacing and line if h2 directly follows a hr, summary, or blockquote */
-    article[id='wikiArticle'] > hr + h2,
-    article[id='wikiArticle'] > .summary + h2,
-    article[id='wikiArticle'] > blockquote + h2 {
-        margin-top: ($grid-spacing + $section-border-width) * -1;
-        padding-top: $grid-spacing * 2 + $section-border-width;
-        background-color: #fff;
+        /*  remove top spacing if h2 is effectivly first element in article */
+        > h2:first-child,
+        > div:first-child:empty + h2,
+        > p:first-child:empty + h2,
+        > div:first-child:empty + div:not([class]) > h2:first-child,
+        > p:first-child:empty + div:not([class]) > h2:first-child {
+            margin-top: 0;
+            padding-top: 0;
 
-        &:before {
-            top: 0;
+            &:before {
+                display: none;
+            }
+        }
+
+        /* fix spacing and line if h2 directly follows a hr, summary, or blockquote */
+        > hr,
+        > .summary,
+        > blockquote {
+            + h2 {
+                margin-top: ($grid-spacing + $section-border-width) * -1;
+                padding-top: $grid-spacing * 2 + $section-border-width;
+                background-color: #fff;
+
+                &:before {
+                    top: 0;
+                }
+            }
         }
     }
 
@@ -120,17 +125,16 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     }
 
     /* indent if we think this is a top level h3 */
-    article[id='wikiArticle'] > h3:not(.highlight-spanned),
-    article[id='wikiArticle'] > h3 .highlight-span,
-    article[id='wikiArticle'] > div:not([class]) > h3 .highlight-span {
-        @include bidi-value(padding, 0 4px 0 $grid-spacing, 0 $grid-spacing 0 4px);
-    }
+    article[id='wikiArticle'] {
+        > h3:not(.highlight-spanned),
+        > h3 .highlight-span,
+        > div:not([class]) > h3 .highlight-span {
+            @include bidi-value(padding, 0 4px 0 $grid-spacing, 0 $grid-spacing 0 4px);
 
-    @media #{$mq-tablet-and-up} {
-        article[id='wikiArticle'] > h3:not(.highlight-spanned),
-        article[id='wikiArticle'] > h3 .highlight-span,
-        article[id='wikiArticle'] > div:not([class]) > h3 .highlight-span {
-            @include bidi-value(padding, 0 4px 0 $grid-spacing * 2, 0 $grid-spacing * 2 0 4px);
+            /* indent more on larger screen */
+            @media #{$mq-tablet-and-up} {
+                @include bidi-value(padding, 0 4px 0 $grid-spacing * 2, 0 $grid-spacing * 2 0 4px);
+            }
         }
     }
 

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -356,6 +356,11 @@ class ContentSectionTool(object):
                                     ignore_heading=ignore_heading)
         return self
 
+    @newrelic.agent.function_trace()
+    def removeSection(self, id):
+        self.stream = RemoveFilter(self.stream, id)
+        return self
+
 
 class LinkAnnotationFilter(html5lib_Filter):
     """
@@ -975,6 +980,54 @@ class SectionFilter(html5lib_Filter):
             # encountered in the stream. Not doing that right now.
             # For now, just assume an hgroup is equivalent to h1
             return 1
+
+
+class RemoveFilter(html5lib_Filter):
+
+    def __init__(self, source, id):
+        html5lib_Filter.__init__(self, source)
+
+        self.section_id = id
+
+        self.open_level = 0
+        self.parent_level = None
+        self.in_section = False
+        self.skip = False
+
+    def __iter__(self):
+        input = html5lib_Filter.__iter__(self)
+
+        # loop through all 'tokens'
+        for token in input:
+
+            # if this token is a start tag...
+            if token['type'] == 'StartTag':
+                # increment counter that tracks nesting
+                self.open_level += 1
+
+                for key in token['data']:
+                    if 'id' == key[1] and token['data'][key] == self.section_id:
+                        # note we're in the matching section
+                        self.in_section = True
+                        # keep track of how nested we were when section started
+                        self.parent_level = self.open_level
+
+            elif token['type'] == 'EndTag':
+                # If the parent of the section has ended, end the section.
+                if (self.parent_level is not None and
+                        self.open_level is self.parent_level):
+                    self.in_section = False
+                    self.skip = True
+                    self.parent_level = None
+
+                # reduce nesting counter
+                self.open_level -= 1
+
+            # emit tokens if we're not in the section being removed
+            if not self.in_section and not self.skip:
+                yield token
+            else:
+                self.skip = False
 
 
 class CodeSyntaxFilter(html5lib_Filter):

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -323,7 +323,8 @@ class Document(NotificationsMixin, models.Model):
         sections_to_hide = ('Quick_Links', 'Subnav')
         doc = parse_content(html)
         for sid in sections_to_hide:
-            doc = doc.replaceSection(sid, '<!-- -->')
+            doc = doc.replaceSection(sid, '')
+            doc = doc.removeSection(sid)
         doc.injectSectionIDs()
         doc.annotateLinks(base_url=settings.SITE_URL)
         return doc.serialize()

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -313,6 +313,26 @@ class ReplaceSectionTests(TestCase):
         eq_(normalize_html(expected), normalize_html(result))
 
 
+class RemoveSectionTests(TestCase):
+    def test_basic_section_remove(self):
+        doc_src = """
+            <h1 id="s1">Head 1</h1>
+            <div id="here">Remove <span>this</span>.</div>
+            <p>test</p>
+            <div class="here">Leave <span>this</span>.</div>
+        """
+        expected = """
+            <h1 id="s1">Head 1</h1>
+            <p>test</p>
+            <div class="here">Leave <span>this</span>.</div>
+        """
+        result = (kuma.wiki.content
+                  .parse(doc_src)
+                  .removeSection('here')
+                  .serialize())
+        eq_(normalize_html(expected), normalize_html(result))
+
+
 class InjectSectionEditingLinksTests(TestCase):
     def test_section_edit_links(self):
         doc_src = """

--- a/kuma/wiki/tests/test_models_document.py
+++ b/kuma/wiki/tests/test_models_document.py
@@ -360,10 +360,6 @@ def test_get_body_html(doc_with_sections):
     expected = """
     <h2 id="First">First</h2>
     <p>This is a document</p>
-    <section class="Quick_Links" id="Quick_Links">
-      <!-- -->
-    </section>
-    <!-- -->
     <h2 id="Second">Second</h2>
     <p>Another section, with an
       <a href="/en-US/docs/Root">existing link</a> and a

--- a/kuma/wiki/tests/test_models_document.py
+++ b/kuma/wiki/tests/test_models_document.py
@@ -22,12 +22,12 @@ def doc_with_sections(root_doc, wiki_user):
     <h2 id="First">First</h2>
     <p>This is a document</p>
 
-    <h3 id="Quick_Links">Quick Links</h3>
-    <p>Quick Links:</p>
-    <ul>
-      <li><a href="%(root_url)s">Existing link</a></li>
-      <li><a href="/en-US/docs/NewPage">New link</a></li>
-    </ul>
+    <section id="Quick_Links" class="Quick_Links">
+      <ol>
+        <li><a href="%(root_url)s">Existing link</a></li>
+        <li><a href="/en-US/docs/NewPage">New link</a></li>
+      </ol>
+    </section>
 
     <h3 id="Subnav">Subnav</h3>
     <p>Subnav:</p>
@@ -360,7 +360,9 @@ def test_get_body_html(doc_with_sections):
     expected = """
     <h2 id="First">First</h2>
     <p>This is a document</p>
-    <!-- -->
+    <section class="Quick_Links" id="Quick_Links">
+      <!-- -->
+    </section>
     <!-- -->
     <h2 id="Second">Second</h2>
     <p>Another section, with an
@@ -377,11 +379,10 @@ def test_get_quick_links_html(doc_with_sections):
     """The quick_links HTML can be extracted from the revision."""
     result = doc_with_sections.get_quick_links_html()
     expected = """
-    <p>Quick Links:</p>
-    <ul>
+    <ol>
       <li><a href="/en-US/docs/Root">Existing link</a></li>
       <li><a class="new" rel="nofollow" href="/en-US/docs/NewPage">New link</a></li>
-    </ul>
+    </ol>
     """
     assert normalize_html(result) == normalize_html(expected)
 


### PR DESCRIPTION
Added a function to remove a section according to it's ID, existing function will remove the contents of a section but leave the wrapper. 