### PR TITLE
[Bug 1431139] Optimize Documents view of kuma

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -24,6 +24,14 @@ def wiki_user(db, django_user_model):
 
 
 @pytest.fixture
+def user_client(client, wiki_user):
+    wiki_user.set_password('password')
+    wiki_user.save()
+    client.login(username=wiki_user.username, password='password')
+    return client
+
+
+@pytest.fixture
 def root_doc(wiki_user):
     """A newly-created top-level English document."""
     root_doc = Document.objects.create(

--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -7,7 +7,7 @@ from elasticsearch_dsl.connections import connections as es_connections
 
 from .models import Document, DocumentZone
 from .jobs import (DocumentContributorsJob, DocumentNearestZoneJob,
-                   DocumentZoneURLRemapsJob, DocumentCodeSampleJob)
+                   DocumentZoneURLRemapsJob, DocumentCodeSampleJob, DocumentTagsJob)
 from .signals import render_done
 
 
@@ -114,6 +114,7 @@ class WikiConfig(AppConfig):
         invalidate_nearest_zone_cache(instance.pk, async=async)
 
         DocumentContributorsJob().invalidate(instance.pk)
+        DocumentTagsJob().invalidate(instance.pk)
 
         code_sample_job = DocumentCodeSampleJob(generation_args=[instance.pk])
         code_sample_job.invalidate_generation()

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -23,11 +23,10 @@
 {% set nearest_zone = document.nearest_zone %}
 {% set is_zone = nearest_zone %}
 {% set is_zone_root = document.is_zone_root %}
-{% set other_translations = document.other_translations %}
 
 {% set show_left = zone_subnav_html or quick_links_html or approvals_html %}
 
-{% set buttons = get_document_buttons(document, help_link) %}
+{% set buttons = get_document_buttons(document, help_link, other_translations) %}
 {% set crumbs = build_document_crumbs(document) %}
 
 
@@ -202,7 +201,7 @@
                 {% include 'wiki/includes/kumascript_errors.html' %}
               {% endif %}
 
-              {% if document.current_revision %}
+              {% if document.parent_id and document.current_revision %}
                 {% if document.current_revision.localization_in_progress %}
                   {% if not settings.MAINTENANCE_MODE and document.current_revision.translation_age >= 10 %}
                     <div class="overheadIndicator translationInProgress"><p>{% trans translate_url=document.get_edit_url() %}
@@ -245,7 +244,7 @@
               <!-- contributors -->
               <div class="wiki-block contributors">
                 <h2 class="offscreen">{{ _('Document Tags and Contributors') }}</h2>
-                {% set tags = document.tags.all().order_by('name') %}
+                {% set tags = document.all_tags_name %}
                 {% include "wiki/includes/document_tag.html" %}
 
                 {% if has_contributors %}

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -1,5 +1,5 @@
 {% from "wiki/includes/document_macros.html" import watch_menu_items with context%}
