### PR TITLE
bug 1412891: Adjust Brotli compression level

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -263,7 +263,7 @@ class BrotliMiddleware(object):
             # ---------
             return response
 
-        compressed_content = brotli.compress(response.content)
+        compressed_content = brotli.compress(response.content, quality=5)
 
         # Return the uncompressed content if compression didn't help
         if len(compressed_content) >= len(response.content):


### PR DESCRIPTION
The current settings for Brotli compression level is too high and it's
increasing our average page load time as a side effect.

This patch put the compression level at a more reasonnable level to
lower the tradeoff.