### PR TITLE
fix bug 1420354 - Use rel="license" instead of rel="copyright"

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -13,7 +13,7 @@
   <meta name="robots" content="{% block robots_value%}index, follow{% endblock %}">
   {%- if not untrusted %}
     <link rel="home" href="{{ url('home') }}">
-    <link rel="license" href="#copyright">
+    <link rel="license" href="#license">
   {% endif %}
 
   {% block site_css %}
@@ -228,7 +228,7 @@
               <li><a href="https://www.mozilla.org/privacy/websites/#cookies">{{ _('Cookies') }}</a></li>
             </ul>
 
-            <div class="contentinfo">
+            <div id="license" class="contentinfo">
               {% trans copyright_url='/en-US/docs/MDN/About#Copyrights_and_licenses', thisyear=thisyear() %}
                 <p>&copy; 2005-{{ thisyear }} Mozilla and individual contributors.</p>
                 <p>Content is available under <a href="{{ copyright_url }}">these licenses</a>.</p>

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -13,7 +13,7 @@
   <meta name="robots" content="{% block robots_value%}index, follow{% endblock %}">
   {%- if not untrusted %}
     <link rel="home" href="{{ url('home') }}">
-    <link rel="copyright" href="#copyright">
+    <link rel="license" href="#copyright">
   {% endif %}
 
   {% block site_css %}


### PR DESCRIPTION
Per Bugzilla bug 1420354 change rel="copyright" to rel="license" at https://github.com/mozilla/kuma/blob/9d102e004e2fd9694704d9a08f145b3282a90ba9/jinja2/base.html#L16

Please let me know if I need to do anything else. Thanks!