### PR TITLE
bug 1406546: ensure Kuma tests return proper exit code

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -151,7 +151,8 @@ def compose_test() {
     // Build the static assets required for many tests.
     sh_with_notify("${dc} run noext make build-static", 'Build static assets')
     // Run the Kuma tests, building the mysql image before starting.
-    sh_with_notify("${dc} up --build test", 'Kuma tests')
+    sh_with_notify("${dc} build mysql", 'Build mysql')
+    sh_with_notify("${dc} run test", 'Kuma tests')
     // Tear everything down.
     sh_with_notify("${dc} down", 'Post-test tear-down')
 }


### PR DESCRIPTION
This PR fixes a problem within the Groovy `utils.compose_test` function. Currently, when [this line](https://github.com/mozilla/kuma/blob/24744d780cb6a80f250a399feb2ed6f707cffbb5/Jenkinsfiles/utils.groovy#L138) is run, the exit code is NOT the exit code from the `test` container's command (`py.test ...`) as it should be. This resulted in Jenkins builds that failed the tests but would pass the stage, resulting in an "unstable" build (labelled with an exclamation point in yellow). This fixes that.

I like the approach in https://github.com/mozilla/kuma/pull/4585 a bit better, but the `docker-compose` upgrade in Jenkins is blocking that.