### PR TITLE
bug 1423738: Fix sample DB process for squashed migrations, rate limiting

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -148,7 +148,7 @@ the commamd in the the container::
 
     time scripts/create_sample_db.sh
 
-This takes 30 - 60 minutes with a good internet connection.  This is then
+This takes 2 to 2½ hours with a good internet connection.  This is then
 uploaded to the ``mdn-downloads`` site:
 
 * https://mdn-downloads.s3-us-west-2.amazonaws.com/index.html

--- a/etc/sample_db.json
+++ b/etc/sample_db.json
@@ -329,8 +329,7 @@
         "note": "Decides whether spam checks are enabled site-wide.",
         "everyone": true,
         "superusers": false,
-        "created": "2015-10-28",
-        "FORCE": true
+        "created": "2015-10-28"
       }, {
         "name": "spam_submisions_enabled",
         "note": "Decides whether ham and spam submissions are allowed to be done.",


### PR DESCRIPTION
Fix the sample database code and docs:

* ``spam_checks_enabled`` flag had an invalid attribute ``FORCE``
* Handle ``429 Too Many Requests`` by taking a nap
* Handle ``504 Gateway Timeout`` by counting to 10
* Try 33% harder

I used this to generate a new [sample database](https://mdn-downloads.s3-us-west-2.amazonaws.com/list.html?prefix=sampledb/) in a little over two hours. I suggest that manual testing isn't needed.