### PR TITLE
bug 1406546: ensure image can be pulled prior to deployment

### DIFF
--- a/Jenkinsfiles/stage-push.groovy
+++ b/Jenkinsfiles/stage-push.groovy
@@ -2,6 +2,11 @@ stage("Announce") {
     utils.announce_push()
 }
 
+stage("Check Pull") {
+    // Check that the image can be successfully pulled from the registry.
+    utils.ensure_pull()
+}
+
 stage("Prepare Infra") {
     // Checkout the "mozmeao/infra" repo's "master" branch into the
     // "infra" sub-directory of the current working directory.

--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -55,6 +55,22 @@ def notify_irc(Map args) {
     sh command
 }
 
+def ensure_pull() {
+    /*
+     * This can be used to avoid deploying images to Kubernetes that don't
+     * exist in the registry, since the deployment to Kubernetes will succeed
+     * (the deployment just cares that an image URL is provided, not that
+     * it actually exists) but each pod's image download will then fail
+     * causing the pod to loop in an image-pull error.
+     */
+    def repo = get_repo_name()
+    def tag = get_commit_tag()
+    utils.sh_with_notify(
+        "make pull-${repo}",
+        "Ensure pull of ${repo} image ${tag} works"
+    )
+}
+
 def sh_with_notify(cmd, display, notify_on_success=false) {
     def nick = "mdn-${env.BRANCH_NAME}"
     try {

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,9 @@ pull-base:
 pull-kuma:
 	docker pull ${KUMA_IMAGE}
 
+pull-kumascript:
+	docker pull ${KUMASCRIPT_IMAGE}
+
 pull-base-latest:
 	docker pull ${BASE_IMAGE_LATEST}
 


### PR DESCRIPTION
The aim of this PR is to prevent a pitfall, when pushing to stage and production, that occurs when the image specified by the tag determined from the latest commit hash was not successfully pushed to the Docker image registry. The deployment succeeds, but the pods affected by the deployment loop in an image-pull error. This PR prevents that. I wanted to put this in place before we create the `prod-push` branch.