### PR TITLE
bug 1431259: caching headers/tests for wiki revision views

### DIFF
--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -468,6 +468,9 @@ def test_revision_template(root_doc, client):
     url = reverse('wiki.revision', args=[root_doc.slug, rev.id], locale=root_doc.locale)
     response = client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     page = pq(response.content)
     assert page('h1').text() == 'Revision %s of %s' % (rev.id, root_doc.title)
     assert page('#doc-source pre').text() == rev.content
@@ -853,6 +856,9 @@ def test_compare_revisions(edit_revision, client):
 
     response = client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     page = pq(response.content)
     assert page('span.diff_sub').text() == u'Getting\xa0started...'
     assert page('span.diff_add').text() == u'The\xa0root\xa0document.'
@@ -893,6 +899,9 @@ def test_compare_first_translation(trans_revision, client):
 
     response = client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
     page = pq(response.content)
     assert page('span.diff_sub').text() == u'Getting\xa0started...'
     assert page('span.diff_add').text() == u'Mise\xa0en\xa0route...'
@@ -1184,17 +1193,24 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
 
     def test_preview_GET_405(self):
         """Preview with HTTP GET results in 405."""
-        response = self.client.get(reverse('wiki.preview'), follow=True)
-        eq_(405, response.status_code)
+        response = self.client.get(reverse('wiki.preview', locale='en-US'))
+        assert response.status_code == 405
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
 
     def test_preview(self):
         """Preview the wiki syntax content."""
-        response = self.client.post(reverse('wiki.preview'),
-                                    {'content': '<h1>Test Content</h1>'},
-                                    follow=True)
-        eq_(200, response.status_code)
+        response = self.client.post(reverse('wiki.preview', locale='en-US'),
+                                    {'content': '<h1>Test Content</h1>'})
+        assert response.status_code == 200
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
         doc = pq(response.content)
-        eq_('Test Content', doc('article#wikiArticle h1').text())
+        assert doc('article#wikiArticle h1').text() == 'Test Content'
 
     @pytest.mark.xfail(reason='broken test')
     def test_preview_locale(self):
@@ -1205,10 +1221,14 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
         # Preview content that links to it and verify link is in locale.
         url = reverse('wiki.preview', locale='es')
         response = self.client.post(url, {'content': '[[Test Document]]'})
-        eq_(200, response.status_code)
+        assert response.status_code == 200
+        assert 'max-age=0' in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'no-store' in response['Cache-Control']
+        assert 'must-revalidate' in response['Cache-Control']
         doc = pq(response.content)
         link = doc('#doc-content a')
-        eq_('Prueba', link.text())
+        assert link.text() == 'Prueba'
         eq_('/es/docs/prueba', link[0].attrib['href'])
 
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -614,7 +614,12 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         mock_requests.post(requests_mock.ANY, content=content.encode('utf8'))
 
         self.client.login(username='admin', password='testpass')
-        self.client.post(reverse('wiki.preview'), {'content': content})
+        resp = self.client.post(reverse('wiki.preview', locale='en-US'),
+                                {'content': content})
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
         # No UnicodeDecodeError
         mock_requests.request_history[0].body.decode('utf8')
 
@@ -633,7 +638,12 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         mock_post.side_effect = Exception("Should not be called")
 
         self.client.login(username='admin', password='testpass')
-        self.client.post(reverse('wiki.preview'), {'doc_id': self.doc.id})
+        resp = self.client.post(reverse('wiki.preview', locale='en-US'),
+                                {'doc_id': self.doc.id})
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
 
 
 class DocumentSEOTests(UserTestCase, WikiTestCase):
@@ -1851,17 +1861,20 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
             params = dict(data_dict['params'], revision_id=rev.id)
             resp = self.client.post(review_url, params)
-            eq_(302, resp.status_code)
-
+            assert resp.status_code == 302
+            assert 'max-age=0' in resp['Cache-Control']
+            assert 'no-cache' in resp['Cache-Control']
+            assert 'no-store' in resp['Cache-Control']
+            assert 'must-revalidate' in resp['Cache-Control']
             doc = Document.objects.get(locale=settings.WIKI_DEFAULT_LANGUAGE,
                                        slug=slug)
             rev = doc.revisions.order_by('-id').all()[0]
             review_tags = [x.name for x in rev.review_tags.all()]
             review_tags.sort()
             for expected_str in data_dict['message_contains']:
-                ok_(expected_str in rev.summary)
-                ok_(expected_str in rev.comment)
-            eq_(data_dict['expected_tags'], review_tags)
+                assert expected_str in rev.summary
+                assert expected_str in rev.comment
+            assert review_tags == data_dict['expected_tags']
 
     @pytest.mark.midair
     def test_edit_midair_collisions(self, is_ajax=False, translate_locale=None):

--- a/kuma/wiki/tests/test_views_revision.py
+++ b/kuma/wiki/tests/test_views_revision.py
@@ -21,6 +21,9 @@ def test_compare_revisions(edit_revision, client, raw):
 
     response = client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
 
 
 @pytest.mark.parametrize('raw', [True, False])
@@ -38,6 +41,9 @@ def test_compare_translation(trans_revision, client, raw):
 
     response = client.get(url)
     assert response.status_code == 200
+    assert response['X-Robots-Tag'] == 'noindex'
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
 
 
 @pytest.mark.parametrize('raw', [True, False])

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
-import newrelic.agent
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_GET, require_POST
+from django.views.decorators.cache import never_cache
 from ratelimit.decorators import ratelimit
+import newrelic.agent
 
-from kuma.core.decorators import block_user_agents, login_required
+from kuma.core.decorators import (block_user_agents, login_required,
+                                  shared_cache_control)
 from kuma.core.utils import smart_int
 
 from .. import kumascript
@@ -18,6 +20,7 @@ from ..templatetags.jinja_helpers import format_comment
 
 
 @newrelic.agent.function_trace()
+@shared_cache_control
 @block_user_agents
 @prevent_indexing
 @process_document_path
@@ -37,6 +40,7 @@ def revision(request, document_slug, document_locale, revision_id):
     return render(request, 'wiki/revision.html', context)
 
 
+@never_cache
 @login_required
 @require_POST
 def preview(request):
@@ -74,6 +78,7 @@ def preview(request):
     return render(request, 'wiki/preview.html', context)
 
 
+@shared_cache_control
 @block_user_agents
 @require_GET
 @xframe_options_sameorigin
@@ -120,6 +125,7 @@ def compare(request, document_slug, document_locale):
     return render(request, template, context)
 
 
+@never_cache
 @login_required
 @require_POST
 @process_document_path


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds/modifies caching headers and tests for the endpoints for the kuma wiki revision views.