### PR TITLE
Upgrade polib to 1.1.0

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -260,9 +260,9 @@ newrelic==3.2.0.91 \
     --hash=sha256:2d1cf00e105f423c5c5fa9ce3f6179773683e6ee52fb64016441abd225b43bf3
 
 # Compile .po files into .mo files, used in locale/compile-mo.sh
-polib==1.0.7 \
-    --hash=sha256:d70a315cd5c6adfe7adcf9b541b023348c8b714587e5357886c7e990a91216f3 \
-    --hash=sha256:43ce60d05ffa442ba9d3c5722193aadb93c38174b9fb471c8ea7ccbf8349bbca
+polib==1.1.0 \
+    --hash=sha256:93b730477c16380c9a96726c54016822ff81acfa553977fdd131f2b90ba858d7 \
+    --hash=sha256:fad87d13696127ffb27ea0882d6182f1a9cf8a5e2b37a587751166c51e5a332a
 
 # String extraction and l10n tools
 puente==0.4.1 \


### PR DESCRIPTION
Address the following error seen when doing a pip install of the current requirements:

dennis 0.9 has requirement polib>=1.0.8, but you'll have polib 1.0.7 which is incompatible.