### PR TITLE
Use TravisCI Edge images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+group: edge
 branches:
     only:
         - master


### PR DESCRIPTION
This is the ``travis_latest`` version that will go live on Dec 11 2017:

https://blog.travis-ci.com/2017-12-01-new-update-schedule-for-linux-build-images