### PR TITLE
fix bug 1419466 - added jinja2 extension of translating the 404 page

### DIFF
--- a/jinja2/404.html
+++ b/jinja2/404.html
@@ -10,7 +10,7 @@
 <section id="content">
   <div class="wrap">
   <section id="content-main" class="full" role="main">
-    <h1>Not Found</h1>
+    <h1>{{_('Not Found')}}</h1>
     <div id="beastainer">
       <img id="beast404le" src="{{ static('img/beast-404_LE.png') }}" alt="">
       <img id="beast404re" src="{{ static('img/beast-404_RE.png') }}" alt="">

--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -13,7 +13,7 @@
 
   <section id="content-main" class="full" role="main">
 
-    <h1 class="page-title">Internal Server Error</h1>
+    <h1 class="page-title">{{_('Internal Server Error')}}</h1>
 
     <img src="{{ static('img/beast-500.png') }}" alt="" class="beast 500">
 


### PR DESCRIPTION
This commit adds the extension of jinja2 for translating the "Not Found" in the jinja2/404.html file and in the jinja2/500.html page