### PR TITLE
bug 1054271: Remove xfail from passing test

### DIFF
--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -1053,7 +1053,6 @@ class TranslateTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(0, len(doc('form input[name="slug"]')))
 
-    @pytest.mark.xfail(reason='Figure out wtf is going on with this test')
     def test_translate_form_maintains_based_on_rev(self):
         """
         Revision.based_on should be the rev that was current when the


### PR DESCRIPTION
This test was passing when the xfail tag was added in PR #3757. It is unknown when it started passing.