### PR TITLE
bug 1136741: Make compat_data flag permanent

### DIFF
--- a/docs/feature-toggles.rst
+++ b/docs/feature-toggles.rst
@@ -36,7 +36,6 @@ Flags
 `Waffle flags`_ control behavior by specific users, groups, percentages, and
 other advanced criteria.
 
-* ``compat_data`` - View the new JSON backed compat tables.
 * ``kumaediting`` - Enable/disable wiki editing.
 * ``page_move`` - (deprecated) enable/disable page move feature.
 * ``section_edit`` - Show section edit buttons.

--- a/kuma/static/js/wiki-compat-trigger.js
+++ b/kuma/static/js/wiki-compat-trigger.js
@@ -6,11 +6,6 @@
         var compatCSS;
         var compatJS;
 
-        // don't run if waffle not active
-        if(!win.waffle || !win.waffle.flag_is_active('compat_data')) {
-            return;
-        }
-
         // don't run if no compat table on page with min 1 row
         var $compatFeatureRows = $('.bc-table tbody tr');
         if(!$compatFeatureRows.length) {


### PR DESCRIPTION
This removes the flag, but keeps the just-in-time loading of the JS and CSS. However, it may make sense to merge those into ``wiki.js`` / ``wiki.css``. 