### PR TITLE
Fix bug 1421790: a[name] should not get a:link styles

### DIFF
--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -572,6 +572,11 @@ Placeholders
 
         a {
             color: $accent-light;
+
+            &[name] {
+                color: inherit;
+                text-decoration: none;
+            }
         }
 
         code {


### PR DESCRIPTION
Our code base is old enough that we still have `<a name="linkToHere">Link to me!</a>` in the articles, link styles need to not apply to anchors used in this way.

I vaguely recall running into problems using `a:link` in the past but can't recall exactly what. My testing did not turn up any problems.

I've only applied the `:link` restriction to elements that appear in the body of an article, submenus, header, footer, etc where were have control of the content and can be sure there are no named anchors exist I left alone.