### PR TITLE
bug 1431259: caching headers/tests for wiki create/edit/delete views

### DIFF
--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -6,6 +6,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
 
+@never_cache
 def _error_page(request, status):
     """Render error pages with jinja2."""
     return render(request, '%d.html' % status, status=status)

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -222,27 +222,6 @@ LOCALIZATION_FLAG_TAGS = (
     ('inprogress', _('Localization in progress - not completely translated yet.')),
 )
 
-# TODO: This is info derived from urls.py, but unsure how to DRY it
-RESERVED_SLUGS = (
-    r'ckeditor_config\.js$',
-    r'watch-ready-for-review$',
-    r'unwatch-ready-for-review$',
-    r'watch-approved$',
-    r'unwatch-approved$',
-    r'\.json$',
-    r'new$',
-    r'all$',
-    r'templates$',
-    r'preview-wiki-content$',
-    r'category/\d+$',
-    r'needs-review/?[^/]+$',
-    r'needs-review/?',
-    r'feeds/[^/]+/all/?',
-    r'feeds/[^/]+/needs-review/[^/]+$',
-    r'feeds/[^/]+/needs-review/?',
-    r'tag/[^/]+'
-)
-RESERVED_SLUGS_RES = [re.compile(pattern) for pattern in RESERVED_SLUGS]
 SLUG_CLEANSING_RE = re.compile(r'^\/?(([A-z-]+)?\/?docs\/)?')
 # ?, whitespace, percentage, quote disallowed in slugs altogether
 INVALID_DOC_SLUG_CHARS_RE = re.compile(r"""[\s'"%%\?\$]+""")

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
 from django.shortcuts import render
+from django.views.decorators.cache import never_cache
 
 from kuma.core.utils import urlparams
 
@@ -15,7 +16,13 @@ class ReadOnlyMiddleware(object):
     def process_exception(self, request, exception):
         if isinstance(exception, ReadOnlyException):
             context = {'reason': exception.args[0]}
-            return render(request, '403.html', context, status=403)
+
+            @never_cache
+            def render403(request):
+                return render(request, '403.html', context, status=403)
+
+            return render403(request)
+
         return None
 
 

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -16,13 +16,8 @@ class ReadOnlyMiddleware(object):
     def process_exception(self, request, exception):
         if isinstance(exception, ReadOnlyException):
             context = {'reason': exception.args[0]}
-
-            @never_cache
-            def render403(request):
-                return render(request, '403.html', context, status=403)
-
-            return render403(request)
-
+            return never_cache(render)(request, '403.html', context,
+                                       status=403)
         return None
 
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -22,7 +22,7 @@ from kuma.core.tests import eq_, get_user, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.spam.constants import (
     SPAM_CHECKS_FLAG, SPAM_SUBMISSIONS_FLAG, VERIFY_URL)
-from kuma.users.tests import UserTestCase, user
+from kuma.users.tests import UserTestCase
 
 from . import (create_document_editor_user, create_document_tree,
                document, make_translation, new_document_data, normalize_html,
@@ -31,8 +31,7 @@ from .conftest import ks_toolbox
 from ..content import get_seo_description
 from ..events import EditDocumentEvent, EditDocumentInTreeEvent
 from ..forms import MIDAIR_COLLISION
-from ..models import (Document, DocumentDeletionLog, DocumentZone,
-                      Revision, RevisionIP)
+from ..models import Document, DocumentDeletionLog, DocumentZone, RevisionIP
 from ..templatetags.jinja_helpers import get_compare_url
 from ..views.document import _get_seo_parent_title
 
@@ -339,17 +338,6 @@ class ViewTests(UserTestCase, WikiTestCase):
         eq_(page.find('#doc-source').parent().attr('open'), None)
 
 
-class PermissionTests(WikiTestCase):
-    def test_new_user_does_not_have_add_document_permission(self):
-        newuser = user(save=True, username='newuser', password='password')
-        assert not newuser.has_perm('wiki.add_document')
-        url = reverse('wiki.create', locale='en-US')
-        assert self.client.login(username='newuser',
-                                 password='password'), 'Failed to login.'
-        response = self.client.get(url, slug='NewPage')
-        assert response.status_code == 403
-
-
 class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
     """Tests for conditional GET on document view"""
     localizing_client = True
@@ -402,7 +390,12 @@ class ReadOnlyTests(UserTestCase, WikiTestCase):
 
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.edit_url)
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
     def test_superusers_only(self):
         """ kumaediting: superusers, kumabanned: none """
@@ -412,13 +405,22 @@ class ReadOnlyTests(UserTestCase, WikiTestCase):
 
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.edit_url)
-        eq_(403, resp.status_code)
-        ok_('The wiki is in read-only mode.' in resp.content)
+        assert resp.status_code == 403
+        assert 'The wiki is in read-only mode.' in resp.content
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
         self.client.logout()
 
         self.client.login(username='admin', password='testpass')
         resp = self.client.get(self.edit_url)
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
 
 class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
@@ -742,14 +744,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
     """Tests for the document-editing view"""
     localizing_client = True
 
-    def test_noindex_post(self):
-        self.client.login(username='admin', password='testpass')
-
-        # Go to new document page to ensure no-index header works
-        response = self.client.get(reverse('wiki.create', args=[],
-                                           locale=settings.WIKI_DEFAULT_LANGUAGE))
-        eq_(response['X-Robots-Tag'], 'noindex')
-
     def test_editor_safety_filter(self):
         """Safety filter should be applied before rendering editor
 
@@ -874,39 +868,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         parameters = parse_qs(response.request['QUERY_STRING'])
         assert parameters['parent'][0] == str(root_doc.id)
 
-    def test_new_document_comment(self):
-        """Creating a new document with a revision comment saves the comment"""
-        self.client.login(username='admin', password='testpass')
-
-        comment = 'I am the revision comment'
-        slug = 'Test-doc-comment'
-        loc = settings.WIKI_DEFAULT_LANGUAGE
-
-        # Create a new doc.
-        data = new_document_data()
-        data.update({'slug': slug, 'comment': comment})
-        self.client.post(reverse('wiki.create'), data)
-        doc = Document.objects.get(slug=slug, locale=loc)
-        eq_(comment, doc.current_revision.comment)
-
-    @pytest.mark.toc
-    def test_toc_initial(self):
-        self.client.login(username='admin', password='testpass')
-
-        resp = self.client.get(reverse('wiki.create'))
-        eq_(200, resp.status_code)
-
-        page = pq(resp.content)
-        toc_select = page.find('#id_toc_depth')
-        toc_options = toc_select.find('option')
-        for option in toc_options:
-            opt_element = pq(option)
-            found_selected = False
-            if opt_element.attr('selected'):
-                found_selected = True
-                eq_(str(Revision.TOC_DEPTH_H4), opt_element.attr('value'))
-        assert found_selected, "No ToC depth initially selected."
-
     @pytest.mark.retitle
     def test_retitling_solo_doc(self):
         """ Editing just title of non-parent doc:
@@ -928,10 +889,16 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'title': new_title,
                      'form-type': 'rev'})
         data['slug'] = ''
-        url = reverse('wiki.edit', args=[doc.slug])
-        self.client.post(url, data)
-        eq_(new_title,
-            Document.objects.get(slug=doc.slug, locale=doc.locale).title)
+        url = reverse('wiki.edit', locale='en-US', args=[doc.slug])
+        response = self.client.post(url, data)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert (Document.objects.get(slug=doc.slug, locale=doc.locale).title ==
+                new_title)
         assert not Document.objects.filter(title=old_title).exists()
 
     @pytest.mark.retitle
@@ -958,10 +925,16 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'title': new_title,
                      'form-type': 'rev'})
         data['slug'] = ''
