### PR TITLE
bug 1431259: add cache control header to locale redirects

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -16,6 +16,7 @@ from django.utils.cache import patch_vary_headers
 from django.utils.encoding import iri_to_uri, smart_str
 from whitenoise.middleware import WhiteNoiseMiddleware
 
+from .decorators import add_shared_cache_control
 from .urlresolvers import Prefixer, set_url_prefixer, split_path
 from .utils import is_untrusted, urlparams
 from .views import handler403
@@ -47,7 +48,9 @@ class LocaleURLMiddleware(object):
 
             # Never use HttpResponsePermanentRedirect here.
             # Its a temporary redirect and should return with http 302, not 301
-            return HttpResponseRedirect(urlparams(new_path, **query))
+            response = HttpResponseRedirect(urlparams(new_path, **query))
+            add_shared_cache_control(response)
+            return response
 
         if full_path != request.path:
             query_string = request.META.get('QUERY_STRING', '')
@@ -64,6 +67,7 @@ class LocaleURLMiddleware(object):
             if old_locale != new_locale:
                 response['Vary'] = 'Accept-Language'
 
+            add_shared_cache_control(response)
             return response
 
         request.path_info = '/' + prefixer.shortened_path


### PR DESCRIPTION
This PR does the following:
- adds the shared cache control header to the locale redirects performed by `LocaleURLMiddleware`
- in the spirit of DRY, factors out the `add_shared_cache_control` function to use independently of the `shared_cache_control` decorator
- changes the `nocache` check to be an `or` of the no-cache and no-store cases (sorry, that was my mistake to suggest `and` when originally proposing the addition of no-store to the check)