### PR TITLE
bug 1431259: caching headers/tests for wiki code/legacy/akismet views

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -861,6 +861,14 @@ class RevisionAkismetSubmissionAdminForm(AkismetSubmissionFormMixin,
         akismet_data = AkismetHistoricalData(revision, self.request)
         return akismet_data.parameters
 
+    def clean(self):
+        if 'revision' not in self.cleaned_data:
+            raise forms.ValidationError(
+                _('Unable to make the Akismet submission (invalid revision).'),
+                code='invalid'
+            )
+        return super(RevisionAkismetSubmissionAdminForm, self).clean()
+
 
 class RevisionAkismetSubmissionSpamForm(RevisionAkismetSubmissionAdminForm):
     """

--- a/kuma/wiki/tests/test_views_akismet.py
+++ b/kuma/wiki/tests/test_views_akismet.py
@@ -1,0 +1,163 @@
+import json
+
+from django.contrib.auth.models import Permission
+from waffle.models import Flag
+import pytest
+
+from kuma.core.urlresolvers import reverse
+from kuma.spam.akismet import Akismet
+from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
+from kuma.wiki.models import RevisionAkismetSubmission
+
+
+@pytest.fixture
+def permission_add_revisionakismetsubmission(db):
+    return Permission.objects.get(codename='add_revisionakismetsubmission')
+
+
+@pytest.fixture
+def akismet_wiki_user(wiki_user, permission_add_revisionakismetsubmission):
+    """A user with "add_revisionakismetsubmission" permission."""
+    wiki_user.user_permissions.add(permission_add_revisionakismetsubmission)
+    return wiki_user
+
+
+@pytest.fixture
+def akismet_wiki_user_2(wiki_user_2, permission_add_revisionakismetsubmission):
+    """A second user with "add_revisionakismetsubmission" permission."""
+    wiki_user_2.user_permissions.add(permission_add_revisionakismetsubmission)
+    return wiki_user_2
+
+
+@pytest.fixture
+def akismet_mock_requests(mock_requests):
+    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(SPAM_URL, content=Akismet.submission_success)
+    return mock_requests
+
+
+@pytest.fixture
+def enable_akismet_submissions(constance_config):
+    constance_config.AKISMET_KEY = 'dashboard'
+    Flag.objects.create(name=SPAM_SUBMISSIONS_FLAG, everyone=True)
+    return constance_config
+
+
+@pytest.mark.spam
+@pytest.mark.parametrize(
+    'http_method', ['get', 'put', 'delete', 'options', 'head'])
+def test_disallowed_methods(db, client, http_method):
+    """HTTP methods other than POST are not allowed."""
+    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    response = getattr(client, http_method)(url)
+    assert response.status_code == 405
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.spam
+def test_spam_valid_response(create_revision, akismet_wiki_user, user_client,
+                             enable_akismet_submissions,
+                             akismet_mock_requests):
+    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    response = user_client.post(url, data={'revision': create_revision.id})
+    assert response.status_code == 201
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+    # One RevisionAkismetSubmission record should exist for this revision.
+    ras = RevisionAkismetSubmission.objects.get(revision=create_revision)
+    assert ras.type == u'spam'
+
+    # Check that the Akismet endpoints were called.
+    assert akismet_mock_requests.called
+    assert akismet_mock_requests.call_count == 2
+
+    data = json.loads(response.content)
+    assert len(data) == 1
+    assert data[0]['sender'] == akismet_wiki_user.username
+    assert data[0]['type'] == u'spam'
+
+
+@pytest.mark.spam
+def test_spam_with_many_response(create_revision, akismet_wiki_user,
+                                 akismet_wiki_user_2, user_client,
+                                 enable_akismet_submissions,
+                                 akismet_mock_requests):
+    submission = RevisionAkismetSubmission(
+        type="ham",
+        sender=akismet_wiki_user_2,
+        revision=create_revision
+    )
+    submission.save()
+
+    # Check that one RevisionAkismetSubmission instance exists.
+    ras = RevisionAkismetSubmission.objects.filter(revision=create_revision)
+    assert ras.count() == 1
+
+    # Create another Akismet revision via the endpoint.
+    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    response = user_client.post(url, data={'revision': create_revision.id})
+    assert response.status_code == 201
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    data = json.loads(response.content)
+    assert len(data) == 2
+    assert data[0]['type'] == 'ham'
+    assert data[0]['sender'] == akismet_wiki_user_2.username
+    assert data[1]['type'] == 'spam'
+    assert data[1]['sender'] == akismet_wiki_user.username
+
+    # Check that the Akismet endpoints were called.
+    assert akismet_mock_requests.called
+    assert akismet_mock_requests.call_count == 2
+
+
+@pytest.mark.spam
+def test_spam_no_permission(create_revision, wiki_user, user_client,
+                            enable_akismet_submissions, akismet_mock_requests):
+    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    response = user_client.post(url, data={'revision': create_revision.id})
+    # Redirects to login page when without permission.
+    assert response.status_code == 302
+    assert response['Location'].endswith('users/signin?next={}'.format(url))
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+    # No RevisionAkismetSubmission record should exist.
+    ras = RevisionAkismetSubmission.objects.filter(revision=create_revision)
+    assert ras.count() == 0
+
+    # Check that the Akismet endpoints were not called.
+    assert not akismet_mock_requests.called
+
+
+@pytest.mark.spam
+def test_spam_revision_does_not_exist(create_revision, akismet_wiki_user,
+                                      user_client, enable_akismet_submissions,
+                                      akismet_mock_requests):
+    revision_id = create_revision.id
+    create_revision.delete()
+
+    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    response = user_client.post(url, data={'revision': revision_id})
+    assert response.status_code == 400
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+    # No RevisionAkismetSubmission record should exist.
+    ras = RevisionAkismetSubmission.objects.filter(revision_id=revision_id)
+    assert ras.count() == 0
+
+    # Check that the Akismet endpoints were not called.
+    assert not akismet_mock_requests.called

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -43,7 +43,6 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
     assert response['Vary'] == 'Accept-Encoding'
     assert 'Last-Modified' not in response
     assert 'ETag' in response
-    assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']
     assert response.content.startswith('<!DOCTYPE html>')
@@ -86,9 +85,10 @@ def test_code_sample_host_restriction(code_sample_doc, constance_config,
     response = client.get(url, HTTP_HOST='testserver')
     assert response.status_code == 403
     assert 'Last-Modified' not in response
-    assert 'Cache-Control' not in response
     response = client.get(url, HTTP_HOST='sampleserver')
     assert response.status_code == 200
+    assert 'public' in response['Cache-Control']
+    assert 'max-age=86400' in response['Cache-Control']
 
 
 def test_raw_code_sample_file(code_sample_doc, constance_config,
@@ -132,6 +132,8 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     response = admin_client.get(sample_url)
     assert response.status_code == 200
     assert url_css in response.content
+    assert 'public' in response['Cache-Control']
+    assert 'max-age=86400' in response['Cache-Control']
 
     # Getting the URL redirects to the attachment
     file_url = reverse('wiki.raw_code_sample_file', locale='en-US',

--- a/kuma/wiki/views/akismet_revision.py
+++ b/kuma/wiki/views/akismet_revision.py
@@ -4,12 +4,14 @@ from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
+from django.views.decorators.cache import never_cache
 
 from kuma.core.utils import format_date_time
 from kuma.wiki.forms import RevisionAkismetSubmissionSpamForm
 from kuma.wiki.models import RevisionAkismetSubmission
 
 
+@never_cache
 @csrf_exempt
 @require_POST
 @permission_required('wiki.add_revisionakismetsubmission')

--- a/kuma/wiki/views/code.py
+++ b/kuma/wiki/views/code.py
@@ -15,11 +15,11 @@ from ..decorators import process_document_path, allow_CORS_GET
 from ..models import Document
 
 
+@cache_control(public=True, max_age=60 * 60 * 24)
 @require_GET
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
-@cache_control(public=True, max_age=60 * 60 * 24)
 def code_sample(request, document_slug, document_locale, sample_name):
     """
     Extract a code sample from a document and render it as a standalone
@@ -38,11 +38,11 @@ def code_sample(request, document_slug, document_locale, sample_name):
     return render(request, 'wiki/code_sample.html', data)
 
 
+@cache_control(public=True, max_age=60 * 60 * 24 * 5)
 @require_GET
 @allow_CORS_GET
 @xframe_options_exempt
 @process_document_path
-@cache_control(public=True, max_age=60 * 60 * 24 * 5)
 def raw_code_sample_file(request, document_slug, document_locale,
                          sample_name, attachment_id, filename):
     """

--- a/kuma/wiki/views/legacy.py
+++ b/kuma/wiki/views/legacy.py
@@ -4,6 +4,7 @@ from django.http import Http404
 from django.shortcuts import redirect
 
 from ..models import Document, Revision
+from kuma.core.decorators import shared_cache_control
 
 
 # Legacy MindTouch redirects.
@@ -56,6 +57,7 @@ def mindtouch_namespace_redirect(request, namespace, slug):
     return redirect(new_url, permanent=True)
 
 
+@shared_cache_control(s_maxage=60 * 60 * 24 * 30)
 def mindtouch_to_kuma_redirect(request, path):
     """
     Given a request to a Mindtouch-generated URL, generate a redirect


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds/modifies caching headers and tests for the endpoints for the kuma wiki views in `akismet_revision.py`, `code.py`, and `legacy.py`.

- This PR replaces the old-style `AkismetRevisionTests` in `kuma/wiki/tests/test_views.py` with new pytest-style tests in `kuma/wiki/tests/test_views_akismet.py`. As part of that effort, I realized that the existing `AkismetRevisionTests.test_submit_akismet_spam_revision_dne` test was flawed. It did not actually test the case it was intended to test (making an Akismet submission on a non-existent revision). Deep within the form's `clean` method, the Akismet key verification failed because it wasn't set-up properly in the test, which masked an ISE (a `KeyError` when getting the `revision` from the cleaned data). The new pytest-style `test_spam_revision_does_not_exist` actually checks that, so in order for it to pass, I made a fix to `RevisionAkismetSubmissionAdminForm` to check for the `revision` key prior to making any Akismet submissions.

- I didn't see any existing test for the `mindtouch_to_kuma_redirect` view in `legacy.py`, and I didn't add one. It didn't seem worth it, but I can add one if desired.