### PR TITLE
Fix Bug 1432370, change instances of Mozilla Developer Network to MDN Web Docs

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -1,6 +1,6 @@
 {
     "name": "Kuma",
-    "description": "The app powering the Mozilla Developer Network (MDN).",
+    "description": "The app powering the MDN Web Docs.",
     "repository": {
         "url": "https://github.com/mozilla/kuma",
         "license": "MPL2",

--- a/contribute.json
+++ b/contribute.json
@@ -1,6 +1,6 @@
 {
     "name": "Kuma",
-    "description": "The app powering the MDN Web Docs.",
+    "description": "The app powering MDN Web Docs.",
     "repository": {
         "url": "https://github.com/mozilla/kuma",
         "license": "MPL2",

--- a/docs/ckeditor.rst
+++ b/docs/ckeditor.rst
@@ -2,7 +2,7 @@
 CKEditor
 ========
 
-The Mozilla Developer Network uses a WYSIWYG editor called CKEditor_.  CKEditor
+MDN Web Docs uses a WYSIWYG editor called CKEditor_.  CKEditor
 is an open source utility which brings the power of rich text editing to the
 web.  This document details how to update CKEditor within the MDN codebase.
 

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -42,12 +42,12 @@
     {% set social_logo = request.build_absolute_uri(static('img/opengraph-logo.png')) %}
     <meta property="og:type" content="website">
     <meta property="og:image" content="{{ social_logo }}">
-    <meta property="og:site_name" content="{{ _('Mozilla Developer Network') }}">
+    <meta property="og:site_name" content="{{ _('MDN Web Docs') }}">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:image" content="{{ social_logo }}">
     <meta name="twitter:site" content="@MozDevNet">
     <meta name="twitter:creator" content="@MozDevNet">
-    <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.LANGUAGE_CODE }}/search/xml" title="{{ _('Mozilla Developer Network') }}">
+    <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.LANGUAGE_CODE }}/search/xml" title="{{ _('MDN Web Docs') }}">
   {% endif %}
 
   <!-- third-generation iPad with high-resolution Retina display: -->

--- a/kuma/landing/jinja2/landing/fellowship.html
+++ b/kuma/landing/jinja2/landing/fellowship.html
@@ -9,7 +9,7 @@
 
 {% block extrahead %}
 
-  {% set seo_description = _('The Mozilla Developer Network (MDN) Fellowship Program invites world-class web developers to come change the world with Mozilla.') %}
+  {% set seo_description = _('The MDN Web Docs Fellowship Program invites world-class web developers to come change the world with Mozilla.') %}
   {% set social_title = 'MDN Fellowship Program' %}
   <meta property="og:description" content="{{ seo_description }}">
   <meta name="description" content="{{ seo_description }}">
@@ -132,7 +132,7 @@
                         <dt>Required skills and experience</dt>
                         <dd>Experienced Web developer with expertise in JavaScript, CSS, HTML and/or other key technologies. Proficient in written and spoken English.</dd>
                         <dt>Mentor information</dt>
-                        <dd>Chris Mills, Senior Technology Writer, Mozilla Developer Network.<br>
+                        <dd>Chris Mills, Senior Technology Writer, MDN Web Docs.<br>
                             GitHub: <a href="https://github.com/ChrisDavidMills">ChrisDavidMills</a><br>
                             Twitter: <a href="https://twitter.com/chrisdavidmills">@chrisdavidmills</a>
                         </dd>

--- a/kuma/landing/jinja2/landing/fellowship.html
+++ b/kuma/landing/jinja2/landing/fellowship.html
@@ -9,7 +9,7 @@
 
 {% block extrahead %}
 
-  {% set seo_description = _('The MDN Web Docs Fellowship Program invites world-class web developers to come change the world with Mozilla.') %}
+  {% set seo_description = _('The Mozilla Developer Network (MDN) Fellowship Program invites world-class web developers to come change the world with Mozilla.') %}
   {% set social_title = 'MDN Fellowship Program' %}
   <meta property="og:description" content="{{ seo_description }}">
   <meta name="description" content="{{ seo_description }}">
@@ -132,7 +132,7 @@
                         <dt>Required skills and experience</dt>
                         <dd>Experienced Web developer with expertise in JavaScript, CSS, HTML and/or other key technologies. Proficient in written and spoken English.</dd>
                         <dt>Mentor information</dt>
-                        <dd>Chris Mills, Senior Technology Writer, MDN Web Docs.<br>
+                        <dd>Chris Mills, Senior Technology Writer, Mozilla Developer Network (MDN).<br>
                             GitHub: <a href="https://github.com/ChrisDavidMills">ChrisDavidMills</a><br>
                             Twitter: <a href="https://twitter.com/chrisdavidmills">@chrisdavidmills</a>
                         </dd>

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -12,8 +12,8 @@
   <meta name="google-site-verification" content="Phj8dHc2oKwic3FGPsKIhdOBk_1wnCTnKwjcjiLgJPc">
   <meta name="google-site-verification" content="TH9rA27HbfjO_XqYWTIPrW1E7E7Dtgsh7ULzHi3UTVA">
 
-  {% set seo_description = _('The Mozilla Developer Network (MDN) provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and HTML5 Apps. It also documents Mozilla products, like Firefox OS.') %}
-  {% set social_title = 'Mozilla Developer Network' %}
+  {% set seo_description = _('MDN Web Docs provides information about Open Web technologies including HTML, CSS, and APIs for both Web sites and HTML5 Apps. It also documents Mozilla products, like Firefox OS.') %}
+  {% set social_title = 'MDN Web Docs' %}
   <meta property="og:description" content="{{ seo_description }}">
   <meta name="description" content="{{ seo_description }}">
   <meta name="twitter:description" content="{{ seo_description }}">

--- a/kuma/search/jinja2/search/plugin.html
+++ b/kuma/search/jinja2/search/plugin.html
@@ -1,8 +1,8 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
                        xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
-<ShortName>{{ _('Mozilla Developer Network') }}</ShortName>
-{# L10n: Search Mozilla Developer Network documentation #}
-<Description>{{ _('Search Mozilla Developer Network documentation') }}</Description>
+<ShortName>{{ _('MDN Web Docs') }}</ShortName>
+{# L10n: Search MDN Web Docs documentation #}
+<Description>{{ _('Search MDN Web Docs documentation') }}</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/png">{{ static('img/favicon32.png') }}</Image>
 <Url type="text/html" method="get" template="{{ url('search', locale=locale)|absolutify }}">

--- a/kuma/search/jinja2/search/plugin.html
+++ b/kuma/search/jinja2/search/plugin.html
@@ -1,8 +1,8 @@
 <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/"
                        xmlns:moz="http:/www.mozilla.org/2006/browser/search/">
 <ShortName>{{ _('MDN Web Docs') }}</ShortName>
-{# L10n: Search MDN Web Docs documentation #}
-<Description>{{ _('Search MDN Web Docs documentation') }}</Description>
+{# L10n: Search MDN Web Docs #}
+<Description>{{ _('Search MDN Web Docs') }}</Description>
 <InputEncoding>UTF-8</InputEncoding>
 <Image width="16" height="16" type="image/png">{{ static('img/favicon32.png') }}</Image>
 <Url type="text/html" method="get" template="{{ url('search', locale=locale)|absolutify }}">

--- a/kuma/static/js/libs/ckeditor/build/ckeditor/samples/old/descriptionlist/descriptionlist.html
+++ b/kuma/static/js/libs/ckeditor/build/ckeditor/samples/old/descriptionlist/descriptionlist.html
@@ -42,7 +42,7 @@
 			<dd>JavaScript provides three different value-comparison operations: strict equality using&nbsp;===&nbsp;and loose equality using&nbsp;==.</dd>
 		</dl>
 
-		<p>Source: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">Mozilla Developer Network</a></p>
+		<p>Source: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">MDN Web Docs</a></p>
 
 	</textarea>
 

--- a/kuma/static/js/libs/ckeditor/source/plugins/descriptionlist/samples/descriptionlist.html
+++ b/kuma/static/js/libs/ckeditor/source/plugins/descriptionlist/samples/descriptionlist.html
@@ -42,7 +42,7 @@
 			<dd>JavaScript provides three different value-comparison operations: strict equality using&nbsp;===&nbsp;and loose equality using&nbsp;==.</dd>
 		</dl>
 
-		<p>Source: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">Mozilla Developer Network</a></p>
+		<p>Source: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript">MDN Web Docs</a></p>
 
 	</textarea>
 

--- a/media/maintenance/index.html
+++ b/media/maintenance/index.html
@@ -2,7 +2,7 @@
 <html lang="en-US" dir="ltr">
     <head>
         <meta charset="utf-8">
-        <title>Mozilla Developer Network</title>
+        <title>MDN Web Docs</title>
         <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet">
         <link rel="shortcut icon" href="/media/maintenance/img/favicon32.png">
         <link rel="stylesheet" href="/media/maintenance/css/maintenance.css">
@@ -33,13 +33,13 @@
         <header>
             <div class="wrap">
                 <a href="//www.mozilla.org" id="tabzilla" data-infobar="update">mozilla</a>
-                <a href="/" class="logo">Mozilla Developer Network</a>
+                <a href="/" class="logo">MDN Web Docs</a>
             </div>
         </header>
 
         <main>
             <div class="wrap">
-                <p>The Mozilla Developer Network (MDN) is currently offline for maintenance, so that we can improve service. Select portions of MDN's content are available from these value-added third party services:</p>
+                <p>MDN Web Docs is currently offline for maintenance, so that we can improve service. Select portions of MDN's content are available from these value-added third party services:</p>
                 <dl>
                     <dt><a href="http://devdocs.io/?ref=mdn">DevDocs</a></dt>
                     <dd>An online tool for browsing copies of various reference documentation, including MDN's</dd>


### PR DESCRIPTION
I did not make the change in the following files as I believe that it will break functionality:

```
kuma/authkeys/jinja2/authkeys/list.html
kuma/users/jinja2/users/user_delete.html
kumascript/tests/fixtures/hacks.rss
```

Also, none of the `.po` files as this will be done by localisers.