### PR TITLE
bug 1399639: Update requests

### DIFF
--- a/requirements/README.rst
+++ b/requirements/README.rst
@@ -6,6 +6,7 @@ Kuma.  The files are:
 
 * ``constraints.txt`` - Requirements for our requirements.
 * ``default.txt`` - Requirements for production and deployment.
+* ``default_and_test.txt`` - Requirements production, deployment, and test.
 * ``docs.txt`` - Requirements for building docs in `Read the Docs`_.
 * ``dev.txt`` - Requirements for Docker or native development.
 * ``test.txt`` - Requirements to run functional tests.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -350,6 +350,28 @@ execnet==1.4.1 \
 contextlib2==0.5.1 \
     --hash=sha256:227c79e126e8a8904a81d162750581ed3d49af2395a3100be7067b7296d33d45
 
+#
+# requests
+#
+# Mozilla's CA bundle
+# Code: https://github.com/certifi/python-certifi
+certifi==2018.1.18 \
+    --hash=sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296 \
+    --hash=sha256:ledbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d
+# Character encoding detector
+# Code: https://github.com/chardet/chardet
+# Docs: https://chardet.readthedocs.io/en/latest/
+chardet==3.0.4 \
+    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
+    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
+# Support for i18n domain names, IDNA 2008
+# Code: https://github.com/kjd/idna
+# Changes: https://github.com/kjd/idna/blob/master/HISTORY.rst
+idna==2.6 \
+    --hash=sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4 \
+    --hash=sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f
+
+
 # tox
 virtualenv==15.0.1 \
     --hash=sha256:13ce1079910a6bc60e2ce1d79813a99f30b2fd1e571427fcde1fabb0ff4c436c \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -2,6 +2,7 @@
 # environments
 
 -c constraints.txt
+-r default_and_test.txt
 
 # Sanitize HTML with a whitelist
 bleach==2.1.1 \
@@ -220,12 +221,6 @@ puente==0.4.1 \
     --hash=sha256:bc5ee85521127577d23430832e2f827686efdb7ce95b232f54fbeb5b9166397c \
     --hash=sha256:84f769c0ea607829c77bd8b3d6d6fbc16589cd7a5d4e5023f717cd3d5de54473
 
-# Parse HTML with CSS selectors like jquery, in prod and in tests
-# TODO: Sync version with test.txt
-pyquery==1.2.11 \
-    --hash=sha256:c5e7d7af031f5f4cc98949ff4f8a318956c72741b4075c41022b12d01f118612 \
-    --hash=sha256:4a832ba73bfba03486f5445c75993a26bf62d38d26ff5fcfbde06a7bd0087fc6
-
 # Translate environment variables into native Python types
 python-decouple==3.0 \
     --hash=sha256:99834c9ff7ce5c5b2f4a18bc0880753e54ea3aaabc3cfb16961a92d5046665df
@@ -248,12 +243,6 @@ raven==6.2.1 \
 redis==2.10.5 \
     --hash=sha256:97156b37d7cda4e7d8658be1148c983984e1a975090ba458cc7e244025191dbd \
     --hash=sha256:5dfbae6acfc54edf0a7a415b99e0b21c0a3c27a7f787b292eea727b1facc5533
-
-# Better HTTP requests
-# TODO: Sync version with test.txt
-requests==2.9.1 \
-    --hash=sha256:113fbba5531a9e34945b7d36b33a084e8ba5d0664b703c81a7c572d91919a5b8 \
-    --hash=sha256:c577815dd00f1394203fc44eb979724b098f88264a9ef898ee45b8e5e9cf587f
 
 # Mock HTTP requests for tests
 requests-mock==0.7.0 \

--- a/requirements/default_and_test.txt
+++ b/requirements/default_and_test.txt
@@ -14,6 +14,6 @@ pyquery==1.2.11 \
 # Code: https://github.com/requests/requests
 # Changes: https://github.com/requests/requests/blob/master/HISTORY.rst
 # Docs: http://docs.python-requests.org/en/master/
-requests==2.11.1 \
-    --hash=sha256:545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e \
-    --hash=sha256:5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133
+requests==2.18.4 \
+    --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \
+    --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e

--- a/requirements/default_and_test.txt
+++ b/requirements/default_and_test.txt
@@ -1,0 +1,19 @@
+# Requirements shared between default (runtime) and test environments
+
+-c constraints.txt
+
+# Parse HTML with CSS selectors like jquery
+# Code: https://github.com/gawel/pyquery
+# Changes: https://github.com/gawel/pyquery/blob/master/CHANGES.rst
+pyquery==1.2.11 \
+    --hash=sha256:c5e7d7af031f5f4cc98949ff4f8a318956c72741b4075c41022b12d01f118612 \
+    --hash=sha256:4a832ba73bfba03486f5445c75993a26bf62d38d26ff5fcfbde06a7bd0087fc6
+
+# Better HTTP requests. Used to talk to GitHub, KumaScript, Akismet.
+# Used by the scraper and headless tests.
+# Code: https://github.com/requests/requests
+# Changes: https://github.com/requests/requests/blob/master/HISTORY.rst
+# Docs: http://docs.python-requests.org/en/master/
+requests==2.11.1 \
+    --hash=sha256:545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e \
+    --hash=sha256:5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,7 @@
 # Requirements to run functional tests
 
 -c constraints.txt
+-r default_and_test.txt
 
 # Implement bash brace expansion
 braceexpand==0.1.1 \
@@ -11,11 +12,6 @@ PyPOM==1.0 \
     --hash=sha256:a8728981970404c3c9a14efeb23da92191749a4a4ad489130fd855e4cf8f154e \
     --hash=sha256:5c98e3d8ef2c7f96c3365a3b8295560446f2447eecdcfe393a30abf2fcc16d96
 
-# Parse HTML with CSS selectors like jquery
-# TODO: Sync version with default.txt
-pyquery==1.2.11 \
-    --hash=sha256:c5e7d7af031f5f4cc98949ff4f8a318956c72741b4075c41022b12d01f118612 \
-    --hash=sha256:4a832ba73bfba03486f5445c75993a26bf62d38d26ff5fcfbde06a7bd0087fc6
 
 # Test plugin: Re-run flaky tests
 pytest-rerunfailures==2.1.0 \
@@ -24,8 +20,8 @@ pytest-rerunfailures==2.1.0 \
 
 # Test plugin: Run tests with selenium
 # Code: https://github.com/pytest-dev/pytest-selenium
+# Changes: http://pytest-selenium.readthedocs.io/en/latest/news.html
 # Docs: http://pytest-selenium.readthedocs.io/en/latest/index.html
-# Release Notes: http://pytest-selenium.readthedocs.io/en/latest/news.html
 pytest-selenium==1.11.4 \
     --hash=sha256:b66651fe7cbeee02b511f7b59f250ca77fcdb6024f193ca10da27d1d91240688 \
     --hash=sha256:9a0c48c434b538387ed6fa9d0c2f0b2e32f4fb71a4c41754df49be0aa4c64ae1
@@ -34,8 +30,3 @@ pytest-selenium==1.11.4 \
 pytest-xdist==1.16.0 \
     --hash=sha256:42e5a1e5da9d7cff3e74b07f8692598382f95624f234ff7e00a3b1237e0feba2
 
-# Better HTTP requests
-# TODO: Sync with default.txt
-requests==2.11.1 \
-    --hash=sha256:545c4855cd9d7c12671444326337013766f4eea6068c3f0307fb2dc2696d580e \
-    --hash=sha256:5acf980358283faba0b897c73959cecf8b841205bb4b2ad3ef545f46eae1a133


### PR DESCRIPTION
Move ``pyquery`` and ``requests`` to the new file ``default_and_test.txt``, so that I don't rely on a ``TODO`` to keep the library versions in sync between environments.

Update ``requests`` from 2.9.1 (production) and 2.11.1 (tests) to 2.18.4, along with the new requirements in ``constraints.txt``. Our usage of ``requests`` is pretty basic, so I don't expect problems with this update. Unlike the ``pytest`` and ``pyquery`` updates, which I also tried, which broke so much...