### PR TITLE
bug 1054271: Cleanup locale settings

### DIFF
--- a/kuma/core/tests/test_urlresolvers.py
+++ b/kuma/core/tests/test_urlresolvers.py
@@ -1,5 +1,7 @@
 import pytest
 
+from django.conf import settings
+
 from kuma.core.tests import KumaTestCase, eq_
 from ..urlresolvers import get_best_language
 
@@ -35,12 +37,6 @@ class BestLanguageTests(KumaTestCase):
         best = get_best_language('pt, fr;q=0.5')
         eq_('pt-PT', best)
 
-    @pytest.mark.xfail(reason='no clue what is up with norwegian locales')
-    def test_nonprefix_alias(self):
-        """We only have a single Norwegian locale."""
-        best = get_best_language('nn-NO, nb-NO;q=0.7, fr;q=0.3')
-        eq_('no', best)
-
     def test_script_alias(self):
         """Our traditional Chinese locale is 'zh-TW'."""
         best = get_best_language('zh-Hant, fr;q=0.5')
@@ -70,3 +66,16 @@ class BestLanguageTests(KumaTestCase):
         """Respect user's preferences as much as possible."""
         best = get_best_language('qaz-ZZ, fr-FR;q=0.5')
         eq_('fr', best)
+
+
+@pytest.mark.parametrize("locale", settings.RTL_LANGUAGES)
+def test_rtl_languages(locale):
+    """Check that each RTL language is also a supported locale."""
+    assert locale in settings.ENABLED_LOCALES
+
+
+@pytest.mark.parametrize("alias,locale", settings.LOCALE_ALIASES.items())
+def test_locale_aliases(alias, locale):
+    """Check that each locale alias matches a supported locale."""
+    assert alias not in settings.ENABLED_LOCALES
+    assert locale in settings.ENABLED_LOCALES

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -245,7 +245,6 @@ ENABLED_LOCALES = [FIRST_LOCALE] + sorted(ENABLED_LOCALES_TO_SORT)
 RTL_LANGUAGES = (
     'ar',
     'fa',
-    'fa-IR',
     'he'
 )
 
@@ -260,21 +259,12 @@ LOCALE_ALIASES = {
     'cn': 'zh-CN',
     'fy': 'fy-NL',
     'ga': 'ga-IE',
-    'gu': 'gu-IN',
     'hi': 'hi-IN',
-    'hy': 'hy-AM',
-    'pa': 'pa-IN',
     'sv': 'sv-SE',
-    'ta': 'ta-LK',
 
     # Map a prefix to one of its multiple specific locales.
     'pt': 'pt-PT',
-    'sr': 'sr-Cyrl',
     'zh': 'zh-CN',
-
-    # Create aliases for locales which do not share a prefix.
-    'nb-NO': 'no',
-    'nn-NO': 'no',
 
     # Create aliases for locales which use region subtags to assume scripts.
     'zh-Hans': 'zh-CN',


### PR DESCRIPTION
Ensure (with tests) that:
* ``LOCALE_ALIASES`` is a map of alias locales to accepted locales
* ``RTL_LANGUAGES`` is a list of right-to-left languages in accepted locales

I'm not sure if these should be verified with a unit test, or with ``assert`` in the ``settings.py`` file.

There is an xfail test for Norwegian locales that was copied from [mozilla/kitsune](https://github.com/mozilla/kitsune) in PR #930, including some extra settings that do not apply to MDN. This test is removed.
