### PR TITLE
bug 1461350: Update Middleware tests

### DIFF
--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -75,11 +75,20 @@ def test_locale_middleware_language_cookie(client):
     assert_shared_cache_header(response)
 
 
-def test_locale_middleware_lang_query_param(client):
+@pytest.mark.parametrize('path', ('/', '/en-US/'))
+def test_locale_middleware_lang_query_param(path, client):
     '''The LocaleMiddleware redirects on the ?lang query first.'''
     client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
-    response = client.get('/?lang=fr',
+    response = client.get('%s?lang=fr' % path,
                           HTTP_ACCEPT_LANGUAGE='en;q=0.9, fr;q=0.8')
+    assert response.status_code == 302
+    assert response['Location'] == 'http://testserver/fr/'
+    assert_shared_cache_header(response)
+
+
+def test_locale_middleware_no_change(client, db):
+    '''The LocaleMiddleware redirects on the same ?lang query.'''
+    response = client.get('/fr/?lang=fr')
     assert response.status_code == 302
     assert response['Location'] == 'http://testserver/fr/'
     assert_shared_cache_header(response)

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -1,74 +1,80 @@
+import pytest
 from django.conf import settings
 
-from kuma.core.tests import assert_shared_cache_header
-
-from . import KumaTestCase
+from . import assert_shared_cache_header
 
 
-class TestLocaleMiddleware(KumaTestCase):
-    def test_default_redirect(self):
-        # User wants en-us, we send en-US
-        response = self.client.get('/', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='en-us')
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
+# Simple Accept-Language headers, one term
+SIMPLE_ACCEPT_CASES = (
+    ('', 'en-US'),          # No preference gets default en-US
+    ('en', 'en-US'),        # Default en is en-US
+    ('en-US', 'en-US'),     # Exact match for default
+    ('en-us', 'en-US'),     # Case-insensitive match for default
+    ('fr-FR', 'fr'),        # Overly-specified locale gets default
+    ('fr-fr', 'fr'),        # Overly-specified match is case-insensitive
+)
+# Real-world Accept-Language headers include quality value weights
+WEIGHTED_ACCEPT_CASES = (
+    ('en, fr;q=0.5', 'en-US'),          # English without region gets en-US
+    ('en-GB, fr-FR;q=0.5', 'en-US'),    # Any English gets en-US
+    ('en-US, en;q=0.5', 'en-US'),       # Request for en-US gets en-US
+    ('fr, en-US;q=0.5', 'fr'),          # Exact match of non-English language
+    ('fr-FR, de-DE;q=0.5', 'fr'),       # Highest locale-specific match wins
+    ('fr-FR, de;q=0.5', 'de'),          # Highest exact match wins
+    ('ga, fr;q=0.5', 'ga-IE'),          # Generic Gaelic matches ga-IE
+    ('pt, fr;q=0.5', 'pt-PT'),          # Generic Portuguese matches pt-PT
+    ('pt-BR, en-US;q=0.5', 'pt-BR'),    # Portuguese-Brazil matches
+    ('qaz-ZZ, fr-FR;q=0.5', 'fr'),      # Respect partial match on prefix
+    ('qaz-ZZ, qaz;q=0.5', False),       # No matches gets default en-US
+    ('zh-Hant, fr;q=0.5', 'zh-TW'),     # Traditional Chinese matches zh-TW
+)
+PICKER_CASES = SIMPLE_ACCEPT_CASES + WEIGHTED_ACCEPT_CASES + (
+    ('xx', 'en-US'),        # Unknown in Accept-Language gets default
+)
+REDIRECT_CASES = [case for case in SIMPLE_ACCEPT_CASES if case[0] != case[1]]
 
-        # User wants fr-FR, we send fr
-        response = self.client.get('/', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='fr-fr')
-        self.assertRedirects(response, '/fr/', status_code=302)
-        assert_shared_cache_header(response)
 
-        # User wants xx, we send en-US
-        response = self.client.get('/', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='xx')
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
+@pytest.mark.parametrize('accept_language,locale', PICKER_CASES)
+def test_locale_middleware_picker(accept_language, locale, client):
+    '''The LocaleMiddleware picks locale from the Accept-Language header.'''
+    response = client.get('/', HTTP_ACCEPT_LANGUAGE=accept_language)
+    assert response.status_code == 302
+    url_locale = locale or 'en-US'
+    assert response['Location'] == 'http://testserver/%s/' % url_locale
+    assert_shared_cache_header(response)
 
-        # User doesn't know what they want, we send en-US
-        response = self.client.get('/', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='')
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
 
-    def test_mixed_case_header(self):
-        """Accept-Language is case insensitive."""
-        response = self.client.get('/', follow=True,
-                                   HTTP_ACCEPT_LANGUAGE='en-US')
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
+@pytest.mark.parametrize('original,fixed', REDIRECT_CASES)
+def test_locale_middleware_fixer(original, fixed, client):
+    '''The LocaleMiddleware redirects for non-standard locale URLs.'''
+    response = client.get('/%s/' % original)
+    assert response.status_code == 302
+    assert response['Location'] == 'http://testserver/%s/' % fixed
+    assert_shared_cache_header(response)
 
-    def test_specificity(self):
-        """Requests for /fr-FR/ should end up on /fr/"""
-        response = self.client.get('/fr-FR/', follow=True)
-        self.assertRedirects(response, '/fr/', status_code=302)
-        assert_shared_cache_header(response)
 
-    def test_partial_redirect(self):
-        """Ensure that /en/ gets directed to /en-US/."""
-        response = self.client.get('/en/', follow=True)
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
+def test_locale_middleware_fixer_confusion(client):
+    '''The LocaleMiddleware treats unknown locales and 404 en-US docs.'''
+    response = client.get('/xx/')
+    assert response.status_code == 302
+    assert response['Location'] == 'http://testserver/en-US/xx/'
+    assert_shared_cache_header(response)
 
-    def test_lower_to_upper(self):
-        """/en-us should redirect to /en-US."""
-        response = self.client.get('/en-us/', follow=True)
-        self.assertRedirects(response, '/en-US/', status_code=302)
-        assert_shared_cache_header(response)
 
-    def test_language_cookie_support(self):
-        """Request with language cookie should redirect to the cookie locale"""
-        # Add appropriate language cookie to the client
-        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
-        response = self.client.get('/')
-        self.assertRedirects(response, '/bn-BD/', status_code=302)
-        assert_shared_cache_header(response)
+def test_locale_middleware_language_cookie(client):
+    '''The LocaleMiddleware uses the language cookie.'''
+    client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
+    response = client.get('/')
+    assert response.status_code == 302
+    assert response['Location'] == 'http://testserver/bn-BD/'
+    assert_shared_cache_header(response)
 
-    def test_lang_query_param(self):
-        """Request with lang query param should redirect to that locale"""
-        # Add language cookie and accept-language header as red herrings.
-        self.client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
-        response = self.client.get('/?lang=fr',
-                                   HTTP_ACCEPT_LANGUAGE='en;q=0.9, fr;q=0.8')
-        self.assertRedirects(response, '/fr/', status_code=302)
-        assert_shared_cache_header(response)
+
+def test_locale_middleware_lang_query_param(client):
+    '''The LocaleMiddleware redirects on the ?lang query first.'''
+    client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
+    response = client.get('/?lang=fr',
+                          HTTP_ACCEPT_LANGUAGE='en;q=0.9, fr;q=0.8')
+    assert response.status_code == 302
+    assert response['Location'] == 'http://testserver/fr/'
+    assert_shared_cache_header(response)

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -2,7 +2,6 @@ import pytest
 from django.test import RequestFactory
 from mock import MagicMock, patch
 
-from . import eq_, KumaTestCase
 from ..middleware import (
     ForceAnonymousSessionMiddleware,
     LegacyDomainRedirectsMiddleware,
@@ -13,38 +12,32 @@ from ..middleware import (
 )
 
 
-class TrailingSlashMiddlewareTestCase(KumaTestCase):
-    def test_no_trailing_slash(self):
-        response = self.client.get(u'/en-US/ohnoez')
-        eq_(response.status_code, 404)
-
-    def test_404_trailing_slash(self):
-        response = self.client.get(u'/en-US/ohnoez/')
-        eq_(response.status_code, 404)
-
-    def test_remove_trailing_slash(self):
-        response = self.client.get(u'/en-US/docs/files/?xxx=\xc3')
-        eq_(response.status_code, 301)
-        assert response['Location'].endswith('/en-US/docs/files?xxx=%C3%83')
+@pytest.mark.parametrize('path', ('/en-US/ohnoez', '/en-US/ohnoez/'))
+def test_remove_slash_middleware_keep_404(client, db, path):
+    '''The RemoveSlashMiddleware retains 404s.'''
+    response = client.get(path)
+    assert response.status_code == 404
 
 
-class SetRemoteAddrFromForwardedForTestCase(KumaTestCase):
+def test_remove_slash_middleware_retains_querystring(client, db):
+    '''The RemoveSlashMiddleware handles encoded querystrings.'''
+    response = client.get(u'/en-US/docs/files/?xxx=\xc3')
+    assert response.status_code == 301
+    assert response['Location'].endswith('/en-US/docs/files?xxx=%C3%83')
 
-    def test_rate_x_forwarded_for(self):
-        rf = RequestFactory()
-        middleware = SetRemoteAddrFromForwardedFor()
 
-        req1 = rf.get('/', HTTP_X_FORWARDED_FOR='1.1.1.1')
-        middleware.process_request(req1)
-        eq_(req1.META['REMOTE_ADDR'], '1.1.1.1')
-
-        req2 = rf.get('/', HTTP_X_FORWARDED_FOR='2.2.2.2')
-        middleware.process_request(req2)
-        eq_(req2.META['REMOTE_ADDR'], '2.2.2.2')
-
-        req3 = rf.get('/', HTTP_X_FORWARDED_FOR='3.3.3.3, 4.4.4.4')
-        middleware.process_request(req3)
-        eq_(req3.META['REMOTE_ADDR'], '3.3.3.3')
+@pytest.mark.parametrize(
+    'forwarded_for,remote_addr',
+    (('1.1.1.1', '1.1.1.1'),
+     ('2.2.2.2', '2.2.2.2'),
+     ('3.3.3.3, 4.4.4.4', '3.3.3.3')))
+def test_set_remote_addr_from_forwarded_for(rf, forwarded_for, remote_addr):
+    '''SetRemoteAddrFromForwardedFor parses the X-Forwarded-For Header.'''
+    rf = RequestFactory()
+    middleware = SetRemoteAddrFromForwardedFor()
+    request = rf.get('/', HTTP_X_FORWARDED_FOR=forwarded_for)
+    middleware.process_request(request)
+    assert request.META['REMOTE_ADDR'] == remote_addr
 
 
 def test_force_anonymous_session_middleware(rf, settings):

--- a/kuma/core/tests/test_urlresolvers.py
+++ b/kuma/core/tests/test_urlresolvers.py
@@ -2,71 +2,14 @@ import pytest
 
 from django.conf import settings
 
-from kuma.core.tests import eq_, KumaTestCase
-
+from .test_locale_middleware import WEIGHTED_ACCEPT_CASES
 from ..urlresolvers import get_best_language
 
 
-class BestLanguageTests(KumaTestCase):
-    def test_english_only(self):
-        """Any way you slice it, this should be 'en-US'."""
-        best = get_best_language('en-US, en;q=0.5')
-        eq_('en-US', best)
-
-    def test_exact_match_language(self):
-        """Exact match of a locale with only a language subtag."""
-        best = get_best_language('fr, en-US;q=0.5')
-        eq_('fr', best)
-
-    def test_exact_match_region(self):
-        """Exact match of a locale with language and region subtags."""
-        best = get_best_language('pt-BR, en-US;q=0.5')
-        eq_('pt-BR', best)
-
-    def test_english_alias(self):
-        """Our canonical English locale is 'en-US'."""
-        best = get_best_language('en, fr;q=0.5')
-        eq_('en-US', best)
-
-    def test_overspecific_alias(self):
-        """Our Irish locale is 'ga-IE'."""
-        best = get_best_language('ga, fr;q=0.5')
-        eq_('ga-IE', best)
-
-    def test_prefix_alias(self):
-        """A generic request for Portuguese should go to 'pt-PT'."""
-        best = get_best_language('pt, fr;q=0.5')
-        eq_('pt-PT', best)
-
-    def test_script_alias(self):
-        """Our traditional Chinese locale is 'zh-TW'."""
-        best = get_best_language('zh-Hant, fr;q=0.5')
-        eq_('zh-TW', best)
-
-    def test_non_existent(self):
-        """If we don't have any matches, return false."""
-        best = get_best_language('qaz-ZZ, qaz;q=0.5')
-        eq_(False, best)
-
-    def test_second_choice(self):
-        """Respect the user's preferences during the first pass."""
-        best = get_best_language('fr-FR, de;q=0.5')
-        eq_('de', best)
-
-    def test_prefix_fallback(self):
-        """No matches during the first pass. Fall back to prefix."""
-        best = get_best_language('fr-FR, de-DE;q=0.5')
-        eq_('fr', best)
-
-    def test_english_fallback(self):
-        """Fall back to our canonical English locale, 'en-US'."""
-        best = get_best_language('en-GB, fr-FR;q=0.5')
-        eq_('en-US', best)
-
-    def test_non_existent_fallback(self):
-        """Respect user's preferences as much as possible."""
-        best = get_best_language('qaz-ZZ, fr-FR;q=0.5')
-        eq_('fr', best)
+@pytest.mark.parametrize('accept_language,locale', WEIGHTED_ACCEPT_CASES)
+def test_get_best_language(accept_language, locale):
+    best = get_best_language(accept_language)
+    assert best == locale
 
 
 @pytest.mark.parametrize("locale", settings.RTL_LANGUAGES)


### PR DESCRIPTION
In preparation to update the locale infrastructure, expand tests for middleware and other components, and convert to pytest style:

* ``LocaleURLMiddleware``
   - Convert tests to pytest.
   - Test ``Accept-Language`` header variations from ``get_best_language``
   - Add more ``?lang`` scenarios
   - Add legacy locale redirect tests
   - Add non-locale 404 tests
* ``RemoveSlashMiddleware`` - Convert tests to pytest. The test cases actually exercise the ``mindtouch_to_kuma_redirect`` view, and the middleware code never runs. The next PR will update the test cases and fix the functionality.
* ``SetRemoteAddrFromForwardedFor`` - Convert tests to pytest.

This was originally part of PR #4766, but has been split out to confirm that tests pass with ``LocaleURLMiddleware`` before replacing it.

