### PR TITLE
bug 1431259: change stage domain to developer.allizom.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -277,6 +277,6 @@ Deployment and Closing Bugs
 ---------------------------
 MDN staff deploy new code one to three times a week. Deployments are announced
 in the #mdndev IRC channel. Currently deployed code can be seen on the
-[What's Deployed?](https://whatsdeployed.io/s-NyD) page.
+[What's Deployed?](https://whatsdeployed.io/s-HC0) page.
 
 Once a bug fix is in production, the bug can be marked as RESOLVED:FIXED.

--- a/Jenkinsfiles/stage-integration-tests.yml
+++ b/Jenkinsfiles/stage-integration-tests.yml
@@ -5,6 +5,6 @@ job:
   dockerfile: "docker/images/integration-tests/Dockerfile"
   selenium: "3.8.1"
   selenium_nodes: 5
-  base_url: 'https://stage.mdn.moz.works'
+  base_url: 'https://developer.allizom.org'
   tests: "not login"
   maintenance_mode: false

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ coveragetesthtml: coveragetest
 	coverage html
 
 locust:
-	locust -f tests/performance/smoke.py --host=https://stage.mdn.moz.works
+	locust -f tests/performance/smoke.py --host=https://developer.allizom.org
 
 compilejsi18n:
 	@ echo "## Generating JavaScript translation catalogs ##"

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Development
                 http://logs.glob.uno/?c=mozilla%23mdndev (logs)
 :Servers:       `What's Deployed on MDN?`_
 
-                https://stage.mdn.moz.works/ (stage)
+                https://developer.allizom.org/ (stage)
 
                 https://developer.mozilla.org/ (prod)
 
@@ -50,7 +50,7 @@ Development
 .. _`P2 Bugs`: https://mzl.la/2oniZa3
 .. _`All developer.mozilla.org bugs`: https://mzl.la/2onLvZ8
 .. _`Pull Request Queues`: http://prs.mozilla.io/mozilla:kuma,kuma-lib,kumascript,mozhacks
-.. _`What's Deployed on MDN?`: https://whatsdeployed.io/s-NyD
+.. _`What's Deployed on MDN?`: https://whatsdeployed.io/s-HC0
 
 
 Getting started

--- a/contribute.json
+++ b/contribute.json
@@ -27,7 +27,7 @@
     },
     "urls": {
         "prod": "https://developer.mozilla.org/",
-        "stage": "https://stage.mdn.moz.works/"
+        "stage": "https://developer.allizom.org/"
     },
     "keywords": [
         "python",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -114,7 +114,7 @@ html_theme_options = {
     'codecov_button': False,
     'extra_nav_links': OrderedDict((
         ('MDN', 'https://developer.mozilla.org'),
-        ('MDN Staging', 'https://stage.mdn.moz.works'),
+        ('MDN Staging', 'https://developer.allizom.org'),
         ('Kuma on GitHub', 'https://github.com/mozilla/kuma'),
         ('KumaScript on GitHub', 'https://github.com/mdn/kumascript'),
     )),

--- a/docs/data.rst
+++ b/docs/data.rst
@@ -269,4 +269,4 @@ We suspect that a clever user could de-anonymize the data in the full
 anonymized database, so we do not distribute it, and try to limit our own use
 of the database.
 
-.. _`staging site`: https://stage.mdn.moz.works
+.. _`staging site`: https://developer.allizom.org

--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -95,7 +95,7 @@ Before deploying, a staff member should:
 
 Deploy to Staging
 -----------------
-The staging site is located at https://stage.mdn.moz.works.  It runs on the
+The staging site is located at https://developer.allizom.org.  It runs on the
 same Kuma code as production, but against a different database, other backing
 services, and with less resources. It is used for verifying code changes before
 pushing to production.
@@ -134,15 +134,15 @@ pushing to production.
   This will kick off `functional tests`_ in Jenkins_, which will also report
   to ``#mdndev``.
 
-* Manually test changes on https://stage.mdn.moz.works. Look for server errors
+* Manually test changes on https://developer.allizom.org. Look for server errors
   on homepage and article pages. Try to verify features in the newly pushed
   code. Check the `functional tests`_.
 
 * Announce in IRC that staging looks good, and you are pushing to production.
 
 .. _Jenkins: https://ci.us-west.moz.works
-.. _`What's Deployed on KumaScript`: https://whatsdeployed.io/s-4kW
-.. _`What's Deployed on Kuma`: https://whatsdeployed.io/s-NyD
+.. _`What's Deployed on KumaScript`: https://whatsdeployed.io/s-SWJ
+.. _`What's Deployed on Kuma`: https://whatsdeployed.io/s-HC0
 .. _`functional tests`: https://ci.us-west.moz.works/blue/organizations/jenkins/mdn_multibranch_pipeline/branches/
 
 

--- a/docs/localization.rst
+++ b/docs/localization.rst
@@ -187,7 +187,7 @@ Add a new locale to Pontoon
 The process for getting a new locale on MDN is documented at
 `Starting a new MDN localization`_. One step is to enable translation of the
 UI strings. This will also enable the locale in development environments and
-on https://stage.mdn.moz.works.
+on https://developer.allizom.org.
 
 .. Note::
 

--- a/docs/tests-ui.rst
+++ b/docs/tests-ui.rst
@@ -151,7 +151,7 @@ Run tests on MDN's Continuous Integration (CI) infrastructure
 If you have commit rights on the `mozilla/kuma GitHub repository`_
 you can run the UI tests using the `MDN CI Infrastructure`_. Just force push
 to `mozilla/kuma@stage-integration-tests`_ to run the tests
-against https://stage.mdn.moz.works.
+against https://developer.allizom.org.
 
 You can check the status, progress, and logs of the
 test runs at `MDN's Jenkins-based multi-branch pipeline`_.
@@ -191,11 +191,11 @@ You can replace the default ``pytest`` options by passing arguments::
 
 You can test staging by setting a new base URL as a ``pytest`` argument::
 
-    $ scripts/run_functional_tests.sh --base-url https://stage.mdn.moz.works -m "not login" tests/functional/test_article_edit.py
+    $ scripts/run_functional_tests.sh --base-url https://developer.allizom.org -m "not login" tests/functional/test_article_edit.py
 
 You can also use an environment variable and get the default ``pytest`` arguments::
 
-    $ BASE_URL=https://stage.mdn.moz.works scripts/run_functional_tests.sh
+    $ BASE_URL=https://developer.allizom.org scripts/run_functional_tests.sh
 
 See ``scripts/run_functional_tests.sh`` for the all the configuration options.
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -45,7 +45,7 @@ PROTOCOL = config('PROTOCOL', default='https://')
 DOMAIN = config('DOMAIN', default='developer.mozilla.org')
 SITE_URL = config('SITE_URL', default=PROTOCOL + DOMAIN)
 PRODUCTION_DOMAIN = 'developer.mozilla.org'
-STAGING_DOMAIN = 'stage.mdn.moz.works'
+STAGING_DOMAIN = 'developer.allizom.org'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
 INTERACTIVE_EXAMPLES_BASE = config(

--- a/scripts/run_functional_tests.sh
+++ b/scripts/run_functional_tests.sh
@@ -7,8 +7,8 @@
 #   scripts/run_functional_tests.sh tests/functional/test_home.py::test_footer_displays
 # Run just in Chrome
 #   BROWSERS=chrome scripts/run_functional_tests.sh
-# Run against stage.mdn.moz.works
-#   BASE_URL=https://stage.mdn.moz.works scripts/run_functional_tests.sh
+# Run against developer.allizom.org
+#   BASE_URL=https://developer.allizom.org scripts/run_functional_tests.sh
 
 #
 # Configuration
@@ -22,7 +22,7 @@ if [[ "$DEBUG_SCRIPT" != "0" ]]; then
     set -x
 fi
 
-# BASE_URL: Protocol + domain to test against, such as https://stage.mdn.moz.works
+# BASE_URL: Protocol + domain to test against, such as https://developer.allizom.org
 BASE_URL=${BASE_URL:-http://web:8000}
 
 # PYTEST_ARGS: Arguments to pytest, i.e. what to run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,7 +33,7 @@ def pytest_configure(config):
     # The pytest-base-url plugin adds --base-url, and sets the default from
     # environment variable PYTEST_BASE_URL. If still unset, force to staging.
     if config.option.base_url is None:
-        config.option.base_url = 'https://stage.mdn.moz.works'
+        config.option.base_url = 'https://developer.allizom.org'
     base_url = config.getoption('base_url')
 
     # Process the server status from _kuma_status.json

--- a/tests/performance/smoke.py
+++ b/tests/performance/smoke.py
@@ -12,7 +12,7 @@ class SmokeBehavior(TaskSet):
     """
 
     def on_start(self):
-        locust_host = os.environ.get('LOCUST_HOST', 'stage.mdn.moz.works')
+        locust_host = os.environ.get('LOCUST_HOST', 'developer.allizom.org')
         self.client.headers['Host'] = locust_host
 
     @task(weight=265)


### PR DESCRIPTION
This PR updates kuma to reflect the new domain name (actually a return to the old domain name!) for stage: `developer.allizom.org`.