### PR TITLE
bug 1431259: caching headers/tests for purge view

### DIFF
--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -6,6 +6,7 @@ import json
 from django.contrib import admin
 from django.contrib import messages
 from django.conf import settings
+from django.views.decorators.cache import never_cache
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponseRedirect
 from django.template.response import TemplateResponse
@@ -46,6 +47,7 @@ def purge_documents(self, request, queryset):
 purge_documents.short_description = "Permanently purge deleted documents"
 
 
+@never_cache
 @login_required
 @staff_member_required
 @permission_required('wiki.purge_document')

--- a/kuma/wiki/tests/test_views_admin.py
+++ b/kuma/wiki/tests/test_views_admin.py
@@ -1,0 +1,102 @@
+from datetime import datetime
+
+from waffle.models import Flag
+import pytest
+
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.models import Document, Revision
+
+
+@pytest.fixture
+def purge_client(admin_client):
+    Flag.objects.create(name='kumaediting', everyone=True)
+    return admin_client
+
+
+@pytest.fixture
+def another_root_doc(wiki_user):
+    """Another newly-created top-level English document."""
+    root_doc = Document.objects.create(
+        locale='en-US', slug='AnotherRoot', title='Another Root Document')
+    Revision.objects.create(
+        document=root_doc,
+        creator=wiki_user,
+        content='<p>Getting started again...</p>',
+        title='Another Root Document',
+        created=datetime(2017, 5, 14, 12, 15))
+    return root_doc
+
+
+def test_login(client):
+    """Tests that login is required. The "client" fixture is not logged in."""
+    url = reverse('wiki.admin_bulk_purge')
+    response = client.get(url)
+    assert response.status_code == 302
+    assert 'en-US/users/signin?' in response['Location']
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_staff_permission(editor_client):
+    """
+    Tests that staff permission is required. The "editor_client"
+    fixture, although logged in, does not have staff permission.
+    """
+    url = reverse('wiki.admin_bulk_purge')
+    response = editor_client.get(url)
+    assert response.status_code == 302
+    assert response['Location'].endswith(
+        'admin/login/?next=/admin/wiki/document/purge/')
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_read_only_mode(admin_client):
+    """
+    Tests that editting has been enabled. The "admin_client"
+    fixture has not enabled document editting.
+    """
+    url = reverse('wiki.admin_bulk_purge')
+    response = admin_client.get(url)
+    assert response.status_code == 403
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def test_purge_get(root_doc, another_root_doc, purge_client):
+    root_doc.delete()
+    another_root_doc.delete()
+    url = reverse('wiki.admin_bulk_purge')
+    response = purge_client.get(
+        url, {'ids': '{},{}'.format(root_doc.id, another_root_doc.id)})
+    assert response.status_code == 200
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    # Make sure nothing has happended (i.e. the docs haven't been purged).
+    for doc in (root_doc, another_root_doc):
+        assert Document.admin_objects.get(slug=doc.slug, locale=doc.locale)
+
+
+def test_purge_post(root_doc, another_root_doc, purge_client):
+    root_doc.delete()
+    another_root_doc.delete()
+    query_params = '?ids={},{}'.format(root_doc.id, another_root_doc.id)
+    url = reverse('wiki.admin_bulk_purge') + query_params
+    response = purge_client.post(url, data={'confirm_purge': 'true'})
+    assert response.status_code == 302
+    assert response['Location'].endswith('/admin/wiki/document/')
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+    for doc in (root_doc, another_root_doc):
+        with pytest.raises(Document.DoesNotExist):
+            Document.admin_objects.get(slug=doc.slug, locale=doc.locale)


### PR DESCRIPTION
This PR depends on https://github.com/mozilla/kuma/pull/4701 for it's tests to pass.

This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds/modifies caching headers and tests for the endpoints for the kuma wiki admin bulk-purge view.