### PR TITLE
Bug 1447446: Increase InnoDB log file size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci
       - --innodb-flush-log-at-trx-commit=0
+      - --innodb_log_file_size=100M
       - --max-allowed-packet=100M
     volumes:
       - mysqlvolume:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci
       - --innodb-flush-log-at-trx-commit=0
-      - --innodb_log_file_size=132M
+      - --innodb-log-file-size=132M
       - --max-allowed-packet=100M
     volumes:
       - mysqlvolume:/var/lib/mysql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
       - --character-set-server=utf8
       - --collation-server=utf8_general_ci
       - --innodb-flush-log-at-trx-commit=0
-      - --innodb_log_file_size=100M
+      - --innodb_log_file_size=132M
       - --max-allowed-packet=100M
     volumes:
       - mysqlvolume:/var/lib/mysql


### PR DESCRIPTION
Updates docker-compose.yml to set innodb_log_file_size to
100 megabytes, in order to ensure that it's at least 10x
the maximum size of BLOB/TEXT data in any one transaction,
per MySQL 5.6.20 release notes [1]. See bug 1447446 for
more information.

Resolves issues importing the anonymized database, and
probably random database errors that may occur when
dealing with very large transactions.

[1]  https://is.gd/wvSZzV