### PR TITLE
bug 1429933: Update context processor paths

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -456,15 +456,15 @@ _NEED_DEBREACH = LooseVersion(get_version()) < LooseVersion('1.10')
 if _NEED_DEBREACH:
     _CSRF_CONTEXT_PROCESSOR = 'debreach.context_processors.csrf'
 else:
-    _CSRF_CONTEXT_PROCESSOR = 'django.core.context_processors.csrf',
+    _CSRF_CONTEXT_PROCESSOR = 'django.template.context_processors.csrf'
 
 
 _CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
-    'django.core.context_processors.debug',
-    'django.core.context_processors.media',
-    'django.core.context_processors.static',
-    'django.core.context_processors.request',
+    'django.template.context_processors.debug',
+    'django.template.context_processors.media',
+    'django.template.context_processors.static',
+    'django.template.context_processors.request',
     _CSRF_CONTEXT_PROCESSOR,
     'django.contrib.messages.context_processors.messages',
 


### PR DESCRIPTION
Context processors moved from ``django.core.context_processors`` to ``django.template.context_processors`` in Django 1.8. This removes a deprecation warning in 1.8, and a run-time error in Django 1.10.

It also fixes a stray trailing comma in the ``!_NEED_DEBREACH`` path.