### PR TITLE
[Bug 1437022] Tags dont get updated after document edit

### DIFF
--- a/kuma/wiki/apps.py
+++ b/kuma/wiki/apps.py
@@ -114,7 +114,7 @@ class WikiConfig(AppConfig):
         invalidate_nearest_zone_cache(instance.pk, async=async)
 
         DocumentContributorsJob().invalidate(instance.pk)
-        DocumentTagsJob().invalidate(instance.pk)
+        DocumentTagsJob().invalidate(pk=instance.pk)
 
         code_sample_job = DocumentCodeSampleJob(generation_args=[instance.pk])
         code_sample_job.invalidate_generation()

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -137,9 +137,7 @@ class DocumentTagsJob(KumaJob):
     Longer lifetime as tags are rarely modified
     """
 
-    # A wiki document can be updated with a short interval
-    # So task for refreshing tags should be created always
-    refresh_timeout = 0
+    refresh_timeout = 180
 
     @property
     def lifetime(self):

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -136,7 +136,10 @@ class DocumentTagsJob(KumaJob):
     We invalidate this when a document is saved only.
     Longer lifetime as tags are rarely modified
     """
-    refresh_timeout = 180
+
+    # A wiki document can be updated with a short interval
+    # So task for refreshing tags should be created always
+    refresh_timeout = 0
 
     @property
     def lifetime(self):
@@ -149,5 +152,6 @@ class DocumentTagsJob(KumaJob):
     def fetch(self, pk):
         from .models import Document
 
-        tags = Document.objects.filter(id=pk).values_list('tags__name', flat=True).order_by('tags__name')
+        tags = (Document.objects.filter(id=pk).exclude(tags__name=None)
+                                .values_list('tags__name', flat=True).order_by('tags__name'))
         return list(tags)

--- a/kuma/wiki/tests/test_signals.py
+++ b/kuma/wiki/tests/test_signals.py
@@ -1,0 +1,21 @@
+import pytest
+
+from kuma.wiki.models import Revision, Document
+
+
+@pytest.mark.tags
+def test_document_tags_cache_invalidated_correctly(root_doc, wiki_user):
+
+    tags1 = ('JavaScript', 'AJAX', 'DOM')
+    Revision.objects.create(document=root_doc, tags=','.join(tags1), creator=wiki_user)
+
+    # cache the tags of the document and check its the tag that we created and it is sorted
+    assert sorted(tags1) == root_doc.all_tags_name
+
+    # Create another revision with some other tags and check tags get invalidate and get updated
+    tags2 = ('foo', 'bar')
+    Revision.objects.create(document=root_doc, tags=','.join(tags2), creator=wiki_user)
+
+    doc = Document.objects.get(id=root_doc.id)
+
+    assert sorted(tags2) == doc.all_tags_name

--- a/kuma/wiki/tests/test_signals.py
+++ b/kuma/wiki/tests/test_signals.py
@@ -4,7 +4,7 @@ from kuma.wiki.models import Revision, Document
 
 
 @pytest.mark.tags
-def test_document_tags_cache_invalidated_correctly(root_doc, wiki_user):
+def test_on_document_save_signal_invalidated_tags_cache(root_doc, wiki_user):
 
     tags1 = ('JavaScript', 'AJAX', 'DOM')
     Revision.objects.create(document=root_doc, tags=','.join(tags1), creator=wiki_user)

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -577,3 +577,17 @@ def test_tags_show_in_document(root_doc, client, wiki_user):
     assert len(response_tags) == len(tags)
     # The response tags should be sorted
     assert response_tags == sorted(tags)
+
+
+@pytest.mark.tags
+def test_tags_not_show_while_empty(root_doc, client, wiki_user):
+    # Create a revision with no tags
+    Revision.objects.create(document=root_doc, tags=','.join([]), creator=wiki_user)
+
+    response = client.get(root_doc.get_absolute_url())
+    assert response.status_code == 200
+
+    page = pq(response.content)
+    response_tags = page.find('.tags li a').contents()
+    # There should be no tag
+    assert len(response_tags) == 0


### PR DESCRIPTION
There was some mistry in hashing the key of cache.
While creating the cache, the `pk` was explictly defined. So it was regarded as `kwargs`.
But while invalidating the cache, the `pk` was not explictly defined, so it was regarded as `args`

`django-cacheback` generate the cache key by hashing the parameters. But it hash differently while having `args` and `kwargs`.
As there were different hash while storing and invalidating, the old `tags` were not removed and kept serving.

Moreover, if the document has no tags, it was showing `None`. Fixed that also by excluding the `None`.

And the `refresh_timeout` need to be `0` because a document can be update continuously. So if we dont create task for every revision, updated tags will be missing.

Moreover, added some tests for this regression to not happen in future.

@jwhitlock @escattone r?