### PR TITLE
bug 1423738: Add 429 "Too Many Requests" response

### DIFF
--- a/jinja2/403.html
+++ b/jinja2/403.html
@@ -23,6 +23,8 @@
       <p class="notice">{{ _('The wiki is in read-only mode.') }}</p>
     {% elif reason == 'revisions_login_required' %}
       <p class="notice">{{ _("You must sign in to view all history") }}</p>
+    {% elif reason == 'ip_banned' %}
+      <p class="notice">{{ _("Your IP address has been banned.") }}</p>
     {% endif %}
     {% endblock reason %}
 

--- a/jinja2/429.html
+++ b/jinja2/429.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+
+{% block bodyclass %}error{% endblock %}
+
+{% block title %}{{ page_title(_('Too Many Requests')) }}{% endblock %}
+
+{% block site_css %}
+    {{ super() }}
+    {% stylesheet 'error-403-alternate' %}
+{% endblock %}
+
+{% block content %}
+
+<section id="content" class="text-content">
+<div class="wrap">
+
+  <section id="content-main" class="full" role="main">
+
+    <h1 class="page-title">{{ _('Too Many Requests') }}</h1>
+
+    <p>
+      {% if user.username %}
+        {{ _("We're sorry %(name)s, you've made too many requests in a short time.",
+             name=user.username) }}
+      {% else %}
+        {{ _("We're sorry, we've received too many requests from your IP address in a short time.") }}
+      {% endif %}
+      {{ _("You can try again in about one minute.") }}
+    </p>
+
+    {% block tumbeast %}
+      <img src="{{ static('img/beast-403.png') }}" alt="" class="beast 403">
+    {% endblock tumbeast %}
+
+    <p>
+      {% trans content_url='https://developer.mozilla.org/docs/MDN/About#Downloading_content' %}
+        You may be interested in other ways to <a href="{{content_url}}">download MDN Web Docs content</a>.
+      {% endtrans %}
+    </p>
+
+    {% block tumbeast_attribution -%}
+      {% trans %}
+      <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>
+      {% endtrans %}
+    {% endblock tumbeast_attribution %}
+
+  </section>
+
+</div>
+</section>
+
+{% endblock %}
+
+{% block site_js %}
+    {{ super() }}
+    {% javascript 'framebuster' %}
+{% endblock %}
+
+{% block js %}
+<script type="text/javascript">
+    mdn.analytics.trackError('429', String(window.location));
+</script>
+{% endblock %}

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -10,6 +10,8 @@ from kuma.wiki.models import Document, Revision
 @pytest.fixture()
 def cleared_cacheback_cache():
     caches[settings.CACHEBACK_CACHE_ALIAS].clear()
+    yield
+    caches[settings.CACHEBACK_CACHE_ALIAS].clear()
 
 
 @pytest.fixture

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -3,10 +3,15 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from .managers import IPBanManager
-from .jobs import IPBanJob
+from .jobs import BannedIPsJob
 
 
 class IPBan(models.Model):
+    """
+    Ban an IP address.
+
+    Currently, this only bans an IP address from editing.
+    """
     ip = models.GenericIPAddressField()
     created = models.DateTimeField(default=timezone.now, db_index=True)
     deleted = models.DateTimeField(null=True, blank=True)
@@ -24,4 +29,4 @@ class IPBan(models.Model):
 @receiver(models.signals.post_save, sender=IPBan)
 @receiver(models.signals.pre_delete, sender=IPBan)
 def invalidate_ipban_caches(sender, instance, **kwargs):
-    IPBanJob().invalidate(instance.ip)
+    BannedIPsJob().invalidate()

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -27,7 +27,6 @@ from taggit.utils import split_strip
 
 from .cache import memcache
 from .exceptions import DateTimeFormatError
-from .jobs import IPBanJob
 
 
 log = logging.getLogger('kuma.core.utils')
@@ -304,11 +303,6 @@ def chord_flow(pre_task, tasks, post_task):
         return chain(*tasks)
     else:
         return chain(pre_task, chord(header=tasks, body=post_task))
-
-
-def limit_banned_ip_to_0(group, request):
-    ip = request.META.get('REMOTE_ADDR', '10.0.0.1')
-    return IPBanJob().get(ip)
 
 
 def get_unique(content_type, object_pk, name=None, request=None,

--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -1,4 +1,5 @@
 from django.shortcuts import render
+from .decorators import never_cache
 
 
 def _error_page(request, status):
@@ -9,3 +10,11 @@ def _error_page(request, status):
 handler403 = lambda request: _error_page(request, 403)
 handler404 = lambda request: _error_page(request, 404)
 handler500 = lambda request: _error_page(request, 500)
+
+
+@never_cache
+def rate_limited(request, exception):
+    """Render a rate-limited exception."""
+    response = render(request, '429.html', status=429)
+    response['Retry-After'] = '60'
+    return response

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -462,6 +462,7 @@ MIDDLEWARE_CLASSES = (
     'kuma.wiki.middleware.DocumentZoneMiddleware',
     'kuma.wiki.middleware.ReadOnlyMiddleware',
     'kuma.core.middleware.Forbidden403Middleware',
+    'ratelimit.middleware.RatelimitMiddleware',
     'django.middleware.common.CommonMiddleware',
     'kuma.core.middleware.RemoveSlashMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
@@ -1704,5 +1705,7 @@ ce_path = path('kuma', 'settings', 'content_experiments.json')
 with open(ce_path, 'r') as ce_file:
     CONTENT_EXPERIMENTS = json.load(ce_file)
 
+# django-ratelimit
 RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=True, cast=bool)
 RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='memcache')
