### PR TITLE
[BUG: 1401246] Update jinja and django-jinja

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,8 @@ env:
         - TOXENV=flake8
         - TOXENV=docs
         - TOXENV=locales
-          INSTALL_DOCKER_COMPOSE=1
+          CREATE_DB=kuma
+          INSTALL_PIPELINE=1
         - TOXENV=docker
           INSTALL_DOCKER_COMPOSE=1
           UID=0

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -50,7 +50,7 @@ class TestSoapbox(KumaTestCase):
         m = Message(message='Go to http://bit.ly/sample-demo', is_global=True,
                     is_active=True, url='/')
         m.save()
-        ok_('Go to <a href="http://bit.ly/sample-demo">'
+        ok_('Go to <a href="http://bit.ly/sample-demo" rel="noopener">'
             'http://bit.ly/sample-demo</a>' in
             soapbox_messages(get_soapbox_messages('/')))
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -619,9 +619,7 @@ TEMPLATES = [
             'extensions': [
                 'jinja2.ext.do',
                 'jinja2.ext.loopcontrols',
-                'jinja2.ext.with_',
                 'jinja2.ext.i18n',
-                'jinja2.ext.autoescape',
                 'puente.ext.i18n',
                 'django_jinja.builtins.extensions.CsrfExtension',
                 'django_jinja.builtins.extensions.CacheExtension',

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -254,9 +254,12 @@ pyparsing==2.2.0 \
     --hash=sha256:fee43f17a9c4087e7ed1605bd6df994c6173c1e977d7ade7b651292fab2bd010
 
 
-# Jinja2
-MarkupSafe==0.23 \
-    --hash=sha256:a4ec1aff59b95a14b45eb2e23761a0179e98319da5a7eb76b56ea8cdc7b871c3
+# Used for Jinja2
+# Code: https://github.com/pallets/markupsafe
+# Changes: https://github.com/pallets/markupsafe/blob/master/CHANGES
+# Docs: https://pypi.org/project/MarkupSafe/
+MarkupSafe==1.0 \
+    --hash=sha256:a6be69091dac236ea9c6bc7d012beab42010fa914c459791d627dad4910eb665
 
 # meinheld
 greenlet==0.4.12 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -98,8 +98,12 @@ django-honeypot==0.5.0 \
     --hash=sha256:962304f21055f05c73c41f2506f5a94f5b941e831a203b68e54cb5016bdb8d5e
 
 # Use Jinja2 as the template engine in Django
-django-jinja==2.2.1 \
-    --hash=sha256:04c53ba90cbede97e6543b98291f1eec259e57dfa4e014a5fbf0291afcdae6a9
+# Code: https://github.com/niwinz/django-jinja
+# Changes: https://github.com/niwinz/django-jinja/blob/master/CHANGES.adoc
+# Docs: http://niwinz.github.io/django-jinja/latest/
+django-jinja==2.4.1 \
+    --hash=sha256:8a49d73de616a12075eee14c6d3bbab936261a463457d40348d8b8e2995cfbed \
+    --hash=sha256:ceaa0eeebc4d91a5800967e50f4f087f0b6457503e3c2af85dc199bed8732a9a
 
 # Use consistent hashes despite adding or removing servers
 django-memcached-hashring==0.1.2 \
@@ -219,9 +223,12 @@ importlib==1.0.3 \
     --hash=sha256:65f342a604a2e1028707c5e055266ab2431c26e20fe10780b423320870884dac
 
 # Improved template engine
-Jinja2==2.8 \
-    --hash=sha256:1cc03ef32b64be19e0a5b54578dd790906a34943fe9102cfdae0d4495bd536b4 \
-    --hash=sha256:bc1ff2ff88dbfacefde4ddde471d1417d3b304e8df103a7a9437d47269201bf4
+# Code: https://github.com/pallets/jinja
+# Changes: http://jinja.pocoo.org/docs/2.10/changelog/
+# Docs: http://jinja.pocoo.org/docs/2.10/
+Jinja2==2.10 \
+    --hash=sha256:74c935a1b8bb9a3947c50a54766a969d4846290e1e788ea44c1392163723c3bd \
+    --hash=sha256:f84be1bb0040caca4cea721fcbbbbd61f9be9464ca236387158b0feea01914a4
 
 # Serialize pickleable objects to JSON, used in feed processing
 jsonpickle==0.9.2 \

--- a/tox.ini
+++ b/tox.ini
@@ -28,18 +28,21 @@ commands = sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 [testenv:locales]
 whitelist_externals =
     cat
-    docker-compose
+    make
     git
+deps = -rrequirements/dev.txt
 changedir = locale
 setenv =
-    COMPOSE_FILE = {toxinidir}/docker-compose.yml:{toxinidir}/docker-compose.test.yml
-    COMPOSE_PROJECT_NAME = localetox
     GIT_PAGER = cat
 # Test that locales are refreshed w/o error,
 # then display diff only if messages changed
 commands =
-    docker-compose run noext make localerefresh
+    make -C .. localerefresh
     git diff -G "^msgid " templates/LC_MESSAGES
+passenv =
+    DATABASE_URL
+    DJANGO_SETTINGS_MODULE
+    PIPELINE_*
 
 [testenv:docker]
 whitelist_externals = docker-compose


### PR DESCRIPTION
According to the Jinja2 v2.9 changelog:
The with and autoescape tags are now built-in.

Thus I have removed them from the settings file.

Link: http://jinja.pocoo.org/docs/2.10/changelog/#version-2-9