### PR TITLE
bug 1449210: Add hreflang for the current document

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -69,6 +69,8 @@
   <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.slug) | absolutify }}">
   <link rel="canonical" href="{{ canonical }}" >
 
+  {# Google requires the current page to be referenced as an alternate too for SEO purposes see bug 1449210 #}
+  <link rel="alternate" hreflang="{{ document.locale }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
   {% if other_translations %}
     {% for translation in other_translations %}
       <link rel="alternate" hreflang="{{ translation.locale }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">


### PR DESCRIPTION
Google is ignoring the hreflang if the current page is not referenced
too.

This commit add the hreflang for the current page you are in top
of the already existing hreflang for the translations.