### PR TITLE
bug 1406546: make urlwait available in kuma_base image

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -42,6 +42,11 @@ tox==2.3.1 \
     --hash=sha256:1823c93ca378092c10bbde428213d3f5066b30adb09e5c001087a83e3e0a402a \
     --hash=sha256:bf7fcc140863820700d3ccd65b33820ba747b61c5fe4e2b91bb8c64cb21a47ee
 
+# Wait until a database (or other) service is able to accept connections.
+urlwait==0.4 \
+    --hash=sha256:fc39ff2c8abbcaad5043e1f79699dcb15a036cc4b0ff4d1aa825ea105d4889ff \
+    --hash=sha256:395fc0c2a7f9736858a2c2f449aa20c6e9da1f86bfc2d1fda4f2f5b78a5c115a
+
 # Enables ./manage.py runserver_plus with in-browser exception debugging
 Werkzeug==0.11.4 \
     --hash=sha256:7db3cb2d4725be0680abf64a45b18229186f03ad8b9989abbe053f9357b17b37 \


### PR DESCRIPTION
Install the `urlwait` Python package as part of the `kuma_base` Docker image. Required for #4581.