### PR TITLE
bug 1431259: Don't cache the "create page" redirect

### DIFF
--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -779,8 +779,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # child page.
         resp = self.client.get(url)
         assert resp.status_code == 302
-        assert 'public' in resp['Cache-Control']
-        assert 's-maxage' in resp['Cache-Control']
+        assert 'max-age=0' in resp['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'no-store' in resp['Cache-Control']
+        assert 'must-revalidate' in resp['Cache-Control']
+        assert 'public' not in resp['Cache-Control']
+        assert 's-maxage' not in resp['Cache-Control']
         assert 'docs/new' in resp['Location']
         assert ('?slug=%s' % local_slug) in resp['Location']
 
@@ -795,15 +799,17 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         response = self.client.get(reverse('wiki.document',
                                            args=['noExist'], locale=locale))
         assert response.status_code == 302
-        assert 'public' in response['Cache-Control']
-        assert 's-maxage' in response['Cache-Control']
+        assert 'public' not in response['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'docs/new' in response['Location']
 
         response = self.client.get(reverse('wiki.document',
                                            args=['Template:NoExist'],
                                            locale=locale))
         assert response.status_code == 302
-        assert 'public' in response['Cache-Control']
-        assert 's-maxage' in response['Cache-Control']
+        assert 'public' not in response['Cache-Control']
+        assert 'no-cache' in resp['Cache-Control']
+        assert 'docs/new' in response['Location']
 
     def test_creating_child_of_redirect(self):
         """
@@ -822,8 +828,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         url = reverse('wiki.document', locale='en-US', args=[child_full_slug])
         response = self.client.get(url)
         assert response.status_code == 302
-        assert 'public' in response['Cache-Control']
-        assert 's-maxage' in response['Cache-Control']
+        assert 'public' not in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'docs/new' in response['Location']
         # The parent id of the query should be same because while moving,
         # a new document is created with old slug and make redirect to the
         # old document
@@ -848,8 +855,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         zoned_child_full_slug = zoned_doc.url_root + "/" + "children_document"
         response = self.client.get(zoned_child_full_slug)
         assert response.status_code == 302
-        assert 'public' in response['Cache-Control']
-        assert 's-maxage' in response['Cache-Control']
+        assert 'public' not in response['Cache-Control']
+        assert 'no-cache' in response['Cache-Control']
+        assert 'docs/new' in response['Location']
         # The parent id of the query should be same because while moving,
         # a new document is created with old slug and make redirect to the
         # old document

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -15,7 +15,7 @@ from django.http import (Http404, HttpResponse, HttpResponseBadRequest,
                          JsonResponse)
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.cache import patch_vary_headers
+from django.utils.cache import add_never_cache_headers, patch_vary_headers
 from django.utils.http import parse_etags
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
@@ -659,7 +659,9 @@ def document(request, document_slug, document_locale):
             create_url = _document_redirect_to_create(document_slug,
                                                       document_locale,
                                                       slug_dict)
-            return redirect(create_url)
+            response = redirect(create_url)
+            add_never_cache_headers(response)
+            return response
 
     # We found a Document. Now we need to figure out how we're going
     # to display it.


### PR DESCRIPTION
Use a "no-cache" cache control header when redirecting to create a page, to avoid a loop where you have to wait for the cache to expire to see the new page. This also updates the ``shared_cache_control`` decorator to take no action if it detects the cache control header is set to no-cache.