### PR TITLE
bug 1399639: Update to newrelic 3.2.0.91

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -246,8 +246,10 @@ mysqlclient==1.3.7 \
     --hash=sha256:c74a83b4cb2933d0e43370117eeebdfa03077ae72686d2df43d31879267f1f1b
 
 # Report performance metrics and exceptions to New Relic
-newrelic==2.96.0.80 \
-    --hash=sha256:fc7125f3caed2b678c884468c1416ab87e7150ede0d46c738fca08d88c8bd008
+# Docs: https://docs.newrelic.com/docs/agents/python-agent/
+# Changes: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes
+newrelic==3.2.0.91 \
+    --hash=sha256:2d1cf00e105f423c5c5fa9ce3f6179773683e6ee52fb64016441abd225b43bf3
 
 # Compile .po files into .mo files, used in locale/compile-mo.sh
 polib==1.0.7 \


### PR DESCRIPTION
* newrelic 2.96.0.80→3.2.0.91: Manadatory SSL, security issues with SQL analysis and tracing APIs, fix memory leaks.