### PR TITLE
bug 1461209: Ignore DisallowedHost exception

### DIFF
--- a/etc/newrelic.ini
+++ b/etc/newrelic.ini
@@ -170,7 +170,7 @@ error_collector.enabled = true
 # To stop specific errors from reporting to the UI, set this to
 # a space separated list of the Python exception type names to
 # ignore. The exception name should be of the form 'module:class'.
-error_collector.ignore_errors = celery.exceptions:Retry ratelimit.exceptions:Ratelimited
+error_collector.ignore_errors = celery.exceptions:Retry ratelimit.exceptions:Ratelimited django.core.exceptions:DisallowedHost
 
 # Browser monitoring is the Real User Monitoring feature of the UI.
 # For those Python web frameworks that are supported, this


### PR DESCRIPTION
The ``DisallowedHost`` exception is raised when a client's requested hostname does not match one of the accepted hostnames in [ALLOWED_HOSTS](https://docs.djangoproject.com/en/2.0/ref/settings/#allowed-hosts). This is common in AWS from security scanners searching AWS IP blocks, or when AWS allocates an IP address or EC2 instance that was owned by a previous website. There is no security risk or positive action that can be taken, so it should not result in New Relic alerts.

See [bug 1461209](https://bugzilla.mozilla.org/show_bug.cgi?id=1461209).