### PR TITLE
bug 957802: Enforce import order

### DIFF
--- a/kuma/attachments/admin.py
+++ b/kuma/attachments/admin.py
@@ -1,11 +1,9 @@
-from django.contrib import messages
-from django.contrib import admin
-from django.utils.html import format_html
+from constance import config
+from django.contrib import admin, messages
 from django.utils.encoding import force_text
+from django.utils.html import format_html
 from django.utils.text import get_text_list
 from django.utils.translation import ugettext_lazy as _
-
-from constance import config
 
 from kuma.core.admin import DisabledDeleteActionMixin
 from kuma.core.urlresolvers import reverse

--- a/kuma/attachments/models.py
+++ b/kuma/attachments/models.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.db.utils import IntegrityError
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
-
 from django_mysql.models import Model as MySQLModel
 
 from .utils import attachment_upload_to, full_attachment_url

--- a/kuma/attachments/signal_handlers.py
+++ b/kuma/attachments/signal_handlers.py
@@ -1,4 +1,4 @@
-from django.db.models.signals import pre_delete, post_delete
+from django.db.models.signals import post_delete, pre_delete
 from django.dispatch import receiver
 
 from .models import AttachmentRevision, TrashedAttachment

--- a/kuma/attachments/tests/test_models.py
+++ b/kuma/attachments/tests/test_models.py
@@ -1,12 +1,14 @@
 import datetime
+
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.db.utils import IntegrityError
 
+from kuma.users.tests import user, UserTestCase
 from kuma.wiki.models import DocumentAttachment
 from kuma.wiki.tests import document
-from kuma.users.tests import user, UserTestCase
+
 from ..models import Attachment, AttachmentRevision, TrashedAttachment
 from ..utils import allow_add_attachment_by
 

--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -4,8 +4,8 @@ from pyquery import PyQuery as pq
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.models import Revision
 
-from ..models import Attachment
 from . import make_test_file
+from ..models import Attachment
 
 
 @pytest.mark.security

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -1,21 +1,21 @@
-import json
 import datetime
+import json
 
 import pytest
-from pyquery import PyQuery as pq
 from constance.test import override_config
 from django.core.files.base import ContentFile
 from django.db import transaction
 from django.utils.six.moves.urllib.parse import urlparse
+from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 from kuma.wiki.models import DocumentAttachment
-from kuma.wiki.tests import WikiTestCase, document, revision
-from kuma.attachments.utils import convert_to_http_date
+from kuma.wiki.tests import document, revision, WikiTestCase
 
-from ..models import Attachment, AttachmentRevision
 from . import make_test_file
+from ..models import Attachment, AttachmentRevision
+from ..utils import convert_to_http_date
 
 
 @override_config(WIKI_ATTACHMENT_ALLOWED_TYPES='text/plain')

--- a/kuma/attachments/utils.py
+++ b/kuma/attachments/utils.py
@@ -1,6 +1,6 @@
 import calendar
-from datetime import datetime
 import hashlib
+from datetime import datetime
 
 from django.conf import settings
 from django.utils import timezone

--- a/kuma/attachments/views.py
+++ b/kuma/attachments/views.py
@@ -7,13 +7,14 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.cache import cache_control, never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 
-from .forms import AttachmentRevisionForm
-from .models import Attachment
-from .utils import allow_add_attachment_by, convert_to_http_date
 from kuma.core.decorators import login_required, shared_cache_control
 from kuma.core.utils import is_untrusted
 from kuma.wiki.decorators import process_document_path
 from kuma.wiki.models import Document
+
+from .forms import AttachmentRevisionForm
+from .models import Attachment
+from .utils import allow_add_attachment_by, convert_to_http_date
 
 
 # Mime types used on MDN

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -1,11 +1,11 @@
-import hashlib
 import base64
+import hashlib
 import random
 
 from django.conf import settings
-from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
+from django.db import models
 from django.utils.crypto import constant_time_compare
 from django.utils.translation import ugettext_lazy as _
 

--- a/kuma/authkeys/tests/conftest.py
+++ b/kuma/authkeys/tests/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 
 from kuma.users.tests import user
-from kuma.authkeys.models import Key
+
+from ..models import Key
 
 
 class Object(object):

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -1,9 +1,8 @@
 import base64
 
 import pytest
-
-from django.http import HttpRequest
 from django.contrib.auth.models import AnonymousUser
+from django.http import HttpRequest
 
 from kuma.authkeys.decorators import accepts_auth_key
 

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -1,8 +1,7 @@
-from pyquery import PyQuery as pq
-
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission
 from django.test import TestCase
+from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import user

--- a/kuma/authkeys/views.py
+++ b/kuma/authkeys/views.py
@@ -1,11 +1,11 @@
-from django.core.exceptions import PermissionDenied
-from django.shortcuts import get_object_or_404, render, redirect
 from django.contrib.auth.decorators import login_required, permission_required
+from django.core.exceptions import PermissionDenied
+from django.shortcuts import get_object_or_404, redirect, render
 
 from kuma.core.utils import paginate
 
-from .models import Key
 from .forms import KeyForm
+from .models import Key
 
 
 ITEMS_PER_PAGE = 15

--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -1,5 +1,5 @@
-from functools import wraps, partial
 import re
+from functools import partial, wraps
 
 from django.conf import settings
 from django.contrib.auth import REDIRECT_FIELD_NAME
@@ -7,8 +7,8 @@ from django.contrib.auth.decorators import user_passes_test
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect, render
-from django.utils.http import urlquote
 from django.utils.decorators import available_attrs
+from django.utils.http import urlquote
 from django.views.decorators.cache import cache_control
 
 from .jobs import BannedIPsJob

--- a/kuma/core/management/commands/anonymize.py
+++ b/kuma/core/management/commands/anonymize.py
@@ -1,5 +1,5 @@
-from django.db import connection
 from django.core.management.base import BaseCommand
+from django.db import connection
 from manage import path
 
 

--- a/kuma/core/management/commands/delete_old_ip_bans.py
+++ b/kuma/core/management/commands/delete_old_ip_bans.py
@@ -4,6 +4,7 @@ Delete old revision IPs
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
+
 from .tasks import delete_old_ip_bans
 
 

--- a/kuma/core/management/commands/fixaccount.py
+++ b/kuma/core/management/commands/fixaccount.py
@@ -1,8 +1,7 @@
-from django.contrib.auth import get_user_model
-from django.core.management.base import BaseCommand, CommandError
-
 from allauth.account.models import EmailAddress
 from allauth.socialaccount.models import SocialAccount
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
 
 
 class Command(BaseCommand):

--- a/kuma/core/managers.py
+++ b/kuma/core/managers.py
@@ -9,11 +9,10 @@ TODO:
 """
 from datetime import date, timedelta
 
+from django.contrib.auth.models import AnonymousUser
 from django.db import models
 from django.db.models.fields import BLANK_CHOICE_DASH
-from django.contrib.auth.models import AnonymousUser
-
-from taggit.managers import TaggableManager, _TaggableManager
+from taggit.managers import _TaggableManager, TaggableManager
 from taggit.models import Tag
 from taggit.utils import edit_string_for_tags, require_instance_manager
 

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -1,22 +1,23 @@
-import brotli
 import contextlib
 import re
 import urllib
 from urlparse import urljoin
 
+import brotli
+import django.middleware.gzip
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core import urlresolvers
-from django.http import (HttpResponseRedirect, HttpResponseForbidden,
-                         HttpResponsePermanentRedirect)
-import django.middleware.gzip
+from django.http import (HttpResponseForbidden,
+                         HttpResponsePermanentRedirect,
+                         HttpResponseRedirect)
 from django.utils import translation
 from django.utils.cache import patch_vary_headers
 from django.utils.encoding import iri_to_uri, smart_str
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 from .urlresolvers import Prefixer, set_url_prefixer, split_path
-from .utils import urlparams, is_untrusted
+from .utils import is_untrusted, urlparams
 from .views import handler403
 
 

--- a/kuma/core/models.py
+++ b/kuma/core/models.py
@@ -2,8 +2,8 @@ from django.db import models
 from django.dispatch import receiver
 from django.utils import timezone
 
-from .managers import IPBanManager
 from .jobs import BannedIPsJob
+from .managers import IPBanManager
 
 
 class IPBan(models.Model):

--- a/kuma/core/pipeline/storage.py
+++ b/kuma/core/pipeline/storage.py
@@ -1,5 +1,4 @@
 from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
-
 from pipeline.storage import PipelineMixin
 
 

--- a/kuma/core/tasks.py
+++ b/kuma/core/tasks.py
@@ -1,14 +1,12 @@
 from celery.task import task
-
-from django.db import connection
+from constance import config
 from django.contrib.sessions.models import Session
+from django.db import connection
 from django.utils import timezone
 
-from constance import config
-
 from .cache import memcache
+from .decorators import skip_in_maintenance_mode
 from .models import IPBan
-from kuma.core.decorators import skip_in_maintenance_mode
 
 
 LOCK_ID = 'clean-sessions-lock'

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -18,7 +18,7 @@ from statici18n.templatetags.statici18n import statici18n
 from urlobject import URLObject
 
 from ..urlresolvers import reverse, split_path
-from ..utils import urlparams, format_date_time
+from ..utils import format_date_time, urlparams
 
 
 htmlparser = HTMLParser.HTMLParser()

--- a/kuma/core/tests/test_backends.py
+++ b/kuma/core/tests/test_backends.py
@@ -1,7 +1,8 @@
 import pytest
-from mock import patch
-from django.db import models
 from constance.backends.database import DatabaseBackend
+from django.db import models
+from mock import patch
+
 from kuma.core.backends import ReadOnlyConstanceDatabaseBackend
 
 

--- a/kuma/core/tests/test_decorators.py
+++ b/kuma/core/tests/test_decorators.py
@@ -2,17 +2,16 @@ import pytest
 
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
-
 from django.test import RequestFactory
 
-from kuma.core.decorators import (block_user_agents, login_required,
-                                  logout_required, permission_required,
-                                  redirect_in_maintenance_mode,
-                                  shared_cache_control,
-                                  skip_in_maintenance_mode)
-
-from kuma.core.tests import eq_, KumaTestCase
 from kuma.users.tests import UserTestCase
+
+from . import eq_, KumaTestCase
+from ..decorators import (block_user_agents, login_required,
+                          logout_required, permission_required,
+                          redirect_in_maintenance_mode,
+                          shared_cache_control,
+                          skip_in_maintenance_mode)
 
 
 def simple_view(request):

--- a/kuma/core/tests/test_form_fields.py
+++ b/kuma/core/tests/test_form_fields.py
@@ -1,7 +1,6 @@
 from django.utils import translation
 
-from kuma.core.tests import KumaTestCase, eq_
-
+from . import eq_, KumaTestCase
 from ..form_fields import _format_decimal
 
 

--- a/kuma/core/tests/test_forms.py
+++ b/kuma/core/tests/test_forms.py
@@ -1,9 +1,7 @@
 from django import forms
-
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase, eq_
-
+from . import eq_, KumaTestCase
 from ..form_fields import StrippedCharField
 
 

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -6,10 +6,10 @@ import pytest
 import pytz
 from babel.dates import format_date, format_datetime, format_time
 from django.conf import settings
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import override_settings, RequestFactory, TestCase
 from soapbox.models import Message
 
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from kuma.core.tests import eq_, KumaTestCase, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 

--- a/kuma/core/tests/test_jobs.py
+++ b/kuma/core/tests/test_jobs.py
@@ -1,6 +1,7 @@
-from django.utils import six
-from kuma.core.tests import KumaTestCase
 import mock
+from django.utils import six
+
+from kuma.core.tests import KumaTestCase
 
 
 from ..jobs import GenerationJob, GenerationKeyJob, KumaJob

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from kuma.core.tests import KumaTestCase
+
+from . import KumaTestCase
 
 
 class TestLocaleMiddleware(KumaTestCase):

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -1,19 +1,18 @@
-from mock import patch, MagicMock
-
 import pytest
 from django.http import HttpResponse
 from django.test import RequestFactory
+from mock import MagicMock, patch
 
-from kuma.core.tests import KumaTestCase, eq_
-from kuma.core.middleware import (
-    GZipMiddleware,
-    WhiteNoiseMiddleware,
-    SetRemoteAddrFromForwardedFor,
+from . import eq_, KumaTestCase
+from ..middleware import (
+    BrotliMiddleware,
     ForceAnonymousSessionMiddleware,
+    GZipMiddleware,
+    LegacyDomainRedirectsMiddleware,
     RestrictedEndpointsMiddleware,
     RestrictedWhiteNoiseMiddleware,
-    LegacyDomainRedirectsMiddleware,
-    BrotliMiddleware,
+    SetRemoteAddrFromForwardedFor,
+    WhiteNoiseMiddleware,
 )
 
 

--- a/kuma/core/tests/test_misc.py
+++ b/kuma/core/tests/test_misc.py
@@ -1,7 +1,6 @@
 from django.test import RequestFactory
 
-from kuma.core.tests import KumaTestCase, eq_
-
+from . import eq_, KumaTestCase
 from ..context_processors import next_url
 
 

--- a/kuma/core/tests/test_models.py
+++ b/kuma/core/tests/test_models.py
@@ -2,7 +2,7 @@ from datetime import date, timedelta
 
 from django.test import TestCase
 
-from kuma.core.tests import eq_
+from . import eq_
 from ..models import IPBan
 
 

--- a/kuma/core/tests/test_pagination.py
+++ b/kuma/core/tests/test_pagination.py
@@ -1,10 +1,10 @@
-from django.test import RequestFactory
 import pyquery
+from django.test import RequestFactory
 
-from kuma.core.tests import eq_
+from . import eq_
+from ..templatetags.jinja_helpers import paginator
 from ..urlresolvers import reverse
 from ..utils import paginate, urlparams
-from ..templatetags.jinja_helpers import paginator
 
 
 def test_paginated_url():

--- a/kuma/core/tests/test_taggit_extras.py
+++ b/kuma/core/tests/test_taggit_extras.py
@@ -1,7 +1,6 @@
-from django.test import TestCase
-
-from taggit.models import Tag
 import pytest
+from django.test import TestCase
+from taggit.models import Tag
 
 from .taggit_extras.models import Food
 

--- a/kuma/core/tests/test_templates.py
+++ b/kuma/core/tests/test_templates.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 from django.utils import translation
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from . import eq_, KumaTestCase, ok_
 
 
 class MockRequestTests(KumaTestCase):

--- a/kuma/core/tests/test_urlresolvers.py
+++ b/kuma/core/tests/test_urlresolvers.py
@@ -2,7 +2,8 @@ import pytest
 
 from django.conf import settings
 
-from kuma.core.tests import KumaTestCase, eq_
+from kuma.core.tests import eq_, KumaTestCase
+
 from ..urlresolvers import get_best_language
 
 

--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from kuma.core.tests import eq_
+from . import eq_
 from ..utils import smart_int
 
 

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -10,7 +10,7 @@ from pyquery import PyQuery as pq
 from ratelimit.exceptions import Ratelimited
 from soapbox.models import Message
 
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from . import eq_, KumaTestCase, ok_
 from ..urlresolvers import reverse
 
 

--- a/kuma/core/urlresolvers.py
+++ b/kuma/core/urlresolvers.py
@@ -1,8 +1,8 @@
 import threading
 
 from django.conf import settings
-from django.test.client import RequestFactory
 from django.core.urlresolvers import reverse as django_reverse
+from django.test.client import RequestFactory
 from django.utils.translation.trans_real import parse_accept_lang_header
 
 

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -3,7 +3,6 @@ try:
     import urlparse
 except ImportError:
     import urllib.parse as urlparse
-
 import functools
 import hashlib
 import logging

--- a/kuma/core/validators.py
+++ b/kuma/core/validators.py
@@ -5,7 +5,6 @@
 """Validate Javascript Identifiers for use as JSON-P callback parameters."""
 
 import re
-
 from unicodedata import category
 
 # ------------------------------------------------------------------------------

--- a/kuma/dashboards/jobs.py
+++ b/kuma/dashboards/jobs.py
@@ -1,7 +1,8 @@
 from kuma.core.jobs import KumaJob
-from .utils import (spam_day_stats,
-                    spam_dashboard_historical_stats,
-                    spam_dashboard_recent_events)
+
+from .utils import (spam_dashboard_historical_stats,
+                    spam_dashboard_recent_events,
+                    spam_day_stats)
 
 
 class SpamDayStats(KumaJob):

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -1,11 +1,11 @@
 import datetime
 import json
+
 import mock
 import pytest
-from pyquery import PyQuery as pq
-
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
+from pyquery import PyQuery as pq
 from waffle.models import Flag, Switch
 
 from kuma.core.tests import eq_, ok_
@@ -13,8 +13,8 @@ from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
-from kuma.users.tests import create_document, SampleRevisionsMixin, UserTestCase
 from kuma.users.models import User, UserBan
+from kuma.users.tests import create_document, SampleRevisionsMixin, UserTestCase
 from kuma.wiki.models import DocumentSpamAttempt, RevisionAkismetSubmission
 
 

--- a/kuma/dashboards/urls.py
+++ b/kuma/dashboards/urls.py
@@ -1,8 +1,9 @@
 from django.conf.urls import url
 from django.views.generic.base import RedirectView
 
-from . import views
 from kuma.core.decorators import shared_cache_control
+
+from . import views
 
 
 urlpatterns = [

--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -1,12 +1,13 @@
 from __future__ import division
-from collections import defaultdict, Counter
+
 import datetime
+from collections import Counter, defaultdict
 
 from dateutil import parser
 from django.core.exceptions import ImproperlyConfigured
 
-from kuma.wiki.models import (DocumentDeletionLog, RevisionAkismetSubmission,
-                              Revision, DocumentSpamAttempt)
+from kuma.wiki.models import (DocumentDeletionLog, DocumentSpamAttempt,
+                              Revision, RevisionAkismetSubmission)
 from kuma.wiki.utils import analytics_upageviews
 
 

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+import waffle
 from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
@@ -11,7 +12,6 @@ from django.utils import timezone
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_GET
 from django.views.decorators.vary import vary_on_headers
-import waffle
 
 from kuma.core.decorators import login_required
 from kuma.core.decorators import shared_cache_control

--- a/kuma/feeder/admin.py
+++ b/kuma/feeder/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import Feed, Entry, Bundle
+from .models import Bundle, Entry, Feed
 
 
 class BundleInline(admin.TabularInline):

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -1,6 +1,6 @@
-from optparse import make_option
 import logging
 import time
+from optparse import make_option
 
 from django.core.management.base import BaseCommand
 

--- a/kuma/feeder/models.py
+++ b/kuma/feeder/models.py
@@ -1,7 +1,6 @@
+import jsonpickle
 from django.db import models
 from django.utils.functional import cached_property
-
-import jsonpickle
 
 
 class BundleManager(models.Manager):

--- a/kuma/feeder/tasks.py
+++ b/kuma/feeder/tasks.py
@@ -1,4 +1,5 @@
 from celery import task
+
 from kuma.core.decorators import skip_in_maintenance_mode
 
 from .utils import update_feeds as utils_update_feeds

--- a/kuma/feeder/tests/test_models.py
+++ b/kuma/feeder/tests/test_models.py
@@ -1,10 +1,10 @@
 from datetime import datetime, timedelta
 from uuid import uuid4
 
-import pytest
 import jsonpickle
+import pytest
 
-from ..models import Bundle, Feed, Entry
+from ..models import Bundle, Entry, Feed
 
 
 @pytest.fixture

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -1,12 +1,12 @@
 import json
 
-from django.db import DatabaseError
+import mock
+import pytest
 from django.core.urlresolvers import reverse
+from django.db import DatabaseError
 from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
                                       NotFoundError)
 from requests.exceptions import ConnectionError as Requests_ConnectionError
-import mock
-import pytest
 
 from kuma.users.models import User
 

--- a/kuma/humans/tests.py
+++ b/kuma/humans/tests.py
@@ -4,7 +4,7 @@ from os.path import dirname
 from django.test import TestCase
 from django.utils.six import StringIO
 
-from .models import HumansTXT, Human
+from .models import Human, HumansTXT
 
 APP_DIR = dirname(__file__)
 CONTRIBUTORS_JSON = "%s/fixtures/contributors.json" % APP_DIR

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,7 +1,7 @@
 from constance.test import override_config
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from kuma.core.tests import eq_, KumaTestCase, ok_
 from kuma.core.urlresolvers import reverse
 from kuma.search.models import Filter, FilterGroup
 

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -1,7 +1,7 @@
-from django.utils.six.moves.urllib.parse import urlparse
-from ratelimit.exceptions import Ratelimited
 import mock
 import pytest
+from django.utils.six.moves.urllib.parse import urlparse
+from ratelimit.exceptions import Ratelimited
 
 from kuma.core.urlresolvers import reverse
 

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -1,8 +1,8 @@
 from django.conf.urls import url
 
-from . import views
 from kuma.core.decorators import shared_cache_control
 
+from . import views
 
 urlpatterns = [
     url(r'^$',

--- a/kuma/scrape/fixture.py
+++ b/kuma/scrape/fixture.py
@@ -1,9 +1,9 @@
 """Load test fixtures from a specification."""
+import logging
 
 from django.apps import apps
 from django.contrib.auth.hashers import make_password
 
-import logging
 logger = logging.getLogger('kuma.scraper')
 
 

--- a/kuma/scrape/management/commands/__init__.py
+++ b/kuma/scrape/management/commands/__init__.py
@@ -1,6 +1,6 @@
 """Common methods for scraping management commands."""
-from argparse import ArgumentTypeError
 import logging
+from argparse import ArgumentTypeError
 
 from django.core.management.base import BaseCommand
 from django.utils.six.moves.urllib.parse import urlparse

--- a/kuma/scrape/management/commands/sample_mdn.py
+++ b/kuma/scrape/management/commands/sample_mdn.py
@@ -3,6 +3,7 @@ import json
 from django.core.management.base import CommandError
 
 from kuma.scrape.fixture import FixtureLoader
+
 from . import ScrapeCommand
 
 

--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -1,9 +1,9 @@
 """Content scraper for MDN."""
 from __future__ import unicode_literals
 
-from collections import OrderedDict
 import logging
 import time
+from collections import OrderedDict
 
 import requests
 

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -1,8 +1,11 @@
 """Shared interface for data sources."""
 from __future__ import absolute_import, unicode_literals
+
 import re
 
-from django.utils.six import binary_type, text_type, python_2_unicode_compatible
+from django.utils.six import (binary_type,
+                              python_2_unicode_compatible,
+                              text_type)
 from django.utils.six.moves.urllib.parse import unquote
 
 

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -1,5 +1,6 @@
 """DocumentSource scrapes MDN wiki documents."""
 from __future__ import absolute_import, unicode_literals
+
 import logging
 
 import dateutil

--- a/kuma/scrape/sources/document_current.py
+++ b/kuma/scrape/sources/document_current.py
@@ -1,5 +1,6 @@
 """DocumentCurrent checks that the current revision is scraped."""
 from __future__ import absolute_import, unicode_literals
+
 import logging
 
 from .base import DocumentBaseSource

--- a/kuma/scrape/sources/document_history.py
+++ b/kuma/scrape/sources/document_history.py
@@ -1,5 +1,6 @@
 """DocumentHistorySource scrapes the wiki history page."""
 from __future__ import absolute_import, unicode_literals
+
 import logging
 
 from pyquery import PyQuery as pq

--- a/kuma/scrape/sources/document_rendered.py
+++ b/kuma/scrape/sources/document_rendered.py
@@ -1,5 +1,6 @@
 """DocumentRenderedSource requests MDN wiki documents."""
 from __future__ import absolute_import, unicode_literals
+
 import re
 
 from django.utils.six.moves.urllib.parse import urlparse

--- a/kuma/scrape/sources/links.py
+++ b/kuma/scrape/sources/links.py
@@ -1,6 +1,7 @@
 """LinksSource gathers wiki document links from a rendered page."""
 
 from __future__ import absolute_import, unicode_literals
+
 import logging
 
 from django.conf import settings

--- a/kuma/scrape/sources/revision.py
+++ b/kuma/scrape/sources/revision.py
@@ -1,12 +1,13 @@
 """RevisionSource scrapes historical wiki revisions."""
 from __future__ import absolute_import, unicode_literals
-import re
+
 import logging
+import re
 
-from pyquery import PyQuery as pq
 import dateutil
+from pyquery import PyQuery as pq
 
-from .base import Source, DocumentBaseSource
+from .base import DocumentBaseSource, Source
 
 logger = logging.getLogger('kuma.scraper')
 

--- a/kuma/scrape/sources/user.py
+++ b/kuma/scrape/sources/user.py
@@ -1,8 +1,8 @@
 """UserSource scrapes MDN user profiles."""
 from __future__ import absolute_import, unicode_literals
 
-from pyquery import PyQuery as pq
 import dateutil
+from pyquery import PyQuery as pq
 
 from .base import Source
 

--- a/kuma/scrape/sources/zone_root.py
+++ b/kuma/scrape/sources/zone_root.py
@@ -1,7 +1,8 @@
 """ZoneRootSource determine zone URL redirects."""
 from __future__ import absolute_import, unicode_literals
-import re
+
 import logging
+import re
 
 from django.utils.six.moves.urllib.parse import unquote
 

--- a/kuma/scrape/storage.py
+++ b/kuma/scrape/storage.py
@@ -1,14 +1,14 @@
 """Store temporary data and interact with the database."""
-from collections import OrderedDict
 import logging
+from collections import OrderedDict
 
 from django.db import IntegrityError
 from taggit.models import Tag
 
 from kuma.users.models import User, UserBan
 from kuma.wiki.constants import REDIRECT_CONTENT
-from kuma.wiki.models import (Document, DocumentTag, DocumentZone, Revision,
-                              ReviewTag, LocalizationTag)
+from kuma.wiki.models import (Document, DocumentTag, DocumentZone,
+                              LocalizationTag, ReviewTag, Revision)
 
 logger = logging.getLogger('kuma.scraper')
 

--- a/kuma/scrape/tests/conftest.py
+++ b/kuma/scrape/tests/conftest.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """py.test fixtures"""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
 import pytest

--- a/kuma/scrape/tests/test_fixture.py
+++ b/kuma/scrape/tests/test_fixture.py
@@ -1,11 +1,12 @@
 import pytest
 
+from constance import config
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 
-from kuma.scrape.fixture import FixtureLoader
 from kuma.users.models import User, UserBan
-from constance import config
+
+from ..fixture import FixtureLoader
 
 
 def test_empty_fixtures():

--- a/kuma/scrape/tests/test_source.py
+++ b/kuma/scrape/tests/test_source.py
@@ -6,6 +6,7 @@ import mock
 import pytest
 
 from kuma.scrape.sources import Source
+
 from . import mock_requester, mock_storage
 
 

--- a/kuma/scrape/tests/test_source_document.py
+++ b/kuma/scrape/tests/test_source_document.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 """Tests for the DocumentSource class."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
-from kuma.scrape.sources import DocumentSource
 from . import mock_storage
+from ..sources import DocumentSource
 
 
 # Basic metadata for a Document

--- a/kuma/scrape/tests/test_source_document_children.py
+++ b/kuma/scrape/tests/test_source_document_children.py
@@ -2,8 +2,8 @@
 """Tests for the DocumentChildrenSource class ($children API)."""
 from __future__ import unicode_literals
 
-from kuma.scrape.sources import DocumentChildrenSource
 from . import mock_requester, mock_storage
+from ..sources import DocumentChildrenSource
 
 # Partial data from
 # https://developer.mozilla.org/en-US/docs/Web/Guide/HTML/HTML5$children

--- a/kuma/scrape/tests/test_source_document_current.py
+++ b/kuma/scrape/tests/test_source_document_current.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 import mock
 
-from kuma.scrape.sources import DocumentCurrentSource
 from . import mock_storage
+from ..sources import DocumentCurrentSource
 
 
 def test_gather_has_current(root_doc):

--- a/kuma/scrape/tests/test_source_document_history.py
+++ b/kuma/scrape/tests/test_source_document_history.py
@@ -2,8 +2,8 @@
 """Tests for the DocumentHistorySource class ($history API)."""
 from __future__ import unicode_literals
 
-from kuma.scrape.sources import DocumentHistorySource
 from . import mock_requester, mock_storage
+from ..sources import DocumentHistorySource
 
 
 def test_gather_revisions_default(root_doc, client):

--- a/kuma/scrape/tests/test_source_document_meta.py
+++ b/kuma/scrape/tests/test_source_document_meta.py
@@ -2,8 +2,8 @@
 """Tests for the DocumentMetaSource class ($json API)."""
 from __future__ import unicode_literals
 
-from kuma.scrape.sources import DocumentMetaSource
 from . import mock_requester, mock_storage
+from ..sources import DocumentMetaSource
 
 
 # Partial meta from

--- a/kuma/scrape/tests/test_source_document_rendered.py
+++ b/kuma/scrape/tests/test_source_document_rendered.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 """Tests for the DocumentRenderedSource class (GET document)."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
 import pytest
 
-from kuma.scrape.sources import DocumentRenderedSource
 from kuma.wiki.models import Document, DocumentZone, Revision
+
 from . import mock_requester, mock_storage
+from ..sources import DocumentRenderedSource
 
 
 @pytest.fixture

--- a/kuma/scrape/tests/test_source_links.py
+++ b/kuma/scrape/tests/test_source_links.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
 """Tests for the LinksSource class (Links from a page)."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
-from kuma.scrape.sources import LinksSource
 from kuma.wiki.models import Revision
+
 from . import mock_requester, mock_storage
+from ..sources import LinksSource
 
 
 def test_init_blank():

--- a/kuma/scrape/tests/test_source_revision.py
+++ b/kuma/scrape/tests/test_source_revision.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 """Tests for the RevisionSource class ($revision/ID API)."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
 import mock
 import pytest
 
-from kuma.scrape.sources import RevisionSource
 from kuma.wiki.models import Document, Revision
+
 from . import mock_requester, mock_storage
+from ..sources import RevisionSource
 
 
 @pytest.fixture

--- a/kuma/scrape/tests/test_source_user.py
+++ b/kuma/scrape/tests/test_source_user.py
@@ -1,13 +1,15 @@
 # -*- coding: utf-8 -*-
 """Tests for the UserSource class (/profiles/USERNAME)."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
 import pytest
 
-from kuma.scrape.sources import UserSource
 from kuma.users.models import UserBan
+
 from . import mock_requester, mock_storage
+from ..sources import UserSource
 
 
 @pytest.fixture

--- a/kuma/scrape/tests/test_source_zone_root.py
+++ b/kuma/scrape/tests/test_source_zone_root.py
@@ -4,8 +4,8 @@ from __future__ import unicode_literals
 
 import pytest
 
-from kuma.scrape.sources import ZoneRootSource
 from . import mock_requester, mock_storage
+from ..sources import ZoneRootSource
 
 
 def test_escaped_url():

--- a/kuma/scrape/tests/test_storage.py
+++ b/kuma/scrape/tests/test_storage.py
@@ -1,14 +1,16 @@
 from __future__ import unicode_literals
+
 from datetime import datetime
 
-from django.db import IntegrityError
-from taggit.models import Tag
 import mock
 import pytest
+from django.db import IntegrityError
+from taggit.models import Tag
 
-from kuma.scrape.storage import Storage
 from kuma.wiki.constants import REDIRECT_CONTENT
 from kuma.wiki.models import Document, DocumentTag, DocumentZone, Revision
+
+from ..storage import Storage
 
 
 @pytest.mark.parametrize(

--- a/kuma/search/apps.py
+++ b/kuma/search/apps.py
@@ -1,7 +1,6 @@
 from django.apps import AppConfig
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-
 from elasticsearch_dsl.connections import connections as es_connections
 
 

--- a/kuma/search/fields.py
+++ b/kuma/search/fields.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-
 from rest_framework import serializers
 
 from kuma.core.urlresolvers import reverse

--- a/kuma/search/models.py
+++ b/kuma/search/models.py
@@ -7,7 +7,6 @@ from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.text import slugify
-
 from elasticsearch.exceptions import NotFoundError
 from taggit.managers import TaggableManager
 
@@ -15,7 +14,7 @@ from kuma.core.urlresolvers import reverse
 from kuma.wiki.search import WikiDocumentType
 
 from .jobs import AvailableFiltersJob
-from .managers import IndexManager, FilterManager
+from .managers import FilterManager, IndexManager
 
 
 class Index(models.Model):

--- a/kuma/search/pagination.py
+++ b/kuma/search/pagination.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+
 from django.conf import settings
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.response import Response

--- a/kuma/search/store.py
+++ b/kuma/search/store.py
@@ -1,10 +1,9 @@
 import hashlib
 
-from urlobject import URLObject as URL
-
 from django.contrib.sites.models import Site
 from django.utils import translation
 from django.utils.encoding import smart_str
+from urlobject import URLObject as URL
 
 from kuma.core.urlresolvers import reverse
 

--- a/kuma/search/tasks.py
+++ b/kuma/search/tasks.py
@@ -1,9 +1,8 @@
 import logging
 
+from celery.task import task
 from django.conf import settings
 from django.core.mail import mail_admins
-
-from celery.task import task
 
 from kuma.core.decorators import skip_in_maintenance_mode
 

--- a/kuma/search/tests/__init__.py
+++ b/kuma/search/tests/__init__.py
@@ -1,9 +1,8 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-
-from elasticsearch_dsl.connections import connections
 from elasticsearch.exceptions import ConnectionError
+from elasticsearch_dsl.connections import connections
 from rest_framework.test import APIRequestFactory
 
 from kuma.core.middleware import LocaleURLMiddleware

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -1,13 +1,13 @@
+from django.http import QueryDict
+
 from kuma.core.tests import eq_, ok_
 from kuma.wiki.models import Document
 from kuma.wiki.signals import render_done
 
-from django.http import QueryDict
-
 from . import ElasticTestCase
 from ..filters import (AdvancedSearchQueryBackend, DatabaseFilterBackend,
-                       HighlightFilterBackend, LanguageFilterBackend,
-                       SearchQueryBackend, get_filters)
+                       get_filters, HighlightFilterBackend,
+                       LanguageFilterBackend, SearchQueryBackend)
 from ..models import FilterGroup
 from ..views import SearchView
 

--- a/kuma/search/tests/test_indexes.py
+++ b/kuma/search/tests/test_indexes.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-
 from elasticsearch_dsl.connections import connections
 
 from kuma.core.tests import eq_, ok_

--- a/kuma/search/tests/test_store.py
+++ b/kuma/search/tests/test_store.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
+import mock
 from django.contrib.sites.models import Site
 
-import mock
-
 from kuma.core.tests import KumaTestCase
+
 from ..store import get_search_url_from_referer
 
 

--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from kuma.core.tests import KumaTestCase, eq_
+from kuma.core.tests import eq_, KumaTestCase
 
 from ..utils import QueryURLObject
 

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -2,11 +2,12 @@
 import elasticsearch
 import pytest
 
+from kuma.core.urlresolvers import reverse
+
 from . import ElasticTestCase
 from ..models import Filter, FilterGroup, Index
 from ..pagination import SearchPagination
 from ..views import SearchView
-from kuma.core.urlresolvers import reverse
 
 
 class ViewTests(ElasticTestCase):

--- a/kuma/search/urls.py
+++ b/kuma/search/urls.py
@@ -1,5 +1,4 @@
 from django.conf.urls import url
-
 from rest_framework.urlpatterns import format_suffix_patterns
 
 from . import views

--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -8,9 +8,12 @@ from ratelimit.decorators import ratelimit
 from rest_framework.generics import ListAPIView
 from rest_framework.renderers import JSONRenderer
 
+from kuma.core.decorators import shared_cache_control
+from kuma.wiki.search import WikiDocumentType
+
 from .filters import (AdvancedSearchQueryBackend, DatabaseFilterBackend,
-                      HighlightFilterBackend, LanguageFilterBackend,
-                      SearchQueryBackend, get_filters)
+                      get_filters, HighlightFilterBackend,
+                      LanguageFilterBackend, SearchQueryBackend)
 from .jobs import AvailableFiltersJob
 from .pagination import SearchPagination
 from .queries import Filter, FilterGroup
@@ -18,8 +21,6 @@ from .renderers import ExtendedTemplateHTMLRenderer
 from .serializers import (DocumentSerializer, FacetedFilterSerializer,
                           FilterWithGroupSerializer, SearchQuerySerializer)
 from .utils import QueryURLObject
-from kuma.wiki.search import WikiDocumentType
-from kuma.core.decorators import shared_cache_control
 
 
 class SearchView(ListAPIView):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1,16 +1,15 @@
 # Django settings for kuma project.
-from collections import namedtuple
 import json
 import logging
 import os
-from os.path import dirname
 import platform
+from collections import namedtuple
+from os.path import dirname
 
-from decouple import config, Csv
-import djcelery
 import dj_database_url
 import dj_email_url
-
+import djcelery
+from decouple import config, Csv
 from django.core.urlresolvers import reverse_lazy
 
 _Language = namedtuple(u'Language', u'english native')

--- a/kuma/spam/akismet.py
+++ b/kuma/spam/akismet.py
@@ -5,9 +5,9 @@ import newrelic.agent
 from constance import config
 from django.conf import settings
 from requests import Session
-from requests.packages.urllib3.util import Retry
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
+from requests.packages.urllib3.util import Retry
 
 
 class AkismetError(Exception):

--- a/kuma/spam/models.py
+++ b/kuma/spam/models.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import models
 from django.utils.translation import ugettext_lazy as _
-
 from django_extensions.db.fields import CreationDateTimeField
 
 

--- a/kuma/spam/tests/test_akismet.py
+++ b/kuma/spam/tests/test_akismet.py
@@ -1,11 +1,10 @@
-from constance.test import override_config
-from waffle.models import Flag
 import mock
 import pytest
 import requests
 import requests_mock
-
+from constance.test import override_config
 from django.test import SimpleTestCase
+from waffle.models import Flag
 
 from ..akismet import Akismet, AkismetError
 from ..constants import (CHECK_URL, HAM_URL, SPAM_CHECKS_FLAG,

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -1,3 +1,4 @@
+from decorator_include import decorator_include
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -5,7 +6,6 @@ from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import RedirectView
 from django.views.static import serve
-from decorator_include import decorator_include
 
 from kuma.attachments import views as attachment_views
 from kuma.core import views as core_views

--- a/kuma/users/providers/github/provider.py
+++ b/kuma/users/providers/github/provider.py
@@ -1,6 +1,6 @@
 from allauth.account.models import EmailAddress
-from allauth.socialaccount.providers.github.provider import (GitHubProvider,
-                                                             GitHubAccount)
+from allauth.socialaccount.providers.github.provider import (GitHubAccount,
+                                                             GitHubProvider)
 
 
 class KumaGitHubAccount(GitHubAccount):

--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -1,12 +1,12 @@
 import requests
 
 from allauth.account.utils import get_next_redirect_url
-from allauth.socialaccount.providers.oauth2.views import (OAuth2LoginView,
-                                                          OAuth2CallbackView)
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+from allauth.socialaccount.providers.oauth2.views import (OAuth2CallbackView,
+                                                          OAuth2LoginView)
 
-from kuma.core.urlresolvers import reverse
 from kuma.core.decorators import redirect_in_maintenance_mode
+from kuma.core.urlresolvers import reverse
 
 
 class KumaGitHubOAuth2Adapter(GitHubOAuth2Adapter):

--- a/kuma/users/signal_handlers.py
+++ b/kuma/users/signal_handlers.py
@@ -1,19 +1,18 @@
+from allauth.account.signals import email_confirmed, user_signed_up
+from allauth.socialaccount.signals import social_account_removed
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import ObjectDoesNotExist
-from django.dispatch import receiver
 from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
 from django.utils.translation import ugettext_lazy as _
-
-from allauth.account.signals import user_signed_up, email_confirmed
-from allauth.socialaccount.signals import social_account_removed
 from waffle import switch_is_active
 
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.jobs import DocumentContributorsJob
 
-from .models import User, UserBan
 from .jobs import UserGravatarURLJob
+from .models import User, UserBan
 from .tasks import send_welcome_email
 
 

--- a/kuma/users/tasks.py
+++ b/kuma/users/tasks.py
@@ -8,9 +8,9 @@ from django.utils import translation
 from django.utils.translation import ugettext_lazy as _
 from djcelery_transactions import task as transaction_task
 
+from kuma.core.decorators import skip_in_maintenance_mode
 from kuma.core.email_utils import render_email
 from kuma.core.utils import strings_are_translated
-from kuma.core.decorators import skip_in_maintenance_mode
 
 
 log = logging.getLogger('kuma.users.tasks')

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -7,7 +7,7 @@ from django.contrib import admin
 from django.utils.translation import ugettext
 from django_jinja import library
 from honeypot.templatetags.honeypot import render_honeypot_field
-from jinja2 import Markup, contextfunction, escape
+from jinja2 import contextfunction, escape, Markup
 
 from kuma.core.templatetags.jinja_helpers import datetimeformat
 from kuma.core.urlresolvers import reverse

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -1,15 +1,17 @@
 import requests_mock
+from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers import registry
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
-from allauth.socialaccount.models import SocialApp
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
-from django.utils.six.moves.urllib_parse import urlparse, parse_qs
+from django.utils.six.moves.urllib_parse import parse_qs, urlparse
 
 from kuma.core.tests import KumaTestCase
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.tests import revision as create_revision, document as create_document
+from kuma.wiki.tests import document as create_document
+from kuma.wiki.tests import revision as create_revision
+
 from ..providers.github.provider import KumaGitHubProvider
 
 

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -1,14 +1,13 @@
+import pytest
+from allauth.exceptions import ImmediateHttpResponse
+from allauth.socialaccount.models import SocialAccount, SocialLogin
 from django.contrib import messages as django_messages
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
-import pytest
-
-from allauth.exceptions import ImmediateHttpResponse
-from allauth.socialaccount.models import SocialLogin, SocialAccount
 
 from kuma.core.tests import eq_
 from kuma.core.urlresolvers import reverse
-from kuma.users.adapters import KumaSocialAccountAdapter, KumaAccountAdapter
+from kuma.users.adapters import KumaAccountAdapter, KumaSocialAccountAdapter
 from kuma.users.models import User, UserBan
 
 from . import UserTestCase

--- a/kuma/users/tests/test_auth_backends.py
+++ b/kuma/users/tests/test_auth_backends.py
@@ -1,7 +1,7 @@
+import pytest
+
 from ..auth_backends import KumaAuthBackend
 from ..models import User, UserBan
-
-import pytest
 
 
 @pytest.fixture()

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -1,8 +1,9 @@
-from django import forms
-from django.test import RequestFactory
 import mock
 
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from django import forms
+from django.test import RequestFactory
+
+from kuma.core.tests import eq_, KumaTestCase, ok_
 
 from . import user
 from ..adapters import (KumaAccountAdapter, USERNAME_CHARACTERS,

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -4,6 +4,7 @@ from hashlib import md5
 from django.conf import settings
 
 from kuma.core.tests import eq_, ok_
+
 from . import UserTestCase
 from ..templatetags.jinja_helpers import gravatar_url, public_email
 

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -1,18 +1,17 @@
 import mock
-from waffle.models import Switch
-
-from django.conf import settings
-from django.contrib import messages as django_messages
-from django.core import mail
-from kuma.core.urlresolvers import reverse
-from django.test import RequestFactory, TestCase
 
 from allauth.account.models import EmailAddress, EmailConfirmationHMAC
 from allauth.account.signals import user_signed_up
+from django.conf import settings
+from django.contrib import messages as django_messages
+from django.core import mail
+from django.test import RequestFactory, TestCase
+from waffle.models import Switch
 
+from kuma.core.urlresolvers import reverse
 from kuma.users.tasks import send_recovery_email, send_welcome_email
 
-from . import UserTestCase, user
+from . import user, UserTestCase
 
 
 class SendRecoveryEmailTests(TestCase):

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -1,3 +1,6 @@
+import json
+
+import pytest
 from allauth.account.models import EmailAddress
 from constance import config as constance_config
 from constance.test.utils import override_config
@@ -6,8 +9,6 @@ from django.db import IntegrityError
 from mock import patch
 from pyquery import PyQuery as pq
 from waffle.models import Switch
-import json
-import pytest
 
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -14,18 +14,18 @@ from django.db import IntegrityError
 from django.http import Http404
 from django.test import RequestFactory
 from pyquery import PyQuery as pq
-from waffle.models import Flag
 from pytz import timezone, utc
+from waffle.models import Flag
 
 from kuma.core.urlresolvers import reverse
 from kuma.spam.akismet import Akismet
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
-from kuma.wiki.models import (Document, Revision, RevisionAkismetSubmission,
-                              DocumentDeletionLog)
+from kuma.wiki.models import (Document, DocumentDeletionLog, Revision,
+                              RevisionAkismetSubmission)
 from kuma.wiki.tests import document as create_document
 
 
-from . import SampleRevisionsMixin, SocialTestMixin, UserTestCase, user
+from . import SampleRevisionsMixin, SocialTestMixin, user, UserTestCase
 from ..models import User, UserBan
 from ..signup import SignupForm
 from ..views import delete_document, revert_document

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -1,9 +1,8 @@
 import importlib
 
-from django.conf.urls import include, url
-
 from allauth.account import views as account_views
 from allauth.socialaccount import providers, views as socialaccount_views
+from django.conf.urls import include, url
 
 from kuma.core.decorators import redirect_in_maintenance_mode
 

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,8 +1,8 @@
-from datetime import datetime, timedelta
 import collections
 import json
 import operator
 import uuid
+from datetime import datetime, timedelta
 
 from allauth.account.adapter import get_adapter
 from allauth.account.models import EmailAddress
@@ -25,8 +25,8 @@ from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.utils.encoding import force_text
-from django.utils.translation import ugettext_lazy as _
 from django.utils.http import urlsafe_base64_decode
+from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_POST
 from django.views.generic import TemplateView

--- a/kuma/version/views.py
+++ b/kuma/version/views.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.http import HttpResponse
-from django.views.decorators.http import require_safe
 from django.views.decorators.cache import never_cache
+from django.views.decorators.http import require_safe
 
 from kuma.wiki import kumascript
 

--- a/kuma/wiki/admin.py
+++ b/kuma/wiki/admin.py
@@ -1,20 +1,18 @@
 # -*- coding: utf-8 -*-
-
-from string import ascii_lowercase
 import json
+from string import ascii_lowercase
 
-from django.contrib import admin
-from django.contrib import messages
 from django.conf import settings
-from django.views.decorators.cache import never_cache
+from django.contrib import admin, messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.http import HttpResponseRedirect
-from django.template.response import TemplateResponse
 from django.template.defaultfilters import truncatechars
+from django.template.response import TemplateResponse
 from django.utils import timezone
 from django.utils.html import escape, format_html, format_html_join
 from django.utils.safestring import mark_safe
 from django.utils.text import Truncator
+from django.views.decorators.cache import never_cache
 from waffle import flag_is_active
 
 from kuma.core.admin import DisabledDeletionMixin

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -1,9 +1,9 @@
 import re
+from urlparse import urlparse, urlunparse
 
 import bleach
 from django.conf import settings
 from django.utils.translation import ugettext_lazy as _
-from urlparse import urlparse, urlunparse
 
 
 ALLOWED_TAGS = bleach.ALLOWED_TAGS + [

--- a/kuma/wiki/events.py
+++ b/kuma/wiki/events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Send notification emails for editing events."""
 from __future__ import unicode_literals
+
 import logging
 
 from constance import config

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -11,8 +11,8 @@ from django.template.loader import render_to_string
 from django.utils import translation
 from django.utils.safestring import mark_safe
 from django.utils.six import string_types
-from django.utils.translation import ugettext_lazy as _
 from django.utils.translation import ugettext
+from django.utils.translation import ugettext_lazy as _
 from taggit.utils import parse_tags
 
 import kuma.wiki.content
@@ -28,7 +28,7 @@ from .constants import (DOCUMENT_PATH_RE, INVALID_DOC_SLUG_CHARS_RE,
                         SPAM_TRAINING_SWITCH)
 from .events import EditDocumentEvent
 from .models import (Document, DocumentSpamAttempt, DocumentTag, Revision,
-                     RevisionIP, RevisionAkismetSubmission, valid_slug_parent)
+                     RevisionAkismetSubmission, RevisionIP, valid_slug_parent)
 from .tasks import send_first_edit_email
 
 

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -1,11 +1,11 @@
-import time
-import random
 import collections
+import random
+import time
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
-from kuma.core.jobs import KumaJob, GenerationJob
+from kuma.core.jobs import GenerationJob, KumaJob
 from kuma.users.templatetags.jinja_helpers import gravatar_url
 
 

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -1,19 +1,18 @@
 import base64
-from collections import defaultdict
-import json
 import hashlib
+import json
 import time
 import unicodedata
-from urlparse import urljoin
+from collections import defaultdict
 from functools import partial
+from urlparse import urljoin
 
+import requests
+from constance import config
 from django.conf import settings
 from django.contrib.sites.models import Site
-
-from constance import config
 from elasticsearch import TransportError
 from elasticsearch_dsl import Search
-import requests
 
 from kuma.core.cache import memcache
 

--- a/kuma/wiki/management/commands/delete_old_revision_ips.py
+++ b/kuma/wiki/management/commands/delete_old_revision_ips.py
@@ -4,6 +4,7 @@ Delete old revision IPs
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
+
 from kuma.wiki.tasks import delete_old_revision_ips
 
 

--- a/kuma/wiki/management/commands/delete_old_spam_attempt_data.py
+++ b/kuma/wiki/management/commands/delete_old_spam_attempt_data.py
@@ -4,6 +4,7 @@ Delete old DocumentSpamAttempt data
 from optparse import make_option
 
 from django.core.management.base import BaseCommand
+
 from kuma.wiki.tasks import delete_old_documentspamattempt_data
 
 

--- a/kuma/wiki/management/commands/make_sitemaps.py
+++ b/kuma/wiki/management/commands/make_sitemaps.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from kuma.wiki.tasks import build_locale_sitemap, build_index_sitemap
+from kuma.wiki.tasks import build_index_sitemap, build_locale_sitemap
 
 
 class Command(BaseCommand):

--- a/kuma/wiki/management/commands/populate_attachments.py
+++ b/kuma/wiki/management/commands/populate_attachments.py
@@ -1,9 +1,11 @@
 from collections import defaultdict
+
 from django.core.management.base import BaseCommand
 from django.db import models
 from django.utils.text import get_text_list
 
 from kuma.attachments.models import Attachment
+
 from ...constants import DEKI_FILE_URL, KUMA_FILE_URL
 from ...models import Document, DocumentAttachment
 

--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -10,7 +10,6 @@ from math import ceil
 from optparse import make_option
 
 from celery import chain
-
 from django.core.management.base import BaseCommand, CommandError
 from django.db.models import Q
 

--- a/kuma/wiki/management/commands/render_stale_documents.py
+++ b/kuma/wiki/management/commands/render_stale_documents.py
@@ -4,6 +4,7 @@ Manually re-render stale documents
 import logging
 
 from django.core.management.base import BaseCommand
+
 from kuma.wiki.tasks import render_stale_documents
 
 

--- a/kuma/wiki/management/commands/submit_deleted_documents.py
+++ b/kuma/wiki/management/commands/submit_deleted_documents.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+
 from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -1,13 +1,12 @@
 from datetime import date, datetime, timedelta
 
-from django.db import models
-
 import bleach
 from constance import config
+from django.db import models
 from django_mysql.models import QuerySet
 
-from .constants import (ALLOWED_TAGS, ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
-                        ALLOWED_STYLES)
+from .constants import (ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
+                        ALLOWED_STYLES, ALLOWED_TAGS)
 from .content import parse as parse_content
 
 

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
+from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -29,19 +29,19 @@ from kuma.spam.models import AkismetSubmission, SpamAttempt
 from . import kumascript
 from .constants import (DEKI_FILE_URL, EXPERIMENT_TITLE_PREFIX, KUMA_FILE_URL,
                         REDIRECT_CONTENT, REDIRECT_HTML)
+from .content import (Extractor, get_content_sections, get_seo_description,
+                      H2TOCFilter, H3TOCFilter, SectionTOCFilter)
 from .content import parse as parse_content
-from .content import (Extractor, H2TOCFilter, H3TOCFilter, SectionTOCFilter,
-                      get_content_sections, get_seo_description)
 from .exceptions import (DocumentRenderedContentNotAvailable,
-                         DocumentRenderingInProgress, PageMoveError,
-                         SlugCollision, UniqueCollision, NotDocumentView)
+                         DocumentRenderingInProgress, NotDocumentView,
+                         PageMoveError, SlugCollision, UniqueCollision)
 from .jobs import DocumentContributorsJob, DocumentNearestZoneJob, DocumentTagsJob
 from .managers import (DeletedDocumentManager, DocumentAdminManager,
                        DocumentManager, RevisionIPManager,
                        TaggedDocumentManager)
 from .signals import render_done
 from .templatetags.jinja_helpers import absolutify
-from .utils import tidy_content, get_doc_components_from_url
+from .utils import get_doc_components_from_url, tidy_content
 
 
 def cache_with_field(field_name):

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -5,13 +5,12 @@ import logging
 import operator
 from math import ceil
 
+from celery import chain
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils.html import strip_tags
 from django.utils.translation import ugettext_lazy as _
-
-from celery import chain
 from elasticsearch.helpers import bulk
 from elasticsearch_dsl import document, field
 from elasticsearch_dsl.connections import connections
@@ -19,6 +18,7 @@ from elasticsearch_dsl.mapping import Mapping
 from elasticsearch_dsl.search import Search
 
 from kuma.core.utils import chord_flow, chunked
+
 from .constants import EXPERIMENT_TITLE_PREFIX
 
 

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -6,6 +6,7 @@ import os
 import textwrap
 from datetime import datetime, timedelta
 
+from celery import chord, task
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sitemaps import GenericSitemap
@@ -13,14 +14,12 @@ from django.core.mail import mail_admins, send_mail
 from django.db import connection, transaction
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
-
-from celery import chord, task
 from djcelery_transactions import task as transaction_task
 from lxml import etree
 
 from kuma.core.cache import memcache
 from kuma.core.decorators import skip_in_maintenance_mode
-from kuma.core.utils import MemcacheLock, chord_flow, chunked
+from kuma.core.utils import chord_flow, chunked, MemcacheLock
 from kuma.search.models import Index
 
 from .events import first_edit_email

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -3,13 +3,13 @@ from datetime import datetime
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.utils.text import slugify
-
 from html5lib.filters.base import Filter as html5lib_Filter
 from waffle.models import Flag
 
-from kuma.core.tests import get_user, KumaTestCase
-from kuma.wiki.models import Document, Revision
 import kuma.wiki.content
+from kuma.core.tests import get_user, KumaTestCase
+
+from ..models import Document, Revision
 
 
 class WikiTestCase(KumaTestCase):

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -1,15 +1,16 @@
 # -*- coding: utf-8 -*-
 """py.test fixtures for kuma.wiki.tests."""
-import json
 import base64
-from datetime import datetime
+import json
 from collections import namedtuple
+from datetime import datetime
 
 import pytest
 
-from ..models import Document, DocumentZone, Revision
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.constants import REDIRECT_CONTENT
+
+from ..constants import REDIRECT_CONTENT
+from ..models import Document, DocumentZone, Revision
 
 
 BannedUser = namedtuple('BannedUser', 'user ban')

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -1,24 +1,25 @@
 # -*- coding: utf-8 -*-
 import pytest
-from pyquery import PyQuery as pq
-
+import requests_mock
 from constance.test import override_config
 from django.contrib.admin import AdminSite
 from django.test import RequestFactory
 from django.utils.six.moves.urllib.parse import parse_qsl
-import requests_mock
+from pyquery import PyQuery as pq
 from waffle.models import Flag
 
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.spam.akismet import Akismet
-from kuma.spam.constants import HAM_URL, SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
-from kuma.users.tests import UserTestCase
+from kuma.spam.constants import (HAM_URL, SPAM_SUBMISSIONS_FLAG, SPAM_URL,
+                                 VERIFY_URL)
 from kuma.users.models import User
-from kuma.wiki.admin import DocumentSpamAttemptAdmin, SUBMISSION_NOT_AVAILABLE
-from kuma.wiki.models import (DocumentSpamAttempt, RevisionAkismetSubmission,
-                              RevisionIP)
-from kuma.wiki.tests import document, revision
+from kuma.users.tests import UserTestCase
+
+from . import document, revision
+from ..admin import DocumentSpamAttemptAdmin, SUBMISSION_NOT_AVAILABLE
+from ..models import (DocumentSpamAttempt, RevisionAkismetSubmission,
+                      RevisionIP)
 
 
 @pytest.mark.spam

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -2,22 +2,21 @@
 from base64 import b64encode
 from urlparse import urljoin
 
+import bleach
+import pytest
 from django.conf import settings
 from django.test import TestCase
 from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
-import bleach
-import pytest
 
 import kuma.wiki.content
-from kuma.core.tests import KumaTestCase, eq_, ok_
+from kuma.core.tests import eq_, KumaTestCase, ok_
 
 from . import document, normalize_html
-
 from ..constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_TAGS
-from ..content import (SECTION_TAGS, CodeSyntaxFilter, H2TOCFilter,
-                       H3TOCFilter, SectionIDFilter, SectionTOCFilter,
-                       get_content_sections, get_seo_description, parse)
+from ..content import (CodeSyntaxFilter, get_content_sections,
+                       get_seo_description, H2TOCFilter, H3TOCFilter, parse,
+                       SECTION_TAGS, SectionIDFilter, SectionTOCFilter)
 from ..models import Document, Revision
 from ..templatetags.jinja_helpers import bugize_text
 

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Tests for kuma.wiki.events."""
 from __future__ import unicode_literals
+
 from datetime import datetime
 
 import mock

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -1,18 +1,18 @@
 # -*- coding: utf-8 -*-
-from datetime import datetime
 import json
+from datetime import datetime
 
-from django.utils.six.moves.urllib_parse import urlparse, parse_qs
+import pytest
+from django.utils.six.moves.urllib_parse import parse_qs, urlparse
 from django.utils.timezone import make_aware
 from pyquery import PyQuery as pq
 from pytz import AmbiguousTimeError
-import pytest
 
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.feeds import DocumentJSONFeedGenerator
-from kuma.wiki.models import Document, Revision
 
 from . import normalize_html
+from ..feeds import DocumentJSONFeedGenerator
+from ..models import Document, Revision
 
 
 def test_l10n_updates_no_updates(trans_doc, client):

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
 import json
 
-from django.contrib.auth.models import Permission
-from django.core import mail
-from django.test import RequestFactory
-
 import pytest
 import requests_mock
 from constance.test import override_config
+from django.contrib.auth.models import Permission
+from django.core import mail
+from django.test import RequestFactory
 from waffle.models import Flag, Switch
 
 from kuma.core.urlresolvers import reverse
-from kuma.spam.constants import (CHECK_URL, SPAM_ADMIN_FLAG,
+from kuma.spam.constants import (CHECK_URL, SPAM_ADMIN_FLAG, SPAM_CHECKS_FLAG,
                                  SPAM_SPAMMER_FLAG, SPAM_TESTING_FLAG,
-                                 SPAM_CHECKS_FLAG, VERIFY_URL)
+                                 VERIFY_URL)
 from kuma.users.tests import UserTestCase
 
 from ..constants import SPAM_TRAINING_SWITCH

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -8,7 +8,7 @@ from kuma.core.cache import memcache
 from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
-from . import WikiTestCase, document, revision
+from . import document, revision, WikiTestCase
 from ..models import DocumentZone
 from ..templatetags.jinja_helpers import (absolutify,
                                           document_zone_management_links,

--- a/kuma/wiki/tests/test_jobs.py
+++ b/kuma/wiki/tests/test_jobs.py
@@ -3,8 +3,8 @@ from datetime import datetime
 import mock
 import pytest
 
+from ..jobs import DocumentContributorsJob, DocumentNearestZoneJob
 from ..models import Revision
-from ..jobs import DocumentNearestZoneJob, DocumentContributorsJob
 
 
 def test_document_zone_unicode(doc_hierarchy_with_zones):

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -9,9 +9,10 @@ from elasticsearch import TransportError
 from elasticsearch_dsl.connections import connections
 
 from kuma.core.tests import eq_
-from kuma.wiki import kumascript
-from kuma.wiki.constants import KUMASCRIPT_BASE_URL
+
 from . import WikiTestCase
+from .. import kumascript
+from .. constants import KUMASCRIPT_BASE_URL
 
 
 @pytest.yield_fixture

--- a/kuma/wiki/tests/test_managers.py
+++ b/kuma/wiki/tests/test_managers.py
@@ -1,9 +1,10 @@
 from datetime import datetime
+
 import pytest
 
-from kuma.wiki.constants import REDIRECT_CONTENT
-from kuma.wiki.models import (Document, DocumentTag, LocalizationTag,
-                              ReviewTag, Revision)
+from ..constants import REDIRECT_CONTENT
+from ..models import (Document, DocumentTag, LocalizationTag, ReviewTag,
+                      Revision)
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -6,11 +6,9 @@ from kuma.core.cache import memcache
 from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
-from . import revision, document
+from . import document, revision, WikiTestCase
 from ..middleware import DocumentZoneMiddleware
 from ..models import DocumentZone
-
-from . import WikiTestCase
 
 
 class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -6,14 +6,13 @@ import mock
 import pytest
 from constance import config
 from constance.test import override_config
-
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
-from kuma.core.exceptions import ProgrammingError
-from kuma.core.urlresolvers import reverse
-from kuma.core.tests import eq_, get_user, ok_
 from kuma.attachments.models import Attachment, AttachmentRevision
+from kuma.core.exceptions import ProgrammingError
+from kuma.core.tests import eq_, get_user, ok_
+from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
 from . import (create_document_tree, create_topical_parents_docs, document,

--- a/kuma/wiki/tests/test_signal_handlers.py
+++ b/kuma/wiki/tests/test_signal_handlers.py
@@ -1,8 +1,8 @@
 import mock
 import pytest
 
-from kuma.wiki.models import Revision, Document
-from kuma.wiki.signals import render_done
+from ..models import Document, Revision
+from ..signals import render_done
 
 
 @pytest.mark.tags

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -1,14 +1,14 @@
 from __future__ import with_statement
 
-from datetime import datetime
 import os
+from datetime import datetime
 
 from django.conf import settings
 
 from kuma.core.cache import memcache
 from kuma.core.tests import ok_
 from kuma.users.models import User
-from kuma.users.tests import UserTestCase, user
+from kuma.users.tests import user, UserTestCase
 
 from . import document, revision
 from ..models import Document, DocumentSpamAttempt

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -13,7 +13,7 @@ from django.core import mail
 from django.test.utils import override_settings
 from django.utils import translation
 from django.utils.http import urlquote
-from django.utils.six.moves.urllib.parse import urlparse, parse_qs
+from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
 from kuma.core.tests import eq_, ok_
@@ -22,8 +22,8 @@ from kuma.core.utils import urlparams
 from kuma.users.models import User
 from kuma.users.tests import UserTestCase
 
-from . import (WikiTestCase, create_topical_parents_docs, document,
-               new_document_data, revision)
+from . import (create_topical_parents_docs, document,
+               new_document_data, revision, WikiTestCase)
 from ..constants import (EXPERIMENT_TITLE_PREFIX, REDIRECT_CONTENT)
 from ..events import EditDocumentEvent
 from ..models import Document, Revision

--- a/kuma/wiki/tests/test_utils.py
+++ b/kuma/wiki/tests/test_utils.py
@@ -1,13 +1,13 @@
 import datetime
 import os.path
 
-from django.core.exceptions import ImproperlyConfigured
 
-from constance.test import override_config
 import mock
 import pytest
-from googleapiclient.http import HttpMockSequence
+from constance.test import override_config
+from django.core.exceptions import ImproperlyConfigured
 from googleapiclient.errors import HttpError
+from googleapiclient.http import HttpMockSequence
 
 from kuma.core.tests import KumaTestCase
 from kuma.users.tests import UserTestCase

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
-import HTMLParser
 import datetime
+import HTMLParser
 import json
 
+import mock
+import pytest
+import requests_mock
 from constance.test import override_config
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -12,9 +15,6 @@ from django.utils.six.moves.urllib.parse import parse_qs, urlencode, urlparse
 from pyquery import PyQuery as pq
 from waffle.models import Flag, Switch
 from waffle.testutils import override_flag
-import mock
-import pytest
-import requests_mock
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import eq_, get_user, ok_

--- a/kuma/wiki/tests/test_views_admin.py
+++ b/kuma/wiki/tests/test_views_admin.py
@@ -1,10 +1,11 @@
 from datetime import datetime
 
-from waffle.models import Flag
 import pytest
+from waffle.models import Flag
 
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.models import Document, Revision
+
+from ..models import Document, Revision
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_views_akismet.py
+++ b/kuma/wiki/tests/test_views_akismet.py
@@ -1,13 +1,14 @@
 import json
 
+import pytest
 from django.contrib.auth.models import Permission
 from waffle.models import Flag
-import pytest
 
 from kuma.core.urlresolvers import reverse
 from kuma.spam.akismet import Akismet
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
-from kuma.wiki.models import RevisionAkismetSubmission
+
+from ..models import RevisionAkismetSubmission
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -1,12 +1,12 @@
-from waffle.models import Switch
 import pytest
+from waffle.models import Switch
 
 from kuma.attachments.models import Attachment
 from kuma.attachments.tests import make_test_file
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.models import Revision
 
 from . import normalize_html
+from ..models import Revision
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -1,9 +1,10 @@
+import pytest
 from django.contrib.auth.models import Permission
 from pyquery import PyQuery as pq
-import pytest
 
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.models import Document, Revision
+
+from ..models import Document, Revision
 
 
 # dict of case-name --> tuple of slug and expected status code

--- a/kuma/wiki/tests/test_views_delete.py
+++ b/kuma/wiki/tests/test_views_delete.py
@@ -1,8 +1,9 @@
-from django.contrib.auth.models import Permission
 import pytest
+from django.contrib.auth.models import Permission
 
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.models import Document, DocumentDeletionLog
+
+from ..models import Document, DocumentDeletionLog
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -3,28 +3,28 @@ Tests for kuma/wiki/views/document.py
 
 Legacy tests are in test_views.py.
 """
-from collections import namedtuple
-from urllib import quote
 import base64
 import json
+from collections import namedtuple
+from urllib import quote
 
-from pyquery import PyQuery as pq
-from waffle.models import Switch
 import mock
 import pytest
 import requests_mock
-
-from kuma.core.models import IPBan
-from kuma.core.urlresolvers import reverse
-from kuma.authkeys.models import Key
-from kuma.wiki.events import EditDocumentEvent, EditDocumentInTreeEvent
-from kuma.wiki.models import Document, Revision
-from kuma.wiki.views.utils import calculate_etag
-from kuma.wiki.views.document import _apply_content_experiment
-
-from django.test.client import BOUNDARY, MULTIPART_CONTENT, encode_multipart
+from django.test.client import BOUNDARY, encode_multipart, MULTIPART_CONTENT
 from django.utils.six.moves.urllib.parse import urlparse
 from django.utils.text import compress_string
+from pyquery import PyQuery as pq
+from waffle.models import Switch
+
+from kuma.authkeys.models import Key
+from kuma.core.models import IPBan
+from kuma.core.urlresolvers import reverse
+
+from ..events import EditDocumentEvent, EditDocumentInTreeEvent
+from ..models import Document, Revision
+from ..views.document import _apply_content_experiment
+from ..views.utils import calculate_etag
 
 
 AuthKey = namedtuple('AuthKey', 'key header')

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -1,8 +1,9 @@
-from pyquery import PyQuery as pq
 import pytest
+from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
+
 from ..models import Document
 
 

--- a/kuma/wiki/tests/test_views_translate.py
+++ b/kuma/wiki/tests/test_views_translate.py
@@ -1,9 +1,10 @@
+import pytest
 from django.contrib.auth.models import Permission
 from pyquery import PyQuery as pq
-import pytest
 
 from kuma.core.urlresolvers import reverse
-from kuma.wiki.models import Document
+
+from ..models import Document
 
 
 @pytest.fixture

--- a/kuma/wiki/utils.py
+++ b/kuma/wiki/utils.py
@@ -1,20 +1,19 @@
 import datetime
 import json
+from urlparse import urlparse
 
+import tidylib
+from apiclient.discovery import build
+from constance import config
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.core.urlresolvers import resolve, Resolver404
-import tidylib
-
-from apiclient.discovery import build
 from httplib2 import Http
 from oauth2client.service_account import ServiceAccountCredentials
-from urlparse import urlparse
-
-from constance import config
 
 from kuma.core.urlresolvers import split_path
-from kuma.wiki.exceptions import NotDocumentView
+
+from .exceptions import NotDocumentView
 
 
 def locale_and_slug_from_path(path, request=None, path_locale=None):

--- a/kuma/wiki/views/akismet_revision.py
+++ b/kuma/wiki/views/akismet_revision.py
@@ -2,13 +2,14 @@ import json
 
 from django.contrib.auth.decorators import permission_required
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
-from django.views.decorators.cache import never_cache
 
 from kuma.core.utils import format_date_time
-from kuma.wiki.forms import RevisionAkismetSubmissionSpamForm
-from kuma.wiki.models import RevisionAkismetSubmission
+
+from ..forms import RevisionAkismetSubmissionSpamForm
+from ..models import RevisionAkismetSubmission
 
 
 @never_cache

--- a/kuma/wiki/views/code.py
+++ b/kuma/wiki/views/code.py
@@ -1,17 +1,17 @@
 # -*- coding: utf-8 -*-
 import re
 
+from constance import config
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
+from django.views.decorators.cache import cache_control
 from django.views.decorators.clickjacking import xframe_options_exempt
 from django.views.decorators.http import require_GET
-from django.views.decorators.cache import cache_control
-
-from constance import config
 
 from kuma.attachments.utils import full_attachment_url
+
+from ..decorators import allow_CORS_GET, process_document_path
 from ..jobs import DocumentCodeSampleJob
-from ..decorators import process_document_path, allow_CORS_GET
 from ..models import Document
 
 

--- a/kuma/wiki/views/create.py
+++ b/kuma/wiki/views/create.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 import newrelic.agent
-
 from constance import config
-from django.shortcuts import render, redirect
+from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
 
 from kuma.attachments.forms import AttachmentRevisionForm

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -20,12 +20,12 @@ from kuma.core.decorators import (block_banned_ips, block_user_agents,
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 
+from .translate import translate
+from .utils import document_form_initial, split_slug
 from ..decorators import (check_readonly, prevent_indexing,
                           process_document_path)
 from ..forms import DocumentForm, RevisionForm
 from ..models import Document, Revision
-from .translate import translate
-from .utils import document_form_initial, split_slug
 
 
 @xframe_options_sameorigin

--- a/kuma/wiki/views/legacy.py
+++ b/kuma/wiki/views/legacy.py
@@ -3,8 +3,9 @@ from django.conf import settings
 from django.http import Http404
 from django.shortcuts import redirect
 
-from ..models import Document, Revision
 from kuma.core.decorators import shared_cache_control
+
+from ..models import Document, Revision
 
 
 # Legacy MindTouch redirects.

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from django.shortcuts import get_object_or_404, get_list_or_404, render
+from django.shortcuts import get_list_or_404, get_object_or_404, render
 from django.views.decorators.http import require_GET
 from ratelimit.decorators import ratelimit
 
@@ -7,9 +7,9 @@ from kuma.core.decorators import block_user_agents, shared_cache_control
 from kuma.core.utils import paginate
 
 from ..constants import DOCUMENTS_PER_PAGE
-from ..decorators import process_document_path, prevent_indexing
-from ..models import (Document, DocumentTag, ReviewTag, Revision,
-                      LocalizationTag)
+from ..decorators import prevent_indexing, process_document_path
+from ..models import (Document, DocumentTag, LocalizationTag, ReviewTag,
+                      Revision)
 
 
 @shared_cache_control

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -1,13 +1,13 @@
 # -*- coding: utf-8 -*-
+import newrelic.agent
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext_lazy as _
+from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
 from django.views.decorators.http import require_GET, require_POST
-from django.views.decorators.cache import never_cache
 from ratelimit.decorators import ratelimit
-import newrelic.agent
 
 from kuma.core.decorators import (block_user_agents, login_required,
                                   shared_cache_control)

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -9,18 +9,18 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 
+import kuma.wiki.content
 from kuma.attachments.forms import AttachmentRevisionForm
 from kuma.core.decorators import block_user_agents, login_required
 from kuma.core.i18n import get_language_mapping
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import get_object_or_none, smart_int, urlparams
-import kuma.wiki.content
 
+from .utils import document_form_initial, split_slug
 from ..decorators import (check_readonly, prevent_indexing,
                           process_document_path)
 from ..forms import DocumentForm, RevisionForm
 from ..models import Document, Revision
-from .utils import document_form_initial, split_slug
 
 
 @never_cache

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -214,6 +214,33 @@ simplejson==3.8.2 \
 uritemplate==0.6 \
     --hash=sha256:a30e230aeb7ebedbcb5da9999a17fa8a30e512e6d5b06f73d47c6e03c8e357fd
 
+# hashin
+#
+# Core utilities for Python packages
+# Code: https://github.com/pypa/packaging/
+# Docs: https://packaging.pypa.io/en/latest/
+# Changes: https://packaging.pypa.io/en/latest/changelog/
+packaging==17.1 \
+    --hash=sha256:e9215d2d2535d3ae866c3d6efc77d5b24a0192cce0ff20e42896cc0664f889c0 \
+    --hash=sha256:f019b770dd64e585a99714f1fd5e01c7a8f11b45635aa953fd41c689a657375b
+# The unofficial pip API
+# Code: https://github.com/di/pip-api
+pip-api==0.0.1 \
+    --hash=sha256:3cb7b51c541d4c13df43bf254aca371d9feb4669dc6c1cf3cecb9e9360eb3cb6
+# Create and execute simple grammars
+# Code: https://sourceforge.net/p/pyparsing/code/HEAD/tree/trunk/
+# Changes: http://pyparsing.wikispaces.com/News
+# Docs: http://pythonhosted.org/pyparsing/
+pyparsing==2.2.0 \
+    --hash=sha256:0832bcf47acd283788593e7a0f542407bd9550a55a8a8435214a1960e04bcb04 \
+    --hash=sha256:281683241b25fe9b80ec9d66017485f6deff1af5cde372469134b56ca8447a07 \
+    --hash=sha256:8f1e18d3fd36c6795bb7e02a39fd05c611ffc2596c1e0d995d34d67630426c18 \
+    --hash=sha256:9e8143a3e15c13713506886badd96ca4b579a87fbdf49e550dbfc057d6cb218e \
+    --hash=sha256:b8b3117ed9bdf45e14dcc89345ce638ec7e0e29b2b579fa1ecf32ce45ebac8a5 \
+    --hash=sha256:e4d45427c6e20a59bf4f88c639dcc03ce30d193112047f94012102f235853a58 \
+    --hash=sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010
+
+
 # Jinja2
 MarkupSafe==0.23 \
     --hash=sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -17,9 +17,10 @@ flake8==3.5.0 \
     --hash=sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
 
 # Calculate hashes for pip 8.x+
-hashin==0.11.2 \
-    --hash=sha256:a52b094dc7b1603a2f65617502f2de61123a268bab01c2079249c1c506480395 \
-    --hash=sha256:aaf11abf155830b7c2b868bb6dbc5dfde49cd0b17a4c0dc1b8b67ca9f31ec490
+# Code: https://github.com/peterbe/hashin
+hashin==0.13.0 \
+    --hash=sha256:6e3d9abfcb7c622a3432c800fbcdf2b73fe6003243aa58c17ab7852bb7a58120 \
+    --hash=sha256:b8ad3900fd6ad292ff892a7252021143705b8861b0900f5f2f5ab0c3b127f690
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,9 +12,19 @@ django-debug-toolbar==1.8 \
     --hash=sha256:0b4d2b1ac49a8bc5604518e8e20f56c1c08c0c4873336107e7c773c42537876b
 
 # Code quality checker
+# Code: https://github.com/PyCQA/flake8
+# Docs: http://flake8.readthedocs.io/en/latest/
+# Changes: http://flake8.readthedocs.io/en/latest/release-notes/index.html
 flake8==3.5.0 \
     --hash=sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37 \
     --hash=sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
+
+# Standardize Python import order
+# Code: https://github.com/PyCQA/flake8-import-order
+# Change: https://github.com/PyCQA/flake8-import-order/blob/master/CHANGELOG.rst
+flake8-import-order==0.17.1 \
+    --hash=sha256:40d2a39ed91e080f3285f4c16256b252d7c31070e7f11b7854415bb9f924ea81 \
+    --hash=sha256:68d430781a9ef15c85a0121500cf8462f1a4bc7672acb2a32bfdbcab044ae0b7
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 from urlparse import urlsplit, urlunsplit
 
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 import pytest
 import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 
 
 VIEWPORT = {

--- a/tests/functional/test_article_edit.py
+++ b/tests/functional/test_article_edit.py
@@ -1,9 +1,10 @@
-import pytest
 import time
 
+import pytest
+
+from pages.admin import AdminLogin
 from pages.article import ArticlePage
 from pages.article_new import NewPage
-from pages.admin import AdminLogin
 from utils.decorators import skip_if_maintenance_mode
 
 

--- a/tests/functional/test_article_new.py
+++ b/tests/functional/test_article_new.py
@@ -1,8 +1,9 @@
-import pytest
 import time
 
-from pages.article_new import NewPage
+import pytest
+
 from pages.admin import AdminLogin
+from pages.article_new import NewPage
 from utils.decorators import skip_if_maintenance_mode
 
 

--- a/tests/functional/test_article_translate.py
+++ b/tests/functional/test_article_translate.py
@@ -1,7 +1,7 @@
 import pytest
 
-from pages.article_edit import EditPage
 from pages.admin import AdminLogin
+from pages.article_edit import EditPage
 from utils.decorators import skip_if_maintenance_mode
 
 

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -1,8 +1,9 @@
-import pytest
-from urlparse import urlparse, parse_qs
+from urlparse import parse_qs, urlparse
 
-from pages.dashboard import DashboardPage, MacroDashboardPage
+import pytest
+
 from pages.admin import AdminLogin
+from pages.dashboard import DashboardPage, MacroDashboardPage
 from utils.decorators import (
     skip_if_maintenance_mode,
     skip_if_not_maintenance_mode,

--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -1,7 +1,9 @@
 import re
+
 import pytest
-from utils.urls import assert_valid_url
+
 from pages.article import ArticlePage
+from utils.urls import assert_valid_url
 
 ARTICLE_NAME = 'Send feedback (about|on) MDN'
 

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -1,11 +1,11 @@
 import pytest
 
 from pages.home import HomePage
-from utils.urls import assert_valid_url
 from utils.decorators import (
     skip_if_maintenance_mode,
     skip_if_not_maintenance_mode,
 )
+from utils.urls import assert_valid_url
 
 
 # homepage tests

--- a/tests/functional/test_notfound.py
+++ b/tests/functional/test_notfound.py
@@ -2,8 +2,8 @@ import pytest
 import requests
 
 from pages.notfound import NotFoundPage
-from utils.urls import assert_valid_url
 from utils.decorators import skip_if_not_maintenance_mode
+from utils.urls import assert_valid_url
 
 ARTICLE_NAME = 'Not Found'
 ARTICLE_TITLE_SUFIX = " | MDN"

--- a/tests/functional/test_report.py
+++ b/tests/functional/test_report.py
@@ -1,6 +1,7 @@
 import pytest
-from utils.urls import assert_valid_url
+
 from pages.article import ArticlePage
+from utils.urls import assert_valid_url
 
 ARTICLE_NAME = 'User:anonymous:uitest'
 ARTICLE_TITLE_SUFIX = " | MDN"

--- a/tests/functional/test_search.py
+++ b/tests/functional/test_search.py
@@ -1,10 +1,10 @@
 import pytest
 
-from utils.urls import assert_valid_url
-from pages.home import HomePage
 from pages.article import ArticlePage
+from pages.home import HomePage
 from pages.search import SearchPage
 from utils.decorators import skip_if_not_maintenance_mode
+from utils.urls import assert_valid_url
 
 SEARCH_TERM = 'css'
 SEARCH_TERM_ZERO = 'skwiz'

--- a/tests/headless/map_301.py
+++ b/tests/headless/map_301.py
@@ -1,6 +1,7 @@
+import requests
+
 from utils.urls import flatten, url_test
 
-import requests
 
 # Converted from SCL3 Apache files
 SCL3_REDIRECT_URLS = list(flatten((

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -1,5 +1,5 @@
-from urlparse import urlsplit
 import re
+from urlparse import urlsplit
 
 import pytest
 import requests

--- a/tests/headless/test_redirects.py
+++ b/tests/headless/test_redirects.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import
 import pytest
 
 from utils.urls import assert_valid_url
-from .map_301 import (REDIRECT_URLS, GITHUB_IO_URLS, MOZILLADEMOS_URLS,
-                      LEGACY_URLS, SCL3_REDIRECT_URLS)
+
+from .map_301 import (GITHUB_IO_URLS, LEGACY_URLS, MOZILLADEMOS_URLS,
+                      REDIRECT_URLS, SCL3_REDIRECT_URLS)
 
 # while these test methods are similar, they're each testing a
 # subset of redirects, and it was easier to work with them separately.

--- a/tests/pages/article.py
+++ b/tests/pages/article.py
@@ -1,8 +1,8 @@
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 
-from pages.base import BasePage
-from pages.regions.column_container import ColumnContainer
-from selenium.webdriver.common.action_chains import ActionChains
+from .base import BasePage
+from .regions.column_container import ColumnContainer
 
 
 class ArticlePage(BasePage):

--- a/tests/pages/article_edit.py
+++ b/tests/pages/article_edit.py
@@ -1,8 +1,9 @@
 import time
+
 from selenium.webdriver.common.by import By
 
-from pages.base import BasePage
-from pages.regions.ckeditor import Ckeditor
+from .base import BasePage
+from .regions.ckeditor import Ckeditor
 
 
 class EditPage(BasePage):

--- a/tests/pages/article_new.py
+++ b/tests/pages/article_new.py
@@ -1,8 +1,9 @@
 import datetime
 import time
+
 from selenium.webdriver.common.by import By
 
-from pages.article_edit import EditPage
+from .article_edit import EditPage
 
 
 class NewPage(EditPage):

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -1,15 +1,14 @@
-from functools import wraps
-import pytest
 import re
 import time
+from functools import wraps
 
+import pytest
+from pypom import Page, Region
 from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.select import Select
-from selenium.webdriver.common.action_chains import ActionChains
-
-from pypom import Page, Region
 
 
 def wait_for_window(fn):

--- a/tests/pages/content_experiment.py
+++ b/tests/pages/content_experiment.py
@@ -1,6 +1,6 @@
 from selenium.webdriver.common.by import By
 
-from pages.article import ArticlePage
+from .article import ArticlePage
 
 
 class VariantPage(ArticlePage):

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -1,12 +1,12 @@
+import pytest
 from pypom import Region
 from selenium.common.exceptions import (ElementNotInteractableException,
                                         NoSuchElementException,
                                         TimeoutException)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
-import pytest
 
-from pages.base import BasePage
+from .base import BasePage
 
 
 class DashboardPage(BasePage):

--- a/tests/pages/home.py
+++ b/tests/pages/home.py
@@ -1,8 +1,8 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 
-from pages.base import BasePage
-from pages.regions.column_container import ColumnContainer
+from .base import BasePage
+from .regions.column_container import ColumnContainer
 
 
 class HomePage(BasePage):

--- a/tests/pages/notfound.py
+++ b/tests/pages/notfound.py
@@ -1,6 +1,6 @@
 from selenium.webdriver.common.by import By
 
-from pages.base import BasePage
+from .base import BasePage
 
 
 class NotFoundPage(BasePage):

--- a/tests/pages/regions/ckeditor.py
+++ b/tests/pages/regions/ckeditor.py
@@ -2,8 +2,8 @@ import time
 from urlparse import urlparse
 
 from pypom import Region
-from selenium.webdriver.common.by import By
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.by import By
 
 
 class Ckeditor(Region):

--- a/tests/pages/search.py
+++ b/tests/pages/search.py
@@ -1,7 +1,7 @@
 from selenium.webdriver.common.by import By
 
-from pages.base import BasePage
-from pages.regions.column_container import ColumnContainer
+from .base import BasePage
+from .regions.column_container import ColumnContainer
 
 
 class SearchPage(BasePage):

--- a/tests/performance/smoke.py
+++ b/tests/performance/smoke.py
@@ -1,6 +1,6 @@
 import os
 
-from locust import HttpLocust, TaskSet, task
+from locust import HttpLocust, task, TaskSet
 
 
 class SmokeBehavior(TaskSet):

--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -1,7 +1,7 @@
 import re
-import requests
+from urlparse import parse_qs, urlparse
 
-from urlparse import urlparse, parse_qs
+import requests
 from braceexpand import braceexpand
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -88,3 +88,6 @@ exclude = **/migrations/**,.tox,*.egg,vendor
 # E731 - do not assign a lambda expression, use a def
 # F405 - name may be undefined, or defined from star imports: module
 ignore = E501,E731,F405
+# flake8-import-order settings
+import-order-style=edited
+application-import-names=kuma,pages,utils


### PR DESCRIPTION
This uses the plug-in [flake8-import-order](https://pypi.python.org/pypi/flake8-import-order) plugin to enforce the ``edited`` style of import order:

* Group system, 3rd-party, and local packages
* Case-insensitive sorting of imports

Previously, [we agreed on cryptography style](https://github.com/mozilla/kuma/pull/4676#pullrequestreview-98749380). I like the case-sensitive sorting of imports, but not the additional newlines between third party packages.

Here's the ``edited`` import style for ``kuma/wiki/utils.py`` (this PR):

```
import datetime
import json
from urlparse import urlparse

import tidylib
from apiclient.discovery import build
from constance import config
from django.conf import settings
from django.core.exceptions import ImproperlyConfigured
from django.core.urlresolvers import resolve, Resolver404
from httplib2 import Http
from oauth2client.service_account import ServiceAccountCredentials

from kuma.core.urlresolvers import split_path

from .exceptions import NotDocumentView
```

In the ``cryptography`` style, each 3rd-party package gets it's own section, and the ``django.core.urlresolvers`` import order changes:

```
import datetime
import json
from urlparse import urlparse

from apiclient.discovery import build

from constance import config

from django.conf import settings
from django.core.exceptions import ImproperlyConfigured
from django.core.urlresolvers import Resolver404, resolve

from httplib2 import Http

from oauth2client.service_account import ServiceAccountCredentials

import tidylib

from kuma.core.urlresolvers import split_path

from .exceptions import NotDocumentView
```

Neither is exactly what I'd want, but I don't think it is worth adding a custom import order, but instead let the tool pick. If you have a slight preference for ``cryptography``, it will be a small amount of work to change the imports now, and a bit harder later.
