### PR TITLE
bug 1456165: remove csrfmiddlewaretoken from wiki.document view responses

### DIFF
--- a/jinja2/includes/login.html
+++ b/jinja2/includes/login.html
@@ -11,7 +11,6 @@
                     <li><a href="{{ user.get_absolute_url() }}">{{ _('View profile') }}</a></li>
                     <li><a href="{{ url('users.user_edit', username=user.username) }}">{{ _('Edit profile') }}</a></li>
                     <li><form class="login-form" action="{{ url('account_logout') }}" method="post">
-                        {% csrf_token %}
                         <input name="next" type="hidden" value="{{ next_url }}">
                         <button class="logout button link" type="submit">{{ _('Sign out') }}</button>
                     </form></li>

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -169,9 +169,10 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
         # Check next url is provided as input field
         next_input = form.children("input[name='next']")
         assert next_input.val() == home_url
-        # Check CSRF is added
+        # Ensure CSRF protection has not been added, since it creates problems
+        # when used with a CDN like CloudFront (see bugzilla #1456165).
         csrf_input = form.children("input[name='csrfmiddlewaretoken']")
-        assert csrf_input.val() is not None
+        assert not csrf_input
 
     def test_signin_form_present(self):
         """When not authenticated, the GitHub login link is present."""
@@ -229,9 +230,10 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
         # Check next url is provided as input field
         next_input = form.children("input[name='next']")
         assert next_input.val() == home_url
-        # Check CSRF is added
+        # Ensure CSRF protection has not been added, since it creates problems
+        # when used with a CDN like CloudFront (see bugzilla #1456165).
         csrf_input = form.children("input[name='csrfmiddlewaretoken']")
-        assert csrf_input.val() is not None
+        assert not csrf_input
 
 
 @pytest.mark.bans

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -3,6 +3,7 @@ import importlib
 from allauth.account import views as account_views
 from allauth.socialaccount import providers, views as socialaccount_views
 from django.conf.urls import include, url
+from django.views.decorators.csrf import csrf_exempt
 
 from kuma.core.decorators import redirect_in_maintenance_mode
 
@@ -44,7 +45,7 @@ users_patterns = [
         redirect_in_maintenance_mode(account_views.login),
         name='account_login'),
     url(r'^signout/?$',
-        redirect_in_maintenance_mode(account_views.logout),
+        redirect_in_maintenance_mode(csrf_exempt(account_views.logout)),
         name='account_logout'),
     url(r'^account/', include(account_patterns)),
     url(r'^ban/(?P<username>[^/]+)$',

--- a/kuma/wiki/jinja2/wiki/includes/approvals.html
+++ b/kuma/wiki/jinja2/wiki/includes/approvals.html
@@ -5,7 +5,6 @@
       <p>{{ _('This article needs these reviews:') }}</p>
 
       <form method="post" action="{{ url('wiki.quick_review', document.slug) }}">
-        {% csrf_token %}
         <ul>
         {% if document.current_revision.needs_technical_review %}
           <li>

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -118,7 +118,6 @@
                     {% set subscribe_tree_text = _('Subscribe to this article and all its sub-articles') %}
                     {% set unsubscribe_tree_text = _('Unsubscribe from this article and all its sub-articles') %}
                     <form action="{{ url('wiki.subscribe_to_tree', document.slug, locale=document.locale) }}" method="post">
-                        {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_tree_text }}" data-unsubscribe-text="{{ unsubscribe_tree_text }}" data-subscribe-message="{{ _('You are now subscribed to this article and all its sub-articles.') }}" data-unsubscribe-message="{{ _('You have been unsubscribed from this article and all its sub-articles.') }}">
                         {% if document.tree_is_watched_by(user) %}{{ unsubscribe_tree_text }}{% else %}{{ subscribe_tree_text }}{% endif %}
                         </a>
@@ -134,7 +133,6 @@
                     {% set subscribe_text = _('Subscribe to this article') %}
                     {% set unsubscribe_text = _('Unsubscribe from this article') %}
                     <form action="{{ url('wiki.subscribe', document.slug, locale=document.locale) }}" method="post">
-                        {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_text }}" data-unsubscribe-text="{{ unsubscribe_text }}" data-subscribe-message="{{ _('You are now subscribed to %(title)s.', title=title) }}" data-unsubscribe-message="{{ _('You have been unsubscribed from %(title)s.', title=title) }}">
                         {% if document.is_watched_by(user) %}{{ unsubscribe_text }}{% else %}{{ subscribe_text }}{% endif %}
                         </a>
@@ -149,7 +147,6 @@
                     {% set subscribe_parent_text = _('Subscribe to the %(language)s version', language=parent_language) %}
                     {% set unsubscribe_parent_text = _('Unsubscribe from the %(language)s version', language=parent_language) %}
                       <form action="{{ url('wiki.subscribe', document.parent.slug, locale=document.parent.locale) }}" method="post">
-                          {% csrf_token %}
                         <a href="#" data-subscribe-status="{{ subscribe_status }}" data-subscribe-text="{{ subscribe_parent_text }}" data-unsubscribe-text="{{ unsubscribe_parent_text }}" data-subscribe-message="{{ _('You are now subscribed to the %(language)s version of this article.', language=parent_language) }}" data-unsubscribe-message="{{ _('You have been unsubscribed from the %(language)s version of this article.', language=parent_language) }}">
                           {% if document.parent.is_watched_by(user) %}{{ unsubscribe_parent_text|safe }}{% else %}{{ subscribe_parent_text|safe }}{% endif %}
                         </a>

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -191,13 +191,16 @@ class DocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(urlparams(d.get_absolute_url()))
         self.assertNotContains(response, 'Redirected from ')
 
-    def test_watch_includes_csrf(self):
-        """The watch/unwatch forms should include the csrf tag."""
+    def test_does_not_include_csrf(self):
+        """
+        The document should not include CSRF tokens, since it causes
+        problems when used with a CDN like CloudFront (see bugzilla #1456165).
+        """
         self.client.login(username='testuser', password='testpass')
         d = document(save=True)
         resp = self.client.get(d.get_absolute_url())
         doc = pq(resp.content)
-        assert doc('.page-watch input[type=hidden]')
+        assert not doc('input[name="csrfmiddlewaretoken"]')
 
     def test_non_localizable_translate_disabled(self):
         """Non localizable document doesn't show tab for 'Localize'."""

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -507,6 +507,7 @@ def styles(request, document_slug=None, document_locale=None):
 
 
 @never_cache
+@csrf_exempt
 @block_user_agents
 @require_POST
 @login_required
@@ -532,6 +533,7 @@ def subscribe(request, document_slug, document_locale):
 
 
 @never_cache
+@csrf_exempt
 @block_user_agents
 @require_POST
 @login_required

--- a/kuma/wiki/views/revision.py
+++ b/kuma/wiki/views/revision.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin
+from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_GET, require_POST
 from ratelimit.decorators import ratelimit
 
@@ -126,6 +127,7 @@ def compare(request, document_slug, document_locale):
 
 
 @never_cache
+@csrf_exempt
 @login_required
 @require_POST
 @process_document_path


### PR DESCRIPTION
This PR removes `csrfmiddlewaretoken` from the responses of all endpoints that require caching in the CloudFront CDN, which ends up being just the `wiki.document` endpoint. This provides a possible solution to bug 1456165, since it avoids setting a new `csrftoken` cookie on `wiki.document` page loads due to the fact that the CDN behavior can't forward the existing one (it can't forward the existing `csrftoken` cookie without negating caching altogether for that behavior, since CloudFront does not provide separate configuration for caching and forwarding).