### PR TITLE
Fix bug 1184796: Optimize bibi mixin for multiple declarations

### DIFF
--- a/kuma/static/styles/base/elements/forms.scss
+++ b/kuma/static/styles/base/elements/forms.scss
@@ -117,8 +117,10 @@ input[type='button'] {
     }
 
     &:not(.only-icon) #{$selector-icon} {
-        @include bidi-value(float, left, right);
-        @include bidi-style(margin-right, $icon-margin, margin-left, 0);
+        @include bidi((
+            (float, left, right),
+            (margin-right, $icon-margin, margin-left, 0),
+        ));
     }
 }
 

--- a/kuma/static/styles/base/elements/sectioning.scss
+++ b/kuma/static/styles/base/elements/sectioning.scss
@@ -28,12 +28,12 @@ details {
     clear: both;
     display: block;
     margin-bottom: $grid-spacing;
-    @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
+    @include bidi(((margin-left, $grid-spacing, margin-right, 0),));
 }
 
 summary {
     display: block; /* removes Firefox's marker */
-    @include bidi-style(margin-left, ( -1 * $grid-spacing ), margin-right, 0);
+    @include bidi(((margin-left, ( -1 * $grid-spacing ), margin-right, 0),));
     cursor: pointer;
     color: $link-color;
 
@@ -54,7 +54,7 @@ summary {
 
     /* add marker back in way we control */
     &:before {
-        @include bidi-value(content, '\25B6', '\25C0');
+        @include bidi(((content, '\25B6', '\25C0'),));
         display: inline-block;
         width: $grid-spacing; /* fixed width avoids content jog when marker swapped for narrower one */
         color: $blue;

--- a/kuma/static/styles/base/elements/tables.scss
+++ b/kuma/static/styles/base/elements/tables.scss
@@ -12,5 +12,5 @@ caption {
 
 caption,
 th {
-    @include bidi-value(text-align, left, right);
+    @include bidi(((text-align, left, right),));
 }

--- a/kuma/static/styles/base/icons.scss
+++ b/kuma/static/styles/base/icons.scss
@@ -9,6 +9,8 @@
 }
 
 label #{$selector-icon}:first-child {
-    @include bidi-value(margin-left, 0, $icon-margin);
-    @include bidi-value(margin-right, $icon-margin, 0);
+    @include bidi((
+        (margin-left, 0, $icon-margin),
+        (margin-right, $icon-margin, 0),
+    ));
 }

--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -117,16 +117,20 @@ Utility classes
 }
 
 .media-side {
-    @include bidi-value(float, left, right);
-    @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
+    @include bidi((
+        (float, left, right),
+        (margin-right, ($grid-spacing / 2), margin-left, 0),
+    ));
 
     img {
         display: block;
     }
 
     .media-reverse & {
-        @include bidi-value(float, right, left);
-        @include bidi-style(margin-left, ($grid-spacing / 2), margin-right, 0);
+        @include bidi((
+            (float, right, left),
+            (margin-left, ($grid-spacing / 2), margin-right, 0),
+        ));
     }
 }
 

--- a/kuma/static/styles/components/activity.scss
+++ b/kuma/static/styles/components/activity.scss
@@ -52,6 +52,6 @@
 
     li {
         display: inline;
-        @include bidi-style(margin-right, 10px, margin-left, 0);
+        @include bidi(((margin-right, 10px, margin-left, 0),));
     }
 }

--- a/kuma/static/styles/components/compact.scss
+++ b/kuma/static/styles/components/compact.scss
@@ -7,7 +7,7 @@
     dd {
         display: inline;
         margin-bottom: 0;
-        @include bidi-style(padding-left, $content-horizontal-spacing, padding-right, 0);
+        @include bidi(((padding-left, $content-horizontal-spacing, padding-right, 0),));
 
         &:after {
             content: '\A';

--- a/kuma/static/styles/components/compat-tables/bc-beta.scss
+++ b/kuma/static/styles/components/compat-tables/bc-beta.scss
@@ -1,7 +1,7 @@
 .bc-beta-menu {
     position: relative;
     display: inline-block;
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
 
     ul {
         padding-left: $grid-spacing;

--- a/kuma/static/styles/components/components.scss
+++ b/kuma/static/styles/components/components.scss
@@ -15,7 +15,7 @@ toggler component: a basic slide up and slide now system
     #{$selector-icon} {
         position: absolute;
         top: 3px;
-        @include bidi-style(right, $icon-margin, left, auto);
+        @include bidi(((right, $icon-margin, left, auto),));
         color: $text-color;
     }
 
@@ -56,7 +56,7 @@ subnav component:  used within the wiki
 
     #{$selector-icon} {
         top: 23px;
-        @include bidi-style(right, 20px, left, auto);
+        @include bidi(((right, 20px, left, auto),));
     }
 
     .toggle-container {

--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -35,12 +35,12 @@ We cannot put these styles in the base/elements/ files because they don't apply 
 
     ul,
     ol {
-        @include bidi-style(padding-left, ($grid-spacing * 2), padding-right, 0);
+        @include bidi(((padding-left, ($grid-spacing * 2), padding-right, 0),));
         margin-bottom: $content-block-margin;
 
         &.no-bullets {
             list-style-type: none;
-            @include bidi-style(padding-left, 0, padding-right, 0);
+            @include bidi(((padding-left, 0, padding-right, 0),));
         }
     }
 
@@ -60,7 +60,7 @@ We cannot put these styles in the base/elements/ files because they don't apply 
 
     dd {
         margin-bottom: $content-block-margin;
-        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+        @include bidi(((padding-left, $grid-spacing, padding-right, 0),));
     }
 
     /*
@@ -134,11 +134,11 @@ We cannot put these styles in the base/elements/ files because they don't apply 
         > h3:not(.highlight-spanned),
         > h3 .highlight-span,
         > div:not([class]) > h3 .highlight-span {
-            @include bidi-value(padding, 0 4px 0 $grid-spacing, 0 $grid-spacing 0 4px);
+            @include bidi(((padding, 0 4px 0 $grid-spacing, 0 $grid-spacing 0 4px),));
 
             /* indent more on larger screen */
             @media #{$mq-tablet-and-up} {
-                @include bidi-value(padding, 0 4px 0 $grid-spacing * 2, 0 $grid-spacing * 2 0 4px);
+                @include bidi(((padding, 0 4px 0 $grid-spacing * 2, 0 $grid-spacing * 2 0 4px),));
             }
         }
     }
@@ -199,7 +199,7 @@ We cannot put these styles in the base/elements/ files because they don't apply 
             td {
                 border: 1px solid #ccc;
                 padding: 5px;
-                @include bidi-value(text-align, left, right);
+                @include bidi(((text-align, left, right),));
                 vertical-align: top;
             }
 
@@ -217,7 +217,7 @@ We cannot put these styles in the base/elements/ files because they don't apply 
         border: solid #e0e0dc;
         border-width: 0 1px 1px 0;
         padding: $content-vertical-spacing $content-horizontal-spacing;
-        @include bidi-value('text-align', left, right);
+        @include bidi((('text-align', left, right),));
     }
 
     thead th {

--- a/kuma/static/styles/components/home/base.scss
+++ b/kuma/static/styles/components/home/base.scss
@@ -12,8 +12,10 @@
             position: relative;
             top: -5px; // try to center icon vertically
             @include set-font-size(30px);
-            @include bidi-value(margin-right, $icon-margin, 0);
-            @include bidi-value(margin-left, 0, $icon-margin);
+            @include bidi((
+                (margin-right, $icon-margin, 0),
+                (margin-left, 0, $icon-margin),
+            ));
         }
     }
 

--- a/kuma/static/styles/components/home/column-callout.scss
+++ b/kuma/static/styles/components/home/column-callout.scss
@@ -24,15 +24,17 @@ $callout-min-height: 170px;
             display: block;
             position: absolute;
             top: $grid-spacing;
-            @include bidi-style(right, $grid-spacing, left, auto);
+            @include bidi(((right, $grid-spacing, left, auto),));
             height: $callout-icon-width;
             width: $callout-icon-width;
             background-image: url($path-to-embedded-images + 'promo-sprite.png');
         }
 
         &:before {
-            @include bidi-style(content, '\f061', content, '\f060');
-            @include bidi-style(right, $grid-spacing, left, auto);
+            @include bidi((
+                (content, '\f061', content, '\f060'),
+                (right, $grid-spacing, left, auto),
+            ));
             font-family: FontAwesome;
             bottom: 11px;
             position: absolute;
@@ -45,7 +47,7 @@ $callout-min-height: 170px;
         position: absolute;
         z-index: 1;
         bottom: -2px;
-        @include bidi-value(padding, $grid-spacing $callout-icon-space $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing $callout-icon-space);
+        @include bidi(((padding, $grid-spacing $callout-icon-space $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing $callout-icon-space),));
         box-sizing: border-box;
     }
 }
@@ -58,7 +60,7 @@ $callout-min-height: 170px;
         }
 
         span {
-            @include bidi-value(padding, $grid-spacing $callout-arrow-space $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing $callout-arrow-space);
+            @include bidi(((padding, $grid-spacing $callout-arrow-space $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing $callout-arrow-space),));
         }
     }
 }