-        url = reverse('wiki.edit', args=[d.slug])
-        self.client.post(url, data)
-        eq_(new_title,
-            Document.objects.get(slug=d.slug, locale=d.locale).title)
+        url = reverse('wiki.edit', locale='en-US', args=[d.slug])
+        response = self.client.post(url, data)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert (Document.objects.get(slug=d.slug, locale=d.locale).title ==
+                new_title)
         assert not Document.objects.filter(title=old_title).exists()
 
     def test_slug_change_ignored_for_iframe(self):
@@ -975,11 +948,19 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'title': rev.document.title,
                      'slug': new_slug,
                      'form': 'rev'})
-        self.client.post('%s?iframe=1' % reverse('wiki.edit',
-                                                 args=[rev.document.slug]),
-                         data)
-        eq_(old_slug, Document.objects.get(slug=rev.document.slug,
-                                           locale=rev.document.locale).slug)
+        response = self.client.post('%s?iframe=1' %
+                                    reverse('wiki.edit', locale='en-US',
+                                            args=[rev.document.slug]),
+                                    data)
+        assert response.status_code == 200
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert (Document.objects.get(slug=rev.document.slug,
+                                     locale=rev.document.locale).slug ==
+                old_slug)
         assert "REDIRECT" not in Document.objects.get(slug=old_slug).html
 
     @pytest.mark.clobber
@@ -994,26 +975,30 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         data.update({"slug": exist_slug})
         resp = self.client.post(reverse('wiki.create'), data)
-        eq_(302, resp.status_code)
+        assert resp.status_code == 302
 
         # Create another new doc.
         data = new_document_data()
         data.update({"slug": 'some-new-title'})
         resp = self.client.post(reverse('wiki.create'), data)
-        eq_(302, resp.status_code)
+        assert resp.status_code == 302
 
         # Now, post an update with duplicate slug
         data.update({
             'form-type': 'rev',
             'slug': exist_slug
         })
-        resp = self.client.post(reverse('wiki.edit',
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
                                         args=['some-new-title']), data)
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
         p = pq(resp.content)
-
-        ok_(p.find('.errorlist').length > 0)
-        ok_(p.find('.errorlist a[href="#id_slug"]').length > 0)
+        assert p.find('.errorlist').length > 0
+        assert p.find('.errorlist a[href="#id_slug"]').length > 0
 
     @pytest.mark.clobber
     def test_redirect_can_be_clobbered(self):
@@ -1032,248 +1017,36 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         data.update({"title": exist_title, "slug": exist_slug})
         resp = self.client.post(reverse('wiki.create'), data)
-        eq_(302, resp.status_code)
+        assert resp.status_code == 302
 
         # Change title and slug
         data.update({'form-type': 'rev',
                      'title': changed_title,
                      'slug': changed_slug})
-        resp = self.client.post(reverse('wiki.edit',
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
                                         args=[exist_slug]),
                                 data)
-        eq_(302, resp.status_code)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
         # Change title and slug back to originals, clobbering the redirect
         data.update({'form-type': 'rev',
                      'title': exist_title,
                      'slug': exist_slug})
-        resp = self.client.post(reverse('wiki.edit',
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
                                         args=[changed_slug]),
                                 data)
-        eq_(302, resp.status_code)
-
-    def test_invalid_slug(self):
-        """Slugs cannot contain "$", but can contain "/"."""
-        self.client.login(username='admin', password='testpass')
-        data = new_document_data()
-
-        data['title'] = 'valid slug'
-        data['slug'] = 'valid'
-        response = self.client.post(reverse('wiki.create'), data)
-        self.assertRedirects(response,
-                             reverse('wiki.document', args=[data['slug']],
-                                     locale=settings.WIKI_DEFAULT_LANGUAGE))
-
-        new_url = reverse('wiki.create')
-        invalid_slugs = [
-            'va/lid',  # slashes
-            'inva$lid',  # dollar signs
-            'inva?lid',  # question marks
-            'inva%lid',  # percentage sign
-            '"invalid\'',  # quotes
-            'in valid',  # whitespace
-        ]
-        for invalid_slug in invalid_slugs:
-            data['title'] = 'invalid with %s' % invalid_slug
-            data['slug'] = invalid_slug
-            response = self.client.post(new_url, data)
-            self.assertContains(response, 'The slug provided is not valid.')
-
-    def test_invalid_reserved_term_slug(self):
-        """Slugs should not collide with reserved URL patterns"""
-        self.client.login(username='admin', password='testpass')
-        data = new_document_data()
-
-        # TODO: This is info derived from urls.py, but unsure how to DRY it
-        reserved_slugs = (
-            'ckeditor_config.js',
-            'watch-ready-for-review',
-            'unwatch-ready-for-review',
-            'watch-approved',
-            'unwatch-approved',
-            '.json',
-            'new',
-            'all',
-            'preview-wiki-content',
-            'category/10',
-            'needs-review/technical',
-            'needs-review/',
-            'feeds/atom/all/',
-            'feeds/atom/needs-review/technical',
-            'feeds/atom/needs-review/',
-            'tag/tasty-pie'
-        )
-
-        for term in reserved_slugs:
-            data['title'] = 'invalid with %s' % term
-            data['slug'] = term
-            response = self.client.post(reverse('wiki.create'), data)
-            self.assertContains(response, 'The slug provided is not valid.')
+        assert resp.status_code == 302
 
     def test_slug_revamp(self):
         self.client.login(username='admin', password='testpass')
 
