### PR TITLE
bug 1456165: switch to session-based CSRF tokens

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -191,7 +191,6 @@ def test_legacy_redirect(client, file_attachment):
     assert response.status_code == 301
     assert_shared_cache_header(response)
     assert response['Location'] == file_attachment['attachment'].get_file_url()
-    assert not response.has_header('Vary')
 
 
 def test_edit_attachment_get(admin_client, root_doc):
@@ -244,7 +243,6 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']
     assert response['Location'] == url
-    assert 'Vary' not in response
 
     response = client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
     assert response.status_code == 200

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -191,6 +191,7 @@ def test_legacy_redirect(client, file_attachment):
     assert response.status_code == 301
     assert_shared_cache_header(response)
     assert response['Location'] == file_attachment['attachment'].get_file_url()
+    assert not response.has_header('Vary')
 
 
 def test_edit_attachment_get(admin_client, root_doc):
@@ -243,6 +244,7 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']
     assert response['Location'] == url
+    assert 'Vary' not in response
 
     response = client.get(url, HTTP_HOST=settings.ATTACHMENT_HOST)
     assert response.status_code == 200

--- a/kuma/core/csrf.py
+++ b/kuma/core/csrf.py
@@ -1,0 +1,367 @@
+# TODO: Remove this file with Django 1.11
+"""
+Cross Site Request Forgery Middleware.
+
+This module provides a middleware that implements protection
+against request forgeries from other sites.
+
+NOTE: Copied from Django 1.11.12's django.middleware.csrf and slightly
+      modified to work within the context of Django 1.8.19.
+"""
+from __future__ import unicode_literals
+
+import logging
+import re
+import string
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from django.core.urlresolvers import get_callable
+from django.utils.cache import patch_vary_headers
+from django.utils.crypto import constant_time_compare, get_random_string
+from django.utils.encoding import force_text
+from django.utils.six.moves import zip
+from django.utils.six.moves.urllib.parse import urlparse
+
+logger = logging.getLogger('django.security.csrf')
+
+REASON_NO_REFERER = "Referer checking failed - no Referer."
+REASON_BAD_REFERER = "Referer checking failed - %s does not match any trusted origins."
+REASON_NO_CSRF_COOKIE = "CSRF cookie not set."
+REASON_BAD_TOKEN = "CSRF token missing or incorrect."
+REASON_MALFORMED_REFERER = "Referer checking failed - Referer is malformed."
+REASON_INSECURE_REFERER = "Referer checking failed - Referer is insecure while host is secure."
+
+CSRF_SECRET_LENGTH = 32
+CSRF_TOKEN_LENGTH = 2 * CSRF_SECRET_LENGTH
+CSRF_ALLOWED_CHARS = string.ascii_letters + string.digits
+CSRF_SESSION_KEY = '_csrftoken'
+
+
+def is_same_domain(host, pattern):
+    """
+    Return ``True`` if the host is either an exact match or a match
+    to the wildcard pattern.
+
+    Any pattern beginning with a period matches a domain and all of its
+    subdomains. (e.g. ``.example.com`` matches ``example.com`` and
+    ``foo.example.com``). Anything else is an exact string match.
+    """
+    if not pattern:
+        return False
+
+    pattern = pattern.lower()
+    return (
+        pattern[0] == '.' and (host.endswith(pattern) or host == pattern[1:]) or
+        pattern == host
+    )
+
+
+def _get_failure_view():
+    """
+    Returns the view to be used for CSRF rejections
+    """
+    return get_callable(settings.CSRF_FAILURE_VIEW)
+
+
+def _get_new_csrf_string():
+    return get_random_string(CSRF_SECRET_LENGTH, allowed_chars=CSRF_ALLOWED_CHARS)
+
+
+def _salt_cipher_secret(secret):
+    """
+    Given a secret (assumed to be a string of CSRF_ALLOWED_CHARS), generate a
+    token by adding a salt and using it to encrypt the secret.
+    """
+    salt = _get_new_csrf_string()
+    chars = CSRF_ALLOWED_CHARS
+    pairs = zip((chars.index(x) for x in secret), (chars.index(x) for x in salt))
+    cipher = ''.join(chars[(x + y) % len(chars)] for x, y in pairs)
+    return salt + cipher
+
+
+def _unsalt_cipher_token(token):
+    """
+    Given a token (assumed to be a string of CSRF_ALLOWED_CHARS, of length
+    CSRF_TOKEN_LENGTH, and that its first half is a salt), use it to decrypt
+    the second half to produce the original secret.
+    """
+    salt = token[:CSRF_SECRET_LENGTH]
+    token = token[CSRF_SECRET_LENGTH:]
+    chars = CSRF_ALLOWED_CHARS
+    pairs = zip((chars.index(x) for x in token), (chars.index(x) for x in salt))
+    secret = ''.join(chars[x - y] for x, y in pairs)  # Note negative values are ok
+    return secret
+
+
+def _get_new_csrf_token():
+    return _salt_cipher_secret(_get_new_csrf_string())
+
+
+def get_token(request):
+    """
+    Returns the CSRF token required for a POST form. The token is an
+    alphanumeric value. A new token is created if one is not already set.
+
+    A side effect of calling this function is to make the csrf_protect
+    decorator and the CsrfViewMiddleware add a CSRF cookie and a 'Vary: Cookie'
+    header to the outgoing response.  For this reason, you may need to use this
+    function lazily, as is done by the csrf context processor.
+    """
+    if "CSRF_COOKIE" not in request.META:
+        csrf_secret = _get_new_csrf_string()
+        request.META["CSRF_COOKIE"] = _salt_cipher_secret(csrf_secret)
+    else:
+        csrf_secret = _unsalt_cipher_token(request.META["CSRF_COOKIE"])
+    request.META["CSRF_COOKIE_USED"] = True
+    return _salt_cipher_secret(csrf_secret)
+
+
+def rotate_token(request):
+    """
+    Changes the CSRF token in use for a request - should be done on login
+    for security purposes.
+    """
+    request.META.update({
+        "CSRF_COOKIE_USED": True,
+        "CSRF_COOKIE": _get_new_csrf_token(),
+    })
+    request.csrf_cookie_needs_reset = True
+
+
+def _sanitize_token(token):
+    # Allow only ASCII alphanumerics
+    if re.search('[^a-zA-Z0-9]', force_text(token)):
+        return _get_new_csrf_token()
+    elif len(token) == CSRF_TOKEN_LENGTH:
+        return token
+    elif len(token) == CSRF_SECRET_LENGTH:
+        # Older Django versions set cookies to values of CSRF_SECRET_LENGTH
+        # alphanumeric characters. For backwards compatibility, accept
+        # such values as unsalted secrets.
+        # It's easier to salt here and be consistent later, rather than add
+        # different code paths in the checks, although that might be a tad more
+        # efficient.
+        return _salt_cipher_secret(token)
+    return _get_new_csrf_token()
+
+
+def _compare_salted_tokens(request_csrf_token, csrf_token):
+    # Assume both arguments are sanitized -- that is, strings of
+    # length CSRF_TOKEN_LENGTH, all CSRF_ALLOWED_CHARS.
+    return constant_time_compare(
+        _unsalt_cipher_token(request_csrf_token),
+        _unsalt_cipher_token(csrf_token),
+    )
+
+
+class CsrfViewMiddleware(object):
+    """
+    Middleware that requires a present and correct csrfmiddlewaretoken
+    for POST requests that have a CSRF cookie, and sets an outgoing
+    CSRF cookie.
+
+    This middleware should be used in conjunction with the csrf_token template
+    tag.
+    """
+    # The _accept and _reject methods currently only exist for the sake of the
+    # requires_csrf_token decorator.
+    def _accept(self, request):
+        # Avoid checking the request twice by adding a custom attribute to
+        # request.  This will be relevant when both decorator and middleware
+        # are used.
+        request.csrf_processing_done = True
+        return None
+
+    def _reject(self, request, reason):
+        logger.warning(
+            'Forbidden (%s): %s', reason, request.path,
+            extra={
+                'status_code': 403,
+                'request': request,
+            }
+        )
+        return _get_failure_view()(request, reason=reason)
+
+    def _get_token(self, request):
+        if settings.CSRF_USE_SESSIONS:
+            try:
+                return request.session.get(CSRF_SESSION_KEY)
+            except AttributeError:
+                raise ImproperlyConfigured(
+                    'CSRF_USE_SESSIONS is enabled, but request.session is not '
+                    'set. SessionMiddleware must appear before CsrfViewMiddleware '
+                    'in MIDDLEWARE%s.' % ('_CLASSES' if settings.MIDDLEWARE is None else '')
+                )
+        else:
+            try:
+                cookie_token = request.COOKIES[settings.CSRF_COOKIE_NAME]
+            except KeyError:
+                return None
+
+            csrf_token = _sanitize_token(cookie_token)
+            if csrf_token != cookie_token:
+                # Cookie token needed to be replaced;
+                # the cookie needs to be reset.
+                request.csrf_cookie_needs_reset = True
+            return csrf_token
+
+    def _set_token(self, request, response):
+        if settings.CSRF_USE_SESSIONS:
+            request.session[CSRF_SESSION_KEY] = request.META['CSRF_COOKIE']
+        else:
+            response.set_cookie(
+                settings.CSRF_COOKIE_NAME,
+                request.META['CSRF_COOKIE'],
+                max_age=settings.CSRF_COOKIE_AGE,
+                domain=settings.CSRF_COOKIE_DOMAIN,
+                path=settings.CSRF_COOKIE_PATH,
+                secure=settings.CSRF_COOKIE_SECURE,
+                httponly=settings.CSRF_COOKIE_HTTPONLY,
+            )
+            # Set the Vary header since content varies with the CSRF cookie.
+            patch_vary_headers(response, ('Cookie',))
+
+    def process_request(self, request):
+        csrf_token = self._get_token(request)
+        if csrf_token is not None:
+            # Use same token next time.
+            request.META['CSRF_COOKIE'] = csrf_token
+
+    def process_view(self, request, callback, callback_args, callback_kwargs):
+        if getattr(request, 'csrf_processing_done', False):
+            return None
+
+        # Wait until request.META["CSRF_COOKIE"] has been manipulated before
+        # bailing out, so that get_token still works
+        if getattr(callback, 'csrf_exempt', False):
+            return None
+
+        # Assume that anything not defined as 'safe' by RFC7231 needs protection
+        if request.method not in ('GET', 'HEAD', 'OPTIONS', 'TRACE'):
+            if getattr(request, '_dont_enforce_csrf_checks', False):
+                # Mechanism to turn off CSRF checks for test suite.
+                # It comes after the creation of CSRF cookies, so that
+                # everything else continues to work exactly the same
+                # (e.g. cookies are sent, etc.), but before any
+                # branches that call reject().
+                return self._accept(request)
+
+            if request.is_secure():
+                # Suppose user visits http://example.com/
+                # An active network attacker (man-in-the-middle, MITM) sends a
+                # POST form that targets https://example.com/detonate-bomb/ and
+                # submits it via JavaScript.
+                #
+                # The attacker will need to provide a CSRF cookie and token, but
+                # that's no problem for a MITM and the session-independent
+                # secret we're using. So the MITM can circumvent the CSRF
+                # protection. This is true for any HTTP connection, but anyone
+                # using HTTPS expects better! For this reason, for
+                # https://example.com/ we need additional protection that treats
+                # http://example.com/ as completely untrusted. Under HTTPS,
+                # Barth et al. found that the Referer header is missing for
+                # same-domain requests in only about 0.2% of cases or less, so
+                # we can use strict Referer checking.
+                referer = force_text(
+                    request.META.get('HTTP_REFERER'),
+                    strings_only=True,
+                    errors='replace'
+                )
+                if referer is None:
+                    return self._reject(request, REASON_NO_REFERER)
+
+                referer = urlparse(referer)
+
+                # Make sure we have a valid URL for Referer.
+                if '' in (referer.scheme, referer.netloc):
+                    return self._reject(request, REASON_MALFORMED_REFERER)
+
+                # Ensure that our Referer is also secure.
+                if referer.scheme != 'https':
+                    return self._reject(request, REASON_INSECURE_REFERER)
+
+                # If there isn't a CSRF_COOKIE_DOMAIN, require an exact match
+                # match on host:port. If not, obey the cookie rules (or those
+                # for the session cookie, if CSRF_USE_SESSIONS).
+                good_referer = (
+                    settings.SESSION_COOKIE_DOMAIN
+                    if settings.CSRF_USE_SESSIONS
+                    else settings.CSRF_COOKIE_DOMAIN
+                )
+                if good_referer is not None:
+                    server_port = request.get_port()
+                    if server_port not in ('443', '80'):
+                        good_referer = '%s:%s' % (good_referer, server_port)
+                else:
+                    # request.get_host() includes the port.
+                    good_referer = request.get_host()
+
+                # Here we generate a list of all acceptable HTTP referers,
+                # including the current host since that has been validated
+                # upstream.
+                good_hosts = list(settings.CSRF_TRUSTED_ORIGINS)
+                good_hosts.append(good_referer)
+
+                if not any(is_same_domain(referer.netloc, host) for host in good_hosts):
+                    reason = REASON_BAD_REFERER % referer.geturl()
+                    return self._reject(request, reason)
+
+            csrf_token = request.META.get('CSRF_COOKIE')
+            if csrf_token is None:
+                # No CSRF cookie. For POST requests, we insist on a CSRF cookie,
+                # and in this way we can avoid all CSRF attacks, including login
+                # CSRF.
+                return self._reject(request, REASON_NO_CSRF_COOKIE)
+
+            # Check non-cookie token for match.
+            request_csrf_token = ""
+            if request.method == "POST":
+                try:
+                    request_csrf_token = request.POST.get('csrfmiddlewaretoken', '')
+                except IOError:
+                    # Handle a broken connection before we've completed reading
+                    # the POST data. process_view shouldn't raise any
+                    # exceptions, so we'll ignore and serve the user a 403
+                    # (assuming they're still listening, which they probably
+                    # aren't because of the error).
+                    pass
+
+            if request_csrf_token == "":
+                # Fall back to X-CSRFToken, to make things easier for AJAX,
+                # and possible for PUT/DELETE.
+                request_csrf_token = request.META.get(settings.CSRF_HEADER_NAME, '')
+
+            request_csrf_token = _sanitize_token(request_csrf_token)
+            if not _compare_salted_tokens(request_csrf_token, csrf_token):
+                return self._reject(request, REASON_BAD_TOKEN)
+
+        return self._accept(request)
+
+    def process_response(self, request, response):
+        if not getattr(request, 'csrf_cookie_needs_reset', False):
+            if getattr(response, 'csrf_cookie_set', False):
+                return response
+
+        if not request.META.get("CSRF_COOKIE_USED", False):
+            return response
+
+        # Set the CSRF cookie even if it's already set, so we renew
+        # the expiry timer.
+        self._set_token(request, response)
+        response.csrf_cookie_set = True
+        return response
+
+
+def monkey_patch():
+    """
+    Patch the sources of get_token, rotate_token, and CsrfViewMiddleware
+    within Django. Must be run prior to importing the parts of Django or
+    any other packages that import and use those sources.
+    """
+    # Monkey-patch the sources, so any code imported for the first time
+    # after this will pick-up the new stuff.
+    import django.middleware.csrf
+    django.middleware.csrf.get_token = get_token
+    django.middleware.csrf.rotate_token = rotate_token
+    django.middleware.csrf.CsrfViewMiddleware = CsrfViewMiddleware

--- a/kuma/core/monkeypatch.py
+++ b/kuma/core/monkeypatch.py
@@ -1,5 +1,13 @@
 from django.forms import fields, widgets
 
+# TODO: Remove with Django 1.11
+from . import csrf
+
+
+# TODO: Remove with Django 1.11
+csrf.monkey_patch()
+
+
 # Monkey patch preserves the old values, so we can pick up any changes
 # in CharField.widget_attrs and Field.widget_attrs
 # paulc filed a Django ticket for it, #14884

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -177,6 +177,6 @@ def test_smart_session_middleware(rf, session_case):
         middleware.process_response(request, response)
         assert base.called
         if session:
-            assert request.session.accessed
-            assert (request.session.is_empty() ==
-                    (session_case in ('empty', 'anonymous-csrf')))
+            replaced = (session_case in ('empty', 'anonymous-csrf'))
+            assert request.session.accessed != replaced
+            assert request.session.is_empty() == replaced

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -8,7 +8,9 @@ from ..middleware import (
     LegacyDomainRedirectsMiddleware,
     RestrictedEndpointsMiddleware,
     RestrictedWhiteNoiseMiddleware,
+    SessionMiddleware,
     SetRemoteAddrFromForwardedFor,
+    SmartSessionMiddleware,
     WhiteNoiseMiddleware,
 )
 
@@ -118,3 +120,63 @@ def test_legacy_domain_redirects_middleware(rf, settings, site_url, host):
         assert response['Location'] == site_url + path
     else:
         assert response is None
+
+
+@pytest.mark.parametrize(
+    'session_case',
+    ['none', 'empty', 'anonymous-csrf', 'login-step', 'authenticated'])
+def test_smart_session_middleware(rf, session_case):
+    middleware = SmartSessionMiddleware()
+
+    if session_case == 'authenticated':
+        session = middleware.SessionStore('r35pvz8qwu0e0f5qtvbxi7rk6x763ty4')
+        session.clear()
+        session.update({
+            '_auth_user_id': '922',
+            'sociallogin_provider': 'github',
+            'sociallogin_next_url': '/en-US/',
+            '_auth_user_backend': 'kuma.users.auth_backends.KumaAuthBackend',
+            '_auth_user_hash': 'e4b7a284fc0c109a5d73d85fb2a0e8b2fc22bfb3',
+            '_csrftoken': ('ss5vqahzP0Ce33sZNfIOPa36npqLET3N'
+                           'CvPySGs762lu20GspCp94yxpghgUdJED'),
+        })
+    elif session_case == 'login-step':
+        session = middleware.SessionStore()
+        session.update({
+            'sociallogin_next_url': '/en-US/',
+            'socialaccount_state': (
+                {
+                    'process': 'login',
+                    'scope': '',
+                    'auth_params': '',
+                    'next': '/en-US/'
+                },
+                'mVUH9aPKwNHi'
+            ),
+        })
+    elif session_case == 'anonymous-csrf':
+        session = middleware.SessionStore()
+        session['_csrftoken'] = ('ss5vqahzP0Ce33sZNfIOPa36npqLET3N'
+                                 'CvPySGs762lu20GspCp94yxpghgUdJED'),
+    elif session_case == 'empty':
+        session = middleware.SessionStore()
+    else:
+        session = None
+
+    response = object()
+
+    request = rf.get('/foo')
+
+    if session:
+        request.session = session
+        # Mimic the CsrfViewMiddleware.process_request call, which
+        # causes the session's "accessed" attribute to be set.
+        request.session.get('_csrftoken')
+
+    with patch.object(SessionMiddleware, 'process_response') as base:
+        middleware.process_response(request, response)
+        assert base.called
+        if session:
+            assert request.session.accessed
+            assert (request.session.is_empty() ==
+                    (session_case in ('empty', 'anonymous-csrf')))

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -16,6 +16,8 @@ from celery import chain, chord
 from django.conf import settings
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.http import QueryDict
+# TODO: Uncomment in Django 1.11
+# from django.middleware.csrf import CSRF_SESSION_KEY
 from django.shortcuts import _get_queryset
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_unicode, smart_str
@@ -26,10 +28,18 @@ from pytz import timezone
 from taggit.utils import split_strip
 
 from .cache import memcache
+# TODO: Remove in Django 1.11
+from .csrf import CSRF_SESSION_KEY
 from .exceptions import DateTimeFormatError
 
 
 log = logging.getLogger('kuma.core.utils')
+
+
+def is_anonymous_csrf_only_session(request):
+    session = getattr(request, 'session', None)
+    return (session and (not session.session_key) and
+            (session.keys() == [CSRF_SESSION_KEY]))
 
 
 def to_html(pq):

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -36,10 +36,16 @@ from .exceptions import DateTimeFormatError
 log = logging.getLogger('kuma.core.utils')
 
 
-def is_anonymous_csrf_only_session(request):
+def is_anonymous_empty_or_csrf_only_session(request):
+    """
+    Returns True if the request has a session and that session
+    is anonymous (session_key is None) and contains either nothing
+    or just a CSRF_SESSION_KEY.
+    """
     session = getattr(request, 'session', None)
-    return (session and (not session.session_key) and
-            (session.keys() == [CSRF_SESSION_KEY]))
+    return (session and (session.is_empty() or
+                         ((not session.session_key) and
+                          (session.keys() == [CSRF_SESSION_KEY]))))
 
 
 def to_html(pq):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -454,8 +454,7 @@ _CONTEXT_PROCESSORS = (
     'django.core.context_processors.media',
     'django.core.context_processors.static',
     'django.core.context_processors.request',
-    # todo: re-enable with Django 1.11
-    # 'django.core.context_processors.csrf',
+    'django.core.context_processors.csrf',
     'django.contrib.messages.context_processors.messages',
 
     'kuma.core.context_processors.global_settings',
@@ -463,7 +462,6 @@ _CONTEXT_PROCESSORS = (
     'kuma.core.context_processors.next_url',
 
     'constance.context_processors.config',
-    'debreach.context_processors.csrf',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -477,7 +475,7 @@ MIDDLEWARE_CLASSES = (
     'kuma.core.middleware.SetRemoteAddrFromForwardedFor',
     ('kuma.core.middleware.ForceAnonymousSessionMiddleware'
      if MAINTENANCE_MODE else
-     'django.contrib.sessions.middleware.SessionMiddleware'),
+     'kuma.core.middleware.SmartSessionMiddleware'),
     'kuma.core.middleware.LocaleURLMiddleware',
     'kuma.wiki.middleware.DocumentZoneMiddleware',
     'kuma.wiki.middleware.ReadOnlyMiddleware',
@@ -493,7 +491,6 @@ if not MAINTENANCE_MODE:
     # We don't want this in maintence mode, as it adds "Cookie"
     # to the Vary header, which in turn, kills caching.
     MIDDLEWARE_CLASSES += (
-        'debreach.middleware.CSRFCryptMiddleware',
         'django.middleware.csrf.CsrfViewMiddleware',
     )
 
@@ -555,7 +552,6 @@ INSTALLED_APPS = (
     'django.contrib.sitemaps',
     'django.contrib.staticfiles',
     'soapbox',  # must be before kuma.wiki, or RemovedInDjango19Warning
-    'debreach',
 
     # MDN
     'kuma.core',
@@ -1608,6 +1604,7 @@ LOGGING = {
     },
 }
 
+CSRF_USE_SESSIONS = config('CSRF_USE_SESSIONS', default=True, cast=bool)
 CSRF_COOKIE_SECURE = config('CSRF_COOKIE_SECURE', default=True, cast=bool)
 X_FRAME_OPTIONS = 'DENY'
 

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -72,7 +72,7 @@ def test_code_sample_host_restriction(code_sample_doc, constance_config,
 
 
 def test_raw_code_sample_file(code_sample_doc, constance_config,
-                              wiki_user, admin_client):
+                              wiki_user, admin_client, client):
 
     # Upload an attachment
     upload_url = reverse('attachments.edit_attachment', locale='en-US',
@@ -109,9 +109,10 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     sample_url = reverse('wiki.code_sample', locale='en-US',
                          args=[code_sample_doc.slug, 'sample1'])
 
-    response = admin_client.get(sample_url)
+    response = client.get(sample_url)
     assert response.status_code == 200
     assert url_css in response.content
+    assert not response.has_header('Vary')
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']
 
@@ -119,9 +120,10 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     file_url = reverse('wiki.raw_code_sample_file', locale='en-US',
                        args=(code_sample_doc.slug, 'sample1', attachment.id,
                              filename))
-    response = admin_client.get(file_url)
+    response = client.get(file_url)
     assert response.status_code == 302
     assert response.url == attachment.get_file_url()
+    assert not response.has_header('Vary')
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=432000' in response['Cache-Control']

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -122,7 +122,6 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     response = admin_client.get(file_url)
     assert response.status_code == 302
     assert response.url == attachment.get_file_url()
-    assert not response.has_header('Vary')
     assert 'Cache-Control' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=432000' in response['Cache-Control']

--- a/kuma/wsgi.py
+++ b/kuma/wsgi.py
@@ -5,4 +5,8 @@ os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kuma.settings.local')
 # Enable WhiteNoise
 from django.core.wsgi import get_wsgi_application  # noqa
 
+# TODO: Remove with Django 1.11
+# Monkey-patch the Django CSRF functionality prior to loading everything else.
+import kuma.core  # noqa
+
 application = get_wsgi_application()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -67,11 +67,6 @@ django-constance==2.2.0 \
     --hash=sha256:fe601fe384d1629f6f0460175e4ce3d66e8177654525bddd4bdb68025c816adc \
     --hash=sha256:1d74fa615ee6c69512faa214ec7b4962aa039dfe802e967972c3fbdad7852977
 
-# Basic/extra mitigation against the BREACH attack
-django-debreach==1.4.0 \
-    --hash=sha256:bdbf8b87c58b438630038648c5b0e168b59220c04f02e208927e08e11bcddbc4 \
-    --hash=sha256:2474c6e8762b72e12140364f0c869b0b212e0dfc76ca614e02d6a71ad6f3fdfb
-
 # Include Django URL patterns with decorators.
 # Code: https://github.com/twidi/django-decorator-include
 # Changes: https://github.com/twidi/django-decorator-include/blob/develop/CHANGELOG.rst#changelog


### PR DESCRIPTION
**If accepted, this PR eliminates the need for https://github.com/mozilla/kuma/pull/4744, so it should be reviewed/considered prior to that one.**

This PR provides Django-1.11-consistent session-based CSRF tokens for Django 1.8.19, and does so in a way that provides a simple transition for the Django 1.11 upgrade. The broader context of this PR is that it provides a possible solution to [bug 1456165](https://bugzilla.mozilla.org/show_bug.cgi?id=1456165) since it avoids cookie-based CSRF tokens and their implications when used with CloudFront.

* copied `django.middleware.csrf` from Django 1.11, which handles session-based CSRF tokens and token "salting", into `kuma.core.csrf` and modified it slightly to work within the context of Django 1.8 (this code should be removed when moving to Django 1.11)
* monkey-patched the Django 1.8 versions of `get_token`, `rotate_token`, and `CsrfViewMiddleware` with the updated versions from `kuma.core.csrf` so functions like `django.contrib.auth.login` will pick-up and use the updated version (this monkey-patching, which is odious, is only temporary, and should be removed when moving to Django 1.11)
* ~~created `kuma.core.middleware.CsrfViewMiddleware`, which inherits from `kuma.core.csrf.CsrfViewMiddleware`, but prevents it from creating session cookies for anonymous users (this remains after Django 1.11, but of course will inherit directly from Django's `CsrfViewMiddleware` rather than the copied version in `kuma.core.csrf` which will have been removed)~~
* created `kuma.core.middleware.SmartSessionMiddleware`, which inherits from `django.contrib.sessions.middleware.SessionMiddleware`, but prevents it from creating session cookies for anonymous users, which is essential if we want to use a CDN (this remains after Django 1.11)
* ~~created tests for `kuma.core.middleware.CsrfViewMiddleware`~~
* created tests for `kuma.core.middleware.SmartSessionMiddleware`
* added the `CSRF_USE_SESSIONS` setting to `kuma.settings.common` with a default value of `True` (this switches the storage of the CSRF token from the cookie to the session, and remains after the move to Django 1.11)
* removed `django-debreach`, since the `django.middleware.csrf` code copied from Django 1.11 takes care of "salting" the CSRF tokens
* switched back to using `django.core.context_processors.csrf` within the template context processors (it picks up the monkey-patched `get_token` from `kuma.core.csrf`)(this will remain in place after moving to Django 1.11)
* removed the check for the absence of the `Vary` header in three tests, since the ~~new `kuma.core.csrf.CsrfViewMiddleware`~~ `django.middleware.csrf.CsrfViewMiddleware` accesses the session on every request, which in turn triggers the addition of `Cookie` to the `Vary` header within Django's `django.contrib.sessions.middleware.SessionMiddleware` (this will NOT affect the Cloudfront CDN, since it ignores the `Vary` header)
* for the move to Django 1.11, some code needs to be deleted (as commented), but all of the rest (including configuration) remains the same