### PR TITLE
bug 1399639: Use locale name for statici18n path

### DIFF
--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -14,11 +14,11 @@ from django.utils.translation import ugettext_lazy as _
 from django_jinja import library
 from pytz import timezone, utc
 from soapbox.models import Message
-from statici18n.templatetags.statici18n import statici18n
+from statici18n.templatetags.statici18n import statici18n as lib_statici18n
 from urlobject import URLObject
 
 from ..urlresolvers import reverse, split_path
-from ..utils import format_date_time, urlparams
+from ..utils import format_date_time, language_to_locale, urlparams
 
 
 htmlparser = HTMLParser.HTMLParser()
@@ -29,8 +29,6 @@ library.filter(defaultfilters.escapejs)
 library.filter(defaultfilters.linebreaksbr)
 library.filter(strip_tags)
 library.filter(defaultfilters.truncatewords)
-library.global_function(statici18n)
-
 library.filter(urlparams)
 
 
@@ -38,6 +36,13 @@ library.filter(urlparams)
 def paginator(pager):
     """Render list of pages."""
     return Paginator(pager).render()
+
+
+@library.global_function
+def statici18n(language):
+    """Get path to JS i18n file by Kuma langugage code."""
+    locale = language_to_locale(language)
+    return lib_statici18n(locale)
 
 
 @library.global_function


### PR DESCRIPTION
[django-statici18n](https://github.com/zyegfryed/django-statici18n) is now using the locale name, such as ``en_US``, rather than the standardized language code, like ``en-US``. Replace that dash with an underscore, and update some utility functions to be clear about [locale names versus language codes](https://docs.djangoproject.com/en/1.11/topics/i18n/#definitions) (which may be important as we retire the custom locale middleware).