### PR TITLE
bug 1399639: Make requirements more complex, upgrade django-tidings

### DIFF
--- a/requirements/README.rst
+++ b/requirements/README.rst
@@ -11,6 +11,15 @@ Kuma.  The files are:
 * ``test.txt`` - Requirements to run functional tests.
 * ``travis.txt`` - Requirements for testing in TravisCI.
 
+These files have two audiences:
+
+* **Computers** need to know what packages to install. We use exact versions
+  and hashes to ensure each environment installs the same packages.
+* **Developers** need to integrate and update packages. Often, these tasks
+  include reading documentation and source code.  We organize packages by task,
+  split primary packages from support packages, and include URLs to get more
+  information.
+
 Hash-Checking Mode
 ------------------
 For the production and development requirements, we use pip 8.x's
@@ -32,6 +41,38 @@ Or, to update to the latest version of a package::
 It is still up to you to install the requirements, and to specify any
 requirements of your requirements, in ``constraints.txt``.
 
+Requirements format
+-------------------
+Requirements files should include a summary explaining why a requirement
+is used, and URLs for more information. For example::
+
+    # Refresh stale cache items asynchronously
+    # Code: https://github.com/codeinthehole/django-cacheback
+    # Changes: https://github.com/codeinthehole/django-cacheback/blob/master/CHANGELOG.rst
+    # Docs: http://django-cacheback.readthedocs.io/en/latest/
+    django-cacheback==1.0 \
+        --hash=sha256:8feaa8df6cbe23e1fca5d858f518a235442a8ddc4aefb5be0846692c69d65a8e \
+        --hash=sha256:2fc21e0ed78ee8e4cc07ac2c5936b27f956c99c81fc4f965e96fb27171180819
+
+The purpose of the comment is:
+
+* Summarize the purpose of the requirement, to save an internet search.
+* Describe how the requirement is used in Kuma.
+* Help the maintainer to prioritize upgrading requirements.
+* Give a hint on exploratory tests to ensure upgrades do not break things.
+
+The additional links (which we started adding in 2018) help maintainers dive
+deeper. When possible, include the links to:
+
+* **Code**, such as the main Github repository.
+* **Changes**, such as a documentation page or file in the repo that says what
+  changes with each release. Use ``Changes`` for the key, even when the project
+  calls it something else, like changelog or release notes.
+* **Docs**, such as documentation hosted on ReadTheDocs. If the README on the
+  GitHub repository is the only documentation, this can be skipped.
+
+Within a requirements file, requirements should be alphabetical.
+
 Constraints
 -----------
 ``constraints.txt`` contains requirements of requirements, using pip 7.1's
@@ -41,12 +82,22 @@ libraries are not installed. It also helps separate the requirements we need
 from the ones we are using indirectly.
 
 This file requires hashes. The format is to group requirements by the package
-that requires them, and then alphabetically, such as::
+that requires them, and then alphabetically with links, such as::
 
+    #
     # mock
+    #
+    # Backport of function signature features from Python 3.3's inspect
+    # Code: https://github.com/aliles/funcsigs
+    # Changes: https://github.com/aliles/funcsigs/blob/master/CHANGELOG
+    # Docs: http://funcsigs.readthedocs.io/en/latest/
     funcsigs==0.4 \
         --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
         --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
+    # Automation for setuptools
+    # Code: https://github.com/openstack-dev/pbr
+    # Changes: https://docs.openstack.org/pbr/latest/user/history.html
+    # Docs: https://docs.openstack.org/pbr/latest/
     pbr==1.8.1 \
         --hash=sha256:46c8db75ae75a056bd1cc07fa21734fe2e603d11a07833ecc1eeb74c35c72e0c \
         --hash=sha256:e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649
@@ -61,24 +112,6 @@ or indirectly.
 For packages that are both dependencies and used directly, it's up to the
 developer to determine where it goes. The only rule is to not break production
 or deployment. Use comments to justify placement as needed.
-
-Requirements format
--------------------
-Other requirements files (not ``constraints.txt``) should include a short comment
-explaining why a requirement is used. For example::
-
-    # Refresh stale cache items asynchronously
-    django-cacheback==1.1 \
-        --hash=sha256:ba7dc1525de6b6f44d13f6e5b6b93ca7a9ef0ca560315872fe40f044b7b59e95
-
-The purpose of the comment is:
-
-* Summarize the purpose of the requirement, to save an internet search.
-* Describe how the requirement is used in Kuma.
-* Help maintainer to prioritize upgrading requirements.
-* Give a hint on exploratory tests needed to ensure upgrades do not break things.
-
-Within a requirements file, requirements should be alphabetical.
 
 Testing new requirements in Docker
 ----------------------------------
