### PR TITLE
bug 1431259: caching headers/tests for health views

### DIFF
--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -12,35 +12,43 @@ from kuma.users.models import User
 
 
 @pytest.mark.parametrize('http_method', ['put', 'post', 'delete', 'options'])
-@pytest.mark.parametrize('endpoint', ['health.liveness', 'health.readiness'])
+@pytest.mark.parametrize('endpoint', ['liveness', 'readiness', 'status'])
 def test_disallowed_methods(client, http_method, endpoint):
     """Alternate HTTP methods are not allowed."""
-    url = reverse(endpoint)
+    url = reverse('health.{}'.format(endpoint))
     response = getattr(client, http_method)(url)
     assert response.status_code == 405
+    assert 'Cache-Control' in response
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
 @pytest.mark.parametrize('http_method', ['get', 'head'])
-def test_liveness(client, http_method):
-    url = reverse('health.liveness')
+@pytest.mark.parametrize('endpoint', ['liveness', 'readiness'])
+def test_liveness_and_readiness(db, client, http_method, endpoint):
+    url = reverse('health.{}'.format(endpoint))
     response = getattr(client, http_method)(url)
     assert response.status_code == 204
+    assert 'Cache-Control' in response
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
-@pytest.mark.parametrize('http_method', ['get', 'head'])
-def test_readiness(db, client, http_method):
-    url = reverse('health.readiness')
-    response = getattr(client, http_method)(url)
-    assert response.status_code == 204
-
-
-def test_readiness_with_db_error(db, client):
-    url = reverse('health.readiness')
-    with mock.patch('kuma.wiki.models.Document.objects') as mock_manager:
-        mock_manager.filter.side_effect = DatabaseError('fubar')
-        response = client.get(url)
+@mock.patch('kuma.wiki.models.Document.objects')
+def test_readiness_with_db_error(mock_manager, db, client):
+    mock_manager.filter.side_effect = DatabaseError('fubar')
+    response = client.get(reverse('health.readiness'))
     assert response.status_code == 503
     assert 'fubar' in response.reason_phrase
+    assert 'Cache-Control' in response
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
 @pytest.fixture
@@ -121,6 +129,11 @@ def test_status(client, settings, mock_status_externals):
     url = reverse('health.status')
     response = client.get(url)
     assert response.status_code == 200
+    assert 'Cache-Control' in response
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
     assert response['Content-Type'] == 'application/json'
     data = json.loads(response.content)
     assert sorted(data.keys()) == ['request', 'services', 'settings',

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -18,7 +18,6 @@ def test_disallowed_methods(client, http_method, endpoint):
     url = reverse('health.{}'.format(endpoint))
     response = getattr(client, http_method)(url)
     assert response.status_code == 405
-    assert 'Cache-Control' in response
     assert 'max-age=0' in response['Cache-Control']
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']
@@ -31,7 +30,6 @@ def test_liveness_and_readiness(db, client, http_method, endpoint):
     url = reverse('health.{}'.format(endpoint))
     response = getattr(client, http_method)(url)
     assert response.status_code == 204
-    assert 'Cache-Control' in response
     assert 'max-age=0' in response['Cache-Control']
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']
@@ -44,7 +42,6 @@ def test_readiness_with_db_error(mock_manager, db, client):
     response = client.get(reverse('health.readiness'))
     assert response.status_code == 503
     assert 'fubar' in response.reason_phrase
-    assert 'Cache-Control' in response
     assert 'max-age=0' in response['Cache-Control']
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']
@@ -129,7 +126,6 @@ def test_status(client, settings, mock_status_externals):
     url = reverse('health.status')
     response = client.get(url)
     assert response.status_code == 200
-    assert 'Cache-Control' in response
     assert 'max-age=0' in response['Cache-Control']
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -1,10 +1,10 @@
 from django.conf import settings
 from django.db import DatabaseError
 from django.http import HttpResponse, JsonResponse
+from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
                                       NotFoundError)
-
 from requests.exceptions import ConnectionError as Requests_ConnectionError
 
 from kuma.users.models import User
@@ -13,6 +13,7 @@ from kuma.wiki.models import Document
 from kuma.wiki.search import WikiDocumentType
 
 
+@never_cache
 @require_safe
 def liveness(request):
     """
@@ -24,6 +25,7 @@ def liveness(request):
     return HttpResponse(status=204)
 
 
+@never_cache
 @require_safe
 def readiness(request):
     """
@@ -47,6 +49,7 @@ def readiness(request):
     return HttpResponse(status=status, reason=reason)
 
 
+@never_cache
 @require_safe
 def status(request):
     """


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds caching headers and tests for the `kuma.health.urls`.