### PR TITLE
bug 1429933: Avoid BaseException.message

### DIFF
--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -272,7 +272,7 @@ def spam_dashboard_recent_events(start=None, end=None):
         try:
             views = analytics_upageviews(revs, start_date)
         except ImproperlyConfigured as e:
-            data['improperly_configured'] = e.message
+            data['improperly_configured'] = str(e)
             break
 
         for item in chunk:

--- a/kuma/scrape/tests/test_source.py
+++ b/kuma/scrape/tests/test_source.py
@@ -164,7 +164,7 @@ def test_invalid_values(option_type, option, bad_value):
     """Invalid parameter values raise a ValueError."""
     with pytest.raises(ValueError) as err:
         FakeSource('fails', **{option: bad_value})
-    assert option_type in err.value.message
+    assert option_type in str(err.value)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
[PEP 352](https://www.python.org/dev/peps/pep-0352/) makes changes to exceptions, including:
* Python 2.5 added the ``BaseException`` class.
* Python 2.6 deprecated the ``message`` attribute.
* Python 3.0 removes the ``message`` attribute.

Instead of testing ``exception.message``, test ``str(exception)``. Also, convert some tests to pytest style.