### PR TITLE
bug 1461350: Improve is_valid_path

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -4,13 +4,16 @@ from urlparse import urljoin
 
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
-from django.core import urlresolvers
+from django.core.urlresolvers import resolve, Resolver404
 from django.http import (HttpResponseForbidden,
                          HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
 from django.utils import translation
 from django.utils.encoding import iri_to_uri, smart_str
 from whitenoise.middleware import WhiteNoiseMiddleware
+
+from kuma.wiki.views.legacy import (mindtouch_to_kuma_redirect,
+                                    mindtouch_to_kuma_url)
 
 from .decorators import add_shared_cache_control
 from .urlresolvers import Prefixer, set_url_prefixer, split_path
@@ -101,9 +104,18 @@ class Forbidden403Middleware(object):
 def is_valid_path(request, path):
     urlconf = getattr(request, 'urlconf', None)
     try:
-        urlresolvers.resolve(path, urlconf)
-        return True
-    except urlresolvers.Resolver404:
+        match = resolve(path, urlconf)
+        if match.func == mindtouch_to_kuma_redirect:
+            # mindtouch_to_kuma_redirect matches everything.
+            # Check if it would return a redirect or 404.
+            url = mindtouch_to_kuma_url(request.LANGUAGE_CODE,
+                                        match.kwargs['path'])
+            return bool(url)
+        else:
+            return True
+    except Resolver404:
+        # mindtouch_to_kuma_redirect matches everything, so this branch is
+        # not exercised in tests, and possibly not in production.
         return False
 
 

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -113,6 +113,9 @@ class RemoveSlashMiddleware(object):
 
     If the response is a 404 because url resolution failed, we'll look for a
     better url without a trailing slash.
+
+    This middleware only processes non-locale URLs. Locale-prefixed URLs are
+    converted to redirects in LocaleMiddleware.
     """
 
     def process_response(self, request, response):

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -12,18 +12,28 @@ from ..middleware import (
 )
 
 
-@pytest.mark.parametrize('path', ('/en-US/ohnoez', '/en-US/ohnoez/'))
+@pytest.mark.xfail(reason='is_valid_path always returns True')
+@pytest.mark.parametrize('path', ('/missing_url', '/missing_url/'))
 def test_remove_slash_middleware_keep_404(client, db, path):
     '''The RemoveSlashMiddleware retains 404s.'''
     response = client.get(path)
     assert response.status_code == 404
 
 
+@pytest.mark.xfail(reason='is_valid_path always returns True')
+def test_remove_slash_middleware_fixes_url(client, db):
+    '''The RemoveSlashMiddleware fixes a URL that shouldn't have a slash.'''
+    response = client.get(u'/contribute.json/')
+    assert response.status_code == 301
+    assert response['Location'].endswith('/contribute.json')
+
+
+@pytest.mark.xfail(reason='is_valid_path always returns True')
 def test_remove_slash_middleware_retains_querystring(client, db):
     '''The RemoveSlashMiddleware handles encoded querystrings.'''
-    response = client.get(u'/en-US/docs/files/?xxx=\xc3')
+    response = client.get(u'/contribute.json/?xxx=\xc3')
     assert response.status_code == 301
-    assert response['Location'].endswith('/en-US/docs/files?xxx=%C3%83')
+    assert response['Location'].endswith('/contribute.json?xxx=%C3%83')
 
 
 @pytest.mark.parametrize(

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -12,7 +12,7 @@ from ..middleware import (
 )
 
 
-@pytest.mark.xfail(reason='is_valid_path always returns True')
+@pytest.mark.xfail(reason='LocaleURLMiddleware.process_requests redirects.')
 @pytest.mark.parametrize('path', ('/missing_url', '/missing_url/'))
 def test_remove_slash_middleware_keep_404(client, db, path):
     '''The RemoveSlashMiddleware retains 404s.'''
@@ -20,7 +20,6 @@ def test_remove_slash_middleware_keep_404(client, db, path):
     assert response.status_code == 404
 
 
-@pytest.mark.xfail(reason='is_valid_path always returns True')
 def test_remove_slash_middleware_fixes_url(client, db):
     '''The RemoveSlashMiddleware fixes a URL that shouldn't have a slash.'''
     response = client.get(u'/contribute.json/')
@@ -28,7 +27,6 @@ def test_remove_slash_middleware_fixes_url(client, db):
     assert response['Location'].endswith('/contribute.json')
 
 
-@pytest.mark.xfail(reason='is_valid_path always returns True')
 def test_remove_slash_middleware_retains_querystring(client, db):
     '''The RemoveSlashMiddleware handles encoded querystrings.'''
     response = client.get(u'/contribute.json/?xxx=\xc3')

--- a/kuma/wiki/views/legacy.py
+++ b/kuma/wiki/views/legacy.py
@@ -23,25 +23,27 @@ MINDTOUCH_NAMESPACES = (
 )
 
 
-def mindtouch_namespace_redirect(request, namespace, slug):
+def mindtouch_namespace_to_kuma_url(locale, namespace, slug):
     """
-    For URLs in special namespaces (like Talk:, User:, etc.), redirect
-    if possible to the appropriate new URL in the appropriate
-    locale. If the locale cannot be correctly determined, fall back to
-    en-US.
+    Convert MindTouch namespace URLs to Kuma URLs.
+
+    For special namespaces like Talk:, User:, etc., convert to the
+    approproate new URL, converting MT locales to Kuma locales.
+    If the locale cannot be correctly determined, fall back to en-US
     """
     new_locale = new_slug = None
     if namespace in ('Talk', 'Project', 'Project_talk'):
         # These namespaces carry the old locale in their URL, which
         # simplifies figuring out where to send them.
-        locale, _, doc_slug = slug.partition('/')
-        new_locale = settings.MT_TO_KUMA_LOCALE_MAP.get(locale, 'en-US')
+        mt_locale, _, doc_slug = slug.partition('/')
+        new_locale = settings.MT_TO_KUMA_LOCALE_MAP.get(mt_locale, 'en-US')
         new_slug = '%s:%s' % (namespace, doc_slug)
     elif namespace == 'User':
         # For users, we look up the latest revision and get the locale
         # from there.
         new_slug = '%s:%s' % (namespace, slug)
         try:
+            # TODO: Tests do not include a matching revision
             rev = (Revision.objects.filter(document__slug=new_slug)
                                    .latest('created'))
             new_locale = rev.document.locale
@@ -54,20 +56,23 @@ def mindtouch_namespace_redirect(request, namespace, slug):
         new_locale = 'en-US'
         new_slug = '%s:%s' % (namespace, slug)
     if new_locale:
-        new_url = '/%s/docs/%s' % (request.LANGUAGE_CODE, new_slug)
-    return redirect(new_url, permanent=True)
+        # TODO: new_locale is unused, no alternate branch
+        new_url = '/%s/docs/%s' % (locale, new_slug)
+    return new_url
 
 
-@shared_cache_control(s_maxage=60 * 60 * 24 * 30)
-def mindtouch_to_kuma_redirect(request, path):
+def mindtouch_to_kuma_url(locale, path):
     """
-    Given a request to a Mindtouch-generated URL, generate a redirect
-    to the correct corresponding kuma URL.
+    Convert valid MindTouch namespace URLs to Kuma URLs.
+
+    If there is an appropriate Kuma URL, then it is returned.
+    If there is no appropriate Kuma URL, then None is returned.
     """
     if path.startswith('Template:MindTouch'):
         # MindTouch's default templates. There shouldn't be links to
         # them anywhere in the wild, but just in case we 404 them.
-        raise Http404
+        # TODO: Tests don't exercise this branch
+        return None
 
     if path.endswith('/'):
         # If there's a trailing slash, snip it off.
@@ -77,18 +82,37 @@ def mindtouch_to_kuma_redirect(request, path):
         namespace, _, slug = path.partition(':')
         # The namespaces (Talk:, User:, etc.) get their own
         # special-case handling.
+        # TODO: Test invalid namespace
         if namespace in MINDTOUCH_NAMESPACES:
-            return mindtouch_namespace_redirect(request, namespace, slug)
+            return mindtouch_namespace_to_kuma_url(locale, namespace, slug)
 
     # Last attempt: we try the request locale as the document locale,
     # and see if that matches something.
     try:
-        doc = Document.objects.get(slug=path, locale=request.LANGUAGE_CODE)
+        doc = Document.objects.get(slug=path, locale=locale)
     except Document.DoesNotExist:
-        raise Http404
+        return None
 
     location = doc.get_absolute_url()
-    if 'view' in request.GET:
-        location = '%s$%s' % (location, request.GET['view'])
+    return location
 
-    return redirect(location, permanent=True)
+
+@shared_cache_control(s_maxage=60 * 60 * 24 * 30)
+def mindtouch_to_kuma_redirect(request, path):
+    """
+    Given a request to a Mindtouch-generated URL, generate a redirect
+    to the correct corresponding kuma URL.
+
+    TODO: Retire this catch-all view and Mindtouch redirects.
+    Safest: Ensure no current content includes these URLs, no incoming links.
+    Middle: Monitor 404s and their referrer headers, fix links after removal.
+    Fastest: Remove it, ignore 404s.
+    """
+    locale = request.LANGUAGE_CODE
+    url = mindtouch_to_kuma_url(locale, path)
+    if url:
+        if 'view' in request.GET:
+            url = '%s$%s' % (url, request.GET['view'])
+        return redirect(url, permanent=True)
+    else:
+        raise Http404


### PR DESCRIPTION
``is_valid_path`` always returns ``True``, because ``mindtouch_to_kuma_redirect`` is setup as a catch-all view that matches everything that didn't already match a pattern. In turn, ``mindtouch_to_kuma_redirect`` returns either 404s or permanent redirects.

The PR updates ``is_valid_path`` to detect that ``mindtouch_to_kuma_redirect`` was the resolved view, and then calls the refactored ``mindtouch_to_kuma_url`` to see if it would be a 404 or redirect. Since ``is_valid_path`` can now return ``False``, ``RemoveSlashMiddleware`` can actually remove slashes on URLs like ``/contribute.json/``.

There is a similar Django function ``is_valid_path`` that has the same issue detecting 404 URLs. We'll need this improved ``is_valid_path`` to use Django's locale redirect code.


