### PR TITLE
bug 1439608: Update bugzilla links

### DIFF
--- a/kuma/authkeys/jinja2/authkeys/list.html
+++ b/kuma/authkeys/jinja2/authkeys/list.html
@@ -32,7 +32,7 @@
 {% endif %}
 
 {% else %}
-<p>{% trans bugzilla_url="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=Mozilla Developer Network&component=User management" %}
+<p>{% trans bugzilla_url="https://bugzilla.mozilla.org/enter_bug.cgi?format=__standard__&product=developer.mozilla.org&component=User management" %}
   You need a special permission to use API keys.
   You may request permission by <a href="{{ bugzilla_url }}">filing a bug</a>.
 {% endtrans %}

--- a/kuma/users/jinja2/users/user_delete.html
+++ b/kuma/users/jinja2/users/user_delete.html
@@ -48,7 +48,7 @@
             <input type="hidden" name="bug_status" value="NEW">
             <input type="hidden" name="component" value="User management">
             <input type="hidden" name="form_name" value="enter_bug">
-            <input type="hidden" name="product" value="Mozilla Developer Network">
+            <input type="hidden" name="product" value="developer.mozilla.org">
             <input type="hidden" name="format" value="__standard__">
             <input type="hidden" name="status_whiteboard" value="[account-mod]">
 


### PR DESCRIPTION
Update links for product name change from "Mozilla Developer Network" to
[developer.mozilla.org](https://bugzilla.mozilla.org/describecomponents.cgi?product=developer.mozilla.org).