### PR TITLE
bug 1431820: use Django middleware for handling ETag/Last-Modified

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -273,4 +273,3 @@ def test_raw_file_if_modified_since(client, settings, file_attachment):
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']
-    assert 'Vary' not in response

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -5,11 +5,8 @@ from urlparse import urljoin
 import django.middleware.gzip
 from django.conf import settings
 from django.core import urlresolvers
-from django.http import (
-    HttpResponseRedirect,
-    HttpResponseForbidden,
-    HttpResponsePermanentRedirect,
-)
+from django.http import (HttpResponseRedirect, HttpResponseForbidden,
+                         HttpResponsePermanentRedirect)
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from django.contrib.sessions.middleware import SessionMiddleware

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -394,10 +394,10 @@ LOCALE_PATHS = (
 # Last-Modified header). Django's ConditionalGetMiddleware, uses both the ETag
 # and Last-Modified headers to handle conditional GET requests.
 #
-# IMPORTANT NOTE: When we move to Django 1.11, the USE_ETAGS setting is no
-# longer needed, and should be deleted. Django's ConditionalGetMiddleware
-# will take care of both computing/adding the ETag header and handling
-# conditional requests (both only for GET requests).
+# TODO: When moving to Django 1.11, the USE_ETAGS setting is no longer
+#       needed, and should be deleted. Django's ConditionalGetMiddleware
+#       will take care of both computing/adding the ETag header and handling
+#       conditional requests (both only for GET requests).
 USE_ETAGS = True
 
 # Absolute path to the directory that holds media.
@@ -485,7 +485,8 @@ MIDDLEWARE_CLASSES = (
     # LocaleURLMiddleware must be before any middleware that uses
     # kuma.core.urlresolvers.reverse() to add locale prefixes to URLs:
     'kuma.core.middleware.SetRemoteAddrFromForwardedFor',
-    'django.middleware.gzip.GZipMiddleware',
+    # TODO: When moving to Django 1.11, replace with Django's GZipMiddleware.
+    'kuma.core.middleware.GZipMiddleware',
     ('kuma.core.middleware.ForceAnonymousSessionMiddleware'
      if MAINTENANCE_MODE else
      'django.contrib.sessions.middleware.SessionMiddleware'),

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -388,6 +388,18 @@ LOCALE_PATHS = (
     path('locale'),
 )
 
+# When true, Django's CommonMiddleware will compute and add an ETag header
+# to ALL responses, as well as handle conditional GET requests but based soley
+# on the ETag header (it won't handle conditional GET requests based on the
+# Last-Modified header). Django's ConditionalGetMiddleware, uses both the ETag
+# and Last-Modified headers to handle conditional GET requests.
+#
+# IMPORTANT NOTE: When we move to Django 1.11, the USE_ETAGS setting is no
+# longer needed, and should be deleted. Django's ConditionalGetMiddleware
+# will take care of both computing/adding the ETag header and handling
+# conditional requests (both only for GET requests).
+USE_ETAGS = True
+
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"
 MEDIA_ROOT = config('MEDIA_ROOT', default=path('media'))
@@ -482,6 +494,7 @@ MIDDLEWARE_CLASSES = (
     'kuma.wiki.middleware.ReadOnlyMiddleware',
     'kuma.core.middleware.Forbidden403Middleware',
     'ratelimit.middleware.RatelimitMiddleware',
+    'django.middleware.http.ConditionalGetMiddleware',
     'django.middleware.common.CommonMiddleware',
     'kuma.core.middleware.RemoveSlashMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -93,14 +93,6 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
         HTTP_IF_NONE_MATCH=current_etag
     )
     assert response.status_code == 304
-    assert response['Access-Control-Allow-Origin'] == '*'
-    assert 'Vary' not in response
-    assert 'Last-Modified' not in response
-    assert 'ETag' in response
-    assert response['ETag'] == current_etag
-    assert 'Cache-Control' in response
-    assert 'public' in response['Cache-Control']
-    assert 'max-age=86400' in response['Cache-Control']
 
 
 def test_code_sample_host_restriction(code_sample_doc, constance_config,
@@ -111,7 +103,6 @@ def test_code_sample_host_restriction(code_sample_doc, constance_config,
     constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*sampleserver'
     response = client.get(url, HTTP_HOST='testserver')
     assert response.status_code == 403
-    assert 'ETag' not in response
     assert 'Last-Modified' not in response
     assert 'Cache-Control' not in response
     response = client.get(url, HTTP_HOST='sampleserver')

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -85,6 +85,15 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
         % settings.STATIC_URL)
     assert normalized == expected
 
+    # Get the ETag header value when using gzip to test that GZipMiddleware
+    # plays nicely with ConditionalGetMiddleware when making the following
+    # conditional request.
+    response = client.get(
+        url,
+        HTTP_HOST='testserver',
+        HTTP_ACCEPT_ENCODING='gzip',
+    )
+    assert 'ETag' in response
     current_etag = response['ETag']
 
     response = client.get(

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -114,9 +114,9 @@ def test_api_safe(client, section_doc, section_case, if_none_match, method):
 
     headers = {}
     if if_none_match == 'match':
-        headers['HTTP_IF_NONE_MATCH'] = calculate_etag(
+        headers['HTTP_IF_NONE_MATCH'] = '"{}"'.format(calculate_etag(
             section_doc.get_html(section_id)
-        )
+        ))
     elif if_none_match == 'mismatch':
         headers['HTTP_IF_NONE_MATCH'] = 'ABC'
 
@@ -223,9 +223,9 @@ def test_api_put_existing(client, section_doc, authkey, section_case,
 
     headers = dict(HTTP_AUTHORIZATION=authkey.header)
     if if_match == 'match':
-        headers['HTTP_IF_MATCH'] = calculate_etag(
+        headers['HTTP_IF_MATCH'] = '"{}"'.format(calculate_etag(
             section_doc.get_html(section_id)
-        )
+        ))
     elif if_match == 'mismatch':
         headers['HTTP_IF_MATCH'] = 'ABC'
 
@@ -364,8 +364,6 @@ def test_conditional_get(client, root_doc):
     response = client.get(url, HTTP_IF_NONE_MATCH=response['etag'])
 
     assert response.status_code == 304
-    assert 'etag' in response
-    assert 'last-modified' not in response
 
 
 def test_apply_content_experiment_no_experiment(ce_settings, rf):

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -19,8 +19,8 @@ from django.utils.http import parse_etags
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import (etag, require_GET,
-                                          require_http_methods, require_POST)
+from django.views.decorators.http import (require_GET, require_http_methods,
+                                          require_POST)
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from pyquery import PyQuery as pq
 from ratelimit.decorators import ratelimit
@@ -762,17 +762,7 @@ def document(request, document_slug, document_locale):
         }
         response = render(request, 'wiki/document.html', context)
 
-    def get_etag(*args):
-        return calculate_etag(response.content)
-
-    # The etag decorator not only adds the ETag header to the response,
-    # but also handles conditional responses based on the incoming and
-    # outgoing ETag headers.
-    @etag(get_etag)
-    def get_response(request, *args):
-        return _add_kuma_revision_header(doc, response)
-
-    return get_response(request)
+    return _add_kuma_revision_header(doc, response)
 
 
 @csrf_exempt
@@ -800,15 +790,7 @@ def document_api(request, document_slug, document_locale):
 
     section_id = request.GET.get('section', None)
     response = HttpResponse(doc.get_html(section_id))
-
-    def get_etag(*args):
-        return calculate_etag(response.content)
-
-    @etag(get_etag)
-    def get_response(request, *args):
-        return _add_kuma_revision_header(doc, response)
-
-    return get_response(request)
+    return _add_kuma_revision_header(doc, response)
 
 
 def _document_api_PUT(request, document_slug, document_locale):


### PR DESCRIPTION
This PR does the following:

- Sets the `USE_ETAGS` setting to `True`. This enables the `ETag` functionality within Django's `CommonMiddleware`, which includes both computing/adding the `ETag` header to **all** responses (even responses to non-`GET` requests) as well as handling conditional GET requests made using the `IF-NONE-MATCH` header (the `IF-UNMODIFIED-SINCE` header is not handled here). The fact that the `ETag` header is added to **all** responses is a shortcoming of Django 1.8. Another shortcoming is that 304 ("Not Modified") responses due to an `ETag` match clear most of the headers, so headers like `Cache-Control`, `ETag`, `Last-Modified`, and `Vary` are lost. I don't think this will cause any issues, but I'm not certain. **When we move to Django 1.11, the `USE_ETAGS` setting should be deleted, and this deprecated functionality within `CommonMiddleware` will no longer be used.**

- Adds Django's `ConditionalGetMiddleware` to the list of `MIDDLEWARE_CLASSES`. In Django 1.8, this adds handling of the `IF-NONE-MATCH` and `IF-UNMODIFIED-SINCE` headers, but does not actually generate and add the `ETag` header to the response (that's done by `CommonMiddleware` as explained above). When we move to Django 1.11, this middleware will assume full responsibility for generating/handling the `ETag`, and will be free of the shortcomings mentioned in the first point above (properly preserving some headers for 304 responses, and only generating/handling `ETag` headers for GET requests).

- Removes the few `last_modified` and `etag` view decorators that were used. The `etag` decorator is fully replaced by the middleware above (but of course still valid and available for those endpoints that have a faster way to generate the `ETag` value), while the `ConditionalGetMiddleware` only replaces the conditional handling portion of the `last_modified` decorator (the `Last-Modified` header must still be generated and added to the response by an endpoint).

- Removes header checks in tests for 304 responses due to an `ETag` match (see first point above).