-        def _createAndRunTests(slug):
-
-            # Create some vars
-            locale = settings.WIKI_DEFAULT_LANGUAGE
-            foreign_locale = 'es'
-            new_doc_url = reverse('wiki.create')
-            invalid_slug = "some/thing"
-            invalid_slugs = [
-                "some/thing",
-                "some?thing",
-                "some thing",
-                "some%thing",
-                "$omething",
-            ]
-
-            child_slug = 'kiddy'
-            grandchild_slug = 'grandkiddy'
-
-            # Create the document data
-            doc_data = new_document_data()
-            doc_data['title'] = slug + ' Doc'
-            doc_data['slug'] = slug
-            doc_data['content'] = 'This is the content'
-            doc_data['is_localizable'] = True
-
-            """ NEW DOCUMENT CREATION, CHILD CREATION """
-
-            # Create the document, validate it exists
-            response = self.client.post(new_doc_url, doc_data)
-            eq_(302, response.status_code)  # 302 = good, forward to new page
-            ok_(slug in response['Location'])
-            self.assertRedirects(response, reverse('wiki.document',
-                                                   locale=locale, args=[slug]))
-            doc_url = reverse('wiki.document', locale=locale, args=[slug])
-            eq_(self.client.get(doc_url).status_code, 200)
-            doc = Document.objects.get(locale=locale, slug=slug)
-            eq_(doc.slug, slug)
-            eq_(0, len(Document.objects.filter(title=doc_data['title'] + 'Redirect')))
-
-            # Create child document data
-            child_data = new_document_data()
-            child_data['title'] = slug + ' Child Doc'
-            child_data['slug'] = invalid_slug
-            child_data['content'] = 'This is the content'
-            child_data['is_localizable'] = True
-
-            # Attempt to create the child with invalid slug, validate it fails
-            def test_invalid_slug(inv_slug, url, data, doc):
-                data['slug'] = inv_slug
-                response = self.client.post(url, data)
-                page = pq(response.content)
-                eq_(200, response.status_code)  # 200 = bad, invalid data
-                # Slug doesn't add parent
-                eq_(inv_slug, page.find('input[name=slug]')[0].value)
-                eq_(doc.get_absolute_url(),
-                    page.find('.metadataDisplay').attr('href'))
-                self.assertContains(response,
-                                    'The slug provided is not valid.')
-
-            for invalid_slug in invalid_slugs:
-                test_invalid_slug(invalid_slug,
-                                  new_doc_url + '?parent=' + str(doc.id),
-                                  child_data, doc)
-
-            # Attempt to create the child with *valid* slug,
-            # should succeed and redirect
-            child_data['slug'] = child_slug
-            full_child_slug = slug + '/' + child_data['slug']
-            response = self.client.post(new_doc_url + '?parent=' + str(doc.id),
-                                        child_data)
-            eq_(302, response.status_code)
-            self.assertRedirects(response, reverse('wiki.document',
-                                                   locale=locale,
-                                                   args=[full_child_slug]))
-            child_doc = Document.objects.get(locale=locale,
-                                             slug=full_child_slug)
-            eq_(child_doc.slug, full_child_slug)
-            eq_(0, len(Document.objects.filter(
-                title=child_data['title'] + ' Redirect 1',
-                locale=locale)))
-
-            # Create grandchild data
-            grandchild_data = new_document_data()
-            grandchild_data['title'] = slug + ' Grandchild Doc'
-            grandchild_data['slug'] = invalid_slug
-            grandchild_data['content'] = 'This is the content'
-            grandchild_data['is_localizable'] = True
-
-            # Attempt to create the child with invalid slug, validate it fails
-            response = self.client.post(
-                new_doc_url + '?parent=' + str(child_doc.id), grandchild_data)
-            page = pq(response.content)
-            eq_(200, response.status_code)  # 200 = bad, invalid data
-            # Slug doesn't add parent
-            eq_(invalid_slug, page.find('input[name=slug]')[0].value)
-            eq_(child_doc.get_absolute_url(),
-                page.find('.metadataDisplay').attr('href'))
-            self.assertContains(response, 'The slug provided is not valid.')
-
-            # Attempt to create the child with *valid* slug,
-            # should succeed and redirect
-            grandchild_data['slug'] = grandchild_slug
-            full_grandchild_slug = (full_child_slug + '/' +
-                                    grandchild_data['slug'])
-            response = self.client.post(
-                new_doc_url + '?parent=' + str(child_doc.id),
-                grandchild_data)
-            eq_(302, response.status_code)
-            self.assertRedirects(response,
-                                 reverse('wiki.document', locale=locale,
-                                         args=[full_grandchild_slug]))
-            grandchild_doc = Document.objects.get(locale=locale,
-                                                  slug=full_grandchild_slug)
-            eq_(grandchild_doc.slug, full_grandchild_slug)
-            missing_title = grandchild_data['title'] + ' Redirect 1'
-            eq_(0, len(Document.objects.filter(title=missing_title,
-                                               locale=locale)))
-
-            def _run_translate_tests(translate_slug, translate_data,
-                                     translate_doc):
-                """TRANSLATION DOCUMENT TESTING"""
-
-                foreign_url = (reverse('wiki.translate',
-                                       args=[translate_doc.slug],
-                                       locale=locale) +
-                               '?tolocale=' + foreign_locale)
-                foreign_doc_url = reverse('wiki.document',
-                                          args=[translate_doc.slug],
-                                          locale=foreign_locale)
-
-                # Verify translate page form is populated correctly
-                response = self.client.get(foreign_url)
-                eq_(200, response.status_code)
-                page = pq(response.content)
-                eq_(translate_data['slug'],
-                    page.find('input[name=slug]')[0].value)
-
-                # Push a valid translation
-                translate_data['slug'] = translate_slug
-                translate_data['form-type'] = 'both'
-                response = self.client.post(foreign_url, translate_data)
-                eq_(302, response.status_code)
-                # Ensure no redirect
-                redirect_title = translate_data['title'] + ' Redirect 1'
-                eq_(0, len(Document.objects.filter(title=redirect_title,
-                                                   locale=foreign_locale)))
-                self.assertRedirects(response, foreign_doc_url + '?rev_saved=')
-
-                return Document.objects.get(locale=foreign_locale,
-                                            slug=translate_doc.slug)
-
-            _run_translate_tests(slug, doc_data, doc)
-            _run_translate_tests(child_slug, child_data, child_doc)
-            _run_translate_tests(grandchild_slug, grandchild_data,
-                                 grandchild_doc)
-
-        # Run all of the tests
-        _createAndRunTests("parent")
-
         # Test that slugs with the same "specific" slug but in different levels
-        # in the heiharachy are validate properly upon submission
+        # in the heiharachy are validated properly upon submission.
 
         # Create base doc
         parent_doc = document(title='Length',
@@ -1294,7 +1067,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                      '?parent=' +
                      str(parent_doc.id))
         response = self.client.post(child_url, child_data)
-        eq_(302, response.status_code)
+        assert response.status_code == 302
         # grab new revision ID
         child = Document.objects.get(locale='en-US', slug='length/length')
         rev_id = child.current_revision.id
@@ -1309,7 +1082,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         edit_url = reverse('wiki.edit', args=['length/length'],
                            locale=settings.WIKI_DEFAULT_LANGUAGE)
         response = self.client.post(edit_url, child_data)
-        eq_(302, response.status_code)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
         url = reverse('wiki.document',
                       args=['length/length'],
                       locale=settings.WIKI_DEFAULT_LANGUAGE)
@@ -1368,7 +1146,13 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         translate_url = reverse('wiki.edit',
                                 args=[de_child_doc.slug],
                                 locale='de')
-        self.client.post(translate_url, post_data)
+        response = self.client.post(translate_url, post_data)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
 
         de_child_doc = Document.objects.get(locale='de', slug='de-child')
         eq_(en_child_doc, de_child_doc.parent)
@@ -1529,25 +1313,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         doc_url = '%s?%s' % (doc_url, urlencode(params))
         self.assertRedirects(response, doc_url)
 
-    def test_clone(self):
-        self.client.login(username='admin', password='testpass')
-        slug = None
-        title = None
-        content = '<p>Hello!</p>'
-
-        test_revision = revision(save=True, title=title, slug=slug,
-                                 content=content)
-        document = test_revision.document
-
-        response = self.client.get(reverse('wiki.create',
-                                           args=[],
-                                           locale=settings.WIKI_DEFAULT_LANGUAGE) + '?clone=' + str(document.id))
-        page = pq(response.content)
-
-        eq_(page.find('input[name=title]')[0].value, title)
-        eq_(page.find('input[name=slug]')[0].value, slug)
-        self.assertHTMLEqual(page.find('textarea[name=content]')[0].value, content)
-
     def test_localized_based_on(self):
         """Editing a localized article 'based on' an older revision of the
         localization is OK."""
@@ -1558,8 +1323,14 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         url = reverse('wiki.new_revision_based_on',
                       locale='fr', args=(fr_d.slug, fr_r.pk,))
         response = self.client.get(url)
+        assert response.status_code == 200
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
         input = pq(response.content)('#id_based_on')[0]
