### PR TITLE
bug 1441210: Fix checkbox labels in Edit Profile

### DIFF
--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -584,26 +584,6 @@ Placeholders
     }
 }
 
-/* When an element contains a label and a checkbox in order (as on the edit
-   user page and elsewhere) make them appear on the same line, with the
-   checkbox to the left of the label. */
-%checkbox-label-container {
-    @include clearfix();
-
-    input[type='checkbox'] {
-        @include bidi(((float, left, right),));
-    }
-
-    label {
-        position: absolute;
-        @include bidi(((margin-left, 25px, margin-right, 0),));
-    }
-
-    > p {
-        @include bidi(((clear, left, right),));
-    }
-}
-
 /* Styles for code blocks - used for wiki document and WYSIWYG editor */
 %code-block {
     @include example-box($code-block-background-color, $code-block-border-color);

--- a/kuma/static/styles/submission.scss
+++ b/kuma/static/styles/submission.scss
@@ -143,11 +143,6 @@ p.field-note {
     clear: both;
 }
 
-#field-beta,
-#field_is_github_url_public {
-    @extend %checkbox-label-container;
-}
-
 #profiles {
     label {
         margin: 0 0 5px;

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -51,8 +51,10 @@
       <fieldset class="section notitle" id="personal">
         <ul>
           <li id="field-beta" class="field">
-            {{ user_form.beta }}
-            <label for="{{ user_form.beta.id_for_label }}">{{ user_form.beta.label }}</label>
+            <label for="{{ user_form.beta.id_for_label }}">
+              {{ user_form.beta }}
+              {{ user_form.beta.label }}
+            </label>
             <p class="field-note">{{ _("We'd love to have your feedback on site changes! Beta testers get access to new features first and we send the occasional email asking for help testing specific things.") }}</p>
           </li>
           <li id="field_email" class="field type_email required">
@@ -96,8 +98,8 @@
             </div>
 
             <div id="field_is_github_url_public">
-              {{ user_form.is_github_url_public }}
               <label for="{{ user_form.is_github_url_public.id_for_label }}">
+                {{ user_form.is_github_url_public }}
                 {{ user_form.is_github_url_public.label }}
               </label>
             </div>


### PR DESCRIPTION
This pull request fixes [1441210](https://bugzilla.mozilla.org/show_bug.cgi?id=1441210).

Looked at the difference between the labels in Edit Profile and the ones when editing a page and realized that there are [two different ways](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) to use labels. I changed the ones in Edit Profile to be consistent with the latter, and now the appearance is consistent as expected.

It seems like this functionality was leftover from a previous attempt to get "checkboxes after labels" working, an unnecessary hack due to the nature of how [HTML](https://html.spec.whatwg.org/multipage/forms.html#the-label-element) and the [DOM](https://dom.spec.whatwg.org/#trees) work.

I tested the changes with Developer Tools, so everything should be good to go. Did a grep for `checkbox-label-container` and couldn't find any other selectors that use it.