### PR TITLE
bug 1431259: fix headless tests with localhost

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,12 +95,12 @@ def selenium(request, selenium):
 
 
 @pytest.fixture(scope='session')
-def sensitive_url(request, base_url):
-    if not base_url:
-        return False
-    return not any(base_url.startswith(url)
-                   for url in ('http://localhost',
-                               'https://developer-local'))
+def is_local_url(base_url):
+    """
+    Returns True if the system-under-test is the local development
+    instance (localhost).
+    """
+    return base_url and (urlsplit(base_url).hostname == 'localhost')
 
 
 @pytest.fixture(scope='session')
@@ -111,6 +111,12 @@ def kuma_status(base_url):
 @pytest.fixture(scope='session')
 def is_debug(kuma_status):
     return kuma_status['settings']['DEBUG']
+
+
+@pytest.fixture(scope='session')
+def is_searchable(kuma_status):
+    search = kuma_status['services']['search']
+    return search['available'] and search['populated']
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
This PR fixes the headless tests such that they now successfully run against the local development instance loaded with a stock sample database.
- Add `is_local_url` and `is_searchable` fixtures.
- Use pytest's ability to [mark a test with `xfail` from within the test function](https://docs.pytest.org/en/latest/skipping.html#xfail-mark-test-functions-as-expected-to-fail). This was simpler than trying to create a dynamic fixture.
- Modify some URL's to work on both a local instance loaded with the stock sample database as well as the stage and production instances (e.g., `/en-US/docs/Web/HTML$revision/1252409` rather than `/en-US/docs/Web/HTML$revision/1293895`)

I also removed the `sensitive_url` fixture since it was unused.