### PR TITLE
bug 1425760: Use rel="nofollow" for links

### DIFF
--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -49,9 +49,9 @@
                   <th scope="row">
                       <h3><a href="{{ revision.document.get_absolute_url() }}">{{ revision.document.title }}</a></h3>
                       <ul class="activity-actions">
-                          <li><a href="{{ revision.document.get_edit_url() }}" class="edit" rel="nofollow, noindex">{{ _("Edit page") }}</a></li>
-                          <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" rel="nofollow, noindex" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
-                          <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history" rel="nofollow, noindex">{{ _("View page history") }}</a></li>
+                          <li><a href="{{ revision.document.get_edit_url() }}" class="edit" rel="nofollow">{{ _("Edit page") }}</a></li>
+                          <li>{% if revision.previous %}<a href="{{ url('wiki.compare_revisions', revision.document.slug, locale=revision.document.locale) }}?from={{ revision.previous.id }}&amp;to={{ revision.id }}" rel="nofollow" class="diff">{{ _("View complete diff") }}</a>{% endif %}</li>
+                          <li><a href="{{ url('wiki.document_revisions', revision.document.slug, locale=revision.document.locale) }}" class="history" rel="nofollow">{{ _("View page history") }}</a></li>
                       </ul>
                   </th>
                   <td>{{ datetimeformat(revision.created, format='date') }}<br />

--- a/kuma/wiki/jinja2/wiki/compare_revisions.html
+++ b/kuma/wiki/jinja2/wiki/compare_revisions.html
@@ -15,7 +15,7 @@
 
     {{ revision_diff(revision_from, revision_to, 'compare') }}
 
-    <p><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow, noindex">{{ _('Back to History') }}</a></p>
+    <p><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow">{{ _('Back to History') }}</a></p>
 
   </article>
 

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -219,7 +219,7 @@
                 <div id="doc-pending-fallback" class="warning">
                   <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
                     Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.
-                    <a href="{{ help_link }}" rel="nofollow, noindex">Join us and help get the job done!</a><br>
+                    <a href="{{ help_link }}" rel="nofollow">Join us and help get the job done!</a><br>
                     You can also read the article in <a href="{{ doc_abs_url }}">{{ parent_language }}</a>.
                   {% endtrans %}</bdi></p>
                 </div>

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -33,7 +33,7 @@
               {% endif %}
 
               {% if document.is_localizable %}
-                <li><a href="{{ translate_url }}" rel="nofollow, noindex" id="translations-add">{{ _('Add a translation') }}</a></li>
+                <li><a href="{{ translate_url }}" rel="nofollow" id="translations-add">{{ _('Add a translation') }}</a></li>
               {% endif %}
             </ul>
           </div>
@@ -44,7 +44,7 @@
             content_experiment and
             content_experiment.selection_is_valid) %}
       {% if (not is_experiment) %}
-      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button neutral" id="edit-button" rel="nofollow, noindex">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
+      <li class="page-buttons-edit"><a href="{{ edit_link }}" class="button neutral" id="edit-button" rel="nofollow">{{ _('Edit') }}<i aria-hidden="true" class="icon-pencil"></i></a></li>
       {% endif %}
 
         {% if user.is_authenticated() and document %}
@@ -64,16 +64,16 @@
           <div class="submenu-column">
             <div class="title">{{ _('Advanced') }}</div>
             <ul>
-                <li><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow, noindex">{{_('History')}}</a></li>
+                <li><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow">{{_('History')}}</a></li>
                 {% if user.is_authenticated() %}
-                  <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow, noindex">{{ _('New sub-article') }}</a></li>
-                  <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow, noindex">{{ _('Clone this article') }}</a></li>
+                  <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow">{{ _('New sub-article') }}</a></li>
+                  <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow">{{ _('Clone this article') }}</a></li>
                 {% endif %}
                 {% if user.is_authenticated() and user.has_perm('wiki.move_tree') %}
-                  <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}" rel="nofollow, noindex">{{ _('Move this article') }}</a></li>
+                  <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}" rel="nofollow">{{ _('Move this article') }}</a></li>
                 {% endif %}
                 {% if user.is_superuser %}
-                  <li><a href="{{ url('admin:wiki_document_change', document.id) }}" rel="nofollow, noindex">{{ _('View in admin') }}</a></li>
+                  <li><a href="{{ url('admin:wiki_document_change', document.id) }}" rel="nofollow">{{ _('View in admin') }}</a></li>
                 {% endif %}
 
 {#
@@ -81,15 +81,15 @@
     # TODO: https://bugzil.la/972541 -  Deleting a page that has subpages
 #}
                 {% if user.has_perm('wiki.delete_document') and not document.children.exists() %}
-                  <li><a href="{{ url('wiki.delete_document', document.slug) }}" rel="nofollow, noindex">{{ _('Delete this article') }}</a></li>
+                  <li><a href="{{ url('wiki.delete_document', document.slug) }}" rel="nofollow">{{ _('Delete this article') }}</a></li>
                 {% endif %}
 
                 {% set zone_links = document_zone_management_links(request.user, document) %}
                 {% if zone_links['change'] %}
-                  <li><a target="_blank" href="{{ zone_links['change'] }}" rel="nofollow, noindex">{{ _('Manage content zone') }}</a></li>
+                  <li><a target="_blank" href="{{ zone_links['change'] }}" rel="nofollow">{{ _('Manage content zone') }}</a></li>
                 {% endif %}
                 {% if zone_links['add'] %}
-                  <li><a target="_blank" href="{{ zone_links['add'] }}" rel="nofollow, noindex">{{ _('Convert to content zone') }}</a></li>
+                  <li><a target="_blank" href="{{ zone_links['add'] }}" rel="nofollow">{{ _('Convert to content zone') }}</a></li>
                 {% endif %}
                 <li class="page-print"><a href="#" onclick="return window.print();">{{ _('Print this article') }}</a></li>
             </ul>

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -40,7 +40,7 @@
       <header>
         <div class="rev-from">
           <h3>
-            <a href="{{ url('wiki.revision', revision_from.document.slug, revision_from.id, locale=revision_from.document.locale) }}" rel="nofollow, noindex">
+            <a href="{{ url('wiki.revision', revision_from.document.slug, revision_from.id, locale=revision_from.document.locale) }}" rel="nofollow">
               {{ _('Revision %(num)s:', num=revision_from.id) }}
             </a>
           </h3>
@@ -56,7 +56,7 @@
         </div>
         <div class="rev-to">
           <h3>
-            <a href="{{ url('wiki.revision', revision_to.document.slug, revision_to.id, locale=revision_to.document.locale) }}" rel="nofollow, noindex">
+            <a href="{{ url('wiki.revision', revision_to.document.slug, revision_to.id, locale=revision_to.document.locale) }}" rel="nofollow">
               {{ _('Revision %(num)s:', num=revision_to.id) }}
             </a>
           </h3>

--- a/kuma/wiki/jinja2/wiki/includes/document_tag.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_tag.html
@@ -4,7 +4,7 @@
     <strong>{{_('Tags:')}}</strong>&nbsp;
     <ul class="tags tags-small">
       {% for tag in tags %}
-        <li><a href="{{ url('wiki.tag', tag) }}" rel="nofollow, noindex">{{ tag }}</a></li>
+        <li><a href="{{ url('wiki.tag', tag) }}" rel="nofollow">{{ tag }}</a></li>
       {% endfor %}
     </ul>
   </div>

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -19,7 +19,7 @@
       <ul>
         {% if document.parent %}
           <li>
-            <a href="{{ url('wiki.document_revisions', document.parent.slug, locale=document.parent.locale) }}" rel="nofollow, noindex">{{ document.parent.language }}</a>
+            <a href="{{ url('wiki.document_revisions', document.parent.slug, locale=document.parent.locale) }}" rel="nofollow">{{ document.parent.language }}</a>
           </li>
         {% endif %}
         <li>
@@ -56,11 +56,11 @@
               </div>
                <div class="revision-list-cell revision-list-prev">
               {% if prev_id %}
-                <a href="{{ url('wiki.compare_revisions', document.slug) }}?to={{ rev.id }}&amp;from={{ prev_id }}" rel="nofollow, noindex">{{ _('Previous') }}</a>
+                <a href="{{ url('wiki.compare_revisions', document.slug) }}?to={{ rev.id }}&amp;from={{ prev_id }}" rel="nofollow">{{ _('Previous') }}</a>
               {% endif %}
               </div>
               <div class="revision-list-cell revision-list-date">
-                <a href="{{ url('wiki.revision', rev.document.slug, rev.id, locale=rev.document.locale) }}" rel="nofollow, noindex">{{ datetimeformat(rev.created, format='datetime') }}</a>
+                <a href="{{ url('wiki.revision', rev.document.slug, rev.id, locale=rev.document.locale) }}" rel="nofollow">{{ datetimeformat(rev.created, format='datetime') }}</a>
               </div>
               <div class="revision-list-cell revision-list-creator">
                 <a href="{{ rev.creator.get_absolute_url() }}"
@@ -75,7 +75,7 @@
               </div>
               {% if document.current_revision_id != rev_id and document.id == rev.document_id and user_can_delete %}
               <div class="revision-list-cell revision-list-revert">
-                <a href="{{ url('wiki.revert_document', rev.document.slug, rev.id, locale=rev.document.locale) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
+                <a href="{{ url('wiki.revert_document', rev.document.slug, rev.id, locale=rev.document.locale) }}" class="button revert-revision" rel="nofollow">{{ _('Revert to this revision') }}</a>
               </div>
               {% endif %}
             </li>
@@ -106,7 +106,7 @@
       {% set class='hidden' if not request.user.is_authenticated() %}
 
       if($next.length) {
-      $pagination.append('<li title="Sign in to view all history"><a href="?limit=all" id="pagination-all" class="{{ class }}" rel="nofollow, noindex">' + gettext('View All') + '</a></li>');
+      $pagination.append('<li title="Sign in to view all history"><a href="?limit=all" id="pagination-all" class="{{ class }}" rel="nofollow">' + gettext('View All') + '</a></li>');
       }
     });
   </script>

--- a/kuma/wiki/jinja2/wiki/list/tags.html
+++ b/kuma/wiki/jinja2/wiki/list/tags.html
@@ -9,7 +9,7 @@
         <ul class="documents-list cols-3">
           {% for tag in tags.object_list %}
             <li>
-              <a href="{{url('wiki.tag', tag.name)}}" rel="nofollow, noindex">{{ tag.name }}</a>
+              <a href="{{url('wiki.tag', tag.name)}}" rel="nofollow">{{ tag.name }}</a>
             </li>
           {% endfor %}
         </ul>

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -72,6 +72,6 @@
       </div>
     </details>
 
-    <a href="{{ url('wiki.revert_document', document.slug, revision.id) }}" class="button revert-revision" rel="nofollow, noindex">{{ _('Revert to this revision') }}</a>
+    <a href="{{ url('wiki.revert_document', document.slug, revision.id) }}" class="button revert-revision" rel="nofollow">{{ _('Revert to this revision') }}</a>
   </article>
 {% endblock %}

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -130,7 +130,7 @@
                         <ul class="tags">
                           {% for parent_tag in parent_tags %}
                           <li>
-                              <a href="{{url('wiki.tag', parent_tag.name)}}" rel="nofollow, noindex">{{ parent_tag.name }}</a>
+                              <a href="{{url('wiki.tag', parent_tag.name)}}" rel="nofollow">{{ parent_tag.name }}</a>
                           </li>
                           {% endfor %}
                         </ul>


### PR DESCRIPTION
Use ``rel="nofollow"`` for links that we don't want scrapers to follow, instead of ``rel="nofollow, noindex"``, which is not a valid value for the space-separated [rel attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types), but instead for [&lt;meta name="robots"&gt;](https://developers.google.com/search/reference/robots_meta_tag#handling-combined-indexing-and-serving-directives).