### PR TITLE
bug 1399639: Update to celery 3.1.25, deps

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -78,24 +78,37 @@ webencodings==0.5.1 \
     --hash=sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923
 
 # celery
-kombu==3.0.33 \
-    --hash=sha256:6741a5d7e8b8f53151aabd47fd3df1195aed540b169b2d7684b904ff112b483c \
-    --hash=sha256:853d18ca958a598787ceb8c297a369745b82965bf28276861272f14745977999
-billiard==3.3.0.22 \
-    --hash=sha256:24939ed8cec9f6c1fae62312dccaa71cabbaf7af07c70a55935c7d346382d10b \
-    --hash=sha256:7a26bccbba69cd912558edcea7268e63ab184b6fb523b12738848b0508304673 \
-    --hash=sha256:07e774150534e61af70353b1262d2bdad29c3f3bee01f2c7c73373f5cd96ebc4 \
-    --hash=sha256:2b94d17087632e593181860319bce79b715fab3f3219f0c57e1460f958141d0f \
-    --hash=sha256:db1194835915481261f71303c64552860a0080c661da6c19473aef014da5a39b \
-    --hash=sha256:f8c5fd82d64953ea68a7cd447ea29e493f302ab9060ad1ba452c54d2e37bbd2f \
-    --hash=sha256:c75d4905104fd1913025ddd5e0904e28bbf4284e4f7c2a7bbd487d453e473827 \
-    --hash=sha256:0de3a526ba1ee6f561c9e4dd60b8c3ab99d1271f2d32310a81936e77583b9ffd \
-    --hash=sha256:d216181387317f8696c6d1c80a2491258d037493c1f0c6eb58992a549481e77e
+#
+# RabbitMQ client library
+# Code: https://github.com/celery/py-amqp
+# Changes: https://github.com/celery/py-amqp/blob/master/Changelog
+# Docs: https://amqp.readthedocs.io/en/latest/
 amqp==1.4.9 \
-    --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908 \
-    --hash=sha256:2dea4d16d073c902c3b89d9b96620fb6729ac0f7a923bbc777cb4ad827c0c61a
+    --hash=sha256:2dea4d16d073c902c3b89d9b96620fb6729ac0f7a923bbc777cb4ad827c0c61a \
+    --hash=sha256:e0ed0ce6b8ffe5690a2e856c7908dc557e0e605283d6885dd1361d79f2928908
+# Pick fastest JSON implementation available
+# Code: http://bitbucket.org/runeh/anyjson
 anyjson==0.3.3 \
     --hash=sha256:37812d863c9ad3e35c0734c42e0bf0320ce8c3bed82cd20ad54cb34d158157ba
+# Multiprocessing Pool Extensions
+# Code: https://github.com/celery/billiard
+# Changes: https://github.com/celery/billiard/blob/master/CHANGES.txt
+billiard==3.3.0.23 \
+    --hash=sha256:204e75d390ef8f839c30a93b696bd842c3941916e15921745d05edc2a83868ab \
+    --hash=sha256:23cb71472712e96bff3e0d45763b7b8a99e5040385fffb96816028352c255682 \
+    --hash=sha256:692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b \
+    --hash=sha256:82041dbaa62f7fde1464d7ab449978618a38b241b40c0d31dafabb36446635dc \
+    --hash=sha256:958fc9f8fd5cc9b936b2cb9d96f02aa5ec3613ba13ee7f089c77ff0bcc368fac \
+    --hash=sha256:c0cbe8d45ba8d8213ad68ef9a1881002a151569c9424d551634195a18c3a4160 \
+    --hash=sha256:ccfe0419eb5e49f27ad35cf06e75360af903df6d576c66cb8073246d4e023e5c \
+    --hash=sha256:d4d2fed1a251ea58eed47b48db3778ebb92f5ff4407dc91869c6f41c3a9249d0
+# Messaging library
+# Code: https://github.com/celery/kombu
+# Changes: http://kombu.readthedocs.io/en/latest/changelog.html
+# Docs: http://kombu.readthedocs.io/en/latest/
+kombu==3.0.37 \
+    --hash=sha256:7ceab743e3e974f3e5736082e8cc514c009e254e646d6167342e0e192aee81a6 \
+    --hash=sha256:e064a00c66b4d1058cd2b0523fb8d98c82c18450244177b6c0f7913016642650
 
 # dennis
 click==6.6 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -40,9 +40,12 @@ Brotli==1.0.1 \
     --hash=sha256:36c5d56f4f20c952ed998b0d2f9839a282081fd1f18e82bc3b3e9348b27fbe6d
 
 # Process tasks in the background
-celery==3.1.20 \
-    --hash=sha256:3071b71ef8c43178ace8435002b11f2ff06db7690f07d960540eab7f4183ddf7 \
-    --hash=sha256:d02f191c3d92a851c9d2028e91baf2a0f2734cd3b659743d3624011d1ef7a6d5
+# Code: https://github.com/celery/celery
+# Changes: http://docs.celeryproject.org/en/latest/history/index.html
+# Docs: http://docs.celeryproject.org/en/latest/index.html
+celery==3.1.25 \
+    --hash=sha256:1954a224805f3835e5b6f5998ec9fe51db3413cc49e59fc720d314c7913427cf \
+    --hash=sha256:6ced63033bc663e60c992564954dbb5c84c43899f7f1a04b739957350f6b55f3
 
 # Provides middleware for preventing Vary: Cookie
 commonware==0.4.3 \
@@ -71,10 +74,15 @@ django-cacheback==1.0 \
     --hash=sha256:2fc21e0ed78ee8e4cc07ac2c5936b27f956c99c81fc4f965e96fb27171180819
 
 # Integrate celery async tasks with Django (deprecated)
-django-celery==3.1.17 \
-    --hash=sha256:254a95b0a4386df1fd949823942f6312c80fba3c88c5efad79cad8648bc5feb5
+# Code: https://github.com/celery/django-celery
+# Changes: https://github.com/celery/django-celery/blob/master/Changelog
+# Docs: http://celery.github.io/django-celery/
+django-celery==3.2.2 \
+    --hash=sha256:1450264db5ec58e45f3f20d8d361e696920352f62481bf56047288cdb38bcc0b \
+    --hash=sha256:aaba492bf7777f231ec6b02c80aa3ea68758c39f4723864dd4164589b99ad703
 
 # Submit async tasks at the end of the Django transaction (deprecated?)
+# Code: https://github.com/bradleyayers/django-celery-transactions
 django-celery-transactions==0.3.6 \
     --hash=sha256:cdf966ec461e9ec736a7bedcf47cb219fc79ea86f2b39191cb258082dd4f4b33
 


### PR DESCRIPTION
Update celery and dependencies to prepare (again) for Celery 4.x update.

* celery 3.1.20 → 3.1.25: Support Task protocol 2 from 4.x
* billiard 3.3.0.22 → 3.3.0.23: Fix traceback wrapper
* kombu 3.0.33 → 3.0.37: Serialization, Redis fixes
* django-celery 3.1.17 → 3.2.2: Celery 4 compatibility