### PR TITLE
bug 1110799: redirect legacy domains

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -1,9 +1,14 @@
 import contextlib
 import urllib
+from urlparse import urljoin
 
 from django.conf import settings
 from django.core import urlresolvers
-from django.http import HttpResponseForbidden, HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.http import (
+    HttpResponseRedirect,
+    HttpResponseForbidden,
+    HttpResponsePermanentRedirect,
+)
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from django.contrib.sessions.middleware import SessionMiddleware
@@ -190,3 +195,16 @@ class RestrictedWhiteNoiseMiddleware(WhiteNoiseMiddleware):
         return super(RestrictedWhiteNoiseMiddleware, self).process_request(
             request
         )
+
+
+class LegacyDomainRedirectsMiddleware(object):
+
+    def process_request(self, request):
+        """
+        Permanently redirects all requests from legacy domains.
+        """
+        if request.get_host() in settings.LEGACY_HOSTS:
+            return HttpResponsePermanentRedirect(
+                urljoin(settings.SITE_URL, request.get_full_path())
+            )
+        return None

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -445,6 +445,7 @@ _CONTEXT_PROCESSORS = (
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
+    'kuma.core.middleware.LegacyDomainRedirectsMiddleware',
     'kuma.core.middleware.RestrictedWhiteNoiseMiddleware',
     # must come before LocaleURLMiddleware
     'redirect_urls.middleware.RedirectsMiddleware',
@@ -1187,9 +1188,13 @@ SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE',
 SESSION_COOKIE_HTTPONLY = True
 
 # bug 856061
-ALLOWED_HOSTS = config('ALLOWED_HOSTS',
-                       default='developer-local.allizom.org, mdn-local.mozillademos.org',
-                       cast=Csv())
+ALLOWED_HOSTS = config(
+    'ALLOWED_HOSTS',
+    default='developer-local.allizom.org, mdn-local.mozillademos.org',
+    cast=Csv()
+)
+
+LEGACY_HOSTS = config('LEGACY_HOSTS', default='', cast=Csv())
 
 # Maximum length of the filename. Forms should use this and raise
 # ValidationError if the length is exceeded.


### PR DESCRIPTION
This PR provides the ability to configure (via the environment) one or more "legacy" domains. All requests from any one of these "legacy" domains will be redirected to the configured `SITE_URL` with the same path and query parameters. See its companion PR https://github.com/mozmeao/infra/pull/672.