### PR TITLE
bug 1406546: Override kubectl for standby cluster

### DIFF
--- a/Jenkinsfiles/push.groovy
+++ b/Jenkinsfiles/push.groovy
@@ -14,12 +14,18 @@ stage("Prepare Infra") {
 }
 
 stage('Push') {
+    def kubectl = "kubectl"
+    if (config.env && config.env.kubectl) {
+        kubectl = config.env.kubectl
+    }
     dir('infra/apps/mdn/mdn-aws/k8s') {
-        // Run the database migrations.
-        utils.migrate_db()
-        // Start a rolling update of the Kuma-based deployments.
-        utils.rollout()
-        // Monitor the rollout until it has completed.
-        utils.monitor_rollout()
+        withEnv(["KUBECTL=${kubectl}"]) {
+            // Run the database migrations.
+            utils.migrate_db()
+            // Start a rolling update of the Kuma-based deployments.
+            utils.rollout()
+            // Monitor the rollout until it has completed.
+            utils.monitor_rollout()
+        }
     }
 }

--- a/Jenkinsfiles/standby-push.yml
+++ b/Jenkinsfiles/standby-push.yml
@@ -1,3 +1,5 @@
 pipeline:
   enabled: true
   script: "push"
+env:
+  kubectl: "kubectl188"


### PR DESCRIPTION
The standby cluster runs Kubernetes 1.9, and kubectl 1.6 is having issues talking to it. This uses kubectl 1.8 for pushes to that cluster.