@@ -157,13 +159,13 @@ Foundation callout
     button {
         position: relative;
         margin-top: 6px;
-        @include bidi-style(padding-right, 2em, padding-left, inherit);
+        @include bidi(((padding-right, 2em, padding-left, inherit),));
 
         &:after {
             position: absolute;
             top: 50%;
-            @include bidi-style(right, 10px, left, auto);
-            @include bidi-value(content, '\f061', '\f060');
+            @include bidi(((right, 10px, left, auto),));
+            @include bidi(((content, '\f061', '\f060'),));
             font-family: fontAwesome;
             transform: translateY(-50%);
         }
@@ -200,7 +202,7 @@ $saucelabs-callout-image-spacing: 129px + 20px;
 
         &:after {
             display: none;
-            @include bidi-style(right, 20px, left, auto);
+            @include bidi(((right, 20px, left, auto),));
             background-image: url($path-to-embedded-images + 'promos/sauce-labs-home.png');
             height: 140px;
             top: 15px;
@@ -222,7 +224,7 @@ $saucelabs-callout-image-spacing: 129px + 20px;
     }
 
     button {
-        @include bidi-style(text-align, left, text-align, right);
+        @include bidi(((text-align, left, text-align, right),));
         background: #fff;
         border: 2px solid;
         border-radius: 0;
@@ -247,7 +249,7 @@ larger teaser image gets hidden and shown at a different rate than the usual cal
         }
 
         span {
-            @include bidi-value(padding, $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing) $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing));
+            @include bidi(((padding, $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing) $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing)),));
         }
     }
 }
@@ -259,7 +261,7 @@ larger teaser image gets hidden and shown at a different rate than the usual cal
         }
 
         span {
-            @include bidi-value(padding, $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing) $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing));
+            @include bidi(((padding, $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing) $grid-spacing $grid-spacing, $grid-spacing $grid-spacing $grid-spacing ($saucelabs-callout-image-spacing + $grid-spacing)),));
         }
     }
 }

--- a/kuma/static/styles/components/newsletter.scss
+++ b/kuma/static/styles/components/newsletter.scss
@@ -30,7 +30,7 @@ input.newsletter-input-email {
 .newsletter-hide {
     position: absolute;
     top: ($grid-spacing / 2);
-    @include bidi-style(right, ($grid-spacing / 2), left, auto);
+    @include bidi(((right, ($grid-spacing / 2), left, auto),));
     z-index: 11;
     border: none;
     padding: 0;
@@ -38,7 +38,7 @@ input.newsletter-input-email {
 
 /* error messages */
 .newsletter-errors .errorlist {
-    @include bidi-style(padding-left, 0, padding-right, 0);
+    @include bidi(((padding-left, 0, padding-right, 0),));
     list-style-type: none;
 }
 
@@ -61,14 +61,16 @@ input.newsletter-input-email {
     position: relative;
     width: 100%;
     padding: ($grid-spacing / 2);
-    @include bidi-style(padding-right, 2em, padding-left, inherit);
+    @include bidi(((padding-right, 2em, padding-left, inherit),));
     text-align: left;
 
     &:after {
         position: absolute;
         top: 50%;
-        @include bidi-style(right, 10px, left, auto);
-        @include bidi-value(content, '\f061', '\f060');
+        @include bidi((
+            (right, 10px, left, auto),
+            (content, '\f061', '\f060'),
+        ));
         font-family: fontAwesome;
         transition: margin .1s ease-in-out;
         transform: translateY(-50%);
@@ -79,7 +81,7 @@ input.newsletter-input-email {
         text-decoration: none;
 
         &:after {
-            @include bidi-style(margin-right, -4px, margin-left, 0);
+            @include bidi(((margin-right, -4px, margin-left, 0),));
         }
     }
 }
@@ -119,7 +121,7 @@ input and submit on same line
         .newsletter-group-submit {
             box-sizing: border-box;
             width: 40%;
-            @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+            @include bidi(((padding-left, $grid-spacing, padding-right, 0),));
         }
 
         .newsletter-submit {
@@ -170,7 +172,7 @@ text side by side with form fields
 
             .newsletter-group-submit {
                 width: auto;
-                @include bidi-style(padding-left, 0, padding-right, 0);
+                @include bidi(((padding-left, 0, padding-right, 0),));
             }
 
             .newsletter-submit {
@@ -267,7 +269,7 @@ article page modifications
         &:before {
             content: '';
             display: block;
-            @include bidi-value(float, right, left);
+            @include bidi(((float, right, left),));
             height: .5em;
             width: 1.5em;
         }

--- a/kuma/static/styles/components/option-list.scss
+++ b/kuma/static/styles/components/option-list.scss
@@ -11,7 +11,7 @@ ul.option-list {
     list-style-type: none;
     max-width: 100%;
     overflow: hidden;
-    @include bidi-style(padding-left, ($grid-spacing), padding-right, 0);
+    @include bidi(((padding-left, ($grid-spacing), padding-right, 0),));
 
     li {
         @include clearfix();
@@ -19,9 +19,11 @@ ul.option-list {
 }
 
 .option-list-options {
-    @include bidi-value(float, right, left);
-    @include bidi-style(margin-left, $grid-spacing, margin-right, $grid-spacing );
-    @include bidi-value(text-align, right, left);
+    @include bidi((
+        (float, right, left),
+        (margin-left, $grid-spacing, margin-right, $grid-spacing ),
+        (text-align, right, left),
+    ));
 }
 
 /* options drop beneath text on smaller screens */

--- a/kuma/static/styles/components/structure/_mixin_nav.scss
+++ b/kuma/static/styles/components/structure/_mixin_nav.scss
@@ -7,7 +7,7 @@
         padding: $content-vertical-spacing 0;
 
         #{$selector-icon} {
-            @include bidi-value(float, right, left);
+            @include bidi(((float, right, left),));
         }
     }
 }
@@ -34,7 +34,7 @@
             }
         }
 
-        html[dir='rtl']:not(.no-js) & { // can't use bidi-style because html tag is in declaration
+        html[dir='rtl']:not(.no-js) & { // can't use bidi because html tag is in declaration
             #{$selector-icon} {
                 margin-right: 5px;
             }

--- a/kuma/static/styles/components/structure/columns.scss
+++ b/kuma/static/styles/components/structure/columns.scss
@@ -51,28 +51,28 @@ tablet & up - change to columns
 
         #{$grid-column-selector} {
             margin-right: $grid-margin;
-            @include bidi-value(float, left, right);
+            @include bidi(((float, left, right),));
             min-height: 1px;
 
             &:first-child {
-                @include bidi-value(margin-right, $grid-margin, 0);
+                @include bidi(((margin-right, $grid-margin, 0),));
             }
 
             &:last-child {
-                @include bidi-value(margin-right, 0, $grid-margin);
+                @include bidi(((margin-right, 0, $grid-margin),));
             }
         }
 
         &.column-container-reverse {
             #{$grid-column-selector} {
-                @include bidi-value(float, right, left);
+                @include bidi(((float, right, left),));
 
                 &:first-child {
-                    @include bidi-value(margin-right, 0, $grid-margin);
+                    @include bidi(((margin-right, 0, $grid-margin),));
                 }
 
                 &:last-child {
-                    @include bidi-value(margin-right, $grid-margin, 0);
+                    @include bidi(((margin-right, $grid-margin, 0),));
                 }
             }
         }

--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -13,7 +13,7 @@
 
     em {
         font-style: normal;
-        @include bidi-style(margin-left, -3px, margin-right, 0);
+        @include bidi(((margin-left, -3px, margin-right, 0),));
         text-transform: none;
     }
 }
@@ -21,7 +21,7 @@
 .document-actions {
     position: relative;
     z-index: $document-actions-z;
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
     width: 100%;
     margin-bottom: ($grid-spacing / 2);
 }
@@ -35,7 +35,7 @@
 
     .document-actions {
         width: auto;
-        @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
+        @include bidi(((margin-left, $grid-spacing, margin-right, 0),));
         margin-bottom: 0;
     }
 }

--- a/kuma/static/styles/components/structure/main-header.scss
+++ b/kuma/static/styles/components/structure/main-header.scss
@@ -39,8 +39,10 @@ Main header, wraps all components of logo, main, and secondary navigation
         position: relative;
         top: $grid-spacing;
         height: 48px;
-        @include bidi-value(float, left, right);
-        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+        @include bidi((
+            (float, left, right),
+            (margin-right, $grid-spacing, margin-left, 0)
+        ));
     }
 }
 

--- a/kuma/static/styles/components/structure/nav-footer.scss
+++ b/kuma/static/styles/components/structure/nav-footer.scss
@@ -49,10 +49,10 @@
 .footer-social {
     @include set-font-size($h4-font-size);
     display: inline-block;
-    @include bidi-style(margin-right, ($grid-spacing / 2 ), margin-left, 0);
+    @include bidi(((margin-right, ($grid-spacing / 2 ), margin-left, 0),));
 
     a {
-        @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
+        @include bidi(((padding-right, $grid-spacing, padding-left, 0),));
     }
 }
 
@@ -73,7 +73,7 @@
 
     li {
         display: inline-block;
-        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+        @include bidi(((margin-right, $grid-spacing, margin-left, 0),));
     }
 }
 
@@ -103,7 +103,7 @@
 
     .footer-social {
         a {
-            @include bidi-style(padding-right, ($grid-spacing / 2 ), padding-left, 0);
+            @include bidi(((padding-right, ($grid-spacing / 2 ), padding-left, 0),));
         }
     }
 
@@ -149,14 +149,14 @@
         position: absolute;
         top: $grid-spacing;
         width: -calc-col-width(3);