-        eq_(int(input.value), en_r.pk)
+        assert int(input.value) == en_r.pk
 
     def test_restore_translation_source(self):
         """Edit a localized article without an English parent allows user to
@@ -1580,18 +1351,29 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # Check edit doc page for choose parent box
         url = reverse('wiki.edit', args=[fr_d.slug], locale='fr')
         response = self.client.get(url)
-        ok_(pq(response.content)('li.metadata-choose-parent'))
+        assert response.status_code == 200
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert pq(response.content)('li.metadata-choose-parent')
 
         # Set the parent
         data.update({'form-type': 'rev', 'parent_id': en_d.id})
         resp = self.client.post(url, data)
-        eq_(302, resp.status_code)
-        ok_('fr/docs/a-test-article' in resp['Location'])
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert 'fr/docs/a-test-article' in resp['Location']
 
         # Check the languages drop-down
         resp = self.client.get(resp['Location'])
         translations = pq(resp.content)('ul#translations li')
-        ok_('English (US)' in translations.text())
+        assert 'English (US)' in translations.text()
 
     def test_translation_source(self):
         """Allow users to change "translation source" settings"""
@@ -1606,25 +1388,17 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.client.post(reverse('wiki.create'), data)
         child = Document.objects.get(locale=data['locale'], slug=data['slug'])
 
-        url = reverse('wiki.edit', args=[child.slug])
+        url = reverse('wiki.edit', locale='en-US', args=[child.slug])
         response = self.client.get(url)
+        assert response.status_code == 200
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
         content = pq(response.content)
         ok_(content('li.metadata-choose-parent'))
         ok_(str(parent.id) in content.html())
-
-    @pytest.mark.tags
-    def test_tags_while_document_create(self):
-        data = new_document_data()
-        tags = ('JavaScript', 'AJAX', 'DOM')
-        data['tags'] = ','.join(tags)
-
-        self.client.login(username='admin', password='testpass')
-        response = self.client.post(reverse('wiki.create'), data, follow=True)
-        assert response.status_code == 200
-
-        doc = Document.objects.all().get(slug=data['slug'], locale=data['locale'])
-        doc_tags = doc.tags.all().values_list('name', flat=True)
-        assert sorted(doc_tags) == sorted(tags)
 
     @pytest.mark.tags
     def test_tags_while_document_update(self):
@@ -1638,8 +1412,14 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # Update the document with some other tags
         data = new_document_data()
         data.update({'form-type': 'rev', 'tags': ', '.join(ts2)})
-        response = self.client.post(reverse('wiki.edit', args=[doc.slug]), data, follow=True)
-        assert response.status_code == 200
+        response = self.client.post(
+            reverse('wiki.edit', locale='en-US', args=[doc.slug]), data)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
 
         # Check only last added tags are related with the documents
         doc_tags = doc.tags.all().values_list('name', flat=True)
@@ -1658,8 +1438,14 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         del data['slug']
         data.update({'form-type': 'rev', 'tags': ', '.join(ts2)})
-        response = self.client.post(reverse('wiki.edit', args=[doc.slug]), data, follow=True)
-        assert response.status_code == 200
+        response = self.client.post(
+            reverse('wiki.edit', locale='en-US', args=[doc.slug]), data)
+        assert response.status_code == 302
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
 
         # Check document is showing the new tags
         response = self.client.get(doc.get_absolute_url(), follow=True)
@@ -1681,10 +1467,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'review_tags': ['technical']})
         response = self.client.post(reverse('wiki.create'), data)
         assert response.status_code == 302
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
 
         # Ensure there's now a doc with that expected tag in its newest
         # revision
@@ -1698,7 +1480,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             'form-type': 'rev',
             'review_tags': ['editorial', 'technical'],
         })
-        response = self.client.post(reverse('wiki.edit',
+        response = self.client.post(reverse('wiki.edit', locale='en-US',
                                             args=[doc.slug]), data)
         assert response.status_code == 302
         assert 'max-age=0' in response['Cache-Control']
@@ -1871,7 +1653,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         resp = self.client.post(reverse('wiki.create'), data)
         doc = Document.objects.get(slug=data['slug'])
         # This is the url to post new revisions for the rest of this test
-        posting_url = reverse('wiki.edit', args=[doc.slug])
+        posting_url = reverse('wiki.edit', locale='en-US', args=[doc.slug])
 
         # Edit #1 starts...
         resp = self.client.get(
@@ -1920,10 +1702,17 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                 posting_url,
                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest'
             )
-            eq_(False, json.loads(resp.content)['error'])
+            assert resp.status_code == 200
+            assert not json.loads(resp.content)['error']
         else:
             resp = self.client.post(posting_url, data)
-            eq_(302, resp.status_code)
+            assert resp.status_code == 302
+
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
         # Edit #1 submits, but receives a mid-aired notification
         data.update({
@@ -2144,10 +1933,16 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data['toc_depth'] = 0
         data['slug'] = doc.slug
         data['title'] = doc.title
-        self.client.post(reverse('wiki.edit', args=[doc.slug]),
-                         data)
+        resp = self.client.post(
+            reverse('wiki.edit', locale='en-US', args=[doc.slug]), data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
         doc = Document.objects.get(slug=doc.slug, locale=doc.locale)
-        eq_(0, doc.current_revision.toc_depth)
+        assert doc.current_revision.toc_depth == 0
 
     @pytest.mark.toc
     def test_toc_toggle_on(self):
@@ -2157,32 +1952,47 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         new_r = revision(document=rev.document, content=rev.content,
                          toc_depth=0, is_approved=True)
         new_r.save()
-        ok_(not Document.objects.get(slug=rev.document.slug,
-                                     locale=rev.document.locale).show_toc)
+        assert not Document.objects.get(slug=rev.document.slug,
+                                        locale=rev.document.locale).show_toc
         data = new_document_data()
         data['form-type'] = 'rev'
         data['slug'] = rev.document.slug
         data['title'] = rev.document.title
-        self.client.post(reverse('wiki.edit', args=[rev.document.slug]),
-                         data)
-        ok_(Document.objects.get(slug=rev.document.slug,
-                                 locale=rev.document.locale).show_toc)
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
+                                        args=[rev.document.slug]), data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert Document.objects.get(slug=rev.document.slug,
+                                    locale=rev.document.locale).show_toc
 
     def test_parent_topic(self):
         """Selection of a parent topic when creating a document."""
+        # TODO: Do we need this test? This seems broken in that the
+        #       parent specified via the parent topic doesn't get it's
+        #       slug prepended to the new document's slug, as happens
+        #       when specifying the parent via the URL.
         self.client.login(username='admin', password='testpass')
-        d = document(title='HTML8')
-        d.save()
-        r = revision(document=d)
-        r.save()
+        doc = document(title='HTML8')
+        doc.save()
+        rev = revision(document=doc)
+        rev.save()
 
         data = new_document_data()
         data['title'] = 'Replicated local storage'
-        data['parent_topic'] = d.id
-        resp = self.client.post(reverse('wiki.create'), data)
-        eq_(302, resp.status_code)
-        ok_(d.children.count() == 1)
-        ok_(d.children.all()[0].title == 'Replicated local storage')
+        data['parent_topic'] = doc.id
+        resp = self.client.post(reverse('wiki.create', locale='en-US'), data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert doc.children.count() == 1
+        assert doc.children.all()[0].title == 'Replicated local storage'
 
     def test_repair_breadcrumbs(self):
         english_top = document(locale=settings.WIKI_DEFAULT_LANGUAGE,
@@ -2237,7 +2047,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         url = reverse('wiki.edit', args=(d2.slug,), locale=d2.locale)
 
         resp = self.client.get(url)
-        eq_(200, resp.status_code)
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
     def test_discard_location(self):
         """Testing that the 'discard' HREF goes to the correct place when it's
@@ -2276,13 +2091,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             reverse('wiki.document', args=[foreign_doc.slug],
                     locale=foreign_doc.locale))
 
-        # Test new
-        response = self.client.get(reverse('wiki.create',
-                                           locale=settings.WIKI_DEFAULT_LANGUAGE))
-        eq_(pq(response.content).find('.btn-discard').attr('href'),
-            reverse('wiki.create',
-                    locale=settings.WIKI_DEFAULT_LANGUAGE))
-
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get',
                 return_value=('lorem ipsum dolor sit amet', None))
