### PR TITLE
bug 1431259: caching headers/tests for version/set-language views

### DIFF
--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -11,6 +11,7 @@ def _error_page(request, status):
     return render(request, '%d.html' % status, status=status)
 
 
+@never_cache
 @csrf_exempt
 @require_POST
 def set_language(request):

--- a/kuma/version/tests/test_views.py
+++ b/kuma/version/tests/test_views.py
@@ -12,6 +12,10 @@ def test_revision_hash(client, db, method, settings):
     response = getattr(client, method)(reverse('version.kuma'))
     assert response.status_code == 200
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
     if method == 'get':
         assert response.content == 'the_revision_hash'
 
@@ -23,6 +27,10 @@ def test_revision_hash(client, db, method, settings):
 def test_revision_hash_405s(client, db, method):
     response = getattr(client, method)(reverse('version.kuma'))
     assert response.status_code == 405
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
 
 
 @pytest.mark.parametrize('method', ['get', 'head'])
@@ -37,6 +45,10 @@ def test_kumascript_revision_hash(client, db, method, mock_requests):
     response = client.get(reverse('version.kumascript'))
     assert response.status_code == 200
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
     if method == 'get':
         assert response.content == hash
 
@@ -48,3 +60,7 @@ def test_kumascript_revision_hash(client, db, method, mock_requests):
 def test_kumascript_revision_hash_405s(client, db, method):
     response = getattr(client, method)(reverse('version.kumascript'))
     assert response.status_code == 405
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']

--- a/kuma/version/views.py
+++ b/kuma/version/views.py
@@ -1,10 +1,12 @@
 from django.conf import settings
 from django.http import HttpResponse
 from django.views.decorators.http import require_safe
+from django.views.decorators.cache import never_cache
 
 from kuma.wiki import kumascript
 
 
+@never_cache
 @require_safe
 def revision_hash(request):
     """
@@ -16,6 +18,7 @@ def revision_hash(request):
     )
 
 
+@never_cache
 @require_safe
 def kumascript_revision_hash(request):
     """


### PR DESCRIPTION
This is another in a series of PR's that add the appropriate caching headers and related tests to all Kuma endpoints as part of the effort of placing a CDN in front of MDN. This PR adds/modifies caching headers and tests for the endpoints for the kuma version/set-language view.