### PR TITLE
bug 984149: Build assets for candidate locales

### DIFF
--- a/docker/images/kuma/Dockerfile
+++ b/docker/images/kuma/Dockerfile
@@ -13,5 +13,7 @@ USER kuma
 
 ENV DJANGO_SETTINGS_MODULE=kuma.settings.prod
 
-RUN make localecompile
-RUN make build-static && rm -rf build
+# Temporarily enable candidate languages so assets are built for all
+# environments, but still defaults to disabled in production.
+RUN ENABLE_CANDIDATE_LANGUAGES=True \
+    make localecompile build-static && rm -rf build


### PR DESCRIPTION
Use ``ENABLE_CANDIDATE_LANGUAGES=True`` to build assets for the candidate
languages in to the Docker image, but leave unset (picking up the default of ``False``) in production.