### PR TITLE
bug 1455652: Register async search tasks

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1305,6 +1305,7 @@ CELERY_ACCEPT_CONTENT = ['pickle']
 
 CELERY_IMPORTS = (
     'tidings.events',
+    'kuma.search.tasks',
 )
 
 CELERY_ANNOTATIONS = {


### PR DESCRIPTION
After the change to AppConfig, search tasks are no longer auto-registering. Force the issue by using ``CELERY_IMPORTS``.

Other tasks (wiki, user, etc) are being auto-registered.