@@ -102,6 +135,7 @@ branch, run::
 
 Future
 ------
+* Add ``Code``, ``Changes``, and ``Docs`` links to existing requirements
 * Remove unused requirements, and refactor code to eliminate unmaintained
   requirements.
 * Requirements files may be further split into roles, so that there are minimal

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -215,10 +215,21 @@ greenlet==0.4.12 \
     --hash=sha256:b56ac981f07b77e72ad5154278b93396d706572ea52c2fce79fee2abfcc8bfa6 \
     --hash=sha256:e4c99c6010a5d153d481fdaf63b8a0782825c0721506d880403a3b9b82ae347e
 
+
+#
 # mock
+#
+# Backport of function signature features from Python 3.3's inspect
+# Code: https://github.com/aliles/funcsigs
+# Changes: https://github.com/aliles/funcsigs/blob/master/CHANGELOG
+# Docs: http://funcsigs.readthedocs.io/en/latest/
 funcsigs==0.4 \
     --hash=sha256:ff5ad9e2f8d9e5d1e8bbfbcf47722ab527cf0d51caeeed9da6d0f40799383fde \
     --hash=sha256:d83ce6df0b0ea6618700fe1db353526391a8a3ada1b7aba52fed7a61da772033
+# Automation for setuptools
+# Code: https://github.com/openstack-dev/pbr
+# Changes: https://docs.openstack.org/pbr/latest/user/history.html
+# Docs: https://docs.openstack.org/pbr/latest/
 pbr==1.8.1 \
     --hash=sha256:46c8db75ae75a056bd1cc07fa21734fe2e603d11a07833ecc1eeb74c35c72e0c \
     --hash=sha256:e2127626a91e6c885db89668976db31020f0af2da728924b56480fc7ccf09649

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -139,9 +139,12 @@ django-taggit==0.21.6 \
     --hash=sha256:80e22fdf41fba66a3c6f4807e283f38c4557838e35766a942370fb90f21d7435
 
 # Send async emails in response to events
-django-tidings==1.1 \
-    --hash=sha256:d5047c39bf2e1d1d4dcdfd28371e3ab354ba6c26168ff11baac9d20409a804d9 \
-    --hash=sha256:8bf9f1684568095cc0719c2eadd652bd3030f45e98ac0720f70c5a38a459125e
+# Code: https://github.com/mozilla/django-tidings
+# Changes: http://django-tidings.readthedocs.io/en/latest/changes.html
+# Docs: http://django-tidings.readthedocs.io/en/latest/
+django-tidings==2.0 \
+    --hash=sha256:2f1eb0b0e8de80489ffd24f5f70769c8cbfb9144a704d7c987287563cd53312a \
+    --hash=sha256:53da182690636a4521bd5c946e882d03d0abfc86b921f63e0139f99d9fd78def
 
 # Support segmented user experiences
 django-waffle==0.11 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -32,6 +32,9 @@ django-allauth==0.33.0 \
     --hash=sha256:ae64a80b49707c3d4d6aff52424f8e75fd636cebfdce0e88ffdcbf306f9f0a3d
 
 # Refresh stale cache items asynchronously
+# Code: https://github.com/codeinthehole/django-cacheback
+# Changes: https://github.com/codeinthehole/django-cacheback/blob/master/CHANGELOG.rst
+# Docs: http://django-cacheback.readthedocs.io/en/latest/
 django-cacheback==1.0 \
     --hash=sha256:8feaa8df6cbe23e1fca5d858f518a235442a8ddc4aefb5be0846692c69d65a8e \
     --hash=sha256:2fc21e0ed78ee8e4cc07ac2c5936b27f956c99c81fc4f965e96fb27171180819


### PR DESCRIPTION
* Add a section explaining why our requirements are complex
* Make them more complex by adding URLs for code, docs, and changes.
* Swap regular requirements and constraints sections
* Update [django-tidings](https://github.com/mozilla/django-tidings) from [1.1 to 2.0](http://django-tidings.readthedocs.io/en/latest/changes.html), which includes support for Django 1.11 and beyond. 

I tested this locally by adding a watch and unsubscribing, but didn't send a watch email, which requires a second user. I think this can wait for staging, where I'm subscribed to [Ryan's test page](https://stage.mdn.moz.works/en-US/docs/Web/HTTP/ryanHeader).