-        @include bidi-style(left, -calc-col-width(5), right, auto);
+        @include bidi(((left, -calc-col-width(5), right, auto),));
     }
 
     .footer-group-mozilla {
         position: absolute;
         top: $grid-spacing;
         width: -calc-col-width(3);
-        @include bidi-style(left, -calc-col-width(8), right, auto);
+        @include bidi(((left, -calc-col-width(8), right, auto),));
     }
 
     .languages {

--- a/kuma/static/styles/components/structure/nav-main-search.scss
+++ b/kuma/static/styles/components/structure/nav-main-search.scss
@@ -10,7 +10,7 @@ search items in .main-nav
 .search-trigger {
     position: absolute;
     top: 12px;
-    @include bidi-style(left, 15px, right, auto);
+    @include bidi(((left, 15px, right, auto),));
     z-index: 2;
     cursor: pointer;
 
@@ -22,14 +22,16 @@ search items in .main-nav
 #main-q {
     width: 100%;
     margin: $content-vertical-spacing auto;
-    @include bidi-style(padding-left, 2.5em, padding-right, 0);
+    @include bidi(((padding-left, 2.5em, padding-right, 0),));
 }
 
 @media #{$mq-tablet-and-up} {
     .nav-main-search {
         display: list-item; // JS uses this to determine if we're in mobile or not
-        @include bidi-value(float, right, left);
-        @include bidi-value(text-align, right, left);
+        @include bidi((
+            (float, right, left),
+            (text-align, right, left),
+        ));
     }
 
     .search-trigger {
@@ -40,10 +42,12 @@ search items in .main-nav
     .search-wrap {
         position: absolute;
         top: 0;
-        @include bidi-style(right, 0, left, auto);
+        @include bidi((
+            (right, 0, left, auto),
+            (padding-left, 45px, padding-right, 0),
+        ));
         width: 0;
         overflow: hidden;
-        @include bidi-style(padding-left, 45px, padding-right, 0);
         line-height: 48px + ($grid-spacing * 2);
         @include vendorize(transition-property, 'width, opacity');
         @include vendorize(transition-duration, $default-animation-duration);
@@ -55,7 +59,7 @@ search items in .main-nav
 
     #main-q {
         border-color: #fff;
-        @include bidi-style(padding-left, 0, padding-right, 0);
+        @include bidi(((padding-left, 0, padding-right, 0),));
         border-bottom: 1px solid $grey;
     }
 }

--- a/kuma/static/styles/components/structure/nav-sec.scss
+++ b/kuma/static/styles/components/structure/nav-sec.scss
@@ -17,8 +17,10 @@ Secondary navigation, site tools and login info
 
 @media #{$mq-tablet-and-up} {
     #nav-sec {
-        @include bidi-value(float, right, left);
-        @include bidi-style(right, ($gutter-width * -1), left, auto);
+        @include bidi((
+            (float, right, left),
+            (right, ($gutter-width * -1), left, auto),
+        ));
         background-color: $bg-dark;
 
         > ul > li {

--- a/kuma/static/styles/components/structure/pagination.scss
+++ b/kuma/static/styles/components/structure/pagination.scss
@@ -7,16 +7,16 @@ ol.pagination {
     padding: 0 0 ($grid-spacing * 1.5) 0;
 
     li {
-        @include bidi-value(float, left, right);
+        @include bidi(((float, left, right),));
         padding: 0 2px;
 
         &.prev,
         &.prev a {
-            @include bidi-style(padding-left, 0, padding-right, inherit);
+            @include bidi(((padding-left, 0, padding-right, inherit),));
         }
 
         a {
-            @include bidi-value(float, left, right);
+            @include bidi(((float, left, right),));
             padding: 3px 8px 5px;
 
             &:hover {

--- a/kuma/static/styles/components/structure/search-form.scss
+++ b/kuma/static/styles/components/structure/search-form.scss
@@ -20,7 +20,7 @@ Full size form on home and search pages
         width: 100%;
         margin: 0 auto;
         padding: ($grid-spacing / 2);
-        @include bidi-style(padding-left, 48px, padding-right, 0);
+        @include bidi(((padding-left, 48px, padding-right, 0),));
         background: #fff;
         @include set-larger-font-size();
         @include set-placeholder-style(color, $text-color);
@@ -30,7 +30,7 @@ Full size form on home and search pages
         position: absolute;
         top: 0;
         bottom: 0;
-        @include bidi-style(left, 0, right, auto);
+        @include bidi(((left, 0, right, auto),));
         width: 48px;
         display: flex;
         align-items: center;
@@ -41,7 +41,7 @@ Full size form on home and search pages
             position: absolute;
             top: ($grid-spacing / 2);
             bottom: ($grid-spacing / 2);
-            @include bidi-style(left, 40px, right, auto);
+            @include bidi(((left, 40px, right, auto),));
             display: block;
             border-left: 1px solid $form-border-color;
         }
@@ -59,7 +59,7 @@ Full size form on home and search pages
         > input#home-q,
         > input#search-q {
             padding: $grid-spacing;
-            @include bidi-style(padding-left, 70px, padding-right, 0);
+            @include bidi(((padding-left, 70px, padding-right, 0),));
         }
 
         .search-icon {
@@ -68,7 +68,7 @@ Full size form on home and search pages
             &:after {
                 top: $grid-spacing;
                 bottom: $grid-spacing;
-                @include bidi-style(left, 54px, right, auto);
+                @include bidi(((left, 54px, right, auto),));
             }
         }
     }

--- a/kuma/static/styles/components/structure/submenu.scss
+++ b/kuma/static/styles/components/structure/submenu.scss
@@ -3,7 +3,7 @@
     position: absolute;
     z-index: $submenu-z;
     top: 100%;
-    @include bidi-style(left, 0, right, auto);
+    @include bidi(((left, 0, right, auto),));
     width: 250px; // fallback, IE & Edge
     padding: 15px;
     border-top: 5px solid $grey-light;
@@ -18,7 +18,7 @@
         box-sizing: border-box;
         display: inline-block;
         vertical-align: text-top;
-        @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
+        @include bidi(((padding-right, $grid-spacing, padding-left, 0),));
         width: 250px; // fallback, IE & Edge
     }
 
@@ -32,7 +32,7 @@
             @include vendorize-value(width, max-content);
 
             + .submenu-column {
-                @include bidi-style(padding-left, ($grid-spacing * 2), padding-right, $grid-spacing);
+                @include bidi(((padding-left, ($grid-spacing * 2), padding-right, $grid-spacing),));
             }
         }
     }
@@ -43,7 +43,7 @@
     }
 
     #{$selector-icon} {
-        @include bidi-style(margin-left, 5px, margin-right, 0);
+        @include bidi(((margin-left, 5px, margin-right, 0),));
     }
 
     a {
@@ -54,13 +54,17 @@
 
     #nav-sec & {
         border-top-color: $bg-dark;
-        @include bidi-style(left, auto, right, auto);
-        @include bidi-style(right, 0, left, auto);
+        @include bidi((
+            (left, auto, right, auto),
+            (right, 0, left, auto),
+        ));
     }
 
     .page-buttons & {
-        @include bidi-style(left, auto, right, auto);
-        @include bidi-style(right, 0, left, auto);
+        @include bidi((
+            (left, auto, right, auto),
+            (right, 0, left, auto),
+        ));
         border-top: 5px solid $form-border-color;
     }
 }
@@ -68,7 +72,7 @@
 .submenu-close {
     position: absolute;
     top: 0;
-    @include bidi-style(right, 0, left, auto);
+    @include bidi(((right, 0, left, auto),));
     z-index: 1; /* raise above links it might over-lap */
 }
 
@@ -94,7 +98,7 @@ everything else */
                 width: 100%;
 
                 + .submenu-column {
-                    @include bidi-style(padding-left, 0, padding-right, 0);
+                    @include bidi(((padding-left, 0, padding-right, 0),));
                 }
             }
         }

--- a/kuma/static/styles/components/syntax/example.scss
+++ b/kuma/static/styles/components/syntax/example.scss
@@ -14,7 +14,7 @@ $bg-bad: mix($negative, #fff, 5%);
             line-height: 1;
             position: absolute;
             bottom: 2px;
-            @include bidi-style(right, 2px, left, auto);
+            @include bidi(((right, 2px, left, auto),));
             z-index: 10;
             speak: none;
         }

--- a/kuma/static/styles/components/tagit.scss
+++ b/kuma/static/styles/components/tagit.scss
@@ -10,7 +10,7 @@ overrides for tagit widget
     font-size: 1em;
 
     .close {
-        @include bidi-style(margin-left, 4px, margin-right, 0);
+        @include bidi(((margin-left, 4px, margin-right, 0),));
 
         .text-icon {
             display: none;
@@ -22,7 +22,7 @@ overrides for tagit widget
             display: inline-block;
             height: 15px;
             margin: 0 0 -3px 0;
-            @include bidi-style(margin-left, 3px, margin-right, 0);
+            @include bidi(((margin-left, 3px, margin-right, 0),));
             overflow: hidden;
             direction: ltr; // ltr should be set with negative text indent
             text-indent: -9999px;

--- a/kuma/static/styles/components/tags.scss
+++ b/kuma/static/styles/components/tags.scss
@@ -9,7 +9,7 @@ $tag-border-color: #cee9f9;
     border: 1px solid $tag-border-color;
     border-radius: 2px;
     display: inline-block;
-    @include bidi-value(margin, 0 ($grid-spacing / 2) ($grid-spacing / 2) 0, 0 0 ($grid-spacing / 2) ($grid-spacing / 2));
+    @include bidi(((margin, 0 ($grid-spacing / 2) ($grid-spacing / 2) 0, 0 0 ($grid-spacing / 2) ($grid-spacing / 2)),));
     padding: 3px ($grid-spacing / 2) 4px;
 }
 
@@ -18,7 +18,7 @@ ul.tags {
     border: none;
     clear: both;
     margin-bottom: 0; /* doesn't need bottom margin, each tag takes care of that */
-    @include bidi-style(padding-left, 0, padding-right, 0); /* overrides padding added to lists in content areas */
+    @include bidi(((padding-left, 0, padding-right, 0),)); /* overrides padding added to lists in content areas */
     width: 100%;
 
     .wiki-block &,
@@ -43,7 +43,7 @@ small
 $small-tag-spacing: 3px;
 
 ul.tags-small li {
-    @include bidi-value(margin, 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2) 0, 0 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2));
+    @include bidi(((margin, 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2) 0, 0 0 ($small-tag-spacing * 2) ($small-tag-spacing * 2)),));
     padding: 1px $small-tag-spacing;
 }
 

--- a/kuma/static/styles/components/users/docs-activity.scss
+++ b/kuma/static/styles/components/users/docs-activity.scss
@@ -12,6 +12,6 @@
     }
 
     .button {
-        @include bidi-style(margin-left, 10px, margin-right, 0);
+        @include bidi(((margin-left, 10px, margin-right, 0),));
     }
 }

