### PR TITLE
bug 1421016: Log security messages to console

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1600,6 +1600,10 @@ LOGGING = {
             'propagate': True,
             'level': logging.ERROR,
         },
+        'django.security': {
+            'handlers': ['console'],
+            'propagate': False,
+        },
         'elasticsearch': {
             'handlers': ['console'],
             'level': logging.ERROR,


### PR DESCRIPTION
Send security messages to the console, instead of the default of mailing admins.

In development, these will be available from ``docker-compose logs -f web``, and look like:

```
web_1            | http_app_kuma: 2017-11-29 06:58:09,459 django.security.DisallowedHost:ERROR Invalid HTTP_HOST header: '127.0.0.1:8000'. You may need to add u'127.0.0.1' to ALLOWED_HOSTS.: /usr/local/lib/python2.7/site-packages/django/core/handlers/base.py:204
```

To see this error locally, add ``DEBUG=False`` to ``.env``, change ``docker-compose.yml`` to set ``- ALLOWED_HOSTS=localhost,web,api``, ``make up`` to start containers with the new config, and then visit http://127.0.01:8000/en-US/.

In production, this should send the messages to Papertrail, where we can query and monitor them in bulk.

The default is to email security messages to admins, which is useful when starting, but not for the thousands of duplicate ``DisallowedHost`` messages we're getting in AWS.