### PR TITLE
bug 1402950: Add Chrome to integration tests

### DIFF
--- a/Jenkinsfiles/integration-tests.groovy
+++ b/Jenkinsfiles/integration-tests.groovy
@@ -6,41 +6,122 @@ stage('Build') {
   }
 }
 
-stage('Functional') {
-  def pwd = pwd()
-  def cmd = "py.test tests/functional" +
-            " --driver Remote" +
-            " --capability browserName firefox" +
-            " --host hub" +
-            " --base-url='${config.job.base_url}'" +
-            " --junit-xml=/test_results/integration.xml"
-  if (config.job && config.job.tests) {
-    cmd += " -m \"${config.job.tests}\""
-  }
-  if (config.job && config.job.maintenance_mode) {
-    cmd += " --maintenance-mode"
-  }
+def functional_test(browser, hub_name, base_dir) {
+  // Define a parallel build that runs Selenium Node for the given browser
+  return {
+    node {
+      // Setup the pytest command
+      // Timeout after 4 minutes, due to stalled nodes
+      def cmd = "timeout --preserve-status 4m" +
+                " py.test tests/functional" +
+                " --driver Remote" +
+                " --capability browserName ${browser}" +
+                " --host hub" +
+                " --base-url='${config.job.base_url}'" +
+                " --junit-prefix=${browser}" +
+                " --junit-xml=/test_results/functional-${browser}.xml" +
+                " --reruns=2" +
+                " -vv"
+      if (config.job && config.job.tests) {
+        cmd += " -m \"${config.job.tests}\""
+      }
+      if (config.job && config.job.maintenance_mode) {
+        cmd += " --maintenance-mode"
+      }
+      def node_name = "kuma-selenium-node-${browser}-${BUILD_TAG}"
+      def copies = 1
+      if (config.job.selenium_nodes) {
+        copies = config.job.selenium_nodes
+        cmd += " -n ${copies}"
+      }
+      def test_name = "kuma-functional-tests-${browser}-${BUILD_TAG}"
 
-  dockerRun("selenium/hub:${config.job.selenium}",
-            ["docker_args": "--name selenium-hub-${BUILD_TAG}"]) {
-    dockerRun("selenium/node-firefox:${config.job.selenium}",
-              ["docker_args": "--link selenium-hub-${BUILD_TAG}:hub",
-               "copies": config.job.selenium_nodes]) {
-      dockerRun("kuma-integration-tests:${GIT_COMMIT_SHORT}",
-                ["docker_args": "--link selenium-hub-${BUILD_TAG}:hub" +
-                                " --volume ${pwd}/test_results:/test_results" +
-                                " --user 1000",
-                 "cmd": cmd])
+      try {
+        // Create named nodes
+        for (int i=1; i <= copies; i++) {
+          node_name_i = "${node_name}-${i}"
+          dockerRun("selenium/node-${browser}:${config.job.selenium}",
+                    ["docker_args": "-d" +
+                                    " --name ${node_name_i}" +
+                                    " --link ${hub_name}:hub"])
+        }
+
+        try {
+            // Timeout after 5 minutes, if in-container timeout fails
+            timeout(time: 5, unit: 'MINUTES') {
+                // Run test node
+                dockerRun("kuma-integration-tests:${GIT_COMMIT_SHORT}",
+                          ["docker_args": "--link ${hub_name}:hub" +
+                                          " --name ${test_name}" +
+                                          " --volume ${base_dir}/test_results:/test_results" +
+                                          " --user 1000",
+                           "cmd": cmd])
+            }
+        } finally {
+            dockerStop(test_name)
+        }
+      } finally {
+        for (int i=1; i <= copies; i++) {
+          dockerStop("${node_name}-${i}")
+        }
+      }
     }
   }
 }
 
-stage('Headless') {
-  def pwd = pwd()
-  dockerRun("kuma-integration-tests:${GIT_COMMIT_SHORT}",
-            ["docker_args": "--volume ${pwd}/test_results:/test_results" +
-                            " --user 1000",
-             "cmd": "py.test tests/headless" +
-                    " --base-url='${config.job.base_url}'" +
-                    " --junit-xml=/test_results/headless.xml"])
+def headless_test(base_dir) {
+  // Define a parallel build that runs the "headless" (requests, no Selenium) tests
+  return {
+    node {
+      def test_name = "kuma-test-headless-${BUILD_TAG}"
+      dockerRun("kuma-integration-tests:${GIT_COMMIT_SHORT}",
+                  ["docker_args": "--volume ${base_dir}/test_results:/test_results" +
+                                  " --name ${test_name}" +
+                                  " --user 1000",
+                  "cmd": "py.test tests/headless" +
+                          " --base-url='${config.job.base_url}'" +
+                          " --junit-xml=/test_results/headless.xml" +
+                          " --reruns=2"])
+    }
+  }
 }
+
+stage('Test') {
+    // Setup parallel tests
+    def allTests = [:]
+    def base_dir = pwd()
+    def hub_name = "kuma-selenium-hub-${BUILD_TAG}"
+    allTests['chrome'] = functional_test('chrome', hub_name, base_dir)
+    allTests['firefox'] = functional_test('firefox', hub_name, base_dir)
+    allTests['headless'] = headless_test(base_dir)
+
+    def nick =  "ci-bot"
+    try {
+        // Setup the selenium hub
+        dockerRun("selenium/hub:${config.job.selenium}",
+                  ["docker_args": "-d --name ${hub_name}"])
+
+        try {
+            // Run the tests in parallel
+            parallel allTests
+            // Notify on success
+            utils.notify_irc([
+                irc_nick: nick,
+                stage: 'Test',
+                status: 'success'
+            ])
+        } catch(err) {
+            utils.notify_irc([
+                irc_nick: nick,
+                stage: 'Test',
+                status: 'failure'
+            ])
+            throw err
+        } finally {
+            dockerStop(hub_name)
+        }
+    } finally {
+        dockerStop(hub_name)
+    }
+}
+


### PR DESCRIPTION
* Add Google Chrome to the integration test suite. In our selenium 2 version, this is Chrome 47, released December 2016.
* Run Chrome, Firefox, and headless (requests) tests in parallel. Add a browser prefix to distinguish between functional tests.
* Run parallel functionaltests equal to the number of selenium nodes
* Manually create and stop containers, to avoid a bug in auto-stopping containers in dockerRun
* Re-run tests on failure, to deal with flakiness of low-usage infrastructure like staging
* Be doubly verbose
* In several runs, a chrome node would become unresponsive, and the test would hang forever. Timeout the pytest run in 4 minutes, and enforce a Jenkins timeout of 5 minutes.
* Notify IRC on tests success or failure