### PR TITLE
Do not preload fonts set as optional

### DIFF
--- a/jinja2/includes/preload.html
+++ b/jinja2/includes/preload.html
@@ -1,3 +1,2 @@
 {# because this is non-blocking, preload as early as possible #}
-<link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Bold.woff2') }}" as="font" type="font/woff2" crossorigin />
 <link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Regular.woff2') }}" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
Saw this article[1] by Zach Leatherman, shard by Alex Gibson, and it was a real doh! moment. After reading the spec, it makes no sense to preload the Bold font variant. The recommended block time defined in the spec[2] is ~100ms with no swap time.

As the Bold variant take over 400ms to download(see below), preloading this on the first hit is a wasted HTTP request.

<img width="679" alt="screen shot 2018-04-22 at 11 52 29" src="https://user-images.githubusercontent.com/10350960/39093748-d12b764c-4624-11e8-8a5f-388e9cf1dfff.png">

[1] https://www.zachleat.com/web/preload-font-display-optional/
[2] https://drafts.csswg.org/css-fonts-4/#valdef-font-face-font-display-optional