### PR TITLE
bug 1401246: Add test build for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,15 @@ env:
           CREATE_DB=kuma
           INSTALL_PIPELINE=1
           INSTALL_ELASTICSEARCH=1
+        - TOXENV=next
+          CREATE_DB=kuma
+          INSTALL_PIPELINE=1
+          INSTALL_ELASTICSEARCH=1
 
 matrix:
     allow_failures:
         - env: TOXENV=py27 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
+        - env: TOXENV=next CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
 install:
     - nvm install 6
     - nvm use 6

--- a/tox.ini
+++ b/tox.ini
@@ -63,6 +63,24 @@ commands =
     npm install -g stylelint@7.10.1
     stylelint "kuma/static/styles/**/*.scss"
 
+[testenv:next]
+basepython = python2.7
+whitelist_externals =
+    make
+deps =
+    -rrequirements/dev.txt
+commands =
+    pip install "Django>=1.11,<2.0"
+    python manage.py check
+    make compilejsi18n collectstatic clean
+    py.test -vv --cov=kuma --capture=no kuma
+setenv =
+    PYTHONWARNINGS=all
+passenv =
+    DATABASE_URL
+    DJANGO_SETTINGS_MODULE
+    PIPELINE_*
+
 [flake8]
 exclude = **/migrations/**,.tox,*.egg,vendor
 # E501 - line too long (82 > 79 characters)

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ deps =
     -rrequirements/dev.txt
 commands =
     make compilejsi18n collectstatic clean
-    py.test --no-migrations --cov=kuma kuma
+    pytest --cov=kuma kuma
 passenv =
     DATABASE_URL
     DJANGO_SETTINGS_MODULE
@@ -73,7 +73,7 @@ commands =
     pip install "Django>=1.11,<2.0"
     python manage.py check
     make compilejsi18n collectstatic clean
-    py.test -vv --cov=kuma --capture=no kuma
+    pytest -vv --cov=kuma --capture=no kuma
 setenv =
     PYTHONWARNINGS=all
 passenv =


### PR DESCRIPTION
Add a test build for Django 1.11, which is expected to fail. I'd like to continue testing the latest versions of Django and other packages after we've finished this upgrade.