### PR TITLE
bug 1431205: Add /_kuma_status.json, use for dynamic functional tests

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -1,7 +1,13 @@
-import mock
-import pytest
+import json
+
 from django.db import DatabaseError
 from django.core.urlresolvers import reverse
+from elasticsearch.exceptions import ConnectionError as ES_ConnectionError
+from requests.exceptions import ConnectionError as Requests_ConnectionError
+import mock
+import pytest
+
+from kuma.users.models import User
 
 
 @pytest.mark.parametrize('http_method', ['put', 'post', 'delete', 'options'])
@@ -34,3 +40,283 @@ def test_readiness_with_db_error(db, client):
         response = client.get(url)
     assert response.status_code == 503
     assert 'fubar' in response.reason_phrase
+
+
+@pytest.fixture
+def mock_request_revision_hash():
+    ks_hash = '8da6b8f41'
+    with mock.patch('kuma.health.views.request_revision_hash') as func:
+        func.return_value = mock.Mock(spec_set=['status_code', 'text'])
+        func.return_value.status_code = 200
+        func.return_value.text = ks_hash
+        yield func
+
+
+@pytest.fixture
+def mock_document_objects_count():
+    with mock.patch('kuma.health.views.Document') as model:
+        model.objects = mock.Mock(spec_set=['count'])
+        model.objects.count.return_value = 100
+        yield model.objects.count
+
+
+@pytest.fixture
+def mock_search_count():
+    with mock.patch('kuma.health.views.WikiDocumentType.search') as search:
+        search.return_value = mock.Mock(spec_set=['count'])
+        search.return_value.count.return_value = 90
+        yield search.return_value.count
+
+
+@pytest.fixture
+def mock_user_objects_filter():
+    usernames = ['test-super', 'test-moderator', 'test-new', 'test-banned',
+                 'viagra-test-123']
+    users = []
+    for username in usernames:
+        user = User(username=username)
+        user.set_password('test-password')
+        users.append(user)
+    with mock.patch('kuma.health.views.User') as model:
+        model.objects = mock.Mock(spec_set=['only'])
+        model.objects.only.return_value = mock.Mock(spec_set=['filter'])
+        filter_func = model.objects.only.return_value.filter
+        filter_func.return_value = users
+        yield filter_func
+
+
+@pytest.fixture
+def mock_status_externals(mock_request_revision_hash,
+                          mock_document_objects_count,
+                          mock_search_count,
+                          mock_user_objects_filter):
+    yield {
+        'kumascript': mock_request_revision_hash,
+        'document': mock_document_objects_count,
+        'search': mock_search_count,
+        'test_users': mock_user_objects_filter,
+    }
+
+
+def test_status(client, settings, mock_status_externals):
+    """The status JSON reflects the test environment."""
+    # Normalize to docker development settings
+    dev_settings = {
+        'ALLOWED_HOSTS': ['*'],
+        'ATTACHMENT_HOST': 'localhost:8000',
+        'ATTACHMENT_ORIGIN': 'localhost:8000',
+        'DEBUG': False,
+        'INTERACTIVE_EXAMPLES_BASE': 'https://interactive-examples.mdn.mozilla.net',
+        'LEGACY_HOSTS': [],
+        'MAINTENANCE_MODE': False,
+        'PROTOCOL': 'http://',
+        'REVISION_HASH': '3f45719d45f15da73ccc15747c28b80ccc8dfee5',
+        'SITE_URL': 'http://localhost:8000',
+        'STATIC_URL': '/static/',
+    }
+    for name, value in dev_settings.items():
+        setattr(settings, name, value)
+
+    url = reverse('health.status')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert response['Content-Type'] == 'application/json'
+    data = json.loads(response.content)
+    assert sorted(data.keys()) == ['request', 'services', 'settings',
+                                   'version']
+    assert data['settings'] == dev_settings
+    assert data['request'] == {
+        'host': 'testserver',
+        'is_secure': False,
+        'scheme': 'http',
+        'url': 'http://testserver/_kuma_status.json',
+    }
+    assert sorted(data['services'].keys()) == ['database', 'kumascript',
+                                               'search', 'test_accounts']
+    assert data['services']['database'] == {
+        'available': True,
+        'populated': True,
+        'document_count': 100,
+    }
+    assert data['services']['kumascript'] == {
+        'available': True,
+        'revision': '8da6b8f41',
+    }
+    assert data['services']['search'] == {
+        'available': True,
+        'populated': True,
+        'count': 90,
+    }
+    assert data['services']['test_accounts'] == {
+        'available': True,
+    }
+    assert data['version'] == 1
+
+
+STATUS_SETTINGS_CASES = {
+    'ALLOWED_HOSTS': ['localhost', 'testserver'],
+    'ATTACHMENT_HOST': 'attachments.test.moz.works',
+    'ATTACHMENT_ORIGIN': 'attachments-origin.test.moz.works',
+    'DEBUG': True,
+    'INTERACTIVE_EXAMPLES_BASE': 'https://interactive-examples.mdn.moz.works',
+    'LEGACY_HOSTS': ['developer.allizom.org'],
+    'MAINTENANCE_MODE': True,
+    'REVISION_HASH': 'NEW_VALUE',
+    'SITE_URL': 'https://mdn.moz.works',
+    'STATIC_URL': 'https://cdn.test.moz.works/static/',
+}
+
+
+@pytest.mark.parametrize('name,new_value',
+                         STATUS_SETTINGS_CASES.items(),
+                         ids=STATUS_SETTINGS_CASES.keys())
+def test_status_settings_change(name, new_value, client, settings,
+                                mock_status_externals):
+    """The status JSON reflects the current Django settings."""
+    assert getattr(settings, name) != new_value
+    setattr(settings, name, new_value)
+
+    url = reverse('health.status')
+    response = client.get(url)
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data['settings'][name] == new_value
+
+
+@pytest.mark.parametrize('value', ('https://', 'http://'))
+def test_status_settings_protocol(value, client, settings,
+                                  mock_status_externals):
+    """
+    The status JSON reflects the PROTOCOL setting
+
+    In local dev, this is http, but it is https in TravisCI, so it is not a
+    good fit for test_status_settings_change
+    """
+    settings.PROTOCOL = value
+    url = reverse('health.status')
+    response = client.get(url)
+    assert response.status_code == 200
+    data = json.loads(response.content)
+    assert data['settings']['PROTOCOL'] == value
+
+
+def test_status_failed_database(client, mock_status_externals):
+    """The status JSON shows if the database is unavailable."""
+    mock_status_externals['document'].side_effect = DatabaseError('fubar')
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['database'] == {
+        'available': False,
+        'populated': False,
+        'document_count': 0,
+    }
+
+
+def test_status_empty_database(client, mock_status_externals):
+    """The status JSON shows if the database is empty."""
+    mock_status_externals['document'].return_value = 0
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['database'] == {
+        'available': True,
+        'populated': False,
+        'document_count': 0,
+    }
+
+
+def test_status_failed_search(client, mock_status_externals):
+    """The status JSON shows if ElasticSearch is unavailable."""
+    mock_status_externals['search'].side_effect = ES_ConnectionError('No ES')
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['search'] == {
+        'available': False,
+        'populated': False,
+        'count': 0,
+    }
+
+
+def test_status_empty_search(client, mock_status_externals):
+    """The status JSON shows if ElasticSearch is unpopulated."""
+    mock_status_externals['search'].return_value = 0
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['search'] == {
+        'available': True,
+        'populated': False,
+        'count': 0,
+    }
+
+
+def test_status_no_kumascript(client, mock_status_externals):
+    """The status JSON shows if KumaScript is unavailable."""
+    mock_status_externals['kumascript'].side_effect = (
+        Requests_ConnectionError('Nope'))
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['kumascript'] == {
+        'available': False,
+        'revision': None,
+    }
+
+
+def test_status_failed_kumascript(client, mock_status_externals):
+    """The status JSON shows if KumaScript returns an error code."""
+    mock_status_externals['kumascript'].return_value.status_code = 400
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['kumascript'] == {
+        'available': False,
+        'revision': None,
+    }
+
+
+def test_status_test_acccounts_no_database(client, mock_status_externals):
+    """The status JSON shows accounts unavailable if no database."""
+    mock_status_externals['test_users'].side_effect = DatabaseError('wat')
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['test_accounts'] == {
+        'available': False,
+    }
+
+
+def test_status_test_acccounts_unavailable(client, mock_status_externals):
+    """The status JSON shows if the test accounts are unavailable."""
+    mock_status_externals['test_users'].return_value = []
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['test_accounts'] == {
+        'available': False,
+    }
+
+
+def test_status_test_acccounts_one_missing(client, mock_status_externals):
+    """The status JSON shows if there is a missing test account."""
+    mock_status_externals['test_users'].return_value.pop()
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['test_accounts'] == {
+        'available': False,
+    }
+
+
+def test_status_test_acccounts_wrong_password(client, mock_status_externals):
+    """The status JSON shows if a test account has the wrong password."""
+    user = mock_status_externals['test_users'].return_value[0]
+    user.set_password('not_the_password')
+    url = reverse('health.status')
+    response = client.get(url)
+    data = json.loads(response.content)
+    assert data['services']['test_accounts'] == {
+        'available': False,
+    }