@@ -2306,24 +2114,28 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         mock_kumascript_get.reset_mock()
         response = self.client.post(reverse('wiki.revert_document',
+                                            locale='en-US',
                                             args=[doc.slug, rev.id]),
                                     {'revert': True, 'comment': 'Blah blah'})
-        ok_(mock_kumascript_get.called, "kumascript should have been used")
-
-        ok_(302 == response.status_code)
+        assert response.status_code == 302
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert mock_kumascript_get.called, "kumascript should have been used"
         rev = doc.revisions.order_by('-id').all()[0]
-        ok_('lorem ipsum dolor sit amet' == rev.content)
-        ok_('Blah blah' in rev.comment)
+        assert rev.content == 'lorem ipsum dolor sit amet'
+        assert 'Blah blah' in rev.comment
 
         mock_kumascript_get.reset_mock()
         rev = doc.revisions.order_by('-id').all()[1]
         response = self.client.post(reverse('wiki.revert_document',
                                             args=[doc.slug, rev.id]),
                                     {'revert': True})
-        ok_(302 == response.status_code)
+        assert response.status_code == 302
         rev = doc.revisions.order_by('-id').all()[0]
-        ok_(': ' not in rev.comment)
-        ok_(mock_kumascript_get.called, "kumascript should have been used")
+        assert ': ' not in rev.comment
+        assert mock_kumascript_get.called, "kumascript should have been used"
 
     def test_revert_moved(self):
         doc = document(slug='move-me', save=True)
@@ -2334,11 +2146,14 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         resp = self.client.post(reverse('wiki.revert_document',
                                         args=[doc.slug, prev_rev_id],
-                                        locale=doc.locale),
-                                follow=True)
+                                        locale=doc.locale))
 
-        eq_(200, resp.status_code)
-        ok_("cannot revert a document that has been moved" in resp.content)
+        assert resp.status_code == 200
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert "cannot revert a document that has been moved" in resp.content
 
     def test_store_revision_ip(self):
         self.client.login(username='testuser', password='testpass')
@@ -2348,18 +2163,24 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                      'slug': slug})
         self.client.post(reverse('wiki.create'), data)
 
-        doc = Document.objects.get(locale=settings.WIKI_DEFAULT_LANGUAGE,
-                                   slug=slug)
+        doc = Document.objects.get(locale='en-US', slug=slug)
 
         data.update({'form-type': 'rev',
                      'content': 'This revision should NOT record IP',
                      'comment': 'This revision should NOT record IP'})
 
-        self.client.post(reverse('wiki.edit', args=[doc.slug]),
-                         data,
-                         HTTP_USER_AGENT='Mozilla Firefox',
-                         HTTP_REFERER='http://localhost/')
-        eq_(0, RevisionIP.objects.all().count())
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
+                                        args=[doc.slug]),
+                                data,
+                                HTTP_USER_AGENT='Mozilla Firefox',
+                                HTTP_REFERER='http://localhost/')
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert RevisionIP.objects.all().count() == 0
 
         Switch.objects.create(name='store_revision_ips', active=True)
 
@@ -2370,12 +2191,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                          data,
                          HTTP_USER_AGENT='Mozilla Firefox',
                          HTTP_REFERER='http://localhost/')
-        eq_(1, RevisionIP.objects.all().count())
+        assert RevisionIP.objects.all().count() == 1
         rev = doc.revisions.order_by('-id').all()[0]
         rev_ip = RevisionIP.objects.get(revision=rev)
-        eq_(rev_ip.ip, '127.0.0.1')
-        eq_(rev_ip.user_agent, 'Mozilla Firefox')
-        eq_(rev_ip.referrer, 'http://localhost/')
+        assert rev_ip.ip == '127.0.0.1'
+        assert rev_ip.user_agent == 'Mozilla Firefox'
+        assert rev_ip.referrer == 'http://localhost/'
 
     @pytest.mark.edit_emails
     @mock.patch.object(Site.objects, 'get_current')
@@ -2388,7 +2209,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         data.update({'title': 'A Test Article For First Edit Emails',
                      'slug': slug})
         self.client.post(reverse('wiki.create'), data)
-        eq_(1, len(mail.outbox))
+        assert len(mail.outbox) == 1
 
         doc = Document.objects.get(
             locale=settings.WIKI_DEFAULT_LANGUAGE, slug=slug)
@@ -2397,10 +2218,16 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                      'content': 'This edit should not send an email',
                      'comment': 'This edit should not send an email'})
 
-        self.client.post(reverse('wiki.edit',
-                                 args=[doc.slug]),
-                         data)
-        eq_(1, len(mail.outbox))
+        resp = self.client.post(
+            reverse('wiki.edit', locale='en-US', args=[doc.slug]), data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+
+        assert len(mail.outbox) == 1
 
         self.client.login(username='admin', password='testpass')
         data.update({'content': 'Admin first edit should send an email',
@@ -2409,14 +2236,17 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.client.post(reverse('wiki.edit',
                                  args=[doc.slug]),
                          data)
-        eq_(2, len(mail.outbox))
+        assert len(mail.outbox) == 2
 
         def _check_message_for_headers(message, username):
-            ok_("%s made their first edit" % username in message.subject)
-            eq_({'X-Kuma-Document-Url': "https://dev.mo.org%s" % doc.get_absolute_url(),
-                 'X-Kuma-Editor-Username': username,
-                 'X-Kuma-Document-Locale': doc.locale,
-                 'X-Kuma-Document-Title': doc.title}, message.extra_headers)
+            assert "%s made their first edit" % username in message.subject
+            assert message.extra_headers == {
+                'X-Kuma-Document-Url':
+                    "https://dev.mo.org%s" % doc.get_absolute_url(),
+                'X-Kuma-Editor-Username': username,
+                'X-Kuma-Document-Locale': doc.locale,
+                'X-Kuma-Document-Title': doc.title
+            }
 
         testuser_message = mail.outbox[0]
         admin_message = mail.outbox[1]
@@ -2443,7 +2273,15 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                      'title': rev.document.title,
                      'content': 'This edit should send an email',
                      'comment': 'This edit should send an email'})
-        self.client.post(reverse('wiki.edit', args=[rev.document.slug]), data)
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
+                                        args=[rev.document.slug]),
+                                data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
         self.assertEquals(1, len(mail.outbox))
         message = mail.outbox[0]
@@ -2499,10 +2337,16 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                      'slug': child_doc.slug,
                      'content': 'This edit should send an email',
                      'comment': 'This edit should send an email'})
-        self.client.post(reverse('wiki.edit',
-                                 args=[child_doc.slug]),
-                         data)
-        eq_(1, len(mail.outbox))
+        resp = self.client.post(reverse('wiki.edit', locale='en-US',
+                                        args=[child_doc.slug]),
+                                data)
+        assert resp.status_code == 302
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert len(mail.outbox) == 1
         message = mail.outbox[0]
         assert testuser2.email in message.to
         assert 'sub-articles' in message.body
@@ -2529,7 +2373,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.client.post(reverse('wiki.edit',
                                  args=[grandchild_doc.slug]),
                          data)
-        eq_(1, len(mail.outbox))
+        assert len(mail.outbox) == 1
         message = mail.outbox[0]
         assert testuser2.email in message.to
         assert 'sub-articles' in message.body
@@ -2558,7 +2402,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.client.post(reverse('wiki.edit',
                                  args=[child_doc.slug]),
                          data)
-        eq_(1, len(mail.outbox))
+        assert len(mail.outbox) == 1
         message = mail.outbox[0]
         assert testuser2.email in message.to
 
