### PR TITLE
bug 1451261: Use twitter icon for Mozilla twitter

### DIFF
--- a/jinja2/includes/footer/moz-footer.html
+++ b/jinja2/includes/footer/moz-footer.html
@@ -8,7 +8,7 @@
     <li><a href="https://www.mozilla.org/firefox/?utm_source=developer.mozilla.org&utm_campaign=footer&utm_medium=referral">Firefox</a></li>
     <li class="footer-social">
         <a href="https://twitter.com/mozilla">
-            {% include 'includes/icons/social/github.svg' %}
+            {% include 'includes/icons/social/twitter.svg' %}
         </a>
     </li>
     <li class="footer-social">


### PR DESCRIPTION
The GitHub icon was accidentally used when converting to inline SVG. 