### PR TITLE
bug 1422009: Remove DB from readiness probe

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -1,31 +1,12 @@
-import mock
 import pytest
-from django.db import DatabaseError
 from django.core.urlresolvers import reverse
 
 
 @pytest.mark.parametrize('http_method',
                          ['get', 'head', 'put', 'post', 'delete', 'options'])
-def test_liveness(db, client, http_method):
-    url = reverse('health.liveness')
+@pytest.mark.parametrize('endpoint', ['health.liveness', 'health.readiness'])
+def test_basic_health(db, client, http_method, endpoint):
+    url = reverse(endpoint)
     response = getattr(client, http_method)(url)
     assert (response.status_code ==
             204 if http_method in ('get', 'head') else 405)
-
-
-@pytest.mark.parametrize('http_method',
-                         ['get', 'head', 'put', 'post', 'delete', 'options'])
-def test_readiness(db, client, http_method):
-    url = reverse('health.readiness')
-    response = getattr(client, http_method)(url)
-    assert (response.status_code ==
-            204 if http_method in ('get', 'head') else 405)
-
-
-def test_readiness_with_db_error(db, client):
-    url = reverse('health.readiness')
-    with mock.patch('kuma.wiki.models.Document.objects') as mock_manager:
-        mock_manager.filter.side_effect = DatabaseError('fubar')
-        response = client.get(url)
-    assert response.status_code == 503
-    assert 'fubar' in response.reason_phrase

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -5,7 +5,7 @@ from django.core.urlresolvers import reverse
 @pytest.mark.parametrize('http_method',
                          ['get', 'head', 'put', 'post', 'delete', 'options'])
 @pytest.mark.parametrize('endpoint', ['health.liveness', 'health.readiness'])
-def test_basic_health(db, client, http_method, endpoint):
+def test_basic_health(client, http_method, endpoint):
     url = reverse(endpoint)
     response = getattr(client, http_method)(url)
     assert (response.status_code ==

--- a/kuma/health/urls.py
+++ b/kuma/health/urls.py
@@ -5,9 +5,9 @@ from . import views
 
 urlpatterns = [
     url(r'^healthz/?$',
-        views.liveness,
+        views.basic_health,
         name='health.liveness'),
     url(r'^readiness/?$',
-        views.readiness,
+        views.basic_health,
         name='health.readiness'),
 ]

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -1,12 +1,9 @@
-from django.db import DatabaseError
 from django.http import HttpResponse
 from django.views.decorators.http import require_safe
 
-from kuma.wiki.models import Document
-
 
 @require_safe
-def liveness(request):
+def basic_health(request):
     """
     A successful response from this endpoint simply proves
     that Django is up and running. It doesn't mean that its
@@ -14,26 +11,3 @@ def liveness(request):
     be successfully used from within this service.
     """
     return HttpResponse(status=204)
-
-
-@require_safe
-def readiness(request):
-    """
-    A successful response from this endpoint goes a step further
-    and means not only that Django is up and running, but also that
-    the database can be successfully used from within this service.
-    The other supporting services are not checked, but we may find
-    that we want/need to add them later.
-    """
-    try:
-        # Confirm that we can use the database by making a fast query
-        # against the Document table. It's not important that the document
-        # with the requested primary key exists or not, just that the query
-        # completes without error.
-        Document.objects.filter(pk=1).exists()
-    except DatabaseError as e:
-        reason_tmpl = 'service unavailable due to database issue ({!s})'
-        status, reason = 503, reason_tmpl.format(e)
-    else:
-        status, reason = 204, None
-    return HttpResponse(status=status, reason=reason)


### PR DESCRIPTION
Use the same basic smoke test (Django running, middleware working) for both the liveness and readiness probe. See https://github.com/mozmeao/infra/issues/660, [bug 1422009](https://bugzilla.mozilla.org/show_bug.cgi?id=1422009).