### PR TITLE
bug 1431259: caching headers/tests for landing views

### DIFF
--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -1,26 +1,72 @@
+from django.utils.six.moves.urllib.parse import urlparse
+from ratelimit.exceptions import Ratelimited
+import mock
+import pytest
+
 from kuma.core.urlresolvers import reverse
 
 
 def test_contribute_json(client, db):
     response = client.get(reverse('contribute_json'))
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     assert response['Content-Type'].startswith('application/json')
 
 
 def test_home(client, db):
     response = client.get(reverse('home'), follow=True)
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
+
+
+@mock.patch('kuma.landing.views.render')
+def test_home_when_rate_limited(mock_render, client, db):
+    """
+    Cloudfront CDN's don't cache 429's, but let's test this anyway.
+    """
+    mock_render.side_effect = Ratelimited()
+    response = client.get(reverse('home', locale='en-US'))
+    assert response.status_code == 429
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.parametrize('mode', ['maintenance', 'normal'])
+def test_maintenance_mode(db, client, settings, mode):
+    url = reverse('maintenance_mode', locale='en-US')
+    settings.MAINTENANCE_MODE = (mode == 'maintenance')
+    response = client.get(url)
+    if settings.MAINTENANCE_MODE:
+        assert response.status_code == 200
+        assert ('landing/maintenance-mode.html' in
+                [t.name for t in response.templates])
+    else:
+        assert response.status_code == 302
+        assert 'Location' in response
+        assert urlparse(response['Location']).path == '/'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
 def test_promote_buttons(client, db):
     response = client.get(reverse('promote_buttons'), follow=True)
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
 
 
 def test_robots_not_allowed(client):
     """By default, robots.txt shows that robots are not allowed."""
     response = client.get(reverse('robots_txt'))
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     assert response['Content-Type'] == 'text/plain'
     content = response.content
     assert 'Sitemap: ' not in content
@@ -34,6 +80,8 @@ def test_robots_allowed_main_website(client, settings):
     settings.ALLOW_ROBOTS_WEB_DOMAINS = [host]
     response = client.get(reverse('robots_txt'), HTTP_HOST=host)
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     assert response['Content-Type'] == 'text/plain'
     content = response.content
     assert 'Sitemap: ' in content
@@ -47,6 +95,8 @@ def test_robots_allowed_main_attachment_host(client, settings):
     settings.ALLOW_ROBOTS_DOMAINS = [host]
     response = client.get(reverse('robots_txt'), HTTP_HOST=host)
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     assert response['Content-Type'] == 'text/plain'
     content = response.content
     assert content == ''
@@ -55,4 +105,6 @@ def test_robots_allowed_main_attachment_host(client, settings):
 def test_favicon_ico(client):
     response = client.get('favicon.ico')
     assert response.status_code == 302
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     assert response['Location'].endswith('static/img/favicon.ico')

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -1,6 +1,7 @@
 from django.conf.urls import url
 
 from . import views
+from kuma.core.decorators import shared_cache_control
 
 
 urlpatterns = [
@@ -23,6 +24,7 @@ urlpatterns = [
         views.robots_txt,
         name='robots_txt'),
     url(r'^favicon.ico$',
-        views.FaviconRedirect.as_view(icon='favicon.ico'),
+        shared_cache_control(
+            views.FaviconRedirect.as_view(icon='favicon.ico')),
         name='favicon_ico'),
 ]

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -3,20 +3,24 @@ from django.contrib.staticfiles.storage import staticfiles_storage
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.views import static
+from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 from ratelimit.decorators import ratelimit
 
-from kuma.core.sections import SECTION_USAGE
 from kuma.core.cache import memcache
+from kuma.core.decorators import shared_cache_control
+from kuma.core.sections import SECTION_USAGE
 from kuma.feeder.models import Bundle
 from kuma.search.models import Filter
 
 
+@shared_cache_control
 def contribute_json(request):
     return static.serve(request, 'contribute.json',
                         document_root=settings.ROOT)
 
 
+@shared_cache_control
 @ratelimit(key='user_or_ip', rate='400/m', block=True)
 def home(request):
     """Home page."""
@@ -39,6 +43,7 @@ def home(request):
     return render(request, 'landing/homepage.html', context)
 
 
+@never_cache
 def maintenance_mode(request):
     if settings.MAINTENANCE_MODE:
         return render(request, 'landing/maintenance-mode.html')
@@ -46,6 +51,7 @@ def maintenance_mode(request):
         return redirect('home')
 
 
+@shared_cache_control
 def promote_buttons(request):
     """Bug 646192: MDN affiliate buttons"""
     return render(request, 'landing/promote_buttons.html')
@@ -113,6 +119,7 @@ Disallow: /
 '''
 
 
+@shared_cache_control
 def robots_txt(request):
     """
     Serve robots.txt that allows or forbids robots.


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds caching headers and tests for the `kuma.landing.urls`.

The `maintenance_mode` endpoint is excluded from caching (it's decorated with `never_cache`). Whenever MDN is taken into or out-of maintenance mode, it seemed best for that endpoint to reflect the current reality immediately.

When #4676 is merged and it is re-based on master, the `not ready` label can be removed.