### PR TITLE
bug 1268257: Results backend from env, use redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
       - BROKER_URL=redis://redis:6379/0
       - CELERY_ALWAYS_EAGER=False
+      - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - CSRF_COOKIE_SECURE=False
       - DATABASE_URL=mysql://${DATABASE_USER:-root}:${DATABASE_PASSWORD:-kuma}@mysql:3306/developer_mozilla_org
       - DEBUG=${DEBUG:-True}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1267,7 +1267,7 @@ if MAINTENANCE_MODE:
     # loader (see djcelery.setup_loader() above) so we, among other things,
     # acquire the Celery settings from among Django's settings.
     CELERYBEAT_SCHEDULER = 'celery.beat.PersistentScheduler'
-    CELERY_RESULT_BACKEND = (
+    DEFAULT_CELERY_RESULT_BACKEND = (
         'cache+memcached://' + ';'.join(
             config('MEMCACHE_SERVERS',
                    default='127.0.0.1:11211',
@@ -1276,8 +1276,12 @@ if MAINTENANCE_MODE:
     )
 else:
     CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
-    CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
+    DEFAULT_CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'
 
+CELERY_RESULT_BACKEND = config('CELERY_RESULT_BACKEND',
+                               default=DEFAULT_CELERY_RESULT_BACKEND)
+
+# TODO: Default serializer in Celery 4.0 is JSON, need to switch
 CELERY_ACCEPT_CONTENT = ['pickle']
 
 CELERY_IMPORTS = (


### PR DESCRIPTION
Set the ``CELERY_RESULTS_BACKEND`` from the environment, and use Redis DB 1 ([namespacing feature](http://www.rediscookbook.org/multiple_databases.html) to distinguish from DB 0 for task queues) instead of the Django database in development. A similar change is planned in production to reduce database usage.