### PR TITLE
Fix Bug 1428118, prefix icon in new bcd table is broken

### DIFF
--- a/kuma/static/styles/components/compat-tables/ic.scss
+++ b/kuma/static/styles/components/compat-tables/ic.scss
@@ -28,7 +28,7 @@ Custom icon font for compat tables
 }
 
 .ic-prefix:before {
-    content: '\e603';
+    content: '\e602';
 }
 
 .ic-disabled:before {


### PR DESCRIPTION
This fixes the broken prefix icon on the new browser compatibility data tables.