### PR TITLE
Fix Bug 1436666, Firefox for android shown as ie for android

### DIFF
--- a/kuma/static/styles/components/compat-tables/bc-browser.scss
+++ b/kuma/static/styles/components/compat-tables/bc-browser.scss
@@ -40,7 +40,7 @@ Icons in mobile view
     }
 
     .bc-browser-firefox_android:before {
-        content: '\e901\0020\f17b';
+        content: '\f17b\0020\e901';
     }
 
     .bc-browser-edge:before {

--- a/kuma/static/styles/components/compat-tables/bc-browser.scss
+++ b/kuma/static/styles/components/compat-tables/bc-browser.scss
@@ -36,7 +36,7 @@ Icons in mobile view
     }
 
     .bc-browser-firefox:before {
-        content: '\e956\0020\eae6';
+        content: '\e956\0020\e901';
     }
 
     .bc-browser-firefox_android:before {

--- a/kuma/static/styles/components/compat-tables/bc-browser.scss
+++ b/kuma/static/styles/components/compat-tables/bc-browser.scss
@@ -40,7 +40,7 @@ Icons in mobile view
     }
 
     .bc-browser-firefox_android:before {
-        content: '\f17b\0020\eae6';
+        content: '\e901\0020\f17b';
     }
 
     .bc-browser-edge:before {


### PR DESCRIPTION
Shows correct icon for Firefox for Android on mobile view.