### PR TITLE
bug 1422009: Adjust liveness tests, avoid DB query in middleware

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -6,7 +6,7 @@ from django.core.urlresolvers import reverse
 
 @pytest.mark.parametrize('http_method',
                          ['get', 'head', 'put', 'post', 'delete', 'options'])
-def test_liveness(db, client, http_method):
+def test_liveness(client, http_method):
     url = reverse('health.liveness')
     response = getattr(client, http_method)(url)
     assert (response.status_code ==

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -4,22 +4,27 @@ from django.db import DatabaseError
 from django.core.urlresolvers import reverse
 
 
-@pytest.mark.parametrize('http_method',
-                         ['get', 'head', 'put', 'post', 'delete', 'options'])
+@pytest.mark.parametrize('http_method', ['put', 'post', 'delete', 'options'])
+@pytest.mark.parametrize('endpoint', ['health.liveness', 'health.readiness'])
+def test_disallowed_methods(client, http_method, endpoint):
+    """Alternate HTTP methods are not allowed."""
+    url = reverse(endpoint)
+    response = getattr(client, http_method)(url)
+    assert response.status_code == 405
+
+
+@pytest.mark.parametrize('http_method', ['get', 'head'])
 def test_liveness(client, http_method):
     url = reverse('health.liveness')
     response = getattr(client, http_method)(url)
-    assert (response.status_code ==
-            204 if http_method in ('get', 'head') else 405)
+    assert response.status_code == 204
 
 
-@pytest.mark.parametrize('http_method',
-                         ['get', 'head', 'put', 'post', 'delete', 'options'])
+@pytest.mark.parametrize('http_method', ['get', 'head'])
 def test_readiness(db, client, http_method):
     url = reverse('health.readiness')
     response = getattr(client, http_method)(url)
-    assert (response.status_code ==
-            204 if http_method in ('get', 'head') else 405)
+    assert response.status_code == 204
 
 
 def test_readiness_with_db_error(db, client):

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import render
 
@@ -28,6 +29,12 @@ class DocumentZoneMiddleware(object):
         # Don't redirect POST $subscribe requests to GET zone url
         if (request.method == 'POST' and
                 ('$subscribe' in request.path or '$files' in request.path)):
+            return None
+
+        # Skip slugs that don't have locales, and won't be in a zone
+        request_slug = request.path_info.lstrip('/')
+        if any(request_slug.startswith(slug)
+               for slug in settings.LANGUAGE_URL_IGNORED_PATHS):
             return None
 
         remaps = DocumentZoneURLRemapsJob().get(request.LANGUAGE_CODE)

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.conf import settings
 from django.test import RequestFactory
 
 from kuma.core.cache import memcache
@@ -121,6 +122,12 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         for endpoint in ['$subscribe', '$files']:
             request = self.rf.post('/en-US/docs/%s%s?raw' %
                                    (self.other_doc.slug, endpoint))
+            self.assertIsNone(middleware.process_request(request))
+
+    def test_skip_no_language_urls(self):
+        middleware = DocumentZoneMiddleware()
+        for path in settings.LANGUAGE_URL_IGNORED_PATHS:
+            request = self.rf.get('/' + path)
             self.assertIsNone(middleware.process_request(request))
 
     def test_zone_url_ends_with_slash(self):


### PR DESCRIPTION
After a long day of looking into Kubernetes liveness and readiness probes, we decided to keep database connection tests in the readiness views for a bit longer (closing PR #4578), and instead adjust the probe settings in Kubernetes (https://github.com/mozmeao/infra/pull/665). There are some changes that we still want to apply. 

* Refactor the health probe tests, to show that the database is not needed for several tests
* Detect health probe URLs in the ``DocumentZoneMiddleware``, and exit early to avoid the (cached) database query.