### PR TITLE
bug 1429933: Switch to _meta.get_field

### DIFF
--- a/kuma/feeder/utils.py
+++ b/kuma/feeder/utils.py
@@ -172,7 +172,7 @@ def save_entry(feed, entry):
     """Save a new entry or update an existing one."""
     json_entry = jsonpickle.encode(entry)
 
-    max_guid_length = Entry._meta.get_field_by_name('guid')[0].max_length
+    max_guid_length = Entry._meta.get_field('guid').max_length
     if len(entry.guid) <= max_guid_length:
         entry_guid = entry.guid
     else:


### PR DESCRIPTION
Django 1.8 formalized the Model _meta API, and deprecated methods that were private but in common use. Following the [migration guide](https://docs.djangoproject.com/en/1.8/ref/models/meta/#migrating-from-the-old-api), switch from ``_meta.get_field_by_name`` to ``_meta.get_field``.