### PR TITLE
Display tweaks to compat tables

### DIFF
--- a/kuma/static/js/wiki-compat-tables.js
+++ b/kuma/static/js/wiki-compat-tables.js
@@ -15,7 +15,7 @@
     var $historyCloseButton = $('<button class="bc-history-button only-icon"><abbr title="' + gettext('Return to compatibility table.') + '"><span>' + gettext('Close') + '</span><i class="icon-times" aria-hidden="true"></i></abbr></button>');
 
     var animationProps = {
-        duration: 250,
+        duration: 150,
         queue: false,
         easing: 'linear'
     };

--- a/kuma/static/styles/components/compat-tables/_vars.scss
+++ b/kuma/static/styles/components/compat-tables/_vars.scss
@@ -31,6 +31,7 @@ $bc-border-width-thin: 1px;
 $bc-border-width-thick: 2px;
 $bc-support: yes, no, partial, unknown;
 $bc-grid-spacing: 10px;
+$bc-mobile-icon-width: 50px;
 
 $table-types: (
 	web: (

--- a/kuma/static/styles/components/compat-tables/bc-browser.scss
+++ b/kuma/static/styles/components/compat-tables/bc-browser.scss
@@ -8,7 +8,7 @@ Icons in mobile view
         top: 8px;
         left: 0;
         height: 25px;
-        width: 50px;
+        width: $bc-mobile-icon-width;
         font-family: compat-icons;
         speak: none;
         color: $text-color;

--- a/kuma/static/styles/components/compat-tables/bc-history.scss
+++ b/kuma/static/styles/components/compat-tables/bc-history.scss
@@ -15,6 +15,7 @@ $support-dt-width: 120px;
     border-bottom: $bc-border-width-thick solid $bc-border-color;
     cursor: default;
     background-color: #eaeff2;
+    background-image: none;
 }
 
 @each $type, $config in $table-types {

--- a/kuma/static/styles/components/compat-tables/bc-icons.scss
+++ b/kuma/static/styles/components/compat-tables/bc-icons.scss
@@ -5,9 +5,7 @@ Icons denooting complicatons with support (footnote, altname, prefix, etc)
 .bc-icons {
     position: relative;
     z-index: 12; /* raise z-index so tool tips still appear even if overlapping history link */
-
-    /* TODO: center icons if they wrap, :first-line? only on mobile?  */
-    float: right;
+    display: inline-block;
 
     abbr {
         margin: 0 2px;
@@ -18,22 +16,8 @@ Icons denooting complicatons with support (footnote, altname, prefix, etc)
     }
 }
 
-/* tablet display */
-@mixin bc-icons-tablet-display() {
-    th .bc-icons {
-        float: none;
-        display: inline-block;
-    }
-}
-
-/* tablet */
-@media #{$mq-tablet-only} {
-    @include bc-icons-tablet-display();
-}
-
-/* small desktop, but only if there's a left column */
-@media #{$mq-small-desktop-only} {
-    .wiki-left-present {
-        @include bc-icons-tablet-display();
+@media #{$mq-small-desktop-and-up} {
+    .bc-icons {
+        float: right;
     }
 }

--- a/kuma/static/styles/components/compat-tables/bc-legend.scss
+++ b/kuma/static/styles/components/compat-tables/bc-legend.scss
@@ -12,18 +12,19 @@ Legend
 
     dt {
         display: block;
-        grid-column: 1 / 2;
         margin: 0 0 ($bc-grid-spacing / 2) 0;
     }
 
     dd {
         display: block;
-        grid-column: 2 / 3;
         margin: 0 $bc-grid-spacing ($bc-grid-spacing / 2) $bc-grid-spacing;
+    }
+}
 
-        &:after {
-            content: '\a';
-            white-space: pre;
+@media #{$mq-tablet-and-up} {
+    .bc-legend {
+        dl {
+            grid-template-columns: 30px 1fr 30px 1fr;
         }
     }
 }

--- a/kuma/static/styles/components/compat-tables/bc-supports.scss
+++ b/kuma/static/styles/components/compat-tables/bc-supports.scss
@@ -37,7 +37,7 @@ Supports colouring
         rgba($yellow, .3) 144px,
         transparent 144px);
     background-size: 100px 100px;
-    background-position: 50% 50%;
+    background-position: 50%  50%;
     background-repeat: no-repeat;
 }
 
@@ -68,10 +68,21 @@ Supports colouring
         rgba($red, .2) 144px,
         transparent 144px);
     background-size: 100px 100px, 100px 100px;
-    background-position: 50% 50%, 50% 50%;
+    background-position: 50%  50%, 50%  50%;
     background-repeat: no-repeat;
 }
 
 .bc-supports-unknown {
     background-color: map-get($bc-colors, unknown);
+}
+
+@media #{$mq-mobile-and-down} {
+    /* centers the background accounting for space icons take on the left */
+    td.bc-supports-partial {
+        background-position: calc(50% + #{$bc-mobile-icon-width / 2})  50%;
+    }
+
+    td.bc-supports-no {
+        background-position: calc(50% + #{$bc-mobile-icon-width / 2})  50%, calc(50% + #{$bc-mobile-icon-width / 2})  50%;
+    }
 }

--- a/kuma/static/styles/components/compat-tables/bc-supports.scss
+++ b/kuma/static/styles/components/compat-tables/bc-supports.scss
@@ -18,13 +18,11 @@ Supports colouring
     text-decoration: underline;
 }
 
-.bc-supports-yes,
-.bc-supports-yes .bc-history {
+.bc-supports-yes {
     background-color: map-get($bc-colors, yes);
 }
 
-.bc-supports-partial,
-.bc-supports-partial .bc-history {
+.bc-supports-partial {
     background: map-get($bc-colors, partial);
     background-image: linear-gradient(to bottom right,
         rgba($yellow, .3) 0,
@@ -43,8 +41,7 @@ Supports colouring
     background-repeat: no-repeat;
 }
 
-.bc-supports-no,
-.bc-supports-no .bc-history {
+.bc-supports-no {
     background-color: map-get($bc-colors, no);
     background-image: linear-gradient(to bottom right,
         rgba($red, .2) 0,
@@ -75,7 +72,6 @@ Supports colouring
     background-repeat: no-repeat;
 }
 
-.bc-supports-unknown,
-.bc-supports-unknown .bc-history {
+.bc-supports-unknown {
     background-color: map-get($bc-colors, unknown);
 }


### PR DESCRIPTION
Bit of compat table clean up.

- Remove no-support X from history drop down on unsupported features
- Center no-support X in mobile display
- Keep icons with feature text until desktop display
- Two columns for legend on tablet and up
- Speed up history tray animation

Bad:
![screen shot 2017-12-21 at 14 11 17](https://user-images.githubusercontent.com/854701/34277005-d94162aa-e658-11e7-8546-53f18ae01a69.png)

Better:
![screen shot 2017-12-21 at 14 11 58](https://user-images.githubusercontent.com/854701/34277025-f10f6dfa-e658-11e7-84b3-3b61a270dbaa.png)

