### PR TITLE
bug 1429933: Migrate to RegexField.error_messages

### DIFF
--- a/kuma/users/forms.py
+++ b/kuma/users/forms.py
@@ -54,7 +54,7 @@ class UserEditForm(forms.ModelForm):
         regex=USERNAME_REGEX,
         max_length=30,
         required=False,
-        error_message=USERNAME_CHARACTERS,
+        error_messages={'invalid': USERNAME_CHARACTERS},
     )
     twitter_url = forms.CharField(
         label=_('Twitter'),


### PR DESCRIPTION
``RegexField.error_message`` is [deprecated](https://docs.djangoproject.com/en/1.8/_modules/django/forms/fields/#RegexField), and removed in Django 1.11. Replace it with the suggested ``error_messages={'invalid': msg}``.