### PR TITLE
Fixed l10n-aware link to Troubleshooting article

### DIFF
--- a/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
@@ -16,7 +16,7 @@
     }}
   </button>
   <div class="kserrors-details hidden">
-      <p>{% trans troubleshooting_url='/en-US/docs/MDN/Contribute/Tools/KumaScript/Troubleshooting' %}
+      <p>{% trans troubleshooting_url='/docs/MDN/Contribute/Tools/KumaScript/Troubleshooting' %}
         Anyone with an MDN profile can edit a document to fix an error. Use the <a href="{{ troubleshooting_url }}">KumaScript troubleshooting guide</a> as a starting point.
       {% endtrans %}</p>
 


### PR DESCRIPTION
The issue is that the link leads to en-US page even if generated for article in another language.