### PR TITLE
bug 1451261: Translate action button text

### DIFF
--- a/kuma/static/js/dashboard.js
+++ b/kuma/static/js/dashboard.js
@@ -47,7 +47,7 @@
                 pageButtons.appendChild(getListItem({
                     id: 'revert',
                     href: controlURLs.revertURL,
-                    text: gettext(actionsArray[i]),
+                    text: gettext('Revert'),
                     icon: 'undo'
                 }));
             }
@@ -56,7 +56,7 @@
                 pageButtons.appendChild(getListItem({
                     id: 'view',
                     href: controlURLs.viewURL,
-                    text: gettext(actionsArray[i]),
+                    text: gettext('View Page'),
                     icon: 'play'
                 }));
             }
@@ -65,7 +65,7 @@
                 pageButtons.appendChild(getListItem({
                     id: 'edit',
                     href: controlURLs.editURL,
-                    text: gettext(actionsArray[i]),
+                    text: gettext('Edit Page'),
                     icon: 'pencil'
                 }));
             }
@@ -74,7 +74,7 @@
                 pageButtons.appendChild(getListItem({
                     id: 'history',
                     href: controlURLs.editURL,
-                    text: gettext(actionsArray[i]),
+                    text: gettext('History'),
                     icon: 'book'
                 }));
             }


### PR DESCRIPTION
The process that extracts translations doesn't know JS. Change to call ``gettext`` with the string directly, rather than by variable.  Without this change, these strings ('Revert', 'View Page', etc) would be removed from Pontoon and https://github.com/mozilla-l10n/mdn-l10n/ the next time strings are extracted.

The code could be further simplified to eliminate ``actionsArray`` and the ``for`` loop, but I'm not sure if this was the first step in a longer refactor, such as passing the ``actionsArrays`` to the function.