### PR TITLE
[bug 1429933] remove depreciated CELERYD_LOG_LEVEL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   worker: &worker
     image: quay.io/mozmar/kuma_base
-    command: ./manage.py celery worker --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
+    command: ./manage.py celery worker --loglevel=INFO --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
     user: ${UID:-33}
     volumes:
       - ./:/app:z

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1268,7 +1268,6 @@ CELERY_SEND_TASK_ERROR_EMAILS = True
 CELERY_SEND_EVENTS = True
 CELERY_SEND_TASK_SENT_EVENT = True
 CELERY_TRACK_STARTED = True
-CELERYD_LOG_LEVEL = logging.INFO
 CELERYD_CONCURRENCY = config('CELERYD_CONCURRENCY', default=4, cast=int)
 
 # Maximum tasks run before auto-restart of child process,


### PR DESCRIPTION
Removed `CELERYD_LOG_LEVEL` from `kuma/settings/common.py `
Used `--loglevel` flag in `docker-compose.yml` command instead.

This does not completely remove the `RemovedInDjangoXXXWarnings`, since I haven't added the SessionAuthenticationMiddleware. [It is no longer required in Django 1.10 and Session verification is enabled regardless.](https://docs.djangoproject.com/en/2.0/releases/1.10/)

> Session verification is enabled regardless of whether or not 'django.contrib.auth.middleware.SessionAuthenticationMiddleware' is in MIDDLEWARE_CLASSES. SessionAuthenticationMiddleware no longer has any purpose and can be removed from MIDDLEWARE_CLASSES. It’s kept as a stub until Django 2.0 as a courtesy for users who don’t read this note.


