### PR TITLE
bug 1136741: Remove null entry from sample_db.json

### DIFF
--- a/etc/sample_db.json
+++ b/etc/sample_db.json
@@ -383,7 +383,6 @@
         "note": "See https://github.com/mozilla/kuma/pull/3331",
         "created": "2015-07-09"
       }, {
-      },  {
         "name": "registration_disabled",
         "active": false,
         "created": "2015-02-25"


### PR DESCRIPTION
This breaks the sample DB process, and is probably left over from a rebase for one of the many PRs for [bug 1136741](https://bugzilla.mozilla.org/show_bug.cgi?id=1136741).