### PR TITLE
bug 1434296: Use persistent DB connections

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -57,12 +57,28 @@ ALLOW_ROBOTS = config('ALLOW_ROBOTS', default=False, cast=bool)
 
 MANAGERS = ADMINS
 
+
+# CONN_MAX_AGE: 'persistent' to keep open connection, or max requests before
+# releasing. Default is 0 for a new connection per request.
+def parse_conn_max_age(value):
+    try:
+        return int(value)
+    except ValueError:
+        assert value.lower() == 'persistent', 'Must be int or "persistent"'
+        return None
+
+
+CONN_MAX_AGE = config('CONN_MAX_AGE', default=60,
+                      cast=parse_conn_max_age)
 DEFAULT_DATABASE = config('DATABASE_URL',
                           default='mysql://kuma:kuma@localhost:3306/kuma',
                           cast=dj_database_url.parse)
+
+
 if 'mysql' in DEFAULT_DATABASE['ENGINE']:
     # These are the production settings for OPTIONS.
     DEFAULT_DATABASE.update({
+        'CONN_MAX_AGE': CONN_MAX_AGE,
         'OPTIONS': {
             'charset': 'utf8',
             'use_unicode': True,


### PR DESCRIPTION
Use persistent DB connections by setting ``CONN_MAX_AGE``, defaulting to 60 seconds.

AWS RDS [limits the maximum connections](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ConnectToInstance.html) as a factor of the instance size. Our current instance allows 1320 simultaneous connections. My estimate is that we use 1010 connections, and would be below this limit:

|    Deployment | Pod Count | Per Pod | Total |
| ------------- | --------- | ------- | ----- |
| api           |         2 |       4 |     8 |
| celery-beat   |         1 |       1 |     1 |
| celery-cam    |         1 |       1 |     1 |
| celery-worker |        10 |       4 |    40 |
| kumascript    |         6 |       0 |     0 |
| web           |        20 |       8 |   960 |
| **Total**  |  |  |  1010 |

Another limiting factor is that MySQL will close idle connections, set by [wait_timeout](https://dev.mysql.com/doc/refman/5.7/en/server-system-variables.html#sysvar_wait_timeout). It is currently set to ``28800``, or 8 hours. The ``CONN_MAX_AGE`` should be below this number, and we may want to lower MySQL's ``wait_timeout`` so that idle connections are released sooner. I believe this was much lower in SCL3, based on experience with interactive sessions, which made the default ``CONN_MAX_AGE`` a better choice for that environment.

@jgmize and @metadave may have feedback from an SRE perspective on this change.