-{% macro get_document_buttons(document, edit_link) %}
+{% macro get_document_buttons(document, edit_link, other_translations) %}
 
   {% if document.parent %}
     {# If there is a parent doc, use it for translating. #}
@@ -20,12 +20,12 @@
         <div class="submenu js-submenu" id="languages-menu-submenu">
           <div class="submenu-column">
             <ul id="translations">
-              {% if document.other_translations or fallback_reason %}
+              {% if other_translations or fallback_reason %}
                 {# show the parent locale in choices if fall back to parent for any reason #}
                 {% if fallback_reason=='no_translation' %}
                   <li><bdi><a rel="internal" href="{{ document.get_absolute_url() }}" data-locale="{{ document.locale }}" title="{{ get_locale_localized(document.locale) }}">{{ document.language }} ({{ document.locale }})</a></bdi></li>
                 {% endif %}
-                {% for translation in document.other_translations %}
+                {% for translation in other_translations %}
                   <li><bdi><a rel="internal" href="{{ url('wiki.document', translation.slug, locale=translation.locale) }}" data-locale="{{ translation.locale }}" title="{{ get_locale_localized(translation.locale) }}">{{ translation.language }} ({{ translation.locale }})</a></bdi></li>
                 {% endfor %}
               {% else %}

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -207,7 +207,7 @@ def document_zone_management_links(user, document):
 
     # Enable "add" link if there is no zone for this document, or if there's a
     # zone but the document is not itself the root (ie. to add sub-zones).
-    if ((not zone or zone.document != document) and
+    if ((not zone or zone.document_id != document.id) and
             user.has_perm('wiki.add_documentzone')):
         links['add'] = '%s?document=%s' % (
             reverse('admin:wiki_documentzone_add'), document.id)

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -709,8 +709,9 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
 
     def test_get_seo_parent_doesnt_throw_404(self):
         """bug 1190212"""
+        doc = document(save=True)
         slug_dict = {'seo_root': 'Root/Does/Not/Exist'}
-        _get_seo_parent_title(slug_dict, 'bn-BD')  # Should not raise Http404
+        _get_seo_parent_title(doc, slug_dict, 'bn-BD')  # Should not raise Http404
 
     def test_seo_title(self):
         self.client.login(username='admin', password='testpass')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1681,65 +1681,61 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         ok_(str(parent.id) in content.html())
 
     @pytest.mark.tags
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_document_tags(self, get_current):
-        """Document tags can be edited through revisions"""
+    def test_tags_while_document_create(self):
         data = new_document_data()
-        locale = data['locale']
-        slug = data['slug']
-        path = slug
+        tags = ('JavaScript', 'AJAX', 'DOM')
+        data['tags'] = ','.join(tags)
+
+        self.client.login(username='admin', password='testpass')
+        response = self.client.post(reverse('wiki.create'), data, follow=True)
+        assert response.status_code == 200
+
+        doc = Document.objects.all().get(slug=data['slug'], locale=data['locale'])
+        doc_tags = doc.tags.all().values_list('name', flat=True)
+        assert sorted(doc_tags) == sorted(tags)
+
+    @pytest.mark.tags
+    def test_tags_while_document_update(self):
+        self.client.login(username='admin', password='testpass')
         ts1 = ('JavaScript', 'AJAX', 'DOM')
         ts2 = ('XML', 'JSON')
+        # Create a revision with some tags
+        rev = revision(save=True, tags=','.join(ts1))
+        doc = rev.document
 
-        get_current.return_value.domain = 'su.mo.com'
-        self.client.login(username='admin', password='testpass')
-
-        def assert_tag_state(yes_tags, no_tags):
-
-            # Ensure the tags are found for the Documents
-            doc = Document.objects.get(locale=locale, slug=slug)
-            doc_tags = [x.name for x in doc.tags.all()]
-            for t in yes_tags:
-                ok_(t in doc_tags)
-            for t in no_tags:
-                ok_(t not in doc_tags)
-
-            # Ensure the tags are found in the Document view
-            response = self.client.get(reverse('wiki.document',
-                                               args=[doc.slug]), data)
-            page = pq(response.content)
-            for t in yes_tags:
-                eq_(1, page.find('.tags li a:contains("%s")' % t).length,
-                    '%s should NOT appear in document view tags' % t)
-            for t in no_tags:
-                eq_(0, page.find('.tags li a:contains("%s")' % t).length,
-                    '%s should appear in document view tags' % t)
-
-            # Check for the document slug (title in feeds) in the tag listing
-            for t in yes_tags:
-                response = self.client.get(reverse('wiki.tag', args=[t]))
-                self.assertContains(response, doc.slug, msg_prefix=t)
-                response = self.client.get(reverse('wiki.feeds.recent_documents',
-                                                   args=['atom', t]))
-                self.assertContains(response, doc.title)
-
-            for t in no_tags:
-                response = self.client.get(reverse('wiki.tag', args=[t]))
-                ok_(doc.slug not in response.content.decode('utf-8'))
-                response = self.client.get(reverse('wiki.feeds.recent_documents',
-                                                   args=['atom', t]))
-                self.assertNotContains(response, doc.title)
-
-        # Create a new doc with tags
-        data.update({'slug': slug, 'tags': ','.join(ts1)})
-        self.client.post(reverse('wiki.create'), data)
-        assert_tag_state(ts1, ts2)
-
-        # Now, update the tags.
+        # Update the document with some other tags
+        data = new_document_data()
         data.update({'form-type': 'rev', 'tags': ', '.join(ts2)})
-        self.client.post(reverse('wiki.edit',
-                                 args=[path]), data)
-        assert_tag_state(ts2, ts1)
+        response = self.client.post(reverse('wiki.edit', args=[doc.slug]), data, follow=True)
+        assert response.status_code == 200
+
+        # Check only last added tags are related with the documents
+        doc_tags = doc.tags.all().values_list('name', flat=True)
+        assert sorted(doc_tags) == sorted(ts2)
+
+    @pytest.mark.tags
+    def test_tags_showing_correctly_after_doc_update(self):
+        """After any update to the document, the new tags should show correctly"""
+        self.client.login(username='admin', password='testpass')
+        ts1 = ('JavaScript', 'AJAX', 'DOM')
+        ts2 = ('XML', 'JSON')
+        rev = revision(save=True, tags=','.join(ts1))
+        doc = rev.document
+
+        # Update the document with some other tags
+        data = new_document_data()
+        del data['slug']
+        data.update({'form-type': 'rev', 'tags': ', '.join(ts2)})
+        response = self.client.post(reverse('wiki.edit', args=[doc.slug]), data, follow=True)
+        assert response.status_code == 200
+
+        # Check document is showing the new tags
+        response = self.client.get(doc.get_absolute_url(), follow=True)
+        assert response.status_code == 200
+
+        page = pq(response.content)
+        response_tags = page.find('.tags li a').contents()
+        assert response_tags == sorted(ts2)
 
     @pytest.mark.review_tags
     @mock.patch.object(Site.objects, 'get_current')
@@ -3800,6 +3796,47 @@ class ListDocumentTests(UserTestCase, WikiTestCase):
     """Tests for list_documents view"""
     localizing_client = True
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
+
+    def _get_documents_from_list(self, tag):
+        response = self.client.get(reverse('wiki.tag', args=[tag]))
+        page = pq(response.content)
+        cache.clear()
+        return page.find('.document-list li a').contents()
+
+    def test_document_list_by_tag(self):
+        tags = ['foo', 'bar', 'web']
+        rev = revision(save=True, tags=','.join(tags))
+        doc = rev.document
+
+        for t in tags:
+            docs = self._get_documents_from_list(tag=t)
+            assert len(docs) == 1
+            assert doc.slug in docs
+
+    @pytest.mark.tags
+    def test_doc_list_by_tag_after_update(self):
+        """After updating tag of a document, the list should also be updated"""
+        tags1 = ['foo', 'bar', 'js']
+        tags2 = ['lorem', 'ipsum']
+        # Create a document with some tags
+        rev1 = revision(save=True, tags=','.join(tags1))
+        doc = rev1.document
+
+        # Create another revision of the document with other tags
+        revision(save=True, document=doc, tags=','.join(tags2))
+
+        # Check document slug is present in the document list
+        for t in tags2:
+            docs = self._get_documents_from_list(tag=t)
+            assert len(docs) == 1
+            assert doc.slug in docs
+
+        # As the new tag has been added to the document
+        # The document should not be listed in previous tags list
+        for t in tags1:
+            docs = self._get_documents_from_list(tag=t)
+            assert len(docs) == 0
+            assert doc.slug not in docs
 
     def test_case_insensitive_tags(self):
         """

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -7,12 +7,9 @@ from kuma.core.urlresolvers import reverse
 
 
 @pytest.fixture
-def editor_client(client, wiki_user):
+def editor_client(user_client):
     Flag.objects.create(name='kumaediting', everyone=True)
-    wiki_user.set_password('password')
-    wiki_user.save()
-    assert client.login(username=wiki_user.username, password='password')
-    return client
+    return user_client
 
 
 def test_edit_get(editor_client, root_doc):

--- a/kuma/wiki/views/utils.py
+++ b/kuma/wiki/views/utils.py
@@ -57,8 +57,7 @@ def document_last_modified(request, document_slug, document_locale):
     try:
         last_mod = memcache.get(cache_key)
         if last_mod is None:
-            doc = Document.objects.get(locale=document_locale,
-                                       slug=document_slug)
+            doc = Document.objects.only('slug', 'locale', 'modified').get(locale=document_locale, slug=document_slug)
             last_mod = doc.fill_last_modified_cache()
 
         # Convert the cached Unix epoch seconds back to Python datetime


### PR DESCRIPTION
In the current platform, it seems like many more unneeded SQL queries that kills most of the time!

It can be more optimized, but for now I think small is also benefecial.

**Current Situation:**
![image](https://user-images.githubusercontent.com/7114151/35002086-b4d1f99c-fb12-11e7-9d30-73728e732c73.png)

**After this Patch:**
![image](https://user-images.githubusercontent.com/7114151/35001907-2c9600a0-fb12-11e7-9d5c-5a227a0551ce.png)

I was thinking about fetching all the translations data of the document using elasticsearch or cache. As making a sql queries just for showing the translation information is a bit tradeoff with the performance. What do you think @jwhitlock?

@jwhitlock @escattone Can you please review?
It partially fiexes https://github.com/mozmeao/infra/issues/677