--- a/kuma/static/styles/components/users/user-head.scss
+++ b/kuma/static/styles/components/users/user-head.scss
@@ -9,11 +9,13 @@
 .user-buttons {
     position: absolute;
     top: $grid-spacing;
-    @include bidi-style(right, $grid-spacing, left, auto);
+    @include bidi(((right, $grid-spacing, left, auto),));
 
     & > a {
-        @include bidi-value(float, left, right);
-        @include bidi-value(margin, 0 5px 0 0, 0 0 0 5px);
+        @include bidi((
+            (float, left, right),
+            (margin, 0 5px 0 0, 0 0 0 5px),
+        ));
     }
 }
 
@@ -21,7 +23,7 @@
     .user-buttons {
         position: relative;
         top: auto;
-        @include bidi-style(right, auto, left, auto);
+        @include bidi(((right, auto, left, auto),));
         margin: 0 0 $grid-spacing 0;
 
         a {
@@ -37,17 +39,17 @@
 
     li {
         display: inline;
-        @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
+        @include bidi(((margin-right, ($grid-spacing / 2), margin-left, 0),));
 
         &:before {
             color: $user-head-secondary-text-color;
             content: '/';
-            @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0);
+            @include bidi(((margin-right, ($grid-spacing / 2), margin-left, 0),));
         }
 
         &:first-child:before {
             content: '';
-            @include bidi-style(margin-right, 0, margin-left, 0);
+            @include bidi(((margin-right, 0, margin-left, 0),));
         }
     }
 }

--- a/kuma/static/styles/components/users/user-links.scss
+++ b/kuma/static/styles/components/users/user-links.scss
@@ -1,10 +1,10 @@
 .user-links {
     display: inline-block;
-    @include bidi-style(margin-left, ($icon-margin * -1), margin-right, 0);
+    @include bidi(((margin-left, ($icon-margin * -1), margin-right, 0),));
 
     li {
         display: inline-block;
-        @include bidi-style(margin-right, $content-horizontal-spacing, margin-left, 0);
+        @include bidi(((margin-right, $content-horizontal-spacing, margin-left, 0),));
         margin-bottom: $grid-spacing;
     }
 

--- a/kuma/static/styles/components/users/user-tags.scss
+++ b/kuma/static/styles/components/users/user-tags.scss
@@ -9,6 +9,6 @@
     li {
         display: inline;
         @include set-smaller-font-size();
-        @include bidi-style(margin-right, 10px, margin-left, 0);
+        @include bidi(((margin-right, 10px, margin-left, 0),));
     }
 }

--- a/kuma/static/styles/components/users/user-title.scss
+++ b/kuma/static/styles/components/users/user-title.scss
@@ -9,7 +9,7 @@
 }
 
 .user-title-profile {
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
     @include set-font-size($small-bump-font-size);
 }
 

--- a/kuma/static/styles/components/wiki/communitybox.scss
+++ b/kuma/static/styles/components/wiki/communitybox.scss
@@ -11,7 +11,7 @@ $communitybox-spacing: 13px;
     @include restrict-line-length();
     padding: $communitybox-spacing;
     background-color: $blue-light;
-    @include bidi-value(border, 0, 0);
+    @include bidi(((border, 0, 0),));
     @include set-font-size($body-font-size);
 
     strong {
@@ -60,7 +60,7 @@ ul.communitymailinglist { /* needs specificity to get past .text-content ul */
     display: inline-block;
     color: #fff;
     padding: 3px 6px;
-    @include bidi-style(margin-right, 3px, margin-left, 0);
+    @include bidi(((margin-right, 3px, margin-left, 0),));
     border-radius: 3px;
 }
 

--- a/kuma/static/styles/components/wiki/content/callout-box.scss
+++ b/kuma/static/styles/components/wiki/content/callout-box.scss
@@ -1,6 +1,6 @@
 .callout-box {
     @include pull-aside();
-    @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing); /* override behaviour of pull-aside */
+    @include bidi(((margin-bottom, $grid-spacing, $grid-spacing),)); /* override behaviour of pull-aside */
     box-sizing: border-box;
     background: $light-background-color;
     border: 1px solid #f1f1f1;
@@ -12,6 +12,6 @@
 
     /* override behaviour of pull-aside */
     @media #{$mq-small-mobile-and-down} {
-        @include bidi-value(margin-bottom, $grid-spacing, $grid-spacing);
+        @include bidi(((margin-bottom, $grid-spacing, $grid-spacing),));
     }
 }

--- a/kuma/static/styles/components/wiki/content/card-grid.scss
+++ b/kuma/static/styles/components/wiki/content/card-grid.scss
@@ -5,7 +5,7 @@ side by side calls to action
 .text-content .card-grid {
     @include full-width-content();
     margin: 0 0 $grid-spacing;
-    @include bidi-value(padding, 0, 0); /* need some extra specificity for RTL */
+    @include bidi(((padding, 0, 0),)); /* need some extra specificity for RTL */
     list-style-type: none;
 
     > li {

--- a/kuma/static/styles/components/wiki/content/collapsible.scss
+++ b/kuma/static/styles/components/wiki/content/collapsible.scss
@@ -20,7 +20,7 @@ h2 > .collapse-trigger {
     &:before {
         display: inline-block;
         color: $link-color;
-        @include bidi-value(content, '\f0da', '\f0d9');
+        @include bidi(((content, '\f0da', '\f0d9'),));
         cursor: pointer;
         font-family: FontAwesome;
         line-height: 39px;

--- a/kuma/static/styles/components/wiki/content/directory-tree.scss
+++ b/kuma/static/styles/components/wiki/content/directory-tree.scss
@@ -1,14 +1,14 @@
 ul.directory-tree {
-    @include bidi-style(padding-left, 0, padding-right, 0);
+    @include bidi(((padding-left, 0, padding-right, 0),));
 
     &,
     ul {
-        @include bidi-style(margin-left, 0, margin-right, 0);
+        @include bidi(((margin-left, 0, margin-right, 0),));
         list-style: none;
     }
 
     ul {
-        @include bidi-style(padding-left, ($grid-spacing + $content-horizontal-spacing), padding-right, 0);
+        @include bidi(((padding-left, ($grid-spacing + $content-horizontal-spacing), padding-right, 0),));
 
         li {
             position: relative;
@@ -17,7 +17,7 @@ ul.directory-tree {
             &:after {
                 content: '';
                 position: absolute;
-                @include bidi-style(left, -15px, right, auto);
+                @include bidi(((left, -15px, right, auto),));
                 display: block;
             }
 
@@ -26,13 +26,13 @@ ul.directory-tree {
                 height: .75em;
                 width: 10px;
                 border-bottom: 1px solid $grey;
-                @include bidi-style(border-left, 1px solid $grey, border-right, none);
+                @include bidi(((border-left, 1px solid $grey, border-right, none),));
             }
 
             &:after {
                 bottom: -7px;
                 height: 100%;
-                @include bidi-style(border-left, 1px solid $grey, border-right, none);
+                @include bidi(((border-left, 1px solid $grey, border-right, none),));
             }
 
             &:last-child:after {

--- a/kuma/static/styles/components/wiki/content/html5ArticleToc.scss
+++ b/kuma/static/styles/components/wiki/content/html5ArticleToc.scss
@@ -35,7 +35,7 @@ table.html5ArticleToc { // need specificity to override table.text-content
 .html5ArticleToc ul {
     @include vendorize(column-width, 100px);
     margin-bottom: 0;
-    @include bidi-style(padding-left, 0, padding-right, 0);
+    @include bidi(((padding-left, 0, padding-right, 0),));
     list-style-type: none;
 }
 

--- a/kuma/static/styles/components/wiki/contributor-avatars.scss
+++ b/kuma/static/styles/components/wiki/contributor-avatars.scss
@@ -7,15 +7,17 @@ $avatar-margin: 5px;
 $avatar-limit: 6;
 
 .contributor-avatars {
-    @include bidi-value(float, right, left);
+    @include bidi ((
+        (float, right, left),
+        (margin-left, $grid-spacing, margin-right, 0),
+        (text-align, right, left),
+    ));
     position: relative;
     max-width: ($avatar-limit * ($avatar-max-width + $avatar-margin));
     margin-top: 23px;
-    @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
     margin-bottom: $grid-spacing;
     color: $grey;
     @include set-smaller-font-size();
-    @include bidi-value(text-align, right, left);
 
     .no-js & {
         display: none;
@@ -24,7 +26,7 @@ $avatar-limit: 6;
     &.contributor-avatars-open {
         max-width: none;
         width: 100%;
-        @include bidi-style(margin-left, 0, margin-right, 0);
+        @include bidi(((margin-left, 0, margin-right, 0),));
     }
 
 
@@ -41,8 +43,10 @@ $avatar-limit: 6;
     }
 
     li {
-        @include bidi-value(float, left, right);
-        @include bidi-value(margin, 0 0 4px $avatar-margin, 0 $avatar-margin 4px 0);
+        @include bidi((
+            (float, left, right),
+            (margin, 0 0 4px $avatar-margin, 0 $avatar-margin 4px 0),
+        ));
         display: inline-block;
 
 
@@ -76,11 +80,13 @@ $avatar-limit: 6;
     button {
         position: absolute;
         top: 100%;
-        @include bidi-style(right, 0, left, auto);
+        @include bidi((
+            (right, 0, left, auto),
+            (text-align, right, left),
+        ));
         margin-top: -5px;
         padding: 0;
         color: $link-color;
-        @include bidi-value(text-align, right, left);
         text-transform: none;
     }
 }

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -25,14 +25,14 @@ wiki article bread crumbs
     span {
         display: inline-block;
         position: relative;
-        @include bidi-style(padding-right, 5px, padding-left, 0);
+        @include bidi(((padding-right, 5px, padding-left, 0),));
         /* borders increase hit area for mobile without messing with position of arrow */
         border-top: 15px solid transparent;
         border-bottom: 15px solid transparent;
         line-height: 1;
 
         &:after {
-            @include bidi-style(content, '\00a0\00a0\f054', content, '\00a0\00a0\f053');
+            @include bidi(((content, '\00a0\00a0\f054', content, '\00a0\00a0\f053'),));
             font-family: FontAwesome;
             color: $text-color;
             @include set-font-size(70%);

--- a/kuma/static/styles/components/wiki/customcss.scss
+++ b/kuma/static/styles/components/wiki/customcss.scss
@@ -199,15 +199,19 @@ dl {
 /* style for next and previous pages in tutorial */
 
 .previousPage {
-    @include bidi-value(float, left, right);
-    @include bidi-style(margin-right, ($grid-spacing), margin-left, 0);
+    @include bidi((
+        (float, left, right),
+        (margin-right, ($grid-spacing), margin-left, 0)
+    ));
     margin-bottom: $grid-spacing;
 }
 
 
 .nextPage {
-    @include bidi-value(float, right, left);
-    @include bidi-style(margin-left, ($grid-spacing), margin-right, 0);
+    @include bidi((
+        (float, right, left),
+        (margin-left, ($grid-spacing), margin-right, 0)
+    ));
     margin-top: $grid-spacing;
 }
 
@@ -239,9 +243,11 @@ a.liveSample:focus {
 .standardSidebar {
     background: $light-background-color;
     padding: $grid-spacing 15px;
-    @include bidi-value(margin, 0 0 15px 15px, 0 15px 15px 0);
+    @include bidi((
+        (margin, 0 0 15px 15px, 0 15px 15px 0),
+        (float, right, left)
+    ));
     padding: 5px 15px;
-    @include bidi-value(float, right, left);
     background: #eee;
     font-size: .85em;
     position: relative;

--- a/kuma/static/styles/components/wiki/edit/guide-links.scss
+++ b/kuma/static/styles/components/wiki/edit/guide-links.scss
@@ -3,7 +3,7 @@ link to editor and style guide editor that appear above text editor
 ********************************************************************** */
 
 .guide-links {
-    @include bidi-value(text-align, right, left);
+    @include bidi(((text-align, right, left),));
     margin-top: $grid-spacing;
     padding: 0 4px 2px 0;
     color: $grey;

--- a/kuma/static/styles/components/wiki/edit/translate/approved-localized.scss
+++ b/kuma/static/styles/components/wiki/edit/translate/approved-localized.scss
@@ -3,7 +3,7 @@
 .localized {
     box-sizing: border-box;
     width: 50%;
-    @include bidi-value(float, left, right);
+    @include bidi(((float, left, right),));
 
     /* when approved version hideden from view translated version fill full width of page */
     .translate-only & {
@@ -14,9 +14,9 @@
 }
 
 .approved {
-    @include bidi-style(padding-right, $grid-spacing / 2, padding-left, 0);
+    @include bidi(((padding-right, $grid-spacing / 2, padding-left, 0),));
 }
 
 .localized {
-    @include bidi-style(padding-left, $grid-spacing / 2, padding-right, 0);
+    @include bidi(((padding-left, $grid-spacing / 2, padding-right, 0),));
 }

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -119,7 +119,7 @@ inline in a heading
         & + .indicatorInHeadline {
             position: absolute;
             top: 6px;
-            @include bidi-style(right, 0, left, auto);
+            @include bidi(((right, 0, left, auto),));
         }
     }
 
@@ -127,12 +127,12 @@ inline in a heading
     h4,
     h5,
     h6 {
-        @include bidi-value(float, left, right);
+        @include bidi(((float, left, right),));
     }
 }
 
 .indicatorInHeadline {
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
 }
 
 

--- a/kuma/static/styles/components/wiki/page-buttons.scss
+++ b/kuma/static/styles/components/wiki/page-buttons.scss
@@ -4,7 +4,7 @@ edit, language, settings, save, and cancel buttons
 
 .page-buttons,
 #page-buttons {
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
     padding: 5px 0;
     width: auto;
 
@@ -12,7 +12,7 @@ edit, language, settings, save, and cancel buttons
         margin-left: ($grid-spacing / 2);
         display: inline-block;
         position: relative;
-        @include bidi-value(text-align, left, right);
+        @include bidi(((text-align, left, right),));
     }
 }
 
@@ -61,7 +61,7 @@ edit, language, settings, save, and cancel buttons
 #translate-document,
 .move-page {
     .page-buttons {
-        @include bidi-value(text-align, right, left);
+        @include bidi(((text-align, right, left),));
         float: none;
         padding: 0;
         margin-bottom: -10px;

--- a/kuma/static/styles/components/wiki/promos.scss
+++ b/kuma/static/styles/components/wiki/promos.scss
@@ -30,8 +30,10 @@
         }
 
         &:after {
-            @include bidi-style(margin-left, 6px, margin-right, 6px);
-            @include bidi-style(content, '\f105', content, '\f104');
+            @include bidi((
+                (margin-left, 6px, margin-right, 6px),
+                (content, '\f105', content, '\f104'),
+            ));
             @include set-font-size(30px);
             font-family: FontAwesome;
             padding: 0 15px;
@@ -41,19 +43,21 @@
 
 #wiki-promo-sauce-labs-a {
     @include clearfix();
-    @include bidi-style(background-position, bottom 20px right 20px, background-position, bottom 20px left 20px);
-    @include bidi-style(padding, 20px 350px 20px 25px, padding, 20px 25px 20px 350px);
+    @include bidi((
+        (background-position, bottom 20px right 20px, background-position, bottom 20px left 20px),
+        (padding, 20px 350px 20px 25px, padding, 20px 25px 20px 350px),
+    ));
     background-image: url($path-to-embedded-images + 'promos/sauce-labs-wiki-a.png');
     min-height: 106px;
 
     .wiki-promo-copy,
     .wiki-promo-cta {
-        @include bidi-style(float, left, float, right);
+        @include bidi(((float, left, float, right),));
         box-sizing: border-box;
     }
 
     .wiki-promo-copy {
-        @include bidi-style(padding, 0 20px 0 0, padding, 0 0 0 20px);
+        @include bidi(((padding, 0 20px 0 0, padding, 0 0 0 20px),));
         width: 50%;
 
         p {
@@ -69,15 +73,19 @@
 }
 
 #wiki-promo-sauce-labs-b {
-    @include bidi-style(background-position, bottom right 20px, background-position, bottom left 20px);
-    @include bidi-style(padding, 20px 250px 20px 25px, padding, 20px 25px 20px 250px);
+    @include bidi((
+        (background-position, bottom right 20px, background-position, bottom left 20px),
+        (padding, 20px 250px 20px 25px, padding, 20px 25px 20px 250px),
+    ));
     background-image: url($path-to-embedded-images + 'promos/sauce-labs-wiki-b.png');
     min-height: 139px;
 }
 
 #wiki-promo-sauce-labs-c {
-    @include bidi-style(background-position, bottom right 20px, background-position, bottom left 20px);
-    @include bidi-style(padding, 0 230px 0 0, padding, 0 0 0 230px);
+    @include bidi((
+        (background-position, bottom right 20px, background-position, bottom left 20px),
+        (padding, 0 230px 0 0, padding, 0 0 0 230px),
+    ));
     background-color: transparent;
     background-image: url($path-to-embedded-images + 'promos/sauce-labs-wiki-c.png');
     margin-top: 20px;
@@ -113,12 +121,12 @@
     #wiki-promo-sauce-labs-a {
         .wiki-promo-copy,
         .wiki-promo-cta {
-            @include bidi-style(float, none, float, none);
+            @include bidi(((float, none, float, none),));
             width: auto;
         }
 
         .wiki-promo-cta {
-            @include bidi-style(text-align, left, text-align, right);
+            @include bidi(((text-align, left, text-align, right),));
             padding-top: 15px;
         }
     }
@@ -127,35 +135,40 @@
 // max 1200px
 @media #{$mq-small-desktop-and-down} {
     #wiki-promo-sauce-labs-b .wiki-promo-copy {
-        @include bidi-style(padding, 0 120px 0 0, padding, 0 0 0 120px);
+        @include bidi(((padding, 0 120px 0 0, padding, 0 0 0 120px),));
     }
 }
 
 // max 1024px
 @media #{$mq-tablet-and-down} {
     #wiki-promo-sauce-labs-b {
-        @include bidi-style(background-position, bottom right 40px, background-position, bottom left 40px);
-        @include bidi-style(padding, 20px 350px 20px 25px, padding, 20px 25px 20px 350px);
+        @include bidi((
+            (background-position, bottom right 40px, background-position, bottom left 40px),
+            (padding, 20px 350px 20px 25px, padding, 20px 25px 20px 350px),
+        ));
 
         .wiki-promo-copy {
-            @include bidi-style(padding, 0 0 0 0, padding, 0 0 0 0);
+            @include bidi(((padding, 0 0 0 0, padding, 0 0 0 0),));
         }
     }
 
     #wiki-promo-sauce-labs-c .wiki-promo-copy {
-        @include bidi-style(padding, 0 120px 0 0, padding, 0 0 0 120px);
+        @include bidi(((padding, 0 120px 0 0, padding, 0 0 0 120px),));
     }
 }
 
 // max 768px
 @media #{$mq-mobile-and-down} {
     #wiki-promo-sauce-labs-a {
-        @include bidi-style(background-position, bottom 20px center, background-position, bottom 20px center);
-        @include bidi-style(padding, 20px 10px 140px, padding, 20px 10px 140px);
+        /* need bidi to get specificity to override previoius bidi declarations */
+        @include bidi((
+            (background-position, bottom 20px center, background-position, bottom 20px center),
+            (padding, 20px 10px 140px, padding, 20px 10px 140px),
+        ));
 
         .wiki-promo-copy,
         .wiki-promo-cta {
-            @include bidi-style(text-align, center, text-align, center);
+            @include bidi(((text-align, center, text-align, center),));
         }
 
         .wiki-promo-copy {
@@ -168,8 +181,11 @@
     }
 
     #wiki-promo-sauce-labs-b {
-        @include bidi-style(background-position, bottom center, background-position, bottom center);
-        @include bidi-style(padding, 20px 20px 160px, padding, 20px 20px 160px);
+        /* need bidi to get specificity to override previoius bidi declarations */
+        @include bidi((
+            (background-position, bottom center, background-position, bottom center),
+            (padding, 20px 20px 160px, padding, 20px 20px 160px),
+        ));
 
         .wiki-promo-copy,
         .wiki-promo-cta {
@@ -177,32 +193,36 @@
         }
 
         .wiki-promo-copy {
-            @include bidi-style(padding, 0 40px, padding, 0 40px);
+            @include bidi(((padding, 0 40px, padding, 0 40px),));
         }
     }
 
     #wiki-promo-sauce-labs-c .wiki-promo-copy {
-        @include bidi-style(padding, 0, padding, 0);
+        @include bidi(((padding, 0, padding, 0),));
     }
 }
 
 // max 480px
 @media #{$mq-small-mobile-and-down} {
     #wiki-promo-sauce-labs-a .wiki-promo-copy {
-        @include bidi-style(padding, 0, padding, 0);
+        @include bidi(((padding, 0, padding, 0),));
     }
 
     #wiki-promo-sauce-labs-b {
-        @include bidi-style(padding, 20px 10px 160px, padding, 20px 10px 160px);
+        /* need bidi to get specificity to override previoius bidi declarations */
+        @include bidi(((padding, 20px 10px 160px, padding, 20px 10px 160px),));
 
         .wiki-promo-copy {
-            @include bidi-style(padding, 0, padding, 0);
+            @include bidi(((padding, 0, padding, 0),));
         }
     }
 
     #wiki-promo-sauce-labs-c {
-        @include bidi-style(background-position, bottom center, background-position, bottom center);
-        @include bidi-style(padding, 0 0 175px, padding, 0 0 175px);
+        /* need bidi to get specificity to override previoius bidi declarations */
+        @include bidi((
+            (background-position, bottom center, background-position, bottom center),
+            (padding, 0 0 175px, padding, 0 0 175px),
+        ));
         min-height: 0;
     }
 }

--- a/kuma/static/styles/components/wiki/properties.scss
+++ b/kuma/static/styles/components/wiki/properties.scss
@@ -19,17 +19,19 @@ $properties-indent: ($grid-spacing * 2) - $properties-item-spacing;
         display: table;
         margin: 0 0 $grid-spacing 0;
         border-style: solid;
-        @include bidi-value(clear, left, right);
+        @include bidi(((clear, left, right),));
         background: $code-block-background-alt-color;
 
         /* need extra level of specificity to override default text-content styles */
         border-collapse: separate;
-        @include bidi-value(padding, $properties-spacing $properties-indent $properties-spacing $properties-spacing, $properties-spacing $properties-spacing $properties-spacing $properties-indent);
-        @include bidi-value(border-width, 0 0 0 $border-width, 0 $border-width 0 0);
+        @include bidi((
+            (padding, $properties-spacing $properties-indent $properties-spacing $properties-spacing, $properties-spacing $properties-spacing $properties-spacing $properties-indent),
+            (border-width, 0 0 0 $border-width, 0 $border-width 0 0),
+        ));
         border-color: $code-block-border-color;
 
         @media #{$mq-small-mobile-and-down} {
-            @include bidi-value(padding, $properties-item-spacing, $properties-item-spacing);
+            @include bidi(((padding, $properties-item-spacing, $properties-item-spacing),));
         }
     }
 
@@ -42,7 +44,7 @@ $properties-indent: ($grid-spacing * 2) - $properties-item-spacing;
     li dfn {
         display: table-cell;
         width: 30%;
-        @include bidi-value(padding, $properties-item-spacing ($properties-item-spacing * 2) $properties-item-spacing $properties-item-spacing, $properties-item-spacing $properties-item-spacing $properties-item-spacing ($properties-item-spacing* 2 ));
+        @include bidi(((padding, $properties-item-spacing ($properties-item-spacing * 2) $properties-item-spacing $properties-item-spacing, $properties-item-spacing $properties-item-spacing $properties-item-spacing ($properties-item-spacing* 2 )),));
         border-bottom: none;
         font-weight: bold;
         white-space: pre;

--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -31,7 +31,7 @@
     }
 
     li li {
-        @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+        @include bidi(((padding-left, $grid-spacing, padding-right, 0),));
         padding-bottom: $grid-spacing / 2;
 
         &:first-child {
@@ -49,12 +49,12 @@
         }
 
         > a {
-            @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+            @include bidi(((padding-left, $grid-spacing, padding-right, 0),));
             color: $text-color;
             display: inline-block;
 
             #{$selector-icon} {
-                @include bidi-style(left, 0, right, auto);
+                @include bidi(((left, 0, right, auto),));
                 @include set-font-size($body-font-size);
                 color: $link-color;
                 position: absolute;
@@ -79,14 +79,18 @@
 
     /* sidebar icons - deprecated, obsolete, experiemental, etc */
     .sidebar-icon {
-        @include bidi-value(margin-left, $grid-spacing * -1, 5px);
-        @include bidi-value(margin-right, 5px, $grid-spacing * -1);
+        @include bidi((
+            (margin-left, $grid-spacing * -1, 5px),
+            (margin-right, 5px, $grid-spacing * -1),
+        ));
         opacity: .3;
 
         /* only the first sidebar-icon gets pulled into the gutter */
         & + .sidebar-icon {
-            @include bidi-value(margin-left, 0, 5px);
-            @include bidi-value(margin-right, 5px, 0);
+            @include bidi((
+                (margin-left, 0, 5px),
+                (margin-right, 5px, 0),
+            ));
         }
 
         #{$selector-icon} {

--- a/kuma/static/styles/components/wiki/revision-list.scss
+++ b/kuma/static/styles/components/wiki/revision-list.scss
@@ -77,12 +77,12 @@ html[dir=rtl] .revision-list-controls:before {
 }
 
 .revision-list-prev {
-    @include bidi-value(padding, 0 0 0 10px, 0 10px 0 0);
+    @include bidi(((padding, 0 0 0 10px, 0 10px 0 0),));
     width: 45px;
 }
 
 .revision-list-date {
-    @include bidi-value(padding, 0 0 0 10px, 0 10px 0 0);
+    @include bidi(((padding, 0 0 0 10px, 0 10px 0 0),));
     width: 190px;
 }
 
@@ -104,5 +104,5 @@ html[dir=rtl] .revision-list-controls:before {
 
 /* make the Compare selected revisions button align to layout */
 .revision-list-controls .fixed {
-    @include bidi-style(left, 24px, right, auto);
+    @include bidi(((left, 24px, right, auto),));
 }

--- a/kuma/static/styles/components/wiki/sample-code.scss
+++ b/kuma/static/styles/components/wiki/sample-code.scss
@@ -1,13 +1,13 @@
 .sample-code-frame {
     border: 1px $code-block-border-style $code-block-border-color;
-    @include bidi-value(border-width, 1px 1px 1px $code-block-border-width, 1px $code-block-border-width 1px 1px);
+    @include bidi(((border-width, 1px 1px 1px $code-block-border-width, 1px $code-block-border-width 1px 1px),));
     max-width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
     padding: $grid-spacing;
     width: calc(100% - #{$grid-spacing * 2} - #{1px + $code-block-border-width});
 
     .sample-code-table & {
         border: 0;
-        @include bidi-value(border-width, 0, 0);
+        @include bidi(((border-width, 0, 0),));
         max-width: 100%;
         padding: 0;
         width: auto;
@@ -15,7 +15,7 @@
 }
 
 .open-in-host-container {
-    @include bidi-value(text-align, right, left);
+    @include bidi(((text-align, right, left),));
 }
 
 .open-in-host {
@@ -25,12 +25,12 @@
 
 @media #{$mq-mobile-and-up} {
     .open-in-host {
-        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+        @include bidi(((margin-right, $grid-spacing, margin-left, 0),));
         margin-bottom: $grid-spacing;
         width: auto;
 
         &:last-child {
-            @include bidi-style(margin-right, 0, margin-left, 0);
+            @include bidi(((margin-right, 0, margin-left, 0),));
         }
     }
 }

--- a/kuma/static/styles/components/wiki/section-edit.scss
+++ b/kuma/static/styles/components/wiki/section-edit.scss
@@ -1,6 +1,8 @@
 .section-edit {
-    @include bidi-value(float, right, left);
-    @include bidi-style(margin-left, 20px, margin-right, 0);
+    @include bidi((
+        (float, right, left),
+        (margin-left, 20px, margin-right, 0),
+    ));
     @include set-smaller-font-size();
     opacity: 0;
 

--- a/kuma/static/styles/components/wiki/spec.scss
+++ b/kuma/static/styles/components/wiki/spec.scss
@@ -50,7 +50,7 @@ Badges
        name of the spec could be either LTR or RTL (depending on
        if it's been translated) so we add margins to both sides.
        Not perfect but good compromise.  */
-    @include bidi-value(margin, .2em .6em 0 0, .2em .6em 0);
+    @include bidi(((margin, .2em .6em 0 0, .2em .6em 0),));
     direction: ltr;
 }
 

--- a/kuma/static/styles/components/wiki/toc.scss
+++ b/kuma/static/styles/components/wiki/toc.scss
@@ -26,7 +26,7 @@ $padding-horizontal: 30px;
     display: inline-block;
     font-family: $heading-font-family;
     @include set-font-size(22px);
-    @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
+    @include bidi(((padding-right, $grid-spacing, padding-left, 0),));
 }
 
 .toc-links {
@@ -49,7 +49,7 @@ $padding-horizontal: 30px;
         @include set-font-size(17px);
         font-weight: bold;
         letter-spacing: .02em;
-        @include bidi-value(padding, $padding-vertical $padding-horizontal $padding-vertical 0, $padding-vertical 0 $padding-vertical $padding-horizontal);
+        @include bidi(((padding, $padding-vertical $padding-horizontal $padding-vertical 0, $padding-vertical 0 $padding-vertical $padding-horizontal),));
         white-space: nowrap;
         text-decoration: none;
 
@@ -60,7 +60,7 @@ $padding-horizontal: 30px;
     }
 
     li:last-child a {
-        @include bidi-value(padding, $padding-vertical 0 $padding-vertical 0, $padding-vertical 0 $padding-vertical 0);
+        @include bidi(((padding, ($padding-vertical 0 $padding-vertical 0), ($padding-vertical 0 $padding-vertical 0)),));
     }
 }
 
@@ -88,7 +88,7 @@ $emify-tablet-height: (680px / 16px) * 1em;
                     display: block;
                     position: absolute;
                     bottom: 0;
-                    @include bidi-style(left, 0, right, $padding-horizontal);
+                    @include bidi(((left, 0, right, $padding-horizontal),));
                     width: calc(100% - #{$padding-horizontal});
                     height: 0;
                     background-color: $accent-light;

--- a/kuma/static/styles/components/wiki/topicpage-table.scss
+++ b/kuma/static/styles/components/wiki/topicpage-table.scss
@@ -56,15 +56,17 @@ body .topicpage-table { // need the extra specificity of body to over-ride .text
             display: table-cell;
             width: 50%;
             padding: 0 $grid-spacing;
-            @include bidi-style(border-left, solid 6px #eaeff2, border-right, none);
+            @include bidi(((border-left, solid 6px #eaeff2, border-right, none),));
 
             &:first-child {
-                @include bidi-style(border-left, 0, border-right, solid 6px #eaeff2);
-                @include bidi-style(padding-left, 0, padding-right, $grid-spacing);
+                @include bidi((
+                    (border-left, none, border-right, solid 6px #eaeff2),
+                    (padding-left, 0, padding-right, $grid-spacing),
+                ));
             }
 
             &:last-child {
-                @include bidi-style(padding-right, 0, padding-left, $grid-spacing);
+                @include bidi(((padding-right, 0, padding-left, $grid-spacing),));
             }
         }
     }

--- a/kuma/static/styles/dashboards.scss
+++ b/kuma/static/styles/dashboards.scss
@@ -89,7 +89,7 @@ Used to style the dashboard widgets in the dashboard apps
     #page-buttons {
         li {
             display: inline-block;
-            @include bidi-style(margin-right, $content-horizontal-spacing, margin-left, 0);
+            @include bidi(((margin-right, $content-horizontal-spacing, margin-left, 0),));
             margin-top: $content-vertical-spacing;
         }
     }

--- a/kuma/static/styles/includes/_mixin_submenu.scss
+++ b/kuma/static/styles/includes/_mixin_submenu.scss
@@ -56,8 +56,10 @@ submenu
 @mixin submenu() {
     position: absolute;
     top: 40px;
-    @include bidi-style(left, auto, right, 0);
-    @include bidi-style(right, 0, left, auto);
+    @include bidi((
+        (left, auto, right, 0),
+        (right, 0, left, auto),
+    ));
     z-index: 3;
     display: none;
     box-shadow: 3px 3px 5px rgba(0, 0, 0, .4);
@@ -73,15 +75,19 @@ submenu
     &:before {
         position: absolute;
         z-index: 2;
-        @include bidi-style(left, auto, right, 10px);
-        @include bidi-style(right, 10px, left, auto);
+        @include bidi((
+            (left, auto, right, 10px),
+            (right, 10px, left, auto),
+        ));
     }
 
     &:after {
         position: absolute;
         z-index: 1;
-        @include bidi-style(left, auto, right, 10px);
-        @include bidi-style(right, 10px, left, auto);
+        @include bidi((
+            (left, auto, right, 10px),
+            (right, 10px, left, auto),
+        ));
     }
 
     /* lists */
@@ -110,7 +116,7 @@ submenu
 
     /* for language menu */
     bdi {
-        @include bidi-value(text-align, left, right);
+        @include bidi(((text-align, left, right),));
     }
 
     /* columns */
@@ -121,9 +127,11 @@ submenu
             display: inline-block;
 
             &:nth-child(even) {
-                @include bidi-style(margin-left, $grid-spacing, margin-right, 0);
-                @include bidi-style(border-left, 1px dotted #d4dde4, border-right, 0);
-                @include bidi-style(padding-left, $grid-spacing, padding-right, 0);
+                @include bidi((
+                    (margin-left, $grid-spacing, margin-right, 0),
+                    (border-left, 1px dotted #d4dde4, border-right, 0),
+                    (padding-left, $grid-spacing, padding-right, 0),
+                ));
             }
         }
     }
@@ -139,7 +147,7 @@ submenu
            since this button should have a bit of size and the
            rabbit hole that lead me here is pleanty deep enough */
         padding: 10px !important; /* stylelint-disable-line declaration-no-important */
-        @include bidi-style(right, 0, left, auto);
+        @include bidi(((right, 0, left, auto),));
         color: inherit;
 
         i {

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -225,7 +225,7 @@ coloured boxes
     @include set-font-size($body-font-size);
     background: $bg-color;
     border: 0 $code-block-border-style $border-color;
-    @include bidi-style(border-left-width, $code-block-border-width, border-right-width, 0);
+    @include bidi(((border-left-width, $code-block-border-width, border-right-width, 0),));
     color: $text-color;
     margin-top: 0;
     margin-bottom: $grid-spacing;
@@ -274,8 +274,10 @@ coloured boxes
     @include restrict-line-length();
     overflow: hidden;
     margin-bottom: $grid-spacing;
-    @include bidi-style(border-left-width, $border-width, border-right-width, 0);
-    @include bidi-style(border-left-style, solid, border-right-style, none);
+    @include bidi((
+        (border-left-width, $border-width, border-right-width, 0),
+        (border-left-style, solid, border-right-style, none),
+    ));
     padding: ($grid-spacing / 2);
 
     @if ($remove-last-spacing) {
@@ -330,26 +332,104 @@ Spacing
 
 /*
 Bidi / l10n
+- The bidi mixins are used to declare both the LTR and RTL values for
+  a property together and output appropriate declarations
+- This makes it easier to maintain the RTL version since you only have
+  to update values in one place.
 ====================================================================== */
 
-// Allows setting of a property for LTR and RTL without having to deal with duplicating and maintaining selectors:
-// example: @include bidi-style(left, 20px, right, auto)
-@mixin bidi-style($ltr-prop, $value, $inverse-prop, $inverse-value, $make-important: false) {
-    $make-important: if($make-important, unquote('!important'), unquote(''));
+/*
+    @mixin bidi
+    accepts: a list of lists - each list must have 3 or 4 values
 
-    #{$ltr-prop}: $value $make-important;
+    A list with three properties overrides the ltr value in rtl locales
+    @include bidi(((float, left, right),))
+    LTR: float: left;
+    RTL: float: right;
+
+    A list with four properties overrides the ltr value in rtl locales
+    AND provides a new rtl only property value
+    @include bidi(((margin-right, 20px, margin-left, 0),))
+    LTR: margin-right: 10px;
+    RTL: margin-right: 0;
+         margin-left: 10px;
+
+    Example input:
+    .test {
+        @include bidi((
+            (float, left, right),
+            (margin-right, ($grid-spacing / 2), margin-left, 0),
+        ));
+    }
+
+    Example output:
+    .test {
+        float: left;
+        margin-right: 10px;
+    }
+    html[dir='rtl'] .test {
+        float: right;
+        margin-right: 0;
+        margin-left: 10px;
+    }
+}
+*/
+@mixin bidi($list) {
+    & {
+        @each $property, $ltr-value, $inverse-val-or-prop, $inverse-value in $list {
+            @if type-of($ltr-value) == 'null' or type-of($inverse-val-or-prop) == 'null' {
+                @warn $list; /* I don't know why this won't output as part of the error */
+                @error 'Error processing @mixin bidi(), see previous warning for stack trace';
+                /*
+                    Trouble shooting:
+                    - Check that you have the right number of nested (((parentheses)))
+                    - Check that there is a trailing comma:
+                      @include bidi(((float, left, right),));
+                */
+            }
+            #{$property}: $ltr-value;
+        }
+    }
 
     html[dir='rtl'] & {
-        @if ($ltr-prop != $inverse-prop) {
-            #{$inverse-prop}: $value $make-important;
+        @each $property, $ltr-value, $inverse-val-or-prop, $inverse-value in $list {
+            @if $inverse-value {
+                #{$property}: $inverse-value;
+                #{$inverse-val-or-prop}: $ltr-value;
+            }
+            @else {
+                #{$property}: $inverse-val-or-prop;
+            }
         }
-        #{$ltr-prop}: $inverse-value $make-important;
     }
 }
 
-@mixin bidi-value($prop, $ltr, $rtl, $make-important: false) {
-    @include bidi-style($prop, $ltr, $prop, $rtl, $make-important);
+/*
+    @mixin bidi-value-vendorize
+    - adds vendor prefixes to property
+    - does not support multiple declarations
+    - does support !important with optional 4th parameter
+
+    Example input:
+
+    .test {
+        @include bidi-value-vendorize(transform, rotate(90deg), rotate(-90deg));
+    }
+
+    Example output:
+
+    .test {
+        -webkit-transform: rotate(90deg);
+        -moz-transform: rotate(90deg);
+        transform: rotate(90deg);
+    }
+    html[dir='rtl'] .test {
+        -webkit-transform: rotate(-90deg);
+        -moz-transform: rotate(-90deg);
+        transform: rotate(-90deg);
+    }
 }
+*/
 
 @mixin bidi-value-vendorize($prop, $ltr, $rtl, $make-important: false) {
     $make-important: if($make-important, unquote('!important'), unquote(''));
@@ -361,12 +441,15 @@ Bidi / l10n
     }
 }
 
+
+/* =================================================================== */
+
 @mixin right-icons() {
-    @include bidi-value(margin-right, $icon-margin, 0);
+    @include bidi(((margin-right, $icon-margin, 0),));
 }
 
 @mixin left-icons() {
-    @include bidi-value(margin-left, $icon-margin, 0);
+    @include bidi(((margin-left, $icon-margin, 0),));
 }
 
 
@@ -396,7 +479,7 @@ These are not dynamic but serve as mixins
     margin-top: $grid-spacing * 5 + $section-border-width;
 
     &:before {
-        @include bidi-style(left, 0, right, auto);
+        @include bidi(((left, 0, right, auto),));
         border-top: $section-border;
         content: '';
         display: block;
@@ -450,8 +533,10 @@ pull aside
 @mixin pull-aside() {
     @include column-4();
     min-width: 200px;
-    @include bidi-value(float, right, left);
-    @include bidi-value(margin, 0 0 ($grid-spacing / 2) $grid-spacing, 0 $grid-spacing ($grid-spacing / 2) 0);
+    @include bidi((
+        (float, right, left),
+        (margin, 0 0 ($grid-spacing / 2) $grid-spacing, 0 $grid-spacing ($grid-spacing / 2) 0),
+    ));
 
     h3:first-child,
     h4:first-child {
@@ -460,7 +545,7 @@ pull aside
 
     @media #{$mq-small-mobile-and-down} {
         width: 100%;
-        @include bidi-value(margin, 0, 0);
+        @include bidi(((margin, 0, 0),));
     }
 }
 
@@ -506,16 +591,16 @@ Placeholders
     @include clearfix();
 
     input[type='checkbox'] {
-        @include bidi-value(float, left, right);
+        @include bidi(((float, left, right),));
     }
 
     label {
         position: absolute;
-        @include bidi-style(margin-left, 25px, margin-right, 0);
+        @include bidi(((margin-left, 25px, margin-right, 0),));
     }
 
     > p {
-        @include bidi-value(clear, left, right);
+        @include bidi(((clear, left, right),));
     }
 }
 
@@ -529,10 +614,12 @@ Placeholders
     overflow: auto;
 
     /* code is always LTR */
-    direction: ltr;
-    text-align: left;
-    @include bidi-value(border-left-width, $code-block-border-width, $code-block-border-width, !important);
-    @include bidi-value(border-right-width, 0, 0, !important);
+    /* stylelint-disable declaration-no-important  */
+    direction: ltr !important;
+    text-align: left !important;
+    border-left-width: $code-block-border-width !important;
+    border-right-width: 0 !important;
+    /* stylelint-enable */
 
     p {
         @include full-width-content();
@@ -592,14 +679,18 @@ Placeholders
     box-sizing: border-box;
     display: inline-block;
     border-bottom: 2px solid;
-    @include bidi-value(padding, 10px 30px 10px 0, 10px 0 10px 30px);
-    @include bidi-value(text-align, left, right);
+    @include bidi((
+        (padding, 10px 30px 10px 0, 10px 0 10px 30px),
+        (text-align, left, right),
+    ));
 
     &:after {
         position: absolute;
         bottom: 10px;
-        @include bidi-style(right, 0, left, auto);
-        @include bidi-value(content, '\f061', '\f060');
+        @include bidi((
+            (right, 0, left, auto),
+            (content, '\f061', '\f060'),
+        ));
         font-family: fontAwesome;
         transition: margin .1s ease-in-out;
     }
@@ -609,7 +700,7 @@ Placeholders
         text-decoration: none;
 
         &:after {
-            @include bidi-style(margin-right, -4px, margin-left, 0);
+            @include bidi(((margin-right, -4px, margin-left, 0),));
         }
     }
 

--- a/kuma/static/styles/includes/_mixins_indicators.scss
+++ b/kuma/static/styles/includes/_mixins_indicators.scss
@@ -21,8 +21,10 @@ block indicators aka banners
     &:before {
         display: inline-block;
         width: 30px;
-        @include bidi-value(float, left, right);
-        @include bidi-value(margin, -1px 0 -5px ($icon-spacing * -1), -5px ($icon-spacing * -1) -5px 0);
+        @include bidi((
+            (float, left, right),
+            (margin, -1px 0 -5px ($icon-spacing * -1), -5px ($icon-spacing * -1) -5px 0),
+        ));
         font-family: FontAwesome;
         font-size: $larger-font-size;
         font-style: normal;
@@ -43,8 +45,10 @@ block indicators aka banners
 %indicator-system {
     @include restrict-line-length();
     /* need to specifically declare RTL to over-ride RTL inherited from set-message-base */
-    @include bidi-value(border-width, 2px, 2px);
-    @include bidi-value(border-style, solid, solid);
+    @include bidi((
+        (border-width, 2px, 2px),
+        (border-style, solid, solid),
+    ));
 }
 
 /*
@@ -55,9 +59,11 @@ inline indicators aka badges
     display: inline-block;
     min-width: 20px;
     vertical-align: baseline;
-    @include bidi-style(margin-left, ($grid-spacing / 2 ), margin-right, 0);
+    @include bidi((
+        (margin-left, ($grid-spacing / 2 ), margin-right, 0),
+        (border-left, 4px solid, border-right, none),
+    ));
     border-radius: 2px;
-    @include bidi-style(border-left, 4px solid, border-right, 0 none);
     padding: .45em $inline-horizontal-padding .3em;
     background-color: $light-background-color;
     font-family: $tiny-font-family;
@@ -71,8 +77,10 @@ inline indicators aka badges
 %indicator-inline-icon {
     &:before {
         display: inline-block;
-        @include bidi-value(margin-left, ($icon-spacing * -1 + 3px), 3px);
-        @include bidi-value(margin-right, 3px, ($icon-spacing * -1 + 3px));
+        @include bidi((
+            (margin-left, ($icon-spacing * -1 + 3px), 3px),
+            (margin-right, 3px, ($icon-spacing * -1 + 3px)),
+        ));
         font-family: FontAwesome;
     }
 }
@@ -83,7 +91,7 @@ icons for both indicator types
 ====================================================================== */
 
 %indicator-with-icon {
-    @include bidi-style(padding-left, $icon-spacing, padding-right, $inline-horizontal-padding);
+    @include bidi(((padding-left, $icon-spacing, padding-right, $inline-horizontal-padding),));
 
     #{$selector-icon} {
         display: none;

--- a/kuma/static/styles/search.scss
+++ b/kuma/static/styles/search.scss
@@ -15,7 +15,7 @@ main {
 /* block mentioning the number of results returned */
 h3 #{$selector-icon},
 fieldset #{$selector-icon} {
-    @include bidi-style(margin-right, ($grid-spacing * .75), margin-left, 0);
+    @include bidi(((margin-right, ($grid-spacing * .75), margin-left, 0),));
 }
 
 .search-results-explanation {
@@ -152,7 +152,7 @@ fieldset #{$selector-icon} {
         }
 
         .filter-count {
-            @include bidi-value(float, right, left);
+            @include bidi(((float, right, left),));
         }
     }
 }

--- a/kuma/static/styles/submission.scss
+++ b/kuma/static/styles/submission.scss
@@ -135,7 +135,7 @@ p.field-note {
 }
 
 .field-management {
-    @include bidi-value(float, right, left);
+    @include bidi(((float, right, left),));
     margin: 0 0 5px;
 }
 
@@ -151,8 +151,10 @@ p.field-note {
 #profiles {
     label {
         margin: 0 0 5px;
-        @include bidi-value(float, left, right);
-        @include bidi-style(margin-right, 10px, margin-left, 10px);
+        @include bidi((
+            (float, left, right),
+            (margin-right, 10px, margin-left, 10px),
+        ));
     }
 }
 

--- a/kuma/static/styles/zones/components/parent.scss
+++ b/kuma/static/styles/zones/components/parent.scss
@@ -17,10 +17,12 @@ Custom images which appear in zone headers
 @media #{$mq-tablet-and-up} {
     .zone-parent {
         @include heading-1();
-        @include bidi-style(border-right-width, 1px, border-left-width, 0);
-        @include bidi-value(float, left, right);
-        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
-        @include bidi-style(padding-right, $grid-spacing, padding-left, 0);
+        @include bidi((
+            (border-right-width, 1px, border-left-width, 0),
+            (float, left, right),
+            (margin-right, $grid-spacing, margin-left, 0),
+            (padding-right, $grid-spacing, padding-left, 0),
+        ));
     }
 }
 
@@ -31,8 +33,10 @@ Custom images which appear in zone headers
     $image-big-width: round($width * $image-big-size / $height);
 
     .zone-parent {
-        @include bidi-value(float, left, right);
-        @include bidi-style(margin-right, $grid-spacing, margin-left, 0);
+        @include bidi((
+            (float, left, right),
+            (margin-right, $grid-spacing, margin-left, 0),
+        ));
         display: block;
         background-image: url($path-to-images + 'zones/' + $img);
         direction: ltr; // ltr should be set with negative text indent


### PR DESCRIPTION
**Current behaviour:**
```
.test {
    @include bidi-value(float, left, right);
    @include bidi-style(margin-right, ($grid-spacing / 2), margin-left, 0)
}
```
Outputs:
```
.test {
    float: left;
    margin-right: 10px;
}
html[dir='rtl'] .test {
    float: right;
}
html[dir='rtl'] .test {
    margin-right: 0;
    margin-left: 10px;
}
```

**Proposed behaviour:**
```
.test {
    @include bidi((
        (float, left, right),
        (margin-right, ($grid-spacing / 2), margin-left, 0)
    ));
}
```
Outputs:
```
.test {
    float: left;
    margin-right: 10px;
}
html[dir='rtl'] .test {
    float: right;
    margin-right: 0;
    margin-left: 10px;
}
```

This saves about 0.5KB in mdn.css after gzipping.

Questions:
- Is the new syntax confusing? Do we make contributions harder by changing?
- Is 0.5KB enough savings to keep working on this?