### PR TITLE
bug 1429933: Update get_form to match upstream class

### DIFF
--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -466,7 +466,7 @@ class SignupView(BaseSignupView):
     """
     form_class = SignupForm
 
-    def get_form(self, form_class):
+    def get_form(self, form_class=None):
         """
         Returns an instance of the form to be used in this view.
         """

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -35,8 +35,11 @@ Django==1.8.19 \
     --hash=sha256:33d44a5cf9d333247a9a374ae1478b78b83c9b78eb316fc04adde62053b4c047
 
 # 3rd party logins like Github
-django-allauth==0.33.0 \
-    --hash=sha256:ae64a80b49707c3d4d6aff52424f8e75fd636cebfdce0e88ffdcbf306f9f0a3d
+# Code: https://github.com/pennersr/django-allauth
+# Changes: https://django-allauth.readthedocs.io/en/latest/release-notes.html
+# Docs: https://django-allauth.readthedocs.io/en/latest/
+django-allauth==0.34.0 \
+    --hash=sha256:95a9f7fbebe3e97ce3a541d213fc52492b50dac92f0f91483f58949189e5aa4f
 
 # Refresh stale cache items asynchronously
 # Code: https://github.com/codeinthehole/django-cacheback


### PR DESCRIPTION
Update django-allauth to the current version, before updating our customization of the ``SignupView``.

In Django 1.8, ``django.views.generic.edit.FormMixin``'s method
[get_form()](https://docs.djangoproject.com/en/1.8/ref/class-based-views/mixins-editing/#django.views.generic.edit.FormMixin.get_form) changed so that ``form_class`` was no longer a required argument, but instead calls ``get_form_class()`` if it has the default value of ``None``.

In Django 1.8, this removes a deprecation warning. In Django 1.10, this fixes a runtime error.