### PR TITLE
bug 1429933: Use ROOT_URLCONF, not .urls

### DIFF
--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -48,9 +48,9 @@ def sitemaps(db, settings, tmpdir):
 @override_settings(
     DEBUG=False,
     DEBUG_PROPAGATE_EXCEPTIONS=False,
-    ADMINS=(('admin', 'admin@example.com'),))
+    ADMINS=(('admin', 'admin@example.com'),),
+    ROOT_URLCONF='kuma.core.tests.logging_urls')
 class LoggingTests(KumaTestCase):
-    urls = 'kuma.core.tests.logging_urls'
     logger = logging.getLogger('django.security')
     suspicous_path = '/en-US/suspicious/'
 


### PR DESCRIPTION
``SimpleTestCase.urls`` is deprecated in Django 1.8 and will be removed in Django 1.10.