--- a/kuma/health/urls.py
+++ b/kuma/health/urls.py
@@ -10,4 +10,7 @@ urlpatterns = [
     url(r'^readiness/?$',
         views.readiness,
         name='health.readiness'),
+    url(r'^_kuma_status.json$',
+        views.status,
+        name='health.status'),
 ]

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -2,7 +2,8 @@ from django.conf import settings
 from django.db import DatabaseError
 from django.http import HttpResponse, JsonResponse
 from django.views.decorators.http import require_safe
-from elasticsearch.exceptions import ConnectionError as ES_ConnectionError
+from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
+                                      NotFoundError)
 
 from requests.exceptions import ConnectionError as Requests_ConnectionError
 
@@ -123,6 +124,8 @@ def status(request):
         search_count = WikiDocumentType.search().count()
     except ES_ConnectionError:
         search_data['available'] = False
+    except NotFoundError:
+        pass  # available but unpopulated (and maybe uncreated)
     else:
         if search_count:
             search_data['populated'] = True

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -1,8 +1,15 @@
+from django.conf import settings
 from django.db import DatabaseError
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.views.decorators.http import require_safe
+from elasticsearch.exceptions import ConnectionError as ES_ConnectionError
 
+from requests.exceptions import ConnectionError as Requests_ConnectionError
+
+from kuma.users.models import User
+from kuma.wiki.kumascript import request_revision_hash
 from kuma.wiki.models import Document
+from kuma.wiki.search import WikiDocumentType
 
 
 @require_safe
@@ -37,3 +44,109 @@ def readiness(request):
     else:
         status, reason = 204, None
     return HttpResponse(status=status, reason=reason)
+
+
+@require_safe
+def status(request):
+    """
+    Return summary information about this Kuma instance.
+
+    Functional tests can use this to customize the test process.
+    """
+    data = {
+        'version': 1,
+        'request': {
+            'url': request.build_absolute_uri(''),
+            'host': request.get_host(),
+            'is_secure': request.is_secure(),
+            'scheme': request.scheme,
+        },
+        'services': {
+            'database': {},
+            'kumascript': {},
+            'search': {},
+            'test_accounts': {},
+        },
+        'settings': {
+            'ALLOWED_HOSTS': settings.ALLOWED_HOSTS,
+            'ATTACHMENT_HOST': settings.ATTACHMENT_HOST,
+            'ATTACHMENT_ORIGIN': settings.ATTACHMENT_ORIGIN,
+            'DEBUG': settings.DEBUG,
+            'INTERACTIVE_EXAMPLES_BASE': settings.INTERACTIVE_EXAMPLES_BASE,
+            'LEGACY_HOSTS': settings.LEGACY_HOSTS,
+            'MAINTENANCE_MODE': settings.MAINTENANCE_MODE,
+            'PROTOCOL': settings.PROTOCOL,
+            'REVISION_HASH': settings.REVISION_HASH,
+            'SITE_URL': settings.SITE_URL,
+            'STATIC_URL': settings.STATIC_URL,
+        },
+    }
+
+    # Check that database is reachable, populated
+    doc_data = {
+        'available': True,
+        'populated': False,
+        'document_count': 0
+    }
+    try:
+        doc_count = Document.objects.count()
+    except DatabaseError:
+        doc_data['available'] = False
+    else:
+        if doc_count:
+            doc_data['populated'] = True
+            doc_data['document_count'] = doc_count
+    data['services']['database'] = doc_data
+
+    # Check that KumaScript is reachable
+    ks_data = {
+        'available': True,
+        'revision': None,
+    }
+    try:
+        ks_response = request_revision_hash()
+    except Requests_ConnectionError:
+        ks_response = None
+    if not ks_response or ks_response.status_code != 200:
+        ks_data['available'] = False
+    else:
+        ks_data['revision'] = ks_response.text
+    data['services']['kumascript'] = ks_data
+
+    # Check that ElasticSearch is reachable, populated
+    search_data = {
+        'available': True,
+        'populated': False,
+        'count': 0
+    }
+    try:
+        search_count = WikiDocumentType.search().count()
+    except ES_ConnectionError:
+        search_data['available'] = False
+    else:
+        if search_count:
+            search_data['populated'] = True
+            search_data['count'] = search_count
+    data['services']['search'] = search_data
+
+    # Check if the testing accounts are available
+    test_account_data = {
+        'available': False
+    }
+    test_account_names = ['test-super', 'test-moderator', 'test-new',
+                          'test-banned', 'viagra-test-123']
+    try:
+        users = list(User.objects.only('id', 'username', 'password')
+                                 .filter(username__in=test_account_names))
+    except DatabaseError:
+        users = []
+    if len(users) == len(test_account_names):
+        for user in users:
+            if not user.check_password('test-password'):
+                break
+        else:
+            # All users have the testing password
+            test_account_data['available'] = True
+    data['services']['test_accounts'] = test_account_data
+
+    return JsonResponse(data)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -54,6 +54,7 @@ INTERACTIVE_EXAMPLES_BASE = config(
 
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', default=False, cast=bool)
 ALLOW_ROBOTS = config('ALLOW_ROBOTS', default=False, cast=bool)
+REVISION_HASH = config('REVISION_HASH', default='undefined')
 
 MANAGERS = ADMINS
 
@@ -1676,9 +1677,8 @@ if SENTRY_DSN:
             'django.core.exceptions.DisallowedHost',
         ],
     }
-    release = config('REVISION_HASH', default='')
-    if release:
-        RAVEN_CONFIG['release'] = release
+    if REVISION_HASH and REVISION_HASH != 'undefined':
+        RAVEN_CONFIG['release'] = REVISION_HASH
     INSTALLED_APPS = INSTALLED_APPS + (
         'raven.contrib.django.raven_compat',
     )

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -410,6 +410,7 @@ LANGUAGE_URL_IGNORED_PATHS = (
     '.well-known',
     'users/github/login/callback/',
     'favicon.ico',
+    '_kuma_status.json',
     # Legacy files, circa 2008, served in AWS
     'diagrams',
     'presentations',

--- a/kuma/version/tests/test_views.py
+++ b/kuma/version/tests/test_views.py
@@ -1,4 +1,3 @@
-import os
 from urlparse import urljoin
 
 import pytest
@@ -9,12 +8,13 @@ from kuma.wiki.constants import KUMASCRIPT_BASE_URL
 
 
 @pytest.mark.parametrize('method', ['get', 'head'])
-def test_revision_hash(client, db, method):
+def test_revision_hash(client, db, method, settings):
+    settings.REVISION_HASH = 'the_revision_hash'
     response = getattr(client, method)(reverse('version.kuma'))
     assert response.status_code == 200
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
     if method == 'get':
-        assert response.content == os.getenv('REVISION_HASH', 'undefined')
+        assert response.content == 'the_revision_hash'
 
 
 @pytest.mark.parametrize(

--- a/kuma/version/views.py
+++ b/kuma/version/views.py
@@ -1,5 +1,4 @@
-import os
-
+from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.http import require_safe
 
@@ -12,7 +11,7 @@ def revision_hash(request):
     Return the kuma revision hash.
     """
     return HttpResponse(
-        os.getenv('REVISION_HASH', 'undefined'),
+        settings.REVISION_HASH,
         content_type='text/plain; charset=utf-8'
     )
 

--- a/tests/functional/test_notfound.py
+++ b/tests/functional/test_notfound.py
@@ -20,18 +20,24 @@ def test_is_not_found_status(base_url, selenium):
 
 @pytest.mark.nondestructive
 @skip_if_not_maintenance_mode
-def test_is_not_found_status_in_mm(base_url, selenium):
+def test_is_not_found_status_in_mm(base_url, selenium, is_debug):
     page = NotFoundPage(selenium, base_url).open()
-    assert page.is_maintenance_mode_banner_displayed
-    assert not page.header.is_signin_displayed
+    if is_debug:
+        assert selenium.title == 'Page not found at /%s' % page.SLUG
+    else:
+        assert page.is_maintenance_mode_banner_displayed
+        assert not page.header.is_signin_displayed
 
 
 @pytest.mark.smoke
 @pytest.mark.nodata
 @pytest.mark.nondestructive
-def test_is_expected_content(base_url, selenium):
+def test_is_expected_content(base_url, selenium, is_debug):
     page = NotFoundPage(selenium, base_url).open()
-    assert (ARTICLE_NAME + ARTICLE_TITLE_SUFIX) == selenium.title
-    assert page.page_title_text == ARTICLE_NAME
-    assert page.page_title_text in selenium.title
-    assert page.is_report_link_displayed
+    if is_debug:
+        assert selenium.title == 'Page not found at /%s' % page.SLUG
+    else:
+        assert selenium.title == (ARTICLE_NAME + ARTICLE_TITLE_SUFIX)
+        assert page.page_title_text == ARTICLE_NAME
+        assert page.page_title_text in selenium.title
+        assert page.is_report_link_displayed

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -94,6 +94,9 @@ def test_search_layout(base_url, selenium):
     search_results_links = page.search_results_link_list
     for link in search_results_links:
         this_link = link.get_attribute('href')
+        # When running scripts/run_functional_tests.sh,
+        # base_url's hostname is web, but links are localhost
+        this_link = this_link.replace('http://localhost:8000', base_url)
         assert_valid_url(this_link, follow_redirects=True)
 
 

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -112,12 +112,17 @@ def test_search_zero_results(base_url, selenium):
 @pytest.mark.smoke
 @pytest.mark.search
 @pytest.mark.nondestructive
-def test_search_filters(base_url, selenium):
+def test_search_filters(base_url, selenium, kuma_status):
     page = SearchPage(selenium, base_url, term=SEARCH_TERM).open()
     documents_found_initial = page.documents_found
     page.search_all_topics()
     documents_found_after = page.documents_found
-    assert documents_found_after > documents_found_initial
+    if kuma_status['services']['search']['count'] > 10000:
+        # Full production search index
+        assert documents_found_after > documents_found_initial
+    else:
+        # Sample database
+        assert documents_found_after >= documents_found_initial
 
 
 @pytest.mark.nondestructive

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -1,7 +1,8 @@
 from pypom import Region
-from selenium.common.exceptions import NoSuchElementException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
+import pytest
 
 from pages.base import BasePage
 
@@ -72,7 +73,15 @@ class DashboardPage(BasePage):
         page_two_link = self.find_element(*self._page_two_link)
         page_two_link.click()
         # revsion-page updates to not 1
-        self.wait.until(lambda s: int(self.find_element(*self._revision_page_input).get_attribute('value')) is not 1)
+        try:
+            self.wait.until(lambda s: int(
+                            self.find_element(*self._revision_page_input)
+                            .get_attribute('value'))
+                            is not 1)
+        except TimeoutException:
+            if self.selenium._is_remote and self.selenium.name == 'firefox':
+                pytest.xfail("Known issue with AJAX refresh"
+                             " (Selenium 3 w/ Remote Firefox)")
         # form is disabled when ajax request made
         self.wait.until(lambda s: 'disabled' in revision_filter_form.get_attribute('class'))
         # wait for tray to be added

--- a/tests/pages/notfound.py
+++ b/tests/pages/notfound.py
@@ -5,13 +5,19 @@ from pages.base import BasePage
 
 class NotFoundPage(BasePage):
 
-    URL_TEMPLATE = '/{locale}/skwiz'
+    SLUG = 'skwiz'
+    URL_TEMPLATE = '/{locale}/' + SLUG
 
     _page_title = (By.CSS_SELECTOR, '#content-main > h1')
     report_content_form_url = 'https://bugzilla.mozilla.org/form.doc'
     _report_content_locator = (By.CSS_SELECTOR,
                                '#content-main a[href^="' +
                                report_content_form_url + '"]')
+
+    def wait_for_page_to_load(self):
+        """The page varies on DEBUG=True, so just look for URL."""
+        self.wait.until(lambda s: self.seed_url in s.current_url)
+        return self
 
     @property
     def page_title_text(self):


### PR DESCRIPTION
``/_kuma_status.json`` returns settings and services status. The settings can vary between deployments, and can be used either to confirm settings (for example, ``DEBUG`` should be ``False`` in production) or to modify functional test behavior (for example, ``DEBUG=True`` changes the content of the 404 page).

Tests are modified so that ``scripts/run_functional_tests.sh`` works against a fully setup local development environment:

* The 404 tests vary based on ``DEBUG``
* The filtered vs unfitted search test was failing against the sample database. Use the size of the search index to vary test behavior.
* The selenium tests run in Docker with ``scripts/run_functional_tests.sh``, against internal URL http://web:8000, but the search results (correctly) return the external URL, http://localhost:8000. Adjust the URLs so that result URLs checks will succeed.
* The revision dashboard "load page 2" tests are failing about 50% of the time with Firefox, and reruns doesn't help. Detect failure with Firefox and XFAIL the test.

More work could be done in the future, such as automatically switching into testing maintenance mode, but this feels like enough for one PR.
