### PR TITLE
bug 1406546: fix kuma tests by tearing-down volumes as well

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -144,8 +144,9 @@ def announce_push() {
 
 def compose_test() {
     def dc = 'docker-compose -f docker-compose.yml -f docker-compose.test.yml'
+    def dc_down = "${dc} down --volumes --remove-orphans"
     // Pre-test tear down to ensure we're starting with a clean slate.
-    sh_with_notify("${dc} down", 'Pre-test tear-down')
+    sh_with_notify(dc_down, 'Pre-test tear-down')
     // Run the "smoke" tests with no external dependencies.
     sh_with_notify("${dc} run noext", 'Smoke tests')
     // Build the static assets required for many tests.
@@ -154,7 +155,7 @@ def compose_test() {
     sh_with_notify("${dc} build mysql", 'Build mysql')
     sh_with_notify("${dc} run test", 'Kuma tests')
     // Tear everything down.
-    sh_with_notify("${dc} down", 'Post-test tear-down')
+    sh_with_notify(dc_down, 'Post-test tear-down')
 }
 
 return this;


### PR DESCRIPTION
In Jenkins builds, every Kuma test that hit the database started to fail consistently with a `OperationalError: (1130, "Host '172.20.0.5' is not allowed to connect to this MySQL server")`. This was fixed by also tearing down the volumes (using `docker-compose down --volumes`) before running the tests. I also added the "--remove-orphans" option as well, so we start (and end) with a totally clean slate.

Thanks to this thread: https://github.com/docker-library/mysql/issues/275 for the idea.