### PR TITLE
bug 1431259: caching headers/tests for wiki misc/list views

### DIFF
--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -99,6 +99,20 @@ def trans_edit_revision(trans_doc, edit_revision, wiki_user):
 
 
 @pytest.fixture
+def redirect_doc(wiki_user):
+    """A newly-created top-level English redirect document."""
+    redirect_doc = Document.objects.create(
+        locale='en-US', slug='Redirection', title='Redirect Document')
+    Revision.objects.create(
+        document=redirect_doc,
+        creator=wiki_user,
+        content='REDIRECT <a class="redirect" href="/blah">Some Redirect</a>',
+        title='Redirect Document',
+        created=datetime(2017, 4, 17, 12, 15))
+    return redirect_doc
+
+
+@pytest.fixture
 def doc_hierarchy_with_zones(settings, wiki_user, wiki_user_2, wiki_user_3):
     top_doc = Document.objects.create(
         locale='en-US',

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -8,6 +8,8 @@ from collections import namedtuple
 import pytest
 
 from ..models import Document, DocumentZone, Revision
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.constants import REDIRECT_CONTENT
 
 
 BannedUser = namedtuple('BannedUser', 'user ban')
@@ -99,14 +101,19 @@ def trans_edit_revision(trans_doc, edit_revision, wiki_user):
 
 
 @pytest.fixture
-def redirect_doc(wiki_user):
+def redirect_doc(wiki_user, root_doc):
     """A newly-created top-level English redirect document."""
     redirect_doc = Document.objects.create(
         locale='en-US', slug='Redirection', title='Redirect Document')
     Revision.objects.create(
         document=redirect_doc,
         creator=wiki_user,
-        content='REDIRECT <a class="redirect" href="/blah">Some Redirect</a>',
+        content=REDIRECT_CONTENT % {
+            'href': reverse('wiki.document',
+                            args=(root_doc.slug,),
+                            locale=root_doc.locale),
+            'title': root_doc.title,
+        },
         title='Redirect Document',
         created=datetime(2017, 4, 17, 12, 15))
     return redirect_doc

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -26,7 +26,7 @@ from . import (WikiTestCase, create_topical_parents_docs, document,
                new_document_data, revision)
 from ..constants import (EXPERIMENT_TITLE_PREFIX, REDIRECT_CONTENT)
 from ..events import EditDocumentEvent
-from ..models import Document, DocumentTag, Revision
+from ..models import Document, Revision
 
 
 DOCUMENT_EDITED_EMAIL_CONTENT = """
@@ -841,38 +841,6 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
         doc = Document.objects.get(pk=self.d.pk)
         eq_(new_title, doc.title)
-
-
-class DocumentListTests(UserTestCase, WikiTestCase):
-    localizing_client = True
-
-    def setUp(self):
-        super(DocumentListTests, self).setUp()
-        self.locale = settings.WIKI_DEFAULT_LANGUAGE
-        self.doc = _create_document(locale=self.locale)
-        _create_document(locale=self.locale, title='Another one')
-
-        # Create a document in different locale to make sure it doesn't show
-        _create_document(parent=self.doc, locale='es')
-
-    def test_all_list(self):
-        """Verify the all documents list view."""
-        response = self.client.get(reverse('wiki.all_documents'))
-        doc = pq(response.content)
-        eq_(Document.objects.filter(locale=self.locale).count(),
-            len(doc('#document-list ul.document-list li')))
-
-    @pytest.mark.tags
-    def test_tag_list(self):
-        """Verify the tagged documents list view."""
-        tag = DocumentTag(name='Test Tag', slug='test-tag')
-        tag.save()
-        self.doc.tags.add(tag)
-        response = self.client.get(reverse('wiki.tag',
-                                   args=[tag.name]))
-        eq_(200, response.status_code)
-        doc = pq(response.content)
-        eq_(1, len(doc('#document-list ul.document-list li')))
 
 
 def test_compare_revisions(edit_revision, client):

--- a/kuma/wiki/tests/test_views_misc.py
+++ b/kuma/wiki/tests/test_views_misc.py
@@ -52,15 +52,19 @@ def test_autosuggest(client, redirect_doc, doc_hierarchy_with_zones,
         expected_titles = set(('Superiore Documento',))
     elif locale_case == 'current-locale':
         params.update(current_locale='true')
-        expected_titles = set(('Top Document', 'Middle-Top Document',
-                               'Middle-Bottom Document', 'Bottom Document'))
+        # The root document is pulled-in by the redirect_doc fixture.
+        expected_titles = set(('Root Document', 'Top Document',
+                               'Middle-Top Document', 'Middle-Bottom Document',
+                               'Bottom Document'))
     elif locale_case == 'exclude-current-locale':
         params.update(exclude_current_locale='true')
         expected_titles = set(('Haut Document', 'Superiore Documento'))
     else:  # All locales
-        expected_titles = set(('Top Document', 'Haut Document',
-                               'Superiore Documento', 'Middle-Top Document',
-                               'Middle-Bottom Document', 'Bottom Document'))
+        # The root document is pulled-in by the redirect_doc fixture.
+        expected_titles = set(('Root Document', 'Top Document',
+                               'Haut Document', 'Superiore Documento',
+                               'Middle-Top Document', 'Middle-Bottom Document',
+                               'Bottom Document'))
 
     url = reverse('wiki.autosuggest_documents', locale='en-US')
     if params:

--- a/kuma/wiki/tests/test_views_misc.py
+++ b/kuma/wiki/tests/test_views_misc.py
@@ -1,0 +1,79 @@
+import json
+from urllib import urlencode
+
+import pytest
+from waffle.models import Switch
+
+from kuma.core.urlresolvers import reverse
+
+
+@pytest.mark.parametrize(
+    'http_method', ['put', 'post', 'delete', 'options', 'head'])
+@pytest.mark.parametrize(
+    'endpoint', ['ckeditor_config', 'autosuggest_documents'])
+def test_disallowed_methods(db, client, http_method, endpoint):
+    """HTTP methods other than GET & HEAD are not allowed."""
+    url = reverse('wiki.{}'.format(endpoint), locale='en-US')
+    response = getattr(client, http_method)(url)
+    assert response.status_code == 405
+    assert 'Cache-Control' in response
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
+
+
+def test_ckeditor_config(db, client):
+    response = client.get(reverse('wiki.ckeditor_config', locale='en-US'))
+    assert response.status_code == 200
+    assert 'Cache-Control' in response
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
+    assert 'Content-Type' in response
+    assert response['Content-Type'] == 'application/x-javascript'
+    assert 'wiki/ckeditor_config.js' in [t.name for t in response.templates]
+
+
+@pytest.mark.parametrize('term', [None, 'doc'])
+@pytest.mark.parametrize(
+    'locale_case',
+    ['all-locales', 'current-locale',
+     'non-english-locale', 'exclude-current-locale'])
+def test_autosuggest(client, redirect_doc, doc_hierarchy_with_zones,
+                     locale_case, term):
+    Switch.objects.create(name='application_ACAO', active=True)
+
+    params = {}
+    expected_status_code = 200
+    if term:
+        params.update(term=term)
+    else:
+        expected_status_code = 400
+    if locale_case == 'non-english-locale':
+        params.update(locale='it')
+        expected_titles = set(('Superiore Documento',))
+    elif locale_case == 'current-locale':
+        params.update(current_locale='true')
+        expected_titles = set(('Top Document', 'Middle-Top Document',
+                               'Middle-Bottom Document', 'Bottom Document'))
+    elif locale_case == 'exclude-current-locale':
+        params.update(exclude_current_locale='true')
+        expected_titles = set(('Haut Document', 'Superiore Documento'))
+    else:  # All locales
+        expected_titles = set(('Top Document', 'Haut Document',
+                               'Superiore Documento', 'Middle-Top Document',
+                               'Middle-Bottom Document', 'Bottom Document'))
+
+    url = reverse('wiki.autosuggest_documents', locale='en-US')
+    if params:
+        url += '?{}'.format(urlencode(params))
+    response = client.get(url)
+    assert response.status_code == expected_status_code
+    assert 'Cache-Control' in response
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
+    assert 'Access-Control-Allow-Origin' in response
+    assert response['Access-Control-Allow-Origin'] == '*'
+    if expected_status_code == 200:
+        assert 'Content-Type' in response
+        assert response['Content-Type'] == 'application/json'
+        data = json.loads(response.content)
+        assert set(item['title'] for item in data) == expected_titles

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -3,7 +3,7 @@ from django.shortcuts import get_object_or_404, get_list_or_404, render
 from django.views.decorators.http import require_GET
 from ratelimit.decorators import ratelimit
 
-from kuma.core.decorators import block_user_agents
+from kuma.core.decorators import block_user_agents, shared_cache_control
 from kuma.core.utils import paginate
 
 from ..constants import DOCUMENTS_PER_PAGE
@@ -12,6 +12,7 @@ from ..models import (Document, DocumentTag, ReviewTag, Revision,
                       LocalizationTag)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -38,6 +39,7 @@ def documents(request, tag=None):
     return render(request, 'wiki/list/documents.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -50,6 +52,7 @@ def tags(request):
     return render(request, 'wiki/list/tags.html', {'tags': tags})
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -70,6 +73,7 @@ def needs_review(request, tag=None):
     return render(request, 'wiki/list/needs_review.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -90,6 +94,7 @@ def with_localization_tag(request, tag=None):
     return render(request, 'wiki/list/with_localization_tags.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -107,6 +112,7 @@ def with_errors(request):
     return render(request, 'wiki/list/documents.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='40/m', block=True)
@@ -122,6 +128,7 @@ def without_parent(request):
     return render(request, 'wiki/list/documents.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @ratelimit(key='user_or_ip', rate='400/m', block=True)
@@ -137,6 +144,7 @@ def top_level(request):
     return render(request, 'wiki/list/documents.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @process_document_path

--- a/kuma/wiki/views/misc.py
+++ b/kuma/wiki/views/misc.py
@@ -5,13 +5,15 @@ from django.shortcuts import render
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.http import require_GET
 
-from kuma.core.decorators import block_user_agents
+from kuma.core.decorators import block_user_agents, shared_cache_control
 
 from ..constants import ALLOWED_TAGS, REDIRECT_CONTENT
 from ..decorators import allow_CORS_GET
 from ..models import Document, EditorToolbar
 
 
+@shared_cache_control
+@require_GET
 def ckeditor_config(request):
     """
     Return ckeditor config from database
@@ -31,6 +33,7 @@ def ckeditor_config(request):
                   content_type='application/x-javascript')
 
 
+@shared_cache_control
 @newrelic.agent.function_trace()
 @block_user_agents
 @require_GET


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds caching headers and tests for endpoints for the wiki views in `list.py` and `misc.py`.