### PR TITLE
bug 1443586: Make lang preference cookie persistent

### DIFF
--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -156,6 +156,8 @@ def test_setting_language_cookie_working(client):
     # Check language cookie is set
     assert lang_cookie
     assert lang_cookie.value == 'bn-BD'
+    # Check that the max-age from the cookie is the same as our settings
+    assert lang_cookie['max-age'] == settings.LANGUAGE_COOKIE_AGE
 
 
 def test_not_possible_to_set_non_locale_cookie(client):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -364,6 +364,9 @@ MT_TO_KUMA_LOCALE_MAP = {
     'ka': 'ka',
 }
 
+# The number of seconds we are keeping the language preference cookie. (1 year)
+LANGUAGE_COOKIE_AGE = 365 * 24 * 60 * 60
+
 SITE_ID = 1
 
 MDC_PAGES_DIR = path('..', 'mdc_pages')


### PR DESCRIPTION
Increase the max-age of the language preference cookie to one
year instead of only the current session.

This avoids to ask if people wants to keep their current locale
at each of their visits.