### PR TITLE
create/use test functions to encapsulate cache-control header assertions

### DIFF
--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -13,6 +13,18 @@ from ..cache import memcache
 from ..urlresolvers import split_path
 
 
+def assert_no_cache_header(response):
+    assert 'max-age=0' in response['Cache-Control']
+    assert 'no-cache' in response['Cache-Control']
+    assert 'no-store' in response['Cache-Control']
+    assert 'must-revalidate' in response['Cache-Control']
+
+
+def assert_shared_cache_header(response):
+    assert 'public' in response['Cache-Control']
+    assert 's-maxage' in response['Cache-Control']
+
+
 def eq_(first, second, msg=None):
     """Rough reimplementation of nose.tools.eq_
 

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -18,6 +18,7 @@ def assert_no_cache_header(response):
     assert 'no-cache' in response['Cache-Control']
     assert 'no-store' in response['Cache-Control']
     assert 'must-revalidate' in response['Cache-Control']
+    assert 's-maxage' not in response['Cache-Control']
 
 
 def assert_shared_cache_header(response):

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -8,6 +8,7 @@ from django.core import mail
 from django.test import RequestFactory, TestCase
 from waffle.models import Switch
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.users.tasks import send_recovery_email, send_welcome_email
 
@@ -130,16 +131,10 @@ class TestWelcomeEmails(UserTestCase):
                        args=[confirmation.key])
         resp = self.client.get(link)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         resp = self.client.post(link)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # a second email, the welcome email, is sent
         self.assertEqual(len(mail.outbox), 2)
@@ -166,16 +161,10 @@ class TestWelcomeEmails(UserTestCase):
                         args=[confirmation2.key])
         resp = self.client.get(link2)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         resp = self.client.post(link2)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # no increase in number of emails (no 2nd welcome email)
         self.assertEqual(len(mail.outbox), 3)

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -10,6 +10,7 @@ from mock import patch
 from pyquery import PyQuery as pq
 from waffle.models import Switch
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.wiki.models import (Document, DocumentDeletionLog,
@@ -70,10 +71,7 @@ class SignupTests(UserTestCase, SocialTestMixin):
 def test_account_email_page_requires_signin(db, client):
     response = client.get(reverse('account_email', locale='en-US'))
     assert response.status_code == 302
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     response = client.get(response['Location'], follow=True)
     assert response.status_code == 200
     assert 'Please sign in' in response.content
@@ -82,10 +80,7 @@ def test_account_email_page_requires_signin(db, client):
 def test_account_email_page_single_email(user_client):
     response = user_client.get(reverse('account_email', locale='en-US'))
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert 'is your <em>primary</em> email address' in response.content
     assert 'Make Primary' not in response.content
     assert 'Re-send Confirmation' not in response.content
@@ -97,10 +92,7 @@ def test_account_email_page_multiple_emails(wiki_user, user_client):
                                 verified=True, primary=False)
     response = user_client.get(reverse('account_email', locale='en-US'))
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert 'Make Primary' in response.content
     assert 'Re-send Confirmation' in response.content
     assert 'Remove' in response.content
@@ -212,10 +204,7 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
         signup_url = reverse('socialaccount_signup', locale=locale)
         response = self.client.post(signup_url, data=data)
         assert response.status_code == 302
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         response = self.client.get(response['Location'], follow=True)
         assert response.status_code == 200
 
@@ -258,10 +247,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         reasons_to_ban_found = page.find('.ban-common-reason')
@@ -285,10 +271,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         reasons_to_ban_found = page.find('.ban-common-reason')
@@ -310,10 +293,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get(ban_url, follow=True)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         reasons_to_ban_found = page.find('.ban-common-reason')
@@ -340,10 +320,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -366,10 +343,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -398,10 +372,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -427,10 +398,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
                           kwargs={'username': self.testuser.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -459,10 +427,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
                           kwargs={'username': self.testuser2.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -497,10 +462,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -531,10 +493,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -563,10 +522,7 @@ class BanAndCleanupTestCase(SampleRevisionsMixin, UserTestCase):
                           kwargs={'username': self.testuser2.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         revisions_found = page.find('.dashboard-row')
@@ -588,10 +544,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
                           kwargs={'username': self.testuser.username})
         resp = self.client.post(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -649,10 +602,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in revisions_created]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -713,10 +663,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in revisions_created]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -766,10 +713,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in revisions_created]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -822,10 +766,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': []}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -885,10 +826,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-already-spam': revisions_created_ids}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -967,10 +905,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': posted_ids}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # The "Actions taken" section
@@ -1045,10 +980,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev_doc1.id], 'revision-already-spam': [rev_doc2.id]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # TODO: Phase V: The revision done after the reviewing has begun should
@@ -1095,10 +1027,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-already-spam': [revisions_already_spam[0].id]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         delete_url = reverse(
@@ -1157,10 +1086,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-already-spam': [testuser_revisions[0].id]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         delete_url_already_spam = reverse(
@@ -1211,10 +1137,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in spam_revisions]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # 'Actions taken' section
@@ -1279,10 +1202,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in spam_revisions]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # 'Actions taken' section
@@ -1348,10 +1268,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in spam_revisions]}
         resp = self.client.post(ban_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # 'Actions taken' section
@@ -1407,10 +1324,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
             resp = self.client.post(ban_url, data=data)
 
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         assert DocumentDeletionLog.objects.count() == 0
@@ -1474,10 +1388,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
             resp = self.client.post(ban_url, data=data)
 
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         # 'Actions taken' section
@@ -1541,10 +1452,7 @@ class ProfileDetailTestCase(UserTestCase):
         # The user is not banned, display appropriate links
         resp = self.client.get(profile_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         ban_link = page.find('#ban_link')
@@ -1558,10 +1466,7 @@ class ProfileDetailTestCase(UserTestCase):
                                is_active=True)
         resp = self.client.get(profile_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
 
         ban_link = page.find('#ban_link')
@@ -1577,10 +1482,7 @@ class ProfileDetailTestCase(UserTestCase):
                               kwargs={'username': testuser.username})
         resp = self.client.get(profile_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         page = pq(resp.content)
         assert len(page.find('ul.user-links li.github')) == 0
 

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -17,6 +17,7 @@ from pyquery import PyQuery as pq
 from pytz import timezone, utc
 from waffle.models import Flag
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.spam.akismet import Akismet
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
@@ -69,10 +70,7 @@ class BanTestCase(UserTestCase):
                           kwargs={'username': admin.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         assert str(settings.LOGIN_URL) in resp['Location']
         self.client.logout()
 
@@ -83,10 +81,7 @@ class BanTestCase(UserTestCase):
                           kwargs={'username': testuser.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
     def test_ban_view(self):
         testuser = self.user_model.objects.get(username='testuser')
@@ -100,10 +95,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.post(ban_url, data)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         assert testuser.get_absolute_url() in resp['Location']
 
         testuser_banned = self.user_model.objects.get(username='testuser')
@@ -127,10 +119,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.post(ban_url, data)
         assert resp.status_code == 404
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         bans = UserBan.objects.filter(user__username=nonexistent_username,
                                       by=admin,
@@ -150,10 +139,7 @@ class BanTestCase(UserTestCase):
         # POST without data kwargs
         resp = self.client.post(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         bans = UserBan.objects.filter(user=testuser,
                                       by=admin,
@@ -164,10 +150,7 @@ class BanTestCase(UserTestCase):
         data = {'reason': ''}
         resp = self.client.post(ban_url, data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         bans = UserBan.objects.filter(user=testuser,
                                       by=admin,
@@ -183,10 +166,7 @@ class BanTestCase(UserTestCase):
         # User viewable if not banned
         response = self.client.get(url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
 
         # Ban User
         admin = self.user_model.objects.get(username='admin')
@@ -198,19 +178,13 @@ class BanTestCase(UserTestCase):
         # User not viewable if banned
         response = self.client.get(url)
         assert response.status_code == 404
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
 
         # Admin can view banned user
         self.client.login(username='admin', password='testpass')
         response = self.client.get(url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
 
     def test_get_ban_user_view(self):
         # For an unbanned user get the ban_user view
@@ -223,10 +197,7 @@ class BanTestCase(UserTestCase):
 
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # For a banned user redirect to user detail page
         UserBan.objects.create(user=testuser, by=admin,
@@ -234,10 +205,7 @@ class BanTestCase(UserTestCase):
                                is_active=True)
         resp = self.client.get(ban_url)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         assert testuser.get_absolute_url() in resp['Location']
 
 
@@ -257,10 +225,7 @@ class BanAndCleanupTestCase(UserTestCase):
                           kwargs={'username': admin.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 302
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
         assert str(settings.LOGIN_URL) in resp['Location']
         self.client.logout()
 
@@ -271,10 +236,7 @@ class BanAndCleanupTestCase(UserTestCase):
                           kwargs={'username': testuser.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
     def test_ban_nonexistent_user(self):
         """GETs to ban_user_and_cleanup for nonexistent user return 404."""
@@ -288,10 +250,7 @@ class BanAndCleanupTestCase(UserTestCase):
         testuser.delete()
         resp = self.client.get(ban_url)
         assert resp.status_code == 404
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
 
 @pytest.mark.bans
@@ -371,28 +330,19 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.testuser.delete()
         resp = self.client.post(self.ban_testuser_url)
         assert resp.status_code == 404
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
     def test_post_returns_summary_page(self):
         """POSTing to ban_user_and_cleanup returns the summary page."""
         resp = self.client.post(self.ban_testuser_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
     def test_post_bans_user(self):
         """POSTing to the ban_user_and_cleanup bans user for "spam" reason."""
         resp = self.client.post(self.ban_testuser_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         testuser_banned = self.user_model.objects.get(username='testuser')
         assert not testuser_banned.is_active
@@ -410,10 +360,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.post(self.ban_testuser_url)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         assert not self.testuser.is_active
 
@@ -443,10 +390,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         data = {'revision-id': [rev.id for rev in revisions_created]}
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # All of self.testuser's revisions have been submitted
         testuser_submissions = RevisionAkismetSubmission.objects.filter(revision__creator=self.testuser.id)
@@ -469,10 +413,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # Akismet endpoints were not called
         assert mock_requests.call_count == 0
@@ -496,10 +437,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # No revisions submitted for self.testuser, since no revisions were selected
         testuser_submissions = RevisionAkismetSubmission.objects.filter(
@@ -527,10 +465,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         resp = self.client.post(self.ban_testuser2_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # No revisions submitted for self.testuser2, since revisions in the POST
         # were made by self.testuser
@@ -557,10 +492,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # Test that the document was deleted successfully
         deleted_doc = Document.admin_objects.filter(pk=new_document.pk).first()
@@ -595,10 +527,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         new_document = Document.objects.filter(id=new_document.id).first()
         # Make sure that the current revision is not the spam revision
@@ -645,10 +574,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # Document A: No changes should have been made
         new_document_a = Document.objects.filter(id=new_document_a.id).first()
@@ -690,10 +616,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # No changes should have been made to the document
         new_document = Document.objects.get(id=new_document.id)
@@ -728,10 +651,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         # The document should be reverted to the last good revision
         new_document = Document.objects.get(id=new_document.id)
@@ -784,10 +704,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         resp = self.client.post(self.ban_testuser_url, data=data)
         assert resp.status_code == 200
-        assert 'max-age=0' in resp['Cache-Control']
-        assert 'no-cache' in resp['Cache-Control']
-        assert 'no-store' in resp['Cache-Control']
-        assert 'must-revalidate' in resp['Cache-Control']
+        assert_no_cache_header(resp)
 
         tz = timezone(settings.TIME_ZONE)
 
@@ -874,10 +791,7 @@ def test_user_detail_view(wiki_user, client):
                   args=(wiki_user.username,))
     response = client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
     assert doc.find('#user-head.vcard .nickname').text() == wiki_user.username
     assert doc.find('#user-head.vcard .fn').text() == wiki_user.fullname
@@ -891,10 +805,7 @@ def test_user_detail_view(wiki_user, client):
 def test_my_user_page(wiki_user, user_client):
     resp = user_client.get(reverse('users.my_detail_page', locale='en-US'))
     assert resp.status_code == 302
-    assert 'max-age=0' in resp['Cache-Control']
-    assert 'no-cache' in resp['Cache-Control']
-    assert 'no-store' in resp['Cache-Control']
-    assert 'must-revalidate' in resp['Cache-Control']
+    assert_no_cache_header(resp)
     assert resp['Location'].endswith(reverse('users.user_detail',
                                              args=(wiki_user.username,)))
 
@@ -906,10 +817,7 @@ def test_bug_698971(wiki_user, client):
 
     response = client.get(url, dict(page='asdf'))
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 def test_user_edit(wiki_user, client, user_client):
@@ -917,10 +825,7 @@ def test_user_edit(wiki_user, client, user_client):
                   args=(wiki_user.username,))
     response = client.get(url, follow=True)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
     assert doc.find('#user-head .edit .button').length == 0
 
@@ -928,10 +833,7 @@ def test_user_edit(wiki_user, client, user_client):
                   args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
     edit_button = doc.find('#user-head .user-buttons #edit-user')
     assert edit_button.length == 1
@@ -939,10 +841,7 @@ def test_user_edit(wiki_user, client, user_client):
     url = edit_button.attr('href')
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
 
     assert (doc.find('#user-edit input[name="user-fullname"]').val() ==
@@ -983,10 +882,7 @@ def test_user_edit(wiki_user, client, user_client):
 def test_my_user_edit(wiki_user, user_client):
     response = user_client.get(reverse('users.my_edit_page', locale='en-US'))
     assert response.status_code == 302
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert response['Location'].endswith(
         reverse('users.user_edit', args=(wiki_user.username,)))
 
@@ -997,10 +893,7 @@ def test_user_edit_beta(wiki_user, wiki_user_github_account,
                   args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
     assert doc.find('input#id_user-beta').attr('checked') is None
 
@@ -1009,10 +902,7 @@ def test_user_edit_beta(wiki_user, wiki_user_github_account,
 
     response = user_client.post(url, form)
     assert response.status_code == 302
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert response['Location'].endswith(
         reverse('users.user_detail', args=(wiki_user.username,)))
 
@@ -1027,10 +917,7 @@ def test_user_edit_websites(wiki_user, wiki_user_github_account, user_client):
                   args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
 
     test_sites = {
@@ -1095,10 +982,7 @@ def test_user_edit_interests(wiki_user, wiki_user_github_account, user_client):
                   args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc = pq(response.content)
 
     test_tags = ['javascript', 'css', 'canvas', 'html', 'homebrewing']
@@ -1183,19 +1067,13 @@ def test_user_edit_github_is_public(wiki_user, wiki_user_github_account,
                   args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     form = _get_current_form_field_values(pq(response.content))
     assert not form['user-is_github_url_public']
     form['user-is_github_url_public'] = True
     response = user_client.post(url, form)
     assert response.status_code == 302
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert response['Location'].endswith(
         reverse('users.user_detail', args=(wiki_user.username,)))
     wiki_user.refresh_from_db()
@@ -1254,19 +1132,13 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login()
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert 'matching_user' in response.context
         assert response.context['matching_user'] is None
         octocat = user(username='octocat', save=True)
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert response.context['matching_user'] == octocat
 
     @mock.patch.dict(os.environ, {'RECAPTCHA_TESTING': 'True'})
@@ -1295,10 +1167,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login(profile_data=profile_data, email_data=email_data)
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert private_email not in response.context
         email_address = response.context['email_addresses']
 
@@ -1329,10 +1198,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         assert not EmailAddress.objects.filter(email=unverified_email).exists()
         response = self.client.post(self.signup_url, data=data)
         assert response.status_code == 302
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         unverified_email_addresses = EmailAddress.objects.filter(
             email=unverified_email)
         assert unverified_email_addresses.exists()
@@ -1349,10 +1215,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login(profile_data=profile_data, email_data=email_data)
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert response.context["form"].initial["email"] == private_email
 
     def test_email_addresses_with_no_alternatives(self):
@@ -1360,10 +1223,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login(email_data=[])
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert response.context["form"].initial["email"] == private_email
 
     def test_no_email_addresses(self):
@@ -1373,10 +1233,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login(profile_data=profile_data, email_data=[])
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert response.context["form"].initial["email"] == ''
 
     def test_signup_public_github(self, is_public=True):
@@ -1390,10 +1247,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
                 'is_github_url_public': is_public}
         response = self.client.post(self.signup_url, data=data)
         assert response.status_code == 302
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         user = User.objects.get(username='octocat')
         assert user.is_github_url_public == is_public
 
@@ -1416,10 +1270,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         self.github_login(profile_data=profile_data, email_data=email_data)
         response = self.client.get(self.signup_url)
         assert response.status_code == 200
-        assert 'max-age=0' in response['Cache-Control']
-        assert 'no-cache' in response['Cache-Control']
-        assert 'no-store' in response['Cache-Control']
-        assert 'must-revalidate' in response['Cache-Control']
+        assert_no_cache_header(response)
         assert not response.context['matching_accounts']
 
         # Create a legacy Persona account with the given email address
@@ -1488,10 +1339,7 @@ def test_missing_user_is_missing(db, client):
                   kwargs={'username': 'missing'})
     response = client.get(url)
     assert response.status_code == 404
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 @pytest.mark.parametrize('user_case', ['wrong_user', 'right_user'])
@@ -1506,10 +1354,7 @@ def test_user_can_delete(wiki_user, wiki_user_2, user_client, user_case):
                   kwargs={'username': user.username})
     response = user_client.get(url)
     assert response.status_code == expected_status
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 @pytest.mark.parametrize(
@@ -1520,10 +1365,7 @@ def test_send_recovery_email(db, client, email, expected_status):
     url = reverse('users.send_recovery_email', locale='en-US')
     response = client.post(url, {'email': email})
     assert response.status_code == expected_status
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     if expected_status == 302:
         assert response['Location'].endswith(
             reverse('users.recovery_email_sent'))
@@ -1533,10 +1375,7 @@ def test_recover_valid(wiki_user, client):
     recover_url = wiki_user.get_recovery_url()
     response = client.get(recover_url)
     assert response.status_code == 302
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert response['Location'].endswith(reverse('users.recover_done'))
     wiki_user.refresh_from_db()
     assert not wiki_user.has_usable_password()
@@ -1556,8 +1395,5 @@ def test_invalid_uid_fails(wiki_user, client):
     wiki_user.delete()
     response = client.get(bad_recover_url)
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert 'This link is no longer valid.' in response.content

--- a/kuma/version/tests/test_views.py
+++ b/kuma/version/tests/test_views.py
@@ -2,6 +2,7 @@ from urlparse import urljoin
 
 import pytest
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.constants import KUMASCRIPT_BASE_URL
 
@@ -12,10 +13,7 @@ def test_revision_hash(client, db, method, settings):
     response = getattr(client, method)(reverse('version.kuma'))
     assert response.status_code == 200
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     if method == 'get':
         assert response.content == 'the_revision_hash'
 
@@ -27,10 +25,7 @@ def test_revision_hash(client, db, method, settings):
 def test_revision_hash_405s(client, db, method):
     response = getattr(client, method)(reverse('version.kuma'))
     assert response.status_code == 405
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 @pytest.mark.parametrize('method', ['get', 'head'])
@@ -45,10 +40,7 @@ def test_kumascript_revision_hash(client, db, method, mock_requests):
     response = client.get(reverse('version.kumascript'))
     assert response.status_code == 200
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     if method == 'get':
         assert response.content == hash
 
@@ -60,7 +52,4 @@ def test_kumascript_revision_hash(client, db, method, mock_requests):
 def test_kumascript_revision_hash_405s(client, db, method):
     response = getattr(client, method)(reverse('version.kumascript'))
     assert response.status_code == 405
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)

--- a/kuma/wiki/tests/test_views_admin.py
+++ b/kuma/wiki/tests/test_views_admin.py
@@ -3,6 +3,7 @@ from datetime import datetime
 import pytest
 from waffle.models import Flag
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 
 from ..models import Document, Revision
@@ -34,10 +35,7 @@ def test_login(client):
     response = client.get(url)
     assert response.status_code == 302
     assert 'en-US/users/signin?' in response['Location']
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 def test_staff_permission(editor_client):
@@ -50,10 +48,7 @@ def test_staff_permission(editor_client):
     assert response.status_code == 302
     assert response['Location'].endswith(
         'admin/login/?next=/admin/wiki/document/purge/')
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 def test_read_only_mode(admin_client):
@@ -64,10 +59,7 @@ def test_read_only_mode(admin_client):
     url = reverse('wiki.admin_bulk_purge')
     response = admin_client.get(url)
     assert response.status_code == 403
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 def test_purge_get(root_doc, another_root_doc, purge_client):
@@ -77,10 +69,7 @@ def test_purge_get(root_doc, another_root_doc, purge_client):
     response = purge_client.get(
         url, {'ids': '{},{}'.format(root_doc.id, another_root_doc.id)})
     assert response.status_code == 200
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     # Make sure nothing has happended (i.e. the docs haven't been purged).
     for doc in (root_doc, another_root_doc):
         assert Document.admin_objects.get(slug=doc.slug, locale=doc.locale)
@@ -94,10 +83,7 @@ def test_purge_post(root_doc, another_root_doc, purge_client):
     response = purge_client.post(url, data={'confirm_purge': 'true'})
     assert response.status_code == 302
     assert response['Location'].endswith('/admin/wiki/document/')
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     for doc in (root_doc, another_root_doc):
         with pytest.raises(Document.DoesNotExist):
             Document.admin_objects.get(slug=doc.slug, locale=doc.locale)

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth.models import Permission
 from pyquery import PyQuery as pq
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 
 from ..models import Document, Revision
@@ -63,20 +64,14 @@ def add_doc_client(editor_client, wiki_user, permission_add_document):
 def test_check_read_only_mode(user_client):
     response = user_client.get(reverse('wiki.create', locale='en-US'))
     assert response.status_code == 403
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 def test_user_add_document_permission(editor_client):
     response = editor_client.get(reverse('wiki.create', locale='en-US'))
     assert response.status_code == 403
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 @pytest.mark.toc
@@ -84,10 +79,7 @@ def test_get(add_doc_client):
     response = add_doc_client.get(reverse('wiki.create', locale='en-US'))
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     page = pq(response.content)
     toc_select = page.find('#id_toc_depth')
     toc_options = toc_select.find('option')
@@ -123,10 +115,7 @@ def test_create_valid(add_doc_client):
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 302
     assert resp['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in resp['Cache-Control']
-    assert 'no-cache' in resp['Cache-Control']
-    assert 'no-store' in resp['Cache-Control']
-    assert 'must-revalidate' in resp['Cache-Control']
+    assert_no_cache_header(resp)
     assert resp['Location'].endswith(
         reverse('wiki.document', locale='en-US', args=(slug,)))
     doc = Document.objects.get(slug=slug, locale='en-US')
@@ -162,10 +151,7 @@ def test_create_invalid(add_doc_client, slug):
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 200
     assert resp['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in resp['Cache-Control']
-    assert 'no-cache' in resp['Cache-Control']
-    assert 'no-store' in resp['Cache-Control']
-    assert 'must-revalidate' in resp['Cache-Control']
+    assert_no_cache_header(resp)
     assert 'The slug provided is not valid.' in resp.content
     with pytest.raises(Document.DoesNotExist):
         Document.objects.get(slug=slug, locale='en-US')
@@ -194,10 +180,7 @@ def test_create_child_valid(root_doc, add_doc_client, slug):
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 302
     assert resp['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in resp['Cache-Control']
-    assert 'no-cache' in resp['Cache-Control']
-    assert 'no-store' in resp['Cache-Control']
-    assert 'must-revalidate' in resp['Cache-Control']
+    assert_no_cache_header(resp)
     assert resp['Location'].endswith(
         reverse('wiki.document', locale='en-US', args=(full_slug,)))
     assert root_doc.children.count() == 1
@@ -238,10 +221,7 @@ def test_create_child_invalid(root_doc, add_doc_client, slug):
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 200
     assert resp['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in resp['Cache-Control']
-    assert 'no-cache' in resp['Cache-Control']
-    assert 'no-store' in resp['Cache-Control']
-    assert 'must-revalidate' in resp['Cache-Control']
+    assert_no_cache_header(resp)
     assert 'The slug provided is not valid.' in resp.content
     with pytest.raises(Document.DoesNotExist):
         Document.objects.get(slug=full_slug, locale='en-US')
@@ -255,10 +235,7 @@ def test_clone_get(root_doc, add_doc_client):
     response = add_doc_client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     page = pq(response.content)
     assert page.find('input[name=slug]')[0].value is None
     assert page.find('input[name=title]')[0].value is None

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -2,6 +2,7 @@
 import pytest
 
 from kuma.core.models import IPBan
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 
 
@@ -10,10 +11,7 @@ def test_edit_get(editor_client, root_doc):
     response = editor_client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
 
 
 @pytest.mark.parametrize('method', ('GET', 'POST'))
@@ -25,8 +23,5 @@ def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
     caller = getattr(editor_client, method.lower())
     response = caller(url, REMOTE_ADDR=ip)
     assert response.status_code == 403
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     assert 'Your IP address has been banned.' in response.content

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -1,6 +1,7 @@
 import pytest
 from pyquery import PyQuery as pq
 
+from kuma.core.tests import assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 
@@ -22,8 +23,7 @@ def test_disallowed_methods(db, client, http_method, endpoint):
     url = reverse('wiki.{}'.format(endpoint), locale='en-US', kwargs=kwargs)
     resp = getattr(client, http_method)(url)
     assert resp.status_code == 405
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
 
 
 def test_revisions(root_doc, client):
@@ -32,8 +32,7 @@ def test_revisions(root_doc, client):
                   locale=root_doc.locale)
     resp = client.get(url)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
 
 
 def test_revisions_of_translated_document(trans_doc, client):
@@ -98,8 +97,7 @@ def test_revisions_all_params_as_anon_user_is_forbidden(root_doc, client):
     all_url = urlparams(url, limit='all')
     resp = client.get(all_url)
     assert resp.status_code == 403
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
 
 
 def test_revisions_all_params_as_user_is_allowed(root_doc, wiki_user, client):
@@ -152,8 +150,7 @@ def test_list_no_redirects(redirect_doc, doc_hierarchy_with_zones, client):
     url = reverse('wiki.all_documents', locale='en-US')
     resp = client.get(url)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     # There should be 4 documents in the 'en-US' locale from
     # doc_hierarchy_with_zones, plus the root_doc (which is pulled-in by
@@ -171,8 +168,7 @@ def test_tags(root_doc, client):
     assert 'foobar' in resp.content
     assert 'blast' in resp.content
     assert 'wiki/list/tags.html' in [t.name for t in resp.templates]
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
 
 
 @pytest.mark.tags
@@ -191,8 +187,7 @@ def test_tag_list(root_doc, trans_doc, client, locale_case, tag_case, tag):
     url = reverse('wiki.tag', locale=exp_doc.locale, kwargs={'tag': tag_query})
     resp = client.get(url)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     dom = pq(resp.content)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'
     assert len(dom('#document-list ul.document-list li')) == 1
@@ -232,8 +227,7 @@ def test_list_with_errors(redirect_doc, doc_hierarchy_with_zones, client,
     resp = client.get(url)
     dom = pq(resp.content)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     assert len(dom.find('.document-list li')) == len(exp_docs)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'
@@ -257,8 +251,7 @@ def test_list_without_parent(redirect_doc, root_doc, doc_hierarchy_with_zones,
     resp = client.get(url)
     dom = pq(resp.content)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     assert len(dom.find('.document-list li')) == len(exp_docs)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'
@@ -278,8 +271,7 @@ def test_list_top_level(redirect_doc, root_doc, doc_hierarchy_with_zones,
     resp = client.get(url)
     dom = pq(resp.content)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     assert len(dom.find('.document-list li')) == len(exp_docs)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'
@@ -308,8 +300,7 @@ def test_list_with_localization_tag(redirect_doc, doc_hierarchy_with_zones,
     resp = client.get(url)
     dom = pq(resp.content)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     assert len(dom.find('.document-list li')) == len(exp_docs)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'
@@ -337,8 +328,7 @@ def test_list_with_localization_tags(redirect_doc, doc_hierarchy_with_zones,
     resp = client.get(url)
     dom = pq(resp.content)
     assert resp.status_code == 200
-    assert 'public' in resp['Cache-Control']
-    assert 's-maxage' in resp['Cache-Control']
+    assert_shared_cache_header(resp)
     assert 'text/html' in resp['Content-Type']
     assert len(dom.find('.document-list li')) == len(exp_docs)
     selector = 'ul.document-list li a[href="/{}/docs/{}"]'

--- a/kuma/wiki/tests/test_views_revision.py
+++ b/kuma/wiki/tests/test_views_revision.py
@@ -2,6 +2,7 @@
 """Tests for kuma.wiki.views.revision."""
 import pytest
 
+from kuma.core.tests import assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 
@@ -22,8 +23,7 @@ def test_compare_revisions(edit_revision, client, raw):
     response = client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'public' in response['Cache-Control']
-    assert 's-maxage' in response['Cache-Control']
+    assert_shared_cache_header(response)
 
 
 @pytest.mark.parametrize('raw', [True, False])
@@ -42,8 +42,7 @@ def test_compare_translation(trans_revision, client, raw):
     response = client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'public' in response['Cache-Control']
-    assert 's-maxage' in response['Cache-Control']
+    assert_shared_cache_header(response)
 
 
 @pytest.mark.parametrize('raw', [True, False])

--- a/kuma/wiki/tests/test_views_translate.py
+++ b/kuma/wiki/tests/test_views_translate.py
@@ -2,6 +2,7 @@ import pytest
 from django.contrib.auth.models import Permission
 from pyquery import PyQuery as pq
 
+from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 
 from ..models import Document
@@ -28,10 +29,7 @@ def test_translate_get(root_doc, trans_doc_client):
     response = trans_doc_client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     page = pq(response.content)
     assert page.find('input[name=slug]')[0].value == root_doc.slug
 
@@ -54,10 +52,7 @@ def test_translate_post(root_doc, trans_doc_client):
     response = trans_doc_client.post(url, data)
     assert response.status_code == 302
     assert response['X-Robots-Tag'] == 'noindex'
-    assert 'max-age=0' in response['Cache-Control']
-    assert 'no-cache' in response['Cache-Control']
-    assert 'no-store' in response['Cache-Control']
-    assert 'must-revalidate' in response['Cache-Control']
+    assert_no_cache_header(response)
     doc_url = reverse('wiki.document', args=(root_doc.slug,), locale='fr')
     assert doc_url + '?rev_saved=' in response['Location']
     assert len(Document.objects.filter(locale='fr', slug=root_doc.slug)) == 1


### PR DESCRIPTION
This PR arose from @jwhitlock's [comment](https://github.com/mozilla/kuma/pull/4734#discussion_r180241870) in #4734 as well as @safwanrahman's earlier [comment](https://github.com/mozilla/kuma/pull/4719#discussion_r177575655). It creates two new test utility functions `assert_no_cache_header` and `assert_shared_cache_header`, and then replaces all groups of assertions that each encapsulates.