### PR TITLE
bug 1173189: Force timezone-aware times for feeds

### DIFF
--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import time
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
@@ -86,13 +85,6 @@ def make_translation():
     return d1, d2
 
 
-def wait_add_rev(document):
-    # Let the clock tick, then update the translation parent.
-    time.sleep(1.0)
-    revision(document=document, save=True)
-    return document
-
-
 # End model makers.
 
 
@@ -119,13 +111,13 @@ class WhitespaceRemovalFilter(html5lib_Filter):
             yield token
 
 
-def normalize_html(input):
+def normalize_html(html):
     """
     Normalize HTML5 input, discarding parts not significant for
     equivalence in tests
     """
     return (kuma.wiki.content
-            .parse(unicode(input))
+            .parse(unicode(html))
             .filter(WhitespaceRemovalFilter)
             .serialize(alphabetical_attributes=True))
 


### PR DESCRIPTION
Re-write all the feeds tests, to use ``pytest`` and fixtures, for full code coverage of ``kuma/wiki/feeds.py``, and to avoid silly things like sleeping for a second to get a new timestamp.

Then, add some additional handling of our naive timestamps, to turn them into timezone-aware timestamps needed for the feeds. This avoid errors in the second half of the year when the US moves from Daylight Savings Time to standard time, and 1 AM happens twice. When these ambiguous times are encountered, they currently cause the feed to fail with an error. The change is to assume that it is the first 1 AM, avoiding the conversion error.