### PR TITLE
Fix issue #408, add styling for .taller class on interactive example iframe

### DIFF
--- a/kuma/static/styles/components/wiki/interactive.scss
+++ b/kuma/static/styles/components/wiki/interactive.scss
@@ -12,6 +12,10 @@
     height: 490px;
 }
 
+.interactive.taller {
+    height: 585px;
+}
+
 .no-js .interactive {
     background-color: #f8f8f8;
     height: 240px;


### PR DESCRIPTION
This enables us to have a taller iframe size for JS examples that requires a taller editor.
@see https://github.com/mdn/interactive-examples/issues/408