### PR TITLE
Only preload .woff2 font files

### DIFF
--- a/jinja2/includes/preload.html
+++ b/jinja2/includes/preload.html
@@ -1,5 +1,3 @@
 {# because this is non-blocking, preload as early as possible #}
-<link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Bold.woff') }}" as="font" type="font/woff" crossorigin />
 <link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Bold.woff2') }}" as="font" type="font/woff2" crossorigin />
-<link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Regular.woff') }}" as="font" type="font/woff" crossorigin />
 <link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Regular.woff2') }}" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
I currently have a few pages of MDN listed on the [performance dashboard](https://mozmeao-perf-dashboard.netlify.com/) I'm building for our team. Because I'm spending a fair bit of time looking at this, I was intrigued to see a noticable up-tick in both load times and bytes in, as you can see here:

![screenshot-2018-4-3 web performance dashboard](https://user-images.githubusercontent.com/400117/38238633-5eb01430-3722-11e8-8b22-667dfe404aac.png)

After a bit of digging in the [web page test result](https://www.webpagetest.org/results.php?test=180403_16_4c356dcf4f3d6eb2c89cbb53d94a3cbf), I noticed that both `.woff` and `.woff2` files are being loaded, which seemed like a bug:

![screenshot-2018-4-3 webpagetest test details - california dev mozilla org en-us - 04 03 18 03 25 41](https://user-images.githubusercontent.com/400117/38238672-863d2204-3722-11e8-9932-0da68d900293.png)

I think this PR should fix the issue because:

- Any browser that supports `.woff2` should no longer need `.woff` files.
- Any browser that supports `rel="preload"` should also support `.woff2`.
