### PR TITLE
bug 1453796: fix generation of HTML when filtering noincludes

### DIFF
--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -2,6 +2,7 @@ import pytest
 from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import to_html
 from kuma.wiki.models import Revision
 
 from . import make_test_file
@@ -40,7 +41,7 @@ def test_xss_file_attachment_title(admin_client, constance_config, root_doc,
     doc = pq(response.content)
     text = doc('.page-attachments-table .attachment-name-cell').text()
     assert text == ('%s\nxss' % title)
-    html = doc('.page-attachments-table .attachment-name-cell').html()
+    html = to_html(doc('.page-attachments-table .attachment-name-cell'))
     assert '&gt;&lt;img src=x onerror=prompt(navigator.userAgent);&gt;' in html
     # security bug 1272791
     for script in doc('script'):

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -10,6 +10,7 @@ from pyquery import PyQuery as pq
 
 from kuma.core.tests import assert_no_cache_header, assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import to_html
 from kuma.users.tests import UserTestCase
 from kuma.wiki.models import DocumentAttachment
 from kuma.wiki.tests import document, revision, WikiTestCase
@@ -228,7 +229,7 @@ def test_edit_attachment_post_with_vacant_file(admin_client, root_doc, tmpdir,
     response = admin_client.post(url, data=post_data)
     assert response.status_code == 200
     doc = pq(response.content)
-    assert doc('ul.errorlist a[href="#id_file"]').html() == expected
+    assert to_html(doc('ul.errorlist a[href="#id_file"]')) == expected
 
 
 def test_raw_file_requires_attachment_host(client, settings, file_attachment):

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -32,6 +32,19 @@ from .exceptions import DateTimeFormatError
 log = logging.getLogger('kuma.core.utils')
 
 
+def to_html(pq):
+    """
+    Return valid HTML for the given PyQuery instance.
+
+    It uses "method='html'" when calling the "html" method on the given
+    PyQuery instance in order to prevent the improper closure of some empty
+    HTML elements. For example, without "method='html'" the output of an empty
+    "iframe" element would be "<iframe/>", which is illegal in HTML, instead of
+    "<iframe></iframe>".
+    """
+    return pq.html(method='html')
+
+
 def is_untrusted(request):
     return request.get_host() in (
         settings.ATTACHMENT_ORIGIN,

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -11,7 +11,7 @@ from waffle.models import Flag, Switch
 from kuma.core.tests import (assert_no_cache_header,
                              assert_shared_cache_header, eq_, ok_)
 from kuma.core.urlresolvers import reverse
-from kuma.core.utils import urlparams
+from kuma.core.utils import to_html, urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
 from kuma.users.models import User, UserBan
@@ -116,7 +116,7 @@ class RevisionsDashTest(UserTestCase):
         ok_(len(revisions))
         eq_(1, revisions.length)
 
-        ok_('fr' in pq(revisions[0]).find('.locale').html())
+        ok_('fr' in to_html(pq(revisions[0]).find('.locale')))
 
     def test_creator_filter(self):
         url = urlparams(reverse('dashboards.revisions', locale='en-US'),
@@ -145,7 +145,7 @@ class RevisionsDashTest(UserTestCase):
 
         eq_(revisions.length, 7)
         for revision in revisions:
-            ok_('lorem' not in pq(revision).find('.dashboard-title').html())
+            ok_('lorem' not in to_html(pq(revision).find('.dashboard-title')))
 
     def test_known_authors_lookup(self):
         # Only testuser01 is in the Known Authors group
@@ -158,7 +158,7 @@ class RevisionsDashTest(UserTestCase):
         revisions = page.find('.dashboard-row')
 
         for revision in revisions:
-            author = pq(revision).find('.dashboard-author').html()
+            author = to_html(pq(revision).find('.dashboard-author'))
             ok_('testuser01' in author)
             ok_('testuser2' not in author)
 

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -19,6 +19,7 @@ from waffle.models import Flag
 
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import to_html
 from kuma.spam.akismet import Akismet
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
 from kuma.wiki.models import (Document, DocumentDeletionLog, Revision,
@@ -957,7 +958,7 @@ def test_user_edit_websites(wiki_user, wiki_user_github_account, user_client):
     # Github is not an editable field
     github_div = doc.find("#field_github_url div.field-account")
     github_acct = wiki_user.socialaccount_set.get()
-    assert github_div.html().strip() == github_acct.get_profile_url()
+    assert to_html(github_div).strip() == github_acct.get_profile_url()
 
     # Come up with some bad sites, either invalid URL or bad URL prefix
     bad_sites = {

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -264,7 +264,12 @@ def filter_out_noinclude(src):
         return ''
     doc = pq(src)
     doc.remove('*[class=noinclude]')
-    return doc.html()
+    # Use "method='html'" to prevent improper closure of some empty HTML
+    # elements, like the "iframe" element for example, which is not allowed
+    # to be closed in the opening tag. For example, without "method='html'"
+    # the output would be "<iframe/>" instead of the correct
+    # "<iframe></iframe>".
+    return doc.html(method='html')
 
 
 class ContentSectionTool(object):

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -15,6 +15,7 @@ from lxml import etree
 from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import to_html
 
 from .exceptions import DocumentRenderedContentNotAvailable
 from .utils import locale_and_slug_from_path
@@ -218,7 +219,8 @@ def get_seo_description(content, locale=None, strip_markup=True):
             if strip_markup:
                 seo_summary = summaryClasses.text()
             else:
-                seo_summary = summaryClasses.html()
+                seo_summary = ''.join(
+                    to_html(item) for item in summaryClasses.items())
         else:
             paragraphs = page.find('p')
             if paragraphs.length:
@@ -227,7 +229,7 @@ def get_seo_description(content, locale=None, strip_markup=True):
                     if strip_markup:
                         text = item.text()
                     else:
-                        text = item.html()
+                        text = to_html(item)
                     # Checking for a parent length of 2
                     # because we don't want p's wrapped
                     # in DIVs ("<div class='warning'>") and pyQuery adds
@@ -264,12 +266,7 @@ def filter_out_noinclude(src):
         return ''
     doc = pq(src)
     doc.remove('*[class=noinclude]')
-    # Use "method='html'" to prevent improper closure of some empty HTML
-    # elements, like the "iframe" element for example, which is not allowed
-    # to be closed in the opening tag. For example, without "method='html'"
-    # the output would be "<iframe/>" instead of the correct
-    # "<iframe></iframe>".
-    return doc.html(method='html')
+    return to_html(doc)
 
 
 class ContentSectionTool(object):

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -20,6 +20,7 @@ from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import (assert_no_cache_header,
                              assert_shared_cache_header, eq_, get_user, ok_)
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import to_html
 from kuma.spam.constants import (
     SPAM_CHECKS_FLAG, SPAM_SUBMISSIONS_FLAG, VERIFY_URL)
 from kuma.users.tests import UserTestCase
@@ -80,7 +81,7 @@ class RedirectTests(UserTestCase, WikiTestCase):
         response = self.client.get(doc.get_absolute_url(), follow=True)
         eq_(200, response.status_code)
         response_html = pq(response.content)
-        article_body = response_html.find('#wikiArticle').html()
+        article_body = to_html(response_html.find('#wikiArticle'))
         self.assertHTMLEqual(html, article_body)
 
 
@@ -300,7 +301,7 @@ class ViewTests(UserTestCase, WikiTestCase):
         """)
         resp = self.client.get(rev.get_absolute_url())
         page = pq(resp.content)
-        ct = page.find('#wikiArticle').html()
+        ct = to_html(page.find('#wikiArticle'))
         ok_('<svg>' not in ct)
         ok_('<a href="#">Hahaha</a>' in ct)
 
@@ -1361,7 +1362,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert_no_cache_header(response)
         content = pq(response.content)
         ok_(content('li.metadata-choose-parent'))
-        ok_(str(parent.id) in content.html())
+        ok_(str(parent.id) in to_html(content))
 
     @pytest.mark.tags
     def test_tags_while_document_update(self):

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2710,6 +2710,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
               <dd>Type: <em>integer</em></dd>
               <dd>Przykłady 例 예제 示例</dd>
             </dl>
+            <p><iframe></iframe></p>
             <div class="noinclude">
               <p>{{ languages( { &quot;ja&quot;: &quot;ja/XUL/Attribute/maxlength&quot; } ) }}</p>
             </div>
@@ -2721,6 +2722,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
               <dd>Type: <em>integer</em></dd>
               <dd>Przykłady 例 예제 示例</dd>
             </dl>
+            <p><iframe></iframe></p>
         """
         resp = self.client.get('%s?raw&include' %
                                reverse('wiki.document', locale='en-US',

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -30,6 +30,7 @@ from ..views.utils import calculate_etag
 
 AuthKey = namedtuple('AuthKey', 'key header')
 
+EMPTY_IFRAME = '<iframe></iframe>'
 SECTION1 = '<h3 id="S1">Section 1</h3><p>This is a page. Deal with it.</p>'
 SECTION2 = '<h3 id="S2">Section 2</h3><p>This is a page. Deal with it.</p>'
 SECTION3 = '<h3 id="S3">Section 3</h3><p>This is a page. Deal with it.</p>'
@@ -268,7 +269,7 @@ def test_api_put_existing(client, section_doc, authkey, section_case,
         comment="I like this document.",
         title="New Sectioned Root Document",
         summary="An edited sectioned root document.",
-        content="<p>This is an edit.</p>",
+        content=EMPTY_IFRAME + '<p>This is an edit.</p>',
         tags="tagA,tagB,tagC",
         review_tags="editorial,technical",
     )
@@ -345,7 +346,7 @@ def test_api_put_new(settings, client, root_doc, authkey, section_case,
         comment="I like this document.",
         title="Foobar, The Document",
         summary="A sectioned document named foobar.",
-        content=SECTIONS,
+        content=EMPTY_IFRAME + SECTIONS,
         tags="tagA,tagB,tagC",
         review_tags="editorial,technical",
     )

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -35,7 +35,7 @@ from kuma.core.decorators import (block_user_agents,
                                   shared_cache_control,
                                   superuser_required)
 from kuma.core.urlresolvers import reverse
-from kuma.core.utils import urlparams
+from kuma.core.utils import to_html, urlparams
 from kuma.search.store import get_search_url_from_referer
 
 from .utils import calculate_etag, split_slug
@@ -855,7 +855,7 @@ def _document_api_PUT(request, document_slug, document_locale):
                     data['title'] = head_title.text()
                 body_content = doc.find('body')
                 if body_content.length > 0:
-                    data['content'] = body_content.html()
+                    data['content'] = to_html(body_content)
             except Exception:
                 pass
 


### PR DESCRIPTION
This PR fixes [Bugzilla #1453796](https://bugzilla.mozilla.org/show_bug.cgi?id=1453796). The bug occurs when the `include` parameter is used during document requests, for example when using the `page` macro. The `include` parameter triggers a removal of all elements with `class="noinclude"`, which is done using `pyquery`, after which it re-generates the filtered HTML. During the re-generation of the HTML, any empty HTML elements (e.g., `<iframe ...></iframe>`) are output as self-closing elements (e.g., `<iframe ... />`), which in the case of `iframe`, is illegal. When loaded, the self-closing `iframe` seems to be interpreted as simply an opening tag, and so swallows all subsequent HTML.

For example, https://developer.mozilla.org/en-US/docs/Web/CSS/perspective?raw=1&macros=1&section=Setting_perspective works fine, but when the `include=1` is added, the failure appears (https://developer.mozilla.org/en-US/docs/Web/CSS/perspective?raw=1&macros=1&include=1&section=Setting_perspective).

The fix is to call `doc.html(method='html')` instead of `doc.html()` in the `kuma.wiki.content.filter_out_noinclude` function (see http://pyquery.readthedocs.io/en/latest/api.html#pyquery.pyquery.PyQuery.html).

This does not appear to be due to a `pyquery` package version update. I'm not sure why and when this bug appeared. Could it be that the `iframe` elements used to be populated, but then changed to being empty?

