### PR TITLE
bug 1402950: Run tests more reliably with Firefox and Remote driver in Selenium 3.x

### DIFF
--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -50,7 +50,7 @@ def test_dashboard_overflow(base_url, selenium):
     """
     page = DashboardPage(selenium, base_url).open()
     page.open_first_details()
-    assert page.scrollWidth < page.clientWidth
+    assert page.scroll_width <= page.client_width
 
 
 @pytest.mark.nondestructive

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -28,7 +28,7 @@ def test_dashboard(base_url, selenium):
     assert page.details_items_length is 1
     assert page.is_first_details_displayed
     # contains a diff
-    assert page.is_first_details_diff_displayed
+    page.wait_for_first_details_diff_displayed()
     # save id of first revision on page one
     first_row_id = page.first_row_id
     # click on page two link

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -63,6 +63,10 @@ class DashboardPage(BasePage):
         first_details_diff = self.find_element(*self._first_details_diff_locator)
         return first_details_diff.is_displayed()
 
+    def wait_for_first_details_diff_displayed(self):
+        first_details_diff = self.find_element(*self._first_details_diff_locator)
+        self.wait.until(lambda s: first_details_diff.is_displayed())
+
     def click_page_two(self):
         revision_filter_form = self.find_element(*self._revision_filter_form_locator)
         page_two_link = self.find_element(*self._page_two_link)


### PR DESCRIPTION
These changes make Firefox run more reliably with the Remote driver in Selenium 3, and should still work in Selenium 2:

* To display the on-hover submenus, first move the mouse to the logo. This more reliably triggers the hover state on the article page.
* The hover is still unreliable, especially on the homepage. If the driver is Remote for Firefox, then allow hover tests to xfail.
* On the Revision Dashboard, it can take time to expose the revision diff after the other details are displayed. Be patient.

There was also an error in ``test_dashboard_overflow``, where the wrong attributes made it always ``xfail``. Now it can ``xpass`` as well.