### PR TITLE
bug 1429933: Enable session verification

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -499,6 +499,7 @@ if not MAINTENANCE_MODE:
 
 MIDDLEWARE_CLASSES += (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'kuma.core.middleware.RestrictedEndpointsMiddleware',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -499,6 +499,7 @@ if not MAINTENANCE_MODE:
 
 MIDDLEWARE_CLASSES += (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    # TODO: In 1.10, SessionAuth*Middleware does nothing and can be removed
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'waffle.middleware.WaffleMiddleware',


### PR DESCRIPTION
Session verification, which includes invalidating sessions after password changes, is enabled by default in Django 1.10. We don't use passwords, but session verification can still used, and enabling the
middleware will let us detect issues before 1.11 is used.