+RATELIMIT_VIEW = 'kuma.core.views.rate_limited'

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -25,7 +25,6 @@ from waffle.testutils import override_flag
 
 from kuma.authkeys.models import Key
 from kuma.core.cache import memcache as cache
-from kuma.core.models import IPBan
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import eq_, get_user, ok_
 from kuma.core.urlresolvers import reverse
@@ -489,39 +488,6 @@ class ReadOnlyTests(UserTestCase, WikiTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.get(self.edit_url)
         eq_(200, resp.status_code)
-
-
-class BannedIPTests(UserTestCase, WikiTestCase):
-    """Tests readonly scenarios"""
-    fixtures = UserTestCase.fixtures + ['wiki/documents.json']
-    localizing_client = True
-
-    def setUp(self):
-        super(BannedIPTests, self).setUp()
-        self.ip = '127.0.0.1'
-        self.ip_ban = IPBan.objects.create(ip=self.ip)
-        rev = revision(is_approved=True, save=True)
-        self.doc = rev.document
-        self.edit_url = reverse('wiki.edit', args=[self.doc.slug])
-
-    def tearDown(self):
-        super(BannedIPTests, self).tearDown()
-        cache.clear()
-
-    def test_banned_ip_cant_get_edit(self):
-        self.client.login(username='testuser', password='testpass')
-        response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
-        eq_(403, response.status_code)
-
-    def test_banned_ip_cant_post_edit(self):
-        self.client.login(username='testuser', password='testpass')
-        response = self.client.get(self.edit_url, REMOTE_ADDR=self.ip)
-        eq_(403, response.status_code)
-
-    def test_banned_ip_can_still_get_articles(self):
-        response = self.client.get(self.doc.get_absolute_url(),
-                                   REMOTE_ADDR=self.ip)
-        eq_(200, response.status_code)
 
 
 class KumascriptIntegrationTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -8,8 +8,9 @@ import pytest
 import requests_mock
 from pyquery import PyQuery as pq
 
-from kuma.wiki.models import Document
+from kuma.core.models import IPBan
 from kuma.core.urlresolvers import reverse
+from kuma.wiki.models import Document
 from kuma.wiki.views.document import _apply_content_experiment
 
 
@@ -137,6 +138,14 @@ def test_apply_content_experiment_valid_selection_no_doc(ce_settings, rf):
     assert experiment_doc == doc
     assert params['selected'] is None
     assert not params['selection_is_valid']
+
+
+def test_document_banned_ip_can_read(client, root_doc):
+    '''Banned IPs are still allowed to read content, just not edit.'''
+    ip = '127.0.0.1'
+    IPBan.objects.create(ip=ip)
+    response = client.get(root_doc.get_absolute_url(), REMOTE_ADDR=ip)
+    assert response.status_code == 200
 
 
 @pytest.mark.parametrize('endpoint', ['document', 'preview'])

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -1,0 +1,32 @@
+'''Tests for kuma/wiki/views/edit.py'''
+import pytest
+from waffle.models import Flag
+
+from kuma.core.models import IPBan
+from kuma.core.urlresolvers import reverse
+
+
+@pytest.fixture
+def editor_client(client, wiki_user):
+    Flag.objects.create(name='kumaediting', everyone=True)
+    wiki_user.set_password('password')
+    wiki_user.save()
+    assert client.login(username=wiki_user.username, password='password')
+    return client
+
+
+def test_edit_get(editor_client, root_doc):
+    url = reverse('wiki.edit', locale='en-US', args=[root_doc.slug])
+    response = editor_client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize('method', ('GET', 'POST'))
+def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
+                                    cleared_cacheback_cache):
+    ip = '127.0.0.1'
+    IPBan.objects.create(ip=ip)
+    url = reverse('wiki.edit', locale='en-US', args=[root_doc.slug])
+    caller = getattr(editor_client, method.lower())
+    response = caller(url, REMOTE_ADDR=ip)
+    assert response.status_code == 403

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -30,3 +30,4 @@ def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
     caller = getattr(editor_client, method.lower())
     response = caller(url, REMOTE_ADDR=ip)
     assert response.status_code == 403
+    assert 'Your IP address has been banned.' in response.content

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -14,9 +14,10 @@ from ratelimit.decorators import ratelimit
 
 import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
-from kuma.core.decorators import block_user_agents, login_required, never_cache
+from kuma.core.decorators import (block_banned_ips, block_user_agents,
+                                  login_required, never_cache)
 from kuma.core.urlresolvers import reverse
-from kuma.core.utils import limit_banned_ip_to_0, urlparams
+from kuma.core.utils import urlparams
 
 from ..decorators import (check_readonly, prevent_indexing,
                           process_document_path)
@@ -75,7 +76,8 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 @block_user_agents
 @require_http_methods(['GET', 'POST'])
 @login_required  # TODO: Stop repeating this knowledge here and in Document.allows_editing_by.
-@ratelimit(key='user', rate=limit_banned_ip_to_0, block=True)
+@ratelimit(key='user', rate='60/m', block=True)
+@block_banned_ips
 @process_document_path
 @check_readonly
 @prevent_indexing


### PR DESCRIPTION
Return a ``429 TOO MANY REQUESTS`` and custom error page when the rate limit is exceeded.

You can view the rate limit page by adding this to a view, such as ``kuma.landing.views.home``:

```
from ratelimit.exceptions import Ratelimited; raise Ratelimited()
```

It looks a lot like the 403 page:

<img width="689" alt="429-tumbeast" src="https://user-images.githubusercontent.com/286017/34543974-47cbb7fc-f0a9-11e7-9303-05fd6a62c93b.png">

