### PR TITLE
Fix Bug 1440908, show error message to users on 500 internal server error

### DIFF
--- a/kuma/static/js/dashboard.js
+++ b/kuma/static/js/dashboard.js
@@ -124,6 +124,9 @@
             notification.success(gettext('Updated filters.'), 2000);
             // Reset the page count to 0 in case of new filter
             $pageInput.val(1);
+        }).fail(function(jqXHR, textStatus, errorThrown) {
+            notification.error(gettext('Error loading content, please refresh the page'), 5000);
+            console.error('Error thrown while loading content: ' + textStatus, errorThrown);
         });
     });
 


### PR DESCRIPTION
To test this, I load up the initial activity history page, I then use the network panel in devtools to emulate offline mode. Click to go to the next page of results, you should now see an error shown in the Growl message instead of 'Updating filter.....'