### PR TITLE
bug 1431259: caching headers/tests for dashboards views

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -24,6 +24,24 @@ def wiki_user(db, django_user_model):
 
 
 @pytest.fixture
+def wiki_user_2(db, django_user_model):
+    """A second test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_2',
+        email='wiki_user_2@example.com',
+        date_joined=datetime(2017, 4, 17, 10, 30))
+
+
+@pytest.fixture
+def wiki_user_3(db, django_user_model):
+    """A third test user."""
+    return django_user_model.objects.create(
+        username='wiki_user_3',
+        email='wiki_user_3@example.com',
+        date_joined=datetime(2017, 4, 23, 11, 45))
+
+
+@pytest.fixture
 def user_client(client, wiki_user):
     wiki_user.set_password('password')
     wiki_user.save()

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -211,7 +211,6 @@ def test_ratelimit_429(client, db):
     assert response.status_code == 429
     assert '429.html' in [t.name for t in response.templates]
     assert response['Retry-After'] == '60'
-    assert 'Cache-Control' in response
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']
     assert 'max-age=0' in response['Cache-Control']

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -211,4 +211,8 @@ def test_ratelimit_429(client, db):
     assert response.status_code == 429
     assert '429.html' in [t.name for t in response.templates]
     assert response['Retry-After'] == '60'
-    assert response['Cache-Control'] == 'no-cache, no-store, must-revalidate'
+    assert 'Cache-Control' in response
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']

--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -1,10 +1,9 @@
 from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-
-from .decorators import never_cache
 
 
 def _error_page(request, status):

--- a/kuma/dashboards/urls.py
+++ b/kuma/dashboards/urls.py
@@ -2,6 +2,7 @@ from django.conf.urls import url
 from django.views.generic.base import RedirectView
 
 from . import views
+from kuma.core.decorators import shared_cache_control
 
 
 urlpatterns = [
@@ -15,10 +16,10 @@ urlpatterns = [
         views.topic_lookup,
         name='dashboards.topic_lookup'),
     url(r'^dashboards/localization$',
-        RedirectView.as_view(
+        shared_cache_control(RedirectView.as_view(
             url='/docs/MDN/Doc_status/Overview',
             permanent=True,
-        )),
+        ))),
     url(r'^dashboards/spam$',
         views.spam,
         name='dashboards.spam'),

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -8,19 +8,24 @@ from django.db.models import Prefetch
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.utils import timezone
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_GET
+from django.views.decorators.vary import vary_on_headers
 import waffle
 
 from kuma.core.decorators import login_required
+from kuma.core.decorators import shared_cache_control
 from kuma.core.utils import paginate
-from kuma.wiki.models import Document, Revision
 from kuma.wiki.kumascript import macro_usage
+from kuma.wiki.models import Document, Revision
 
+from . import PAGE_SIZE
 from .forms import RevisionDashboardForm
 from .jobs import SpamDashboardHistoricalStats
-from . import PAGE_SIZE
 
 
+@shared_cache_control
+@vary_on_headers('X-Requested-With')
 @require_GET
 def revisions(request):
     """Dashboard for reviewing revisions"""
@@ -128,6 +133,8 @@ def revisions(request):
     return render(request, template, context)
 
 
+@shared_cache_control
+@vary_on_headers('X-Requested-With')
 @require_GET
 def user_lookup(request):
     """Returns partial username matches"""
@@ -146,6 +153,8 @@ def user_lookup(request):
     return HttpResponse(data, content_type='application/json; charset=utf-8')
 
 
+@shared_cache_control
+@vary_on_headers('X-Requested-With')
 @require_GET
 def topic_lookup(request):
     """Returns partial topic matches"""
@@ -163,6 +172,7 @@ def topic_lookup(request):
                         content_type='application/json; charset=utf-8')
 
 
+@never_cache
 @require_GET
 @login_required
 @permission_required((
@@ -182,6 +192,7 @@ def spam(request):
     return render(request, 'dashboards/spam.html', data)
 
 
+@shared_cache_control
 @require_GET
 def macros(request):
     """Returns table of active macros and their page counts."""

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1741,3 +1741,7 @@ with open(ce_path, 'r') as ce_file:
 RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=True, cast=bool)
 RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='memcache')
 RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
+
+# Caching constants for the Cache-Control header.
+CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE = config(
+    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 5, cast=int)

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,8 +1,8 @@
+from datetime import datetime, timedelta
 import collections
 import json
 import operator
 import uuid
-from datetime import datetime, timedelta
 
 from allauth.account.adapter import get_adapter
 from allauth.account.models import EmailAddress
@@ -24,19 +24,19 @@ from django.db.models import Q
 from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
-from django.views.decorators.http import require_POST
-from django.views.generic import TemplateView
 from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 from django.utils.http import urlsafe_base64_decode
+from django.views.decorators.cache import never_cache
+from django.views.decorators.http import require_POST
+from django.views.generic import TemplateView
 from honeypot.decorators import verify_honeypot_value
 from taggit.utils import parse_tags
 
-
-from kuma.core.decorators import (
-    login_required, never_cache, redirect_in_maintenance_mode)
+from kuma.core.decorators import login_required, redirect_in_maintenance_mode
 from kuma.wiki.forms import RevisionAkismetSubmissionSpamForm
-from kuma.wiki.models import Document, DocumentDeletionLog, Revision, RevisionAkismetSubmission
+from kuma.wiki.models import (Document, DocumentDeletionLog, Revision,
+                              RevisionAkismetSubmission)
 
 from .forms import UserBanForm, UserEditForm, UserRecoveryEmailForm
 from .models import User, UserBan

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -21,24 +21,6 @@ KumaScriptToolbox = namedtuple(
 
 
 @pytest.fixture
-def wiki_user_2(db, django_user_model):
-    """A second test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_2',
-        email='wiki_user_2@example.com',
-        date_joined=datetime(2017, 4, 17, 10, 30))
-
-
-@pytest.fixture
-def wiki_user_3(db, django_user_model):
-    """A third test user."""
-    return django_user_model.objects.create(
-        username='wiki_user_3',
-        email='wiki_user_3@example.com',
-        date_joined=datetime(2017, 4, 23, 11, 45))
-
-
-@pytest.fixture
 def inactive_wiki_user(db, django_user_model):
     """An inactive test user."""
     return django_user_model.objects.create(

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -3,9 +3,10 @@ import newrelic.agent
 
 from constance import config
 from django.shortcuts import render, redirect
+from django.views.decorators.cache import never_cache
 
 from kuma.attachments.forms import AttachmentRevisionForm
-from kuma.core.decorators import never_cache, login_required, block_user_agents
+from kuma.core.decorators import block_user_agents, login_required
 from kuma.core.urlresolvers import reverse
 
 from ..constants import DEV_DOC_REQUEST_FORM, REVIEW_FLAG_TAGS_DEFAULT

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
+from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_http_methods
 from ratelimit.decorators import ratelimit
@@ -15,7 +16,7 @@ from ratelimit.decorators import ratelimit
 import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
 from kuma.core.decorators import (block_banned_ips, block_user_agents,
-                                  login_required, never_cache)
+                                  login_required)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -1,18 +1,20 @@
 # -*- coding: utf-8 -*-
+from urllib import urlencode
+
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
-from urllib import urlencode
+from django.views.decorators.cache import never_cache
 
-import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
-from kuma.core.decorators import block_user_agents, login_required, never_cache
+from kuma.core.decorators import block_user_agents, login_required
 from kuma.core.i18n import get_language_mapping
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import get_object_or_none, smart_int, urlparams
+import kuma.wiki.content
 
 from ..decorators import (check_readonly, prevent_indexing,
                           process_document_path)


### PR DESCRIPTION
This is the first of a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds caching headers and tests for the `kuma.dashboards.urls`.

* add `shared_cache_control` decorator as a thin wrapper around Django's `cache_control` decorator to encapsulate default settings for shared caching
* add tests for `shared_cache_control` decorator
* delete custom `never_cache` decorator, and replace with Django's
* delete tests for custom `never_cache` decorator
* decorate the views for `kuma.dashboards.urls` and add tests