### PR TITLE
bug 1429933: Add on_delete specifications

### DIFF
--- a/kuma/attachments/migrations/0001_squashed_0008_attachment_on_delete.py
+++ b/kuma/attachments/migrations/0001_squashed_0008_attachment_on_delete.py
@@ -40,8 +40,8 @@ class Migration(migrations.Migration):
                 ('is_approved', models.BooleanField(default=True, db_index=True)),
                 ('mindtouch_old_id', models.IntegerField(help_text=b'ID for migrated MindTouch resource revision', unique=True, null=True, db_index=True)),
                 ('is_mindtouch_migration', models.BooleanField(default=False, help_text=b'Did this revision come from MindTouch?', db_index=True)),
-                ('attachment', models.ForeignKey(related_name='revisions', to='attachments.Attachment')),
-                ('creator', models.ForeignKey(related_name='created_attachment_revisions', to=settings.AUTH_USER_MODEL)),
+                ('attachment', models.ForeignKey(related_name='revisions', to='attachments.Attachment', on_delete=models.CASCADE)),
+                ('creator', models.ForeignKey(related_name='created_attachment_revisions', to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
             ],
         ),
         migrations.AddField(

--- a/kuma/attachments/models.py
+++ b/kuma/attachments/models.py
@@ -98,7 +98,8 @@ class AttachmentRevision(models.Model):
     """
     DEFAULT_MIME_TYPE = 'application/octet-stream'
 
-    attachment = models.ForeignKey(Attachment, related_name='revisions')
+    attachment = models.ForeignKey(Attachment, related_name='revisions',
+                                   on_delete=models.CASCADE)
 
     file = models.FileField(upload_to=attachment_upload_to, max_length=500)
 
@@ -121,6 +122,7 @@ class AttachmentRevision(models.Model):
     creator = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         related_name='created_attachment_revisions',
+        on_delete=models.PROTECT,
     )
     is_approved = models.BooleanField(default=True, db_index=True)
 

--- a/kuma/authkeys/migrations/0001_initial.py
+++ b/kuma/authkeys/migrations/0001_initial.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('hashed_secret', models.CharField(verbose_name='Hashed secret', max_length=128, editable=False)),
                 ('description', models.TextField(verbose_name='Description of intended use')),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('user', models.ForeignKey(editable=False, to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(editable=False, to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
             ],
             options={
             },
@@ -35,8 +35,8 @@ class Migration(migrations.Migration):
                 ('notes', models.TextField(null=True)),
                 ('object_id', models.PositiveIntegerField()),
                 ('created', models.DateTimeField(auto_now_add=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
-                ('key', models.ForeignKey(related_name='history', to='authkeys.Key')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
+                ('key', models.ForeignKey(related_name='history', to='authkeys.Key', on_delete=models.CASCADE)),
             ],
             options={
             },

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -27,7 +27,8 @@ def hash_secret(secret):
 class Key(models.Model):
     """Authentication key"""
     user = models.ForeignKey(settings.AUTH_USER_MODEL, editable=False,
-                             db_index=True, blank=False, null=False)
+                             db_index=True, blank=False, null=False,
+                             on_delete=models.PROTECT)
     key = models.CharField(_("Lookup key"), max_length=64,
                            editable=False, db_index=True)
     hashed_secret = models.CharField(_("Hashed secret"), max_length=128,
@@ -59,10 +60,11 @@ class Key(models.Model):
 
 class KeyAction(models.Model):
     """Record of an action taken while using a key"""
-    key = models.ForeignKey(Key, related_name='history', db_index=True)
+    key = models.ForeignKey(Key, related_name='history', db_index=True,
+                            on_delete=models.CASCADE)
     action = models.CharField(max_length=128, blank=False)
     notes = models.TextField(null=True)
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
     created = models.DateTimeField(auto_now_add=True)

--- a/kuma/feeder/migrations/0001_initial.py
+++ b/kuma/feeder/migrations/0001_initial.py
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='entry',
             name='feed',
-            field=models.ForeignKey(related_name='entries', to='feeder.Feed'),
+            field=models.ForeignKey(related_name='entries', to='feeder.Feed', on_delete=models.CASCADE),
             preserve_default=True,
         ),
         migrations.AlterUniqueTogether(

--- a/kuma/feeder/models.py
+++ b/kuma/feeder/models.py
@@ -79,7 +79,7 @@ class Feed(models.Model):
 class Entry(models.Model):
     """An entry is an item representing feed content."""
 
-    feed = models.ForeignKey(Feed, related_name='entries')
+    feed = models.ForeignKey(Feed, related_name='entries', on_delete=models.CASCADE)
     guid = models.CharField(max_length=255)
 
     raw = models.TextField()

--- a/kuma/search/migrations/0001_squashed_0003_filter_tags.py
+++ b/kuma/search/migrations/0001_squashed_0003_filter_tags.py
@@ -59,8 +59,8 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('created_at', models.DateTimeField(default=django.utils.timezone.now)),
                 ('object_id', models.PositiveIntegerField()),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
-                ('index', models.ForeignKey(related_name='outdated_objects', to='search.Index')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
+                ('index', models.ForeignKey(related_name='outdated_objects', to='search.Index', on_delete=models.CASCADE)),
             ],
         ),
         migrations.AlterUniqueTogether(
@@ -70,7 +70,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='filter',
             name='group',
-            field=models.ForeignKey(related_name='filters', to='search.FilterGroup', help_text=b'E.g. "Topic", "Skill level" etc'),
+            field=models.ForeignKey(related_name='filters', to='search.FilterGroup', help_text=b'E.g. "Topic", "Skill level" etc', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='filter',

--- a/kuma/search/models.py
+++ b/kuma/search/models.py
@@ -106,9 +106,9 @@ def delete_index(**kwargs):
 
 
 class OutdatedObject(models.Model):
-    index = models.ForeignKey(Index, related_name='outdated_objects')
+    index = models.ForeignKey(Index, related_name='outdated_objects', on_delete=models.CASCADE)
     created_at = models.DateTimeField(default=timezone.now)
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_id = models.PositiveIntegerField()
     content_object = GenericForeignKey('content_type', 'object_id')
 
@@ -168,7 +168,8 @@ class Filter(models.Model):
                                           'show in the command and query UI. '
                                           'e.g. fxos')
     group = models.ForeignKey(FilterGroup, related_name='filters',
-                              help_text='E.g. "Topic", "Skill level" etc')
+                              help_text='E.g. "Topic", "Skill level" etc',
+                              on_delete=models.CASCADE)
     tags = TaggableManager(help_text='A comma-separated list of tags. '
                                      'If more than one tag given the operator '
                                      'specified is used')

--- a/kuma/spam/models.py
+++ b/kuma/spam/models.py
@@ -6,7 +6,8 @@ from django_extensions.db.fields import CreationDateTimeField
 
 
 class SpamAttempt(models.Model):
-    user = models.ForeignKey(settings.AUTH_USER_MODEL)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                             on_delete=models.PROTECT)
     created = CreationDateTimeField(_('created'), db_index=True)
 
     class Meta:
@@ -27,7 +28,8 @@ class AkismetSubmission(models.Model):
         (SPAM_TYPE, _('Spam')),
         (HAM_TYPE, _('Ham')),
     )
-    sender = models.ForeignKey(settings.AUTH_USER_MODEL)
+    sender = models.ForeignKey(settings.AUTH_USER_MODEL,
+                               on_delete=models.PROTECT)
     sent = CreationDateTimeField(
         _('sent at'),
         db_index=True,

--- a/kuma/users/migrations/0001_squashed_0008_update_locales_tz_help.py
+++ b/kuma/users/migrations/0001_squashed_0008_update_locales_tz_help.py
@@ -64,8 +64,8 @@ class Migration(migrations.Migration):
                 ('reason', models.TextField()),
                 ('date', models.DateField(default=datetime.date.today)),
                 ('is_active', models.BooleanField(default=True, help_text=b'(Is ban active)')),
-                ('by', models.ForeignKey(related_name='bans_issued', verbose_name=b'Banned by', to=settings.AUTH_USER_MODEL)),
-                ('user', models.ForeignKey(related_name='bans', verbose_name=b'Banned user', to=settings.AUTH_USER_MODEL)),
+                ('by', models.ForeignKey(related_name='bans_issued', verbose_name=b'Banned by', to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
+                ('user', models.ForeignKey(related_name='bans', verbose_name=b'Banned user', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
         migrations.AlterModelManagers(

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -22,10 +22,12 @@ from .constants import USERNAME_REGEX
 class UserBan(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL,
                              related_name="bans",
-                             verbose_name="Banned user")
+                             verbose_name="Banned user",
+                             on_delete=models.CASCADE)
     by = models.ForeignKey(settings.AUTH_USER_MODEL,
                            related_name="bans_issued",
-                           verbose_name="Banned by")
+                           verbose_name="Banned by",
+                           on_delete=models.PROTECT)
     reason = models.TextField()
     date = models.DateField(default=datetime.date.today)
     is_active = models.BooleanField(default=True, help_text="(Is ban active)")

--- a/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
+++ b/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
@@ -62,9 +62,9 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('name', models.TextField()),
-                ('attached_by', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True)),
-                ('document', models.ForeignKey(related_name='attached_files', to='wiki.Document')),
-                ('file', models.ForeignKey(related_name='document_attachments', to='attachments.Attachment')),
+                ('attached_by', models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL)),
+                ('document', models.ForeignKey(related_name='attached_files', to='wiki.Document', on_delete=models.CASCADE)),
+                ('file', models.ForeignKey(related_name='document_attachments', to='attachments.Attachment', on_delete=models.PROTECT)),
                 ('is_linked', models.BooleanField(default=False, verbose_name='linked in the document content')),
                 ('is_original', models.BooleanField(default=False, verbose_name='uploaded to the document')),
             ],
@@ -80,7 +80,7 @@ class Migration(migrations.Migration):
                 ('slug', models.CharField(max_length=255, db_index=True)),
                 ('timestamp', models.DateTimeField(auto_now=True)),
                 ('reason', models.TextField()),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
             ],
         ),
         migrations.CreateModel(
@@ -100,7 +100,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('url_root', models.CharField(help_text=b'alternative URL path root for documents under this zone', max_length=255, null=True, db_index=True, blank=True)),
-                ('document', models.OneToOneField(related_name='zone', to='wiki.Document')),
+                ('document', models.OneToOneField(related_name='zone', to='wiki.Document', on_delete=models.PROTECT)),
                 ('css_slug', models.CharField(help_text=b'name of an alternative pipeline CSS group for documents under this zone (note that "zone-" will be prepended)', max_length=100, blank=True)),
             ],
         ),
@@ -111,7 +111,7 @@ class Migration(migrations.Migration):
                 ('default', models.BooleanField(default=False)),
                 ('name', models.CharField(max_length=100)),
                 ('code', models.TextField(max_length=2000)),
-                ('creator', models.ForeignKey(related_name='created_toolbars', to=settings.AUTH_USER_MODEL)),
+                ('creator', models.ForeignKey(related_name='created_toolbars', to=settings.AUTH_USER_MODEL, on_delete=models.CASCADE)),
             ],
         ),
         migrations.CreateModel(
@@ -172,9 +172,9 @@ class Migration(migrations.Migration):
                 ('comment', models.CharField(max_length=255)),
                 ('is_approved', models.BooleanField(default=True, db_index=True)),
                 ('is_mindtouch_migration', models.BooleanField(default=False, help_text=b'Did this revision come from MindTouch?', db_index=True)),
-                ('based_on', models.ForeignKey(blank=True, to='wiki.Revision', null=True)),
-                ('creator', models.ForeignKey(related_name='created_revisions', to=settings.AUTH_USER_MODEL)),
-                ('document', models.ForeignKey(related_name='revisions', to='wiki.Document')),
+                ('based_on', models.ForeignKey(blank=True, to='wiki.Revision', null=True, on_delete=models.SET_NULL)),
+                ('creator', models.ForeignKey(related_name='created_revisions', to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
+                ('document', models.ForeignKey(related_name='revisions', to='wiki.Document', on_delete=models.CASCADE)),
                 ('localization_tags', taggit.managers.TaggableManager(to='wiki.LocalizationTag', through='wiki.LocalizationTaggedRevision', help_text='A comma-separated list of tags.', verbose_name='Tags')),
                 ('review_tags', taggit.managers.TaggableManager(to='wiki.ReviewTag', through='wiki.ReviewTaggedRevision', help_text='A comma-separated list of tags.', verbose_name='Tags')),
             ],
@@ -184,7 +184,7 @@ class Migration(migrations.Migration):
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
                 ('ip', models.CharField(editable=False, max_length=40, blank=True, null=True, verbose_name=b'IP address', db_index=True)),
-                ('revision', models.ForeignKey(to='wiki.Revision')),
+                ('revision', models.ForeignKey(to='wiki.Revision', on_delete=models.CASCADE)),
                 ('referrer', models.TextField(verbose_name=b'HTTP Referrer', editable=False, blank=True)),
                 ('user_agent', models.TextField(verbose_name=b'User-Agent', editable=False, blank=True)),
                 ('data', models.TextField(verbose_name='Data submitted to Akismet', null=True, editable=False, blank=True)),
@@ -194,8 +194,8 @@ class Migration(migrations.Migration):
             name='TaggedDocument',
             fields=[
                 ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('content_object', models.ForeignKey(to='wiki.Document')),
-                ('tag', models.ForeignKey(related_name='wiki_taggeddocument_items', to='wiki.DocumentTag')),
+                ('content_object', models.ForeignKey(to='wiki.Document', on_delete=models.CASCADE)),
+                ('tag', models.ForeignKey(related_name='wiki_taggeddocument_items', to='wiki.DocumentTag', on_delete=models.CASCADE)),
             ],
             options={
                 'abstract': False,
@@ -204,27 +204,27 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='reviewtaggedrevision',
             name='content_object',
-            field=models.ForeignKey(to='wiki.Revision'),
+            field=models.ForeignKey(to='wiki.Revision', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='reviewtaggedrevision',
             name='tag',
-            field=models.ForeignKey(related_name='wiki_reviewtaggedrevision_items', to='wiki.ReviewTag'),
+            field=models.ForeignKey(related_name='wiki_reviewtaggedrevision_items', to='wiki.ReviewTag', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='localizationtaggedrevision',
             name='content_object',
-            field=models.ForeignKey(to='wiki.Revision'),
+            field=models.ForeignKey(to='wiki.Revision', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='localizationtaggedrevision',
             name='tag',
-            field=models.ForeignKey(related_name='wiki_localizationtaggedrevision_items', to='wiki.LocalizationTag'),
+            field=models.ForeignKey(related_name='wiki_localizationtaggedrevision_items', to='wiki.LocalizationTag', on_delete=models.CASCADE),
         ),
         migrations.AddField(
             model_name='document',
             name='current_revision',
-            field=models.ForeignKey(related_name='current_for+', to='wiki.Revision', null=True),
+            field=models.ForeignKey(related_name='current_for+', to='wiki.Revision', null=True, on_delete=models.SET_NULL),
         ),
         migrations.AddField(
             model_name='document',
@@ -234,12 +234,12 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='document',
             name='parent',
-            field=models.ForeignKey(related_name='translations', blank=True, to='wiki.Document', null=True),
+            field=models.ForeignKey(related_name='translations', blank=True, to='wiki.Document', null=True, on_delete=models.PROTECT),
         ),
         migrations.AddField(
             model_name='document',
             name='parent_topic',
-            field=models.ForeignKey(related_name='children', blank=True, to='wiki.Document', null=True),
+            field=models.ForeignKey(related_name='children', blank=True, to='wiki.Document', null=True, on_delete=models.PROTECT),
         ),
         migrations.AddField(
             model_name='document',
@@ -273,7 +273,7 @@ class Migration(migrations.Migration):
                 ('title', models.CharField(max_length=255, verbose_name=b'Title')),
                 ('slug', models.CharField(max_length=255, verbose_name=b'Slug')),
                 ('document', models.ForeignKey(related_name='spam_attempts', on_delete=django.db.models.deletion.SET_NULL, verbose_name=b'Document (optional)', blank=True, to='wiki.Document', null=True)),
-                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('user', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
                 ('data', models.TextField(verbose_name='Data submitted to Akismet', null=True, editable=False, blank=True)),
                 ('review', models.IntegerField(default=0, verbose_name="Review of Akismet's classification as spam", choices=[(0, 'Needs Review'), (1, 'Ham / False Positive'), (2, 'Confirmed as Spam'), (3, 'Review Unavailable')])),
                 ('reviewed', models.DateTimeField(null=True, verbose_name='reviewed', blank=True)),
@@ -291,7 +291,7 @@ class Migration(migrations.Migration):
                 ('sent', django_extensions.db.fields.CreationDateTimeField(default=django.utils.timezone.now, auto_now_add=True, verbose_name='sent at', db_index=True)),
                 ('type', models.CharField(db_index=True, max_length=4, verbose_name='submission type', choices=[(b'spam', 'Spam'), (b'ham', 'Ham')])),
                 ('revision', models.ForeignKey(related_name='akismet_submissions', on_delete=django.db.models.deletion.SET_NULL, verbose_name=b'Revision', blank=True, to='wiki.Revision', null=True)),
-                ('sender', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+                ('sender', models.ForeignKey(to=settings.AUTH_USER_MODEL, on_delete=models.PROTECT)),
             ],
             options={
                 'ordering': ('-sent',),
@@ -326,7 +326,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='documentspamattempt',
             name='reviewer',
-            field=models.ForeignKey(related_name='documentspam_reviewed', verbose_name='Staff reviewer', blank=True, to=settings.AUTH_USER_MODEL, null=True),
+            field=models.ForeignKey(related_name='documentspam_reviewed', verbose_name='Staff reviewer', blank=True, to=settings.AUTH_USER_MODEL, null=True, on_delete=models.SET_NULL),
         ),
         migrations.AlterField(
             model_name='documentspamattempt',


### PR DESCRIPTION
[on_delete](https://docs.djangoproject.com/en/2.0/ref/models/fields/#django.db.models.ForeignKey.on_delete) is a required attribute starting in Django 2.0, and is allowed in Django 1.8. Some values:

* CASCADE (the default): Delete this object when the referenced object is deleted.
* SET_NULL: Set the reference to NULL when the referenced object is deleted.
* PROTECT: Deny deletion of the referenced object, forcing this object to be deleted first.

The on_delete attribute must be set in the model as well as the initial migration.