@@ -2757,15 +2601,22 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <p>replace</p>
         """
         response = self.client.post('%s?section=s2&raw=true' %
-                                    reverse('wiki.edit',
+                                    reverse('wiki.edit', locale='en-US',
                                             args=[rev.document.slug]),
                                     {"form-type": "rev",
                                      "slug": rev.document.slug,
                                      "content": replace},
-                                    follow=True,
                                     HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_({'error': False, 'new_revision_id': rev.id + 1},
-            json.loads(response.content))
+        assert response.status_code == 200
+        assert response['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
+        assert json.loads(response.content) == {
+            'error': False,
+            'new_revision_id': rev.id + 1
+        }
 
         expected = """
             <h1 id="s1">s1</h1>
@@ -2783,8 +2634,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                                    reverse('wiki.document',
                                            args=[rev.document.slug]),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(normalize_html(expected),
-            normalize_html(response.content))
+        assert normalize_html(expected) == normalize_html(response.content)
 
     @pytest.mark.midair
     def test_midair_section_merge_ajax(self):
@@ -2833,8 +2683,15 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
 
         # Edit #1 starts...
         resp = self.client.get('%s?section=s1' %
-                               reverse('wiki.edit', args=[rev.document.slug]),
+                               reverse('wiki.edit', locale='en-US',
+                                       args=[rev.document.slug]),
                                HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
         page = pq(resp.content)
         rev_id1 = page.find('input[name="current_rev"]').attr('value')
 
@@ -2854,11 +2711,18 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'slug': rev.document.slug
         })
         resp = self.client.post('%s?section=s2&raw=true' %
-                                reverse('wiki.edit', args=[rev.document.slug]),
+                                reverse('wiki.edit', locale='en-US',
+                                        args=[rev.document.slug]),
                                 data,
                                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        assert resp.status_code == 200
+        assert resp['X-Robots-Tag'] == 'noindex'
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
-        eq_(json.loads(resp.content)['error'], False)
+        assert not json.loads(resp.content)['error']
 
         # Edit #1 submits, but since it's a different section, there's no
         # mid-air collision
@@ -2873,21 +2737,20 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                                 HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         # No conflict, but we should get a 205 Reset as an indication that the
         # page needs a refresh.
-        eq_(205, resp.status_code)
+        assert resp.status_code == 205
 
         # Finally, make sure that all the edits landed
         response = self.client.get('%s?raw=true' %
                                    reverse('wiki.document',
                                            args=[rev.document.slug]),
                                    HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(normalize_html(expected),
-            normalize_html(response.content))
+        assert normalize_html(expected) == normalize_html(response.content)
 
         # Also, ensure that the revision is slipped into the headers
-        eq_(unicode(Document.objects.get(slug=rev.document.slug,
-                                         locale=rev.document.locale)
-                                    .current_revision.id),
-            unicode(response['x-kuma-revision']))
+        assert (unicode(Document.objects.get(slug=rev.document.slug,
+                                             locale=rev.document.locale)
+                                        .current_revision.id) ==
+                unicode(response['x-kuma-revision']))
 
     @pytest.mark.midair
     def test_midair_section_collision_ajax(self):

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -84,7 +84,6 @@ def test_code_sample_host_restriction(code_sample_doc, constance_config,
     constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*sampleserver'
     response = client.get(url, HTTP_HOST='testserver')
     assert response.status_code == 403
-    assert 'Last-Modified' not in response
     response = client.get(url, HTTP_HOST='sampleserver')
     assert response.status_code == 200
     assert 'public' in response['Cache-Control']

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -1,0 +1,216 @@
+from django.contrib.auth.models import Permission
+from pyquery import PyQuery as pq
+import pytest
+
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.models import Document, Revision
+
+
+# dict of case-name --> tuple of slug and expected status code
+SLUG_SIMPLE_CASES = dict(
+    valid=('Foobar', 302),
+    invalid_slash=('Foo/bar', 200),
+    invalid_dollar_sign=('Foo$bar', 200),
+    invalid_question_mark=('Foo?bar', 200),
+    invalid_percent_sign=('Foo%bar', 200),
+    invalid_double_quote=('Foo"bar', 200),
+    invalid_single_quote=("Foo'bar", 200),
+    invalid_whitespace=('Foo bar', 200),
+)
+SLUG_RESERVED_CASES = dict(
+    invalid_reserved_01=('ckeditor_config.js', 200),
+    invalid_reserved_02=('preview-wiki-content', 200),
+    invalid_reserved_03=('get-documents', 200),
+    invalid_reserved_04=('tags', 200),
+    invalid_reserved_05=('tag/editorial', 200),
+    invalid_reserved_06=('new', 200),
+    invalid_reserved_07=('all', 200),
+    invalid_reserved_08=('with-errors', 200),
+    invalid_reserved_09=('without-parent', 200),
+    invalid_reserved_10=('top-level', 200),
+    invalid_reserved_11=('needs-review', 200),
+    invalid_reserved_12=('needs-review/technical', 200),
+    invalid_reserved_13=('localization-tag', 200),
+    invalid_reserved_14=('localization-tag/inprogress', 200),
+    invalid_reserved_15=('templates', 200),
+    invalid_reserved_16=('submit_akismet_spam', 200),
+    invalid_reserved_17=('feeds/atom/all', 200),
+    invalid_reserved_18=('feeds/rss/all', 200),
+    invalid_reserved_19=('feeds/atom/l10n-updates', 200),
+    invalid_reserved_20=('feeds/rss/l10n-updates', 200),
+    invalid_reserved_21=('feeds/atom/tag/editorial', 200),
+    invalid_reserved_22=('feeds/atom/needs-review', 200),
+    invalid_reserved_23=('feeds/rss/needs-review', 200),
+    invalid_reserved_24=('feeds/atom/needs-review/technical', 200),
+    invalid_reserved_25=('feeds/atom/revisions', 200),
+    invalid_reserved_26=('feeds/rss/revisions', 200),
+    invalid_reserved_27=('feeds/atom/files', 200),
+    invalid_reserved_28=('feeds/rss/files', 200),
+)
+
+
+@pytest.fixture
+def permission_add_document(db):
+    return Permission.objects.get(codename='add_document')
+
+
+@pytest.fixture
+def add_doc_client(editor_client, wiki_user, permission_add_document):
+    wiki_user.user_permissions.add(permission_add_document)
+    return editor_client
+
+
+def test_check_read_only_mode(user_client):
+    response = user_client.get(reverse('wiki.create', locale='en-US'))
+    assert response.status_code == 403
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_user_add_document_permission(editor_client):
+    response = editor_client.get(reverse('wiki.create', locale='en-US'))
+    assert response.status_code == 403
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.toc
+def test_get(add_doc_client):
+    response = add_doc_client.get(reverse('wiki.create', locale='en-US'))
+    assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    page = pq(response.content)
+    toc_select = page.find('#id_toc_depth')
+    toc_options = toc_select.find('option')
+    found_selected = False
+    for option in toc_options:
+        opt_element = pq(option)
+        if opt_element.attr('selected'):
+            found_selected = True
+            assert opt_element.attr('value') == str(Revision.TOC_DEPTH_H4)
+    assert found_selected, 'No ToC depth initially selected.'
+    # Check discard button.
+    assert (page.find('.btn-discard').attr('href') ==
+            reverse('wiki.create', locale='en-US'))
+
+
+@pytest.mark.tags
+@pytest.mark.review_tags
+@pytest.mark.parametrize(
+    'slug, expected_status_code',
+    SLUG_SIMPLE_CASES.values() + SLUG_RESERVED_CASES.values(),
+    ids=SLUG_SIMPLE_CASES.keys() + SLUG_RESERVED_CASES.keys())
+def test_create(add_doc_client, slug, expected_status_code):
+    """Test creating a new document with valid and invalid slugs."""
+    data = dict(
+        title='A Foobar Document',
+        slug=slug,
+        tags='tag1, tag2',
+        review_tags=['editorial', 'technical'],
+        keywords='key1, key2',
+        summary='lipsum',
+        content='lorem ipsum dolor sit amet',
+        comment='This is foobar.',
+        toc_depth=1,
+    )
+    url = reverse('wiki.create', locale='en-US')
+    resp = add_doc_client.post(url, data)
+    assert resp.status_code == expected_status_code
+    assert resp['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in resp['Cache-Control']
+    assert 'no-cache' in resp['Cache-Control']
+    assert 'no-store' in resp['Cache-Control']
+    assert 'must-revalidate' in resp['Cache-Control']
+    if expected_status_code == 302:
+        assert resp['Location'].endswith(
+            reverse('wiki.document', locale='en-US', args=(slug,)))
+        doc = Document.objects.get(slug=slug, locale='en-US')
+        for name in (set(data.keys()) - set(('tags', 'review_tags'))):
+            assert getattr(doc.current_revision, name) == data[name]
+        assert (sorted(doc.tags.all().values_list('name', flat=True)) ==
+                ['tag1', 'tag2'])
+        review_tags = doc.current_revision.review_tags
+        assert (sorted(review_tags.all().values_list('name', flat=True)) ==
+                ['editorial', 'technical'])
+    else:
+        assert 'The slug provided is not valid.' in resp.content
+        with pytest.raises(Document.DoesNotExist):
+            Document.objects.get(slug=slug, locale='en-US')
+        assert pq(resp.content).find('input[name=slug]')[0].value == slug
+
+
+@pytest.mark.tags
+@pytest.mark.review_tags
+@pytest.mark.parametrize(
+    'slug, expected_status_code',
+    SLUG_SIMPLE_CASES.values() + [('Root', 302)],
+    ids=SLUG_SIMPLE_CASES.keys() + ['valid_same_slug'])
+def test_create_child(root_doc, add_doc_client, slug, expected_status_code):
+    """Test creating a new child document with valid and invalid slugs."""
+    data = dict(
+        title='A Child of the Root Document',
+        slug=slug,
+        tags='tag1, tag2',
+        review_tags=['editorial', 'technical'],
+        keywords='key1, key2',
+        summary='lipsum',
+        content='lorem ipsum dolor sit amet',
+        comment='This is foobar.',
+        toc_depth=1,
+    )
+    url = reverse('wiki.create', locale='en-US')
+    url += '?parent={}'.format(root_doc.id)
+    full_slug = '{}/{}'.format(root_doc.slug, slug)
+    resp = add_doc_client.post(url, data)
+    assert resp.status_code == expected_status_code
+    assert resp['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in resp['Cache-Control']
+    assert 'no-cache' in resp['Cache-Control']
+    assert 'no-store' in resp['Cache-Control']
+    assert 'must-revalidate' in resp['Cache-Control']
+    if expected_status_code == 302:
+        assert resp['Location'].endswith(
+            reverse('wiki.document', locale='en-US', args=(full_slug,)))
+        assert root_doc.children.count() == 1
+        doc = Document.objects.get(slug=full_slug, locale='en-US')
+        skip_keys = set(('tags', 'review_tags', 'parent_topic'))
+        for name in (set(data.keys()) - skip_keys):
+            expected = full_slug if name == 'slug' else data[name]
+            assert getattr(doc.current_revision, name) == expected
+        assert (sorted(doc.tags.all().values_list('name', flat=True)) ==
+                ['tag1', 'tag2'])
+        review_tags = doc.current_revision.review_tags
+        assert (sorted(review_tags.all().values_list('name', flat=True)) ==
+                ['editorial', 'technical'])
+    else:
+        assert 'The slug provided is not valid.' in resp.content
+        with pytest.raises(Document.DoesNotExist):
+            Document.objects.get(slug=full_slug, locale='en-US')
+        page = pq(resp.content)
+        assert page.find('input[name=slug]')[0].value == slug
+
+
+def test_clone_get(root_doc, add_doc_client):
+    url = reverse('wiki.create', locale='en-US')
+    url += '?clone={}'.format(root_doc.id)
+    response = add_doc_client.get(url)
+    assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    page = pq(response.content)
+    assert page.find('input[name=slug]')[0].value is None
+    assert page.find('input[name=title]')[0].value is None
+    assert (page.find('textarea[name=content]')[0].value.strip() ==
+            root_doc.current_revision.content)

--- a/kuma/wiki/tests/test_views_delete.py
+++ b/kuma/wiki/tests/test_views_delete.py
@@ -1,0 +1,169 @@
+from django.contrib.auth.models import Permission
+import pytest
+
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.models import Document, DocumentDeletionLog
+
+
+@pytest.fixture
+def delete_client(editor_client, wiki_user):
+    wiki_user.user_permissions.add(
+        Permission.objects.get(codename='purge_document'),
+        Permission.objects.get(codename='delete_document'),
+        Permission.objects.get(codename='restore_document')
+    )
+    return editor_client
+
+
+@pytest.mark.parametrize('endpoint', ['revert_document', 'delete_document',
+                                      'restore_document', 'purge_document'])
+def test_login(root_doc, client, endpoint):
+    """Tests that login is required. The "client" fixture is not logged in."""
+    args = [root_doc.slug]
+    if endpoint == 'revert_document':
+        args.append(root_doc.current_revision.id)
+    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    response = client.get(url)
+    assert response.status_code == 302
+    assert 'en-US/users/signin?' in response['Location']
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.parametrize(
+    'endpoint', ['delete_document', 'restore_document', 'purge_document'])
+def test_permission(root_doc, editor_client, endpoint):
+    """
+    Tests that the proper permission is required. The "editor_client"
+    fixture, although logged in, does not have the proper permission.
+    """
+    args = [root_doc.slug]
+    if endpoint == 'revert_document':
+        args.append(root_doc.current_revision.id)
+    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    response = editor_client.get(url)
+    assert response.status_code == 403
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.parametrize('endpoint', ['revert_document', 'delete_document',
+                                      'restore_document', 'purge_document'])
+def test_read_only_mode(root_doc, user_client, endpoint):
+    args = [root_doc.slug]
+    if endpoint == 'revert_document':
+        args.append(root_doc.current_revision.id)
+    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    response = user_client.get(url)
+    assert response.status_code == 403
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_delete_get(root_doc, delete_client):
+    url = reverse('wiki.delete_document', locale='en-US', args=[root_doc.slug])
+    response = delete_client.get(url)
+    assert response.status_code == 200
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+@pytest.mark.xfail(reason='The "wiki/confirm_purge.html" template is missing'
+                          ' (see bugzilla 1197390).')
+def test_purge_get(root_doc, delete_client):
+    root_doc.delete()
+    url = reverse('wiki.purge_document', locale='en-US', args=[root_doc.slug])
+    response = delete_client.get(url)
+    assert response.status_code == 200
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_restore_get(root_doc, delete_client):
+    root_doc.delete()
+    with pytest.raises(Document.DoesNotExist):
+        Document.objects.get(slug=root_doc.slug, locale=root_doc.locale)
+    url = reverse('wiki.restore_document', locale='en-US',
+                  args=[root_doc.slug])
+    response = delete_client.get(url)
+    assert response.status_code == 302
+    assert response['Location'].endswith(root_doc.get_absolute_url())
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    assert Document.objects.get(slug=root_doc.slug, locale=root_doc.locale)
+
+
+def test_revert_get(root_doc, delete_client):
+    url = reverse('wiki.revert_document', locale='en-US',
+                  args=[root_doc.slug, root_doc.current_revision.id])
+    response = delete_client.get(url)
+    assert response.status_code == 200
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_delete_post(root_doc, delete_client):
+    url = reverse('wiki.delete_document', locale='en-US', args=[root_doc.slug])
+    response = delete_client.post(url, data=dict(reason='test'))
+    assert response.status_code == 302
+    assert response['Location'].endswith(root_doc.get_absolute_url())
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    assert len(Document.admin_objects.filter(
+        slug=root_doc.slug, locale=root_doc.locale, deleted=True)) == 1
+    with pytest.raises(Document.DoesNotExist):
+        Document.objects.get(slug=root_doc.slug, locale=root_doc.locale)
+    assert len(DocumentDeletionLog.objects.filter(locale=root_doc.locale,
+                                                  slug=root_doc.slug,
+                                                  reason='test')) == 1
+
+
+def test_purge_post(root_doc, delete_client):
+    root_doc.delete()
+    url = reverse('wiki.purge_document', locale='en-US', args=[root_doc.slug])
+    response = delete_client.post(url, data=dict(confirm='true'))
+    assert response.status_code == 302
+    assert response['Location'].endswith(root_doc.get_absolute_url())
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    with pytest.raises(Document.DoesNotExist):
+        Document.admin_objects.get(slug=root_doc.slug, locale=root_doc.locale)
+
+
+def test_revert_post(edit_revision, delete_client):
+    root_doc = edit_revision.document
+    assert len(root_doc.revisions.all()) == 2
+    first_revision = root_doc.revisions.first()
+    url = reverse('wiki.revert_document', locale='en-US',
+                  args=[root_doc.slug, first_revision.id])
+    response = delete_client.post(url, data=dict(comment='test'))
+    assert response.status_code == 302
+    assert response['Location'].endswith(reverse('wiki.document_revisions',
+                                                 args=[root_doc.slug]))
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    assert len(root_doc.revisions.all()) == 3
+    root_doc.refresh_from_db()
+    assert root_doc.current_revision.id != edit_revision.id
+    assert root_doc.current_revision.id != first_revision.id
+    assert root_doc.current_revision.id == root_doc.revisions.last().id

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -9,6 +9,11 @@ def test_edit_get(editor_client, root_doc):
     url = reverse('wiki.edit', locale='en-US', args=[root_doc.slug])
     response = editor_client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
 @pytest.mark.parametrize('method', ('GET', 'POST'))
@@ -20,4 +25,8 @@ def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
     caller = getattr(editor_client, method.lower())
     response = caller(url, REMOTE_ADDR=ip)
     assert response.status_code == 403
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
     assert 'Your IP address has been banned.' in response.content

--- a/kuma/wiki/tests/test_views_translate.py
+++ b/kuma/wiki/tests/test_views_translate.py
@@ -1,0 +1,65 @@
+from django.contrib.auth.models import Permission
+from pyquery import PyQuery as pq
+import pytest
+
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.models import Document
+
+
+@pytest.fixture
+def permission_change_document(db):
+    return Permission.objects.get(codename='change_document')
+
+
+@pytest.fixture
+def trans_doc_client(editor_client, wiki_user, permission_change_document):
+    wiki_user.user_permissions.add(permission_change_document)
+    return editor_client
+
+
+def test_translate_get(root_doc, trans_doc_client):
+    """Test GET on the translate view."""
+
+    url = reverse(
+        'wiki.translate', args=(root_doc.slug,), locale=root_doc.locale)
+    url += '?tolocale=fr'
+
+    response = trans_doc_client.get(url)
+    assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    page = pq(response.content)
+    assert page.find('input[name=slug]')[0].value == root_doc.slug
+
+
+def test_translate_post(root_doc, trans_doc_client):
+    """Test POST on the translate view."""
+
+    data = {
+        'slug': root_doc.slug,
+        'title': root_doc.title,
+        'content': root_doc.current_revision.content,
+        'form-type': 'both',
+        'toc_depth': 1
+    }
+
+    url = reverse(
+        'wiki.translate', args=(root_doc.slug,), locale=root_doc.locale)
+    url += '?tolocale=fr'
+
+    response = trans_doc_client.post(url, data)
+    assert response.status_code == 302
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    doc_url = reverse('wiki.document', args=(root_doc.slug,), locale='fr')
+    assert doc_url + '?rev_saved=' in response['Location']
+    assert len(Document.objects.filter(locale='fr', slug=root_doc.slug)) == 1
+    # Ensure there is no redirect.
+    assert len(Document.objects.filter(
+        title=root_doc.title + ' Redirect 1', locale='fr')) == 0

--- a/kuma/wiki/urls.py
+++ b/kuma/wiki/urls.py
@@ -92,7 +92,7 @@ document_patterns = [
 
 ]
 
-urlpatterns = [
+non_document_patterns = [
     url(r'^/ckeditor_config.js$',
         views.misc.ckeditor_config,
         name='wiki.ckeditor_config'),
@@ -176,7 +176,9 @@ urlpatterns = [
     url(r'^/feeds/(?P<format>[^/]+)/files/?',
         AttachmentsFeed(),
         name="attachments.feeds.recent_files"),
+]
 
+urlpatterns = non_document_patterns + [
     url(r'^/(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
         include(document_patterns)),
 ]

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -16,11 +16,11 @@ from ..models import Document, Revision
 
 
 @newrelic.agent.function_trace()
+@never_cache
 @block_user_agents
 @login_required
 @check_readonly
 @prevent_indexing
-@never_cache
 def create(request):
     """
     Create a new wiki page, which is a document and a revision.

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -2,6 +2,7 @@
 from django.db import IntegrityError
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext
+from django.views.decorators.cache import never_cache
 
 from kuma.core.decorators import (block_user_agents, login_required,
                                   permission_required)
@@ -13,6 +14,7 @@ from ..models import Document, DocumentDeletionLog, Revision
 from ..utils import locale_and_slug_from_path
 
 
+@never_cache
 @block_user_agents
 @login_required
 @check_readonly
@@ -56,6 +58,7 @@ def revert_document(request, document_path, revision_id):
         return redirect('wiki.document_revisions', revision.document.slug)
 
 
+@never_cache
 @block_user_agents
 @login_required
 @permission_required('wiki.delete_document')
@@ -99,6 +102,7 @@ def delete_document(request, document_slug, document_locale):
     return render(request, 'wiki/confirm_document_delete.html', context)
 
 
+@never_cache
 @block_user_agents
 @login_required
 @permission_required('wiki.restore_document')
@@ -115,6 +119,7 @@ def restore_document(request, document_slug, document_locale):
     return redirect(document)
 
 
+@never_cache
 @block_user_agents
 @login_required
 @permission_required('wiki.purge_document')

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -74,6 +74,7 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 
 
 @newrelic.agent.function_trace()
+@never_cache
 @block_user_agents
 @require_http_methods(['GET', 'POST'])
 @login_required  # TODO: Stop repeating this knowledge here and in Document.allows_editing_by.
@@ -82,7 +83,6 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 @process_document_path
 @check_readonly
 @prevent_indexing
-@never_cache
 def edit(request, document_slug, document_locale, revision_id=None):
     """
     Create a new revision of a wiki document, or edit document metadata.


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds/modifies caching headers and tests for the endpoints for the kuma wiki create/edit/delete views.

I made the mistake of trying to convert all of the tests for the `wiki.create` endpoint. In the end, I did convert many of them, but it's way too much and slowed down this PR considerably. Future CDN PR's will only create new-style tests if there are none for an endpoint. I could have easily converted the `test_parent_topic` test within the hated `kuma/wiki/tests/test_views.py`, but it didn't seem worthwhile to preserve as a test, since the whole approach of using `parent_topic` in the POST data (instead of `?parent=xxx` in the URL) seems broken to me (it doesn't get the slug right for the new child document).

