### PR TITLE
bug 1401246: Don't use django-debreach in Django 1.10 and later

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -4,12 +4,14 @@ import logging
 import os
 import platform
 from collections import namedtuple
+from distutils.version import LooseVersion
 from os.path import dirname
 
 import dj_database_url
 import dj_email_url
 import djcelery
 from decouple import config, Csv
+from django import get_version
 from django.core.urlresolvers import reverse_lazy
 
 _Language = namedtuple(u'Language', u'english native')
@@ -448,14 +450,22 @@ LANGUAGE_URL_IGNORED_PATHS = (
 SECRET_KEY = config('SECRET_KEY',
                     default='#%tc(zja8j01!r#h_y)=hy!^k)9az74k+-ib&ij&+**s3-e^_z')
 
+# Django 1.9 and lower need protection from BREACH attacks
+# Django 1.10 include BREACH protection in CsrfViewMiddleware
+_NEED_DEBREACH = LooseVersion(get_version()) < LooseVersion('1.10')
+if _NEED_DEBREACH:
+    _CSRF_CONTEXT_PROCESSOR = 'debreach.context_processors.csrf'
+else:
+    _CSRF_CONTEXT_PROCESSOR = 'django.core.context_processors.csrf',
+
+
 _CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
     'django.core.context_processors.debug',
     'django.core.context_processors.media',
     'django.core.context_processors.static',
     'django.core.context_processors.request',
-    # todo: re-enable with Django 1.11
-    # 'django.core.context_processors.csrf',
+    _CSRF_CONTEXT_PROCESSOR,
     'django.contrib.messages.context_processors.messages',
 
     'kuma.core.context_processors.global_settings',
@@ -463,8 +473,8 @@ _CONTEXT_PROCESSORS = (
     'kuma.core.context_processors.next_url',
 
     'constance.context_processors.config',
-    'debreach.context_processors.csrf',
 )
+
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.security.SecurityMiddleware',
@@ -495,10 +505,10 @@ MIDDLEWARE_CLASSES = (
 if not MAINTENANCE_MODE:
     # We don't want this in maintence mode, as it adds "Cookie"
     # to the Vary header, which in turn, kills caching.
-    MIDDLEWARE_CLASSES += (
-        'debreach.middleware.CSRFCryptMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-    )
+
+    if _NEED_DEBREACH:
+        MIDDLEWARE_CLASSES += ('debreach.middleware.CSRFCryptMiddleware',)
+    MIDDLEWARE_CLASSES += ('django.middleware.csrf.CsrfViewMiddleware',)
 
 MIDDLEWARE_CLASSES += (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -558,7 +568,12 @@ INSTALLED_APPS = (
     'django.contrib.sitemaps',
     'django.contrib.staticfiles',
     'soapbox',  # must be before kuma.wiki, or RemovedInDjango19Warning
-    'debreach',
+)
+
+if _NEED_DEBREACH:
+    INSTALLED_APPS += ('debreach',)
+
+INSTALLED_APPS += (
 
     # MDN
     'kuma.core',

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -94,10 +94,12 @@ django-constance==2.2.0 \
     --hash=sha256:fe601fe384d1629f6f0460175e4ce3d66e8177654525bddd4bdb68025c816adc \
     --hash=sha256:1d74fa615ee6c69512faa214ec7b4962aa039dfe802e967972c3fbdad7852977
 
-# Basic/extra mitigation against the BREACH attack
-django-debreach==1.4.0 \
-    --hash=sha256:bdbf8b87c58b438630038648c5b0e168b59220c04f02e208927e08e11bcddbc4 \
-    --hash=sha256:2474c6e8762b72e12140364f0c869b0b212e0dfc76ca614e02d6a71ad6f3fdfb
+# Basic/extra mitigation against the BREACH attack for Django 1.9 and lower
+# Code: https://github.com/lpomfrey/django-debreach
+django-debreach==1.4.2 \
+    --hash=sha256:1626677c47a6496c40d1794cd7264280dcccc63fc69893a86545bb84af3e0f4b \
+    --hash=sha256:20fef417bd12de35594ae2456c86ecf65870a24cfb604194254befb59a3dbe5c \
+    --hash=sha256:efefdb754fbce983302610ca3ec278fb29f86bb01ae6a7defcc573d4048fc43f
 
 # Include Django URL patterns with decorators.
 # Code: https://github.com/twidi/django-decorator-include


### PR DESCRIPTION
Update to django-debreach 1.4.2, which adds support for Django 2.0. Then parse the Django version in settings, to avoid installing debreach, using the context processor, or the middleware in Django 1.10 or later, where Django has built-in mitigation of [BREACH](https://en.wikipedia.org/wiki/BREACH) and the debreach middleware raises an ``ImproperlyConfigured`` exception.