### PR TITLE
bug 1442745: upgrade bleach to 2.1.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -58,9 +58,17 @@ pyasn1==0.1.9 \
     --hash=sha256:853cacd96d1f701ddd67aa03ecc05f51890135b7262e922710112f12a2ed2a7f
 
 # bleach
-html5lib==1.0b10 \
-    --hash=sha256:08a3efc117a4fc8c82c3c6d10d6f58ae266428d57ed50258a1466d2cd88de745 \
-    --hash=sha256:0d5fd54d5b2b79b876007a70c033a4023577768d18022c15681c00561432a0f9
+#
+# Parse HTML with Python
+# Code: https://github.com/html5lib/html5lib-python
+# Changes: http://html5lib.readthedocs.io/en/latest/changes.html
+# Docs: http://html5lib.readthedocs.io/en/latest/
+html5lib==1.0.1 \
+    --hash=sha256:20b159aa3badc9d5ee8f5c647e5efd02ed2a66ab8d354930bd9ff139fc1dc0a3 \
+    --hash=sha256:66cb0dcfdbbc4f9c3ba1a63fdb511ffdbd4f513b2b6d81b80cd26ce6b3fb3736
+# Implements WHATWG Encoding standard
+# Code: https://github.com/gsnedders/python-webencodings
+# Docs: https://pythonhosted.org/webencodings/
 webencodings==0.5.1 \
     --hash=sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,6 +5,9 @@
 -r default_and_test.txt
 
 # Sanitize HTML with a whitelist
+# Code: https://github.com/mozilla/bleach
+# Changes: https://bleach.readthedocs.io/en/latest/changes.html
+# Docs: https://bleach.readthedocs.io/en/latest/
 bleach==2.1.3 \
     --hash=sha256:eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44 \
     --hash=sha256:b8fa79e91f96c2c2cd9fd1f9eda906efb1b88b483048978ba62fef680e962b34

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -5,9 +5,9 @@
 -r default_and_test.txt
 
 # Sanitize HTML with a whitelist
-bleach==2.1.1 \
-    --hash=sha256:7a316eac1eef1e98b9813636ebe05878aab1a658d2708047fb00fe2bcbc49f84 \
-    --hash=sha256:760a9368002180fb8a0f4ea48dc6275378e6f311c39d0236d7b904fca1f5ea0d
+bleach==2.1.3 \
+    --hash=sha256:eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44 \
+    --hash=sha256:b8fa79e91f96c2c2cd9fd1f9eda906efb1b88b483048978ba62fef680e962b34
 
 # Process tasks in the background
 celery==3.1.20 \


### PR DESCRIPTION
Upgrades bleach to 2.1.3 the hashes are for the 2.1.3 tgz and whl files respectively.