### PR TITLE
bug 1419419: Handle deleted documents on the revision dashboard

### DIFF
--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -6,15 +6,13 @@ import pytest
 from django.contrib.auth.models import Permission
 from django.core.exceptions import ImproperlyConfigured
 from pyquery import PyQuery as pq
-from waffle.models import Flag, Switch
+from waffle.models import Switch
 
 from kuma.core.tests import (assert_no_cache_header,
                              assert_shared_cache_header, eq_, ok_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html, urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
-from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
-from kuma.users.models import User
 from kuma.users.tests import create_document, SampleRevisionsMixin, UserTestCase
 from kuma.wiki.models import DocumentSpamAttempt, RevisionAkismetSubmission
 
@@ -81,8 +79,6 @@ class RevisionsDashTest(UserTestCase):
         spam_report_button = page.find('.spam-ham-button')
         eq_(spam_report_button, [])
 
-        flag = Flag.objects.create(name=SPAM_SUBMISSIONS_FLAG)
-        flag.users.add(User.objects.get(username='admin'))
         self.client.login(username='admin', password='testpass')
         url = reverse('dashboards.revisions', locale='en-US')
         response = self.client.get(url)

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -14,7 +14,7 @@ from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html, urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG
-from kuma.users.models import User, UserBan
+from kuma.users.models import User
 from kuma.users.tests import create_document, SampleRevisionsMixin, UserTestCase
 from kuma.wiki.models import DocumentSpamAttempt, RevisionAkismetSubmission
 
@@ -34,17 +34,6 @@ class RevisionsDashTest(UserTestCase):
         assert 'text/html' in response['Content-Type']
         assert ('dashboards/revisions.html' in
                 (template.name for template in response.templates))
-
-    def test_main_view_with_banned_user(self):
-        testuser = User.objects.get(username='testuser')
-        admin = User.objects.get(username='admin')
-        ban = UserBan(user=testuser, by=admin, reason='Testing')
-        ban.save()
-
-        self.client.login(username='admin', password='testpass')
-        response = self.client.get(reverse('dashboards.revisions',
-                                           locale='en-US'))
-        eq_(200, response.status_code)
 
     def test_revision_list(self):
         url = reverse('dashboards.revisions', locale='en-US')

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -102,7 +102,7 @@ def revisions(request):
 
     # prefetch_related needs to come after all filters have been applied to qs
     revisions = revisions.prefetch_related('creator__bans').prefetch_related(
-        Prefetch('document', queryset=Document.objects.only(
+        Prefetch('document', queryset=Document.admin_objects.only(
                  'deleted', 'locale', 'slug')))
 
     show_spam_submission = (


### PR DESCRIPTION
Refactor the revision dashboard tests to remove some invalid test paths and get them to the new pytest standard. Then add a new test and a 1-line change that allows deleted documents to be shown on the revision dashboard, without the server error of [bug 1419419](https://bugzilla.mozilla.org/show_bug.cgi?id=1419419).