### PR TITLE
bug 1385405: Fix tox -e locales for submodule

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -30,15 +30,16 @@ whitelist_externals =
     cat
     docker-compose
     git
+changedir = locale
 setenv =
-    COMPOSE_FILE = docker-compose.yml:docker-compose.test.yml
+    COMPOSE_FILE = {toxinidir}/docker-compose.yml:{toxinidir}/docker-compose.test.yml
     COMPOSE_PROJECT_NAME = localetox
     GIT_PAGER = cat
 # Test that locales are refreshed w/o error,
 # then display diff only if messages changed
 commands =
     docker-compose run noext make localerefresh
-    git diff -G "^msgid " locale/templates/LC_MESSAGES
+    git diff -G "^msgid " templates/LC_MESSAGES
 
 [testenv:docker]
 whitelist_externals = docker-compose


### PR DESCRIPTION
The "git diff" command needs to run inside the locale submodule directory, or it won't see any differences.