### PR TITLE
bug 1429933: Migrate NoArgsCommand to BaseCommand

### DIFF
--- a/kuma/attachments/management/commands/empty_attachments_trash.py
+++ b/kuma/attachments/management/commands/empty_attachments_trash.py
@@ -1,12 +1,12 @@
 from datetime import date, timedelta
 
 from constance import config
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from ...models import TrashedAttachment
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Empty the attachments trash"
 
     def add_arguments(self, parser):

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -2,22 +2,22 @@ from optparse import make_option
 import logging
 import time
 
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from kuma.core.utils import memcache_lock
 from kuma.feeder.utils import update_feeds
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     """Update all registered RSS/Atom feeds."""
 
-    option_list = NoArgsCommand.option_list + (
+    option_list = BaseCommand.option_list + (
         make_option('--force', '-f', dest='force', action='store_true',
                     default=False, help='Fetch even disabled feeds.'),
     )
 
     @memcache_lock('kuma_feeder')
-    def handle_noargs(self, **options):
+    def handle(self, *args, **options):
         """
         Locked command handler to avoid running this command more than once
         simultaneously.

--- a/kuma/humans/management/commands/make_humans.py
+++ b/kuma/humans/management/commands/make_humans.py
@@ -1,9 +1,9 @@
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from kuma.humans.tasks import humans_txt
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Create a new MDN contributors file (humans.txt)"
 
     def handle(self, *args, **options):

--- a/kuma/wiki/management/commands/make_sitemaps.py
+++ b/kuma/wiki/management/commands/make_sitemaps.py
@@ -1,10 +1,10 @@
 from django.conf import settings
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 
 from kuma.wiki.tasks import build_locale_sitemap, build_index_sitemap
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = ("Create sitemap files for every MDN language, "
             "as well as a sitemap index file.")
 

--- a/kuma/wiki/management/commands/populate_attachments.py
+++ b/kuma/wiki/management/commands/populate_attachments.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from django.core.management.base import NoArgsCommand
+from django.core.management.base import BaseCommand
 from django.db import models
 from django.utils.text import get_text_list
 
@@ -8,7 +8,7 @@ from ...constants import DEKI_FILE_URL, KUMA_FILE_URL
 from ...models import Document, DocumentAttachment
 
 
-class Command(NoArgsCommand):
+class Command(BaseCommand):
     help = "Populate m2m relations for documents and their attachments"
 
     def add_arguments(self, parser):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -34,6 +34,10 @@ setuptools==26.1.1 \
     --hash=sha256:475ce28993d7cb75335942525b9fac79f7431a7f6e8a0079c0f2680641379481 \
     --hash=sha256:02a06e1a547b16c25143d2bb898008286a3cbd600a7dbe47234ce57dc51abbf6
 # bleach, django-cacheback, django-extensions, mock, etc.
+# Python 2 and 3 compatibility utilities
+# Code: https://github.com/benjaminp/six
+# Changes: https://github.com/benjaminp/six/blob/master/CHANGES
+# Docs: http://six.readthedocs.io
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
@@ -107,6 +111,16 @@ python-openid==2.2.5 \
 requests-oauthlib==0.8.0 \
     --hash=sha256:883ac416757eada6d3d07054ec7092ac21c7f35cb1d2cf82faf205637081f468 \
     --hash=sha256:50a8ae2ce8273e384895972b56193c7409601a66d4975774c60c2aed869639ca
+
+# django-extensions
+#
+# Backport of Python 3.5's type hints
+# Changes: https://pypi.python.org/pypi/typing
+# Docs: https://docs.python.org/3/library/typing.html
+typing==3.6.4 \
+    --hash=sha256:b2c689d54e1144bbcfd191b0832980a21c2dbcf7b5ff7a66248a60c90e951eb8 \
+    --hash=sha256:3a887b021a77b292e151afb75323dea88a7bc1b3dfa92176cff8e44c8b68bddf \
+    --hash=sha256:d400a9344254803a2368533e4533a4200d21eb7b6b729c173bc38201a74db3f2
 
 
 # django-statici18n

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -33,7 +33,7 @@ setuptools==26.1.1 \
     --hash=sha256:226c9ce65e76c6069e805982b036f36dc4b227b37dd87fc219aef721ec8604ae \
     --hash=sha256:475ce28993d7cb75335942525b9fac79f7431a7f6e8a0079c0f2680641379481 \
     --hash=sha256:02a06e1a547b16c25143d2bb898008286a3cbd600a7dbe47234ce57dc51abbf6
-# bleach, django-appconf, django-cacheback, django-extensions, mock, etc.
+# bleach, django-cacheback, django-extensions, mock, etc.
 six==1.11.0 \
     --hash=sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb \
     --hash=sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9
@@ -110,9 +110,14 @@ requests-oauthlib==0.8.0 \
 
 
 # django-statici18n
-django-appconf==1.0.1 \
-    --hash=sha256:ba1375fb1024e8e91547504d4392321795c989fde500b96ebc7c93884f786e60 \
-    --hash=sha256:3d9bc963d8008ae151d6c664f9fd55442705ea9b9e6d7ce77cdd40bf92d91f3a
+#
+# Framework for configuration of Django apps
+# Code: https://github.com/django-compressor/django-appconf
+# Changes: https://django-appconf.readthedocs.io/en/latest/changelog/
+# Docs: https://django-appconf.readthedocs.io/en/latest/
+django-appconf==1.0.2 \
+    --hash=sha256:6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261 \
+    --hash=sha256:ddab987d14b26731352c01ee69c090a4ebfc9141ed223bef039d79587f22acd9
 
 # django-memcached-hashring
 hash-ring==1.3.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -167,8 +167,12 @@ django-soapbox==1.3 \
     --hash=sha256:69ccf5eb9200f294f400864c9f11990a8bdcd75ed8965cd984b7d6d3d243cf49
 
 # Generate localization catalogs for JavaScript
-django-statici18n==1.1.5 \
-    --hash=sha256:f8d7b523da8fa635de8c359f6dbde9821e2e8e1a092d915786455ffd2533808b
+# Code: https://github.com/zyegfryed/django-statici18n
+# Changes: https://github.com/zyegfryed/django-statici18n/blob/master/docs/changelog.rst
+# Docs: https://django-statici18n.readthedocs.io/en/latest/
+django-statici18n==1.7.0 \
+    --hash=sha256:2c5214d520a25e2d226cae099947778cde593ba7b1b03924f70215ce9ec9e6ce \
+    --hash=sha256:e84fc081166433886220a814356a66760f50196a4d00a3e25327427160e5ccd1
 
 # Better timezone picker for user profiles
 django-sundial==1.0.2 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -100,9 +100,12 @@ django-decorator-include==1.3 \
     --hash=sha256:fd172a88de1dd38e19ddb0d91525ab7240139a3b11687bf1ea2eb775549fd073
 
 # Add CreationDateTimeField, management commands
-django-extensions==1.6.1 \
-    --hash=sha256:4799534f35eba1c07cb6f9859aa5bb719886769f5d35d2a38e7490ce90c0ce69 \
-    --hash=sha256:f98f991d2b039033ac5faa638c0d1afb2720abf4d9d781573c3592d6899480a1
+# Code: https://github.com/django-extensions/django-extensions
+# Changes: https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
+# Docs: http://django-extensions.readthedocs.io/en/latest/
+django-extensions==2.0.6 \
+    --hash=sha256:bc9f2946c117bb2f49e5e0633eba783787790ae810ea112fe7fd82fa64de2ff1 \
+    --hash=sha256:37a543af370ee3b0721ff50442d33c357dd083e6ea06c5b94a199283b6f9e361
 
 # Modern flat theme for Django admin
 django-flat-theme==1.1.3 \


### PR DESCRIPTION
The management command class ``NoArgsCommand`` was [deprecated](https://docs.djangoproject.com/en/1.11/releases/1.8/#django-core-management-noargscommand) in Django 1.8, and removed in 1.10.  ``BaseCommand`` now takes no arguments by default, and acts as a replacement.

``NoArgsCommand`` was used by some libraries as well (grepped in the docker image to find them all), so there are some package updates for ``django-statici18n`` and ``django-extensions``, as well as their requirements ``django-appconf`` and ``typing``.

With this change, the "next" build gets to the point where [unit tests run](https://travis-ci.org/mozilla/kuma/jobs/359595579) (with many failures)