### PR TITLE
bug 1461350: Avoid runtime cache in tests

### DIFF
--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -32,6 +32,15 @@ LOGGING['loggers'].update({
     },
 })
 
+# Use the local memory cache in tests, so that test cacheback jobs
+# will expire at the end of the test.
+CACHEBACK_CACHE_ALIAS = 'default'
+
+# Change the cache key prefix for tests, to avoid overwriting runtime.
+for cache_settings in CACHES.values():
+    current_prefix = cache_settings.get('KEY_PREFIX', '')
+    cache_settings['KEY_PREFIX'] = 'test.' + current_prefix
+
 # Use un-versioned file names, like main.css, instead of versioned
 # filenames requiring hashing, like mdn.1cb62215bf0c.css
 STATICFILES_STORAGE = 'pipeline.storage.PipelineStorage'


### PR DESCRIPTION
Avoid interacting with the runtime cache in tests by using the local memory cache for django cacheback, and by changing the cache key prefix in tests.

On current master, the tests update cached values, such as the zone remaps list:

```
www-data@d02dc8105233:/app$ ./manage.py shell_plus
>>> from kuma.wiki.jobs import DocumentZoneURLRemapsJob
>>> print DocumentZoneURLRemapsJob().get('en-US')
[(u'/docs/Web/Apps', u'/Apps'), (u'/docs/Mozilla/Firefox', u'/Firefox'), (u'/docs/Mozilla/Add-ons', u'/Add-ons')]
>>> exit()
www-data@d02dc8105233:/app$ pytest kuma/wiki/tests/test_views_list.py
www-data@d02dc8105233:/app$ ./manage.py shell_plus
>>> from kuma.wiki.jobs import DocumentZoneURLRemapsJob
>>> print DocumentZoneURLRemapsJob().get('en-US')
[(u'/docs/top', u'/fleetwood-mac'), (u'/docs/top/middle-top', u'/spinners')]
>>>  DocumentZoneURLRemapsJob().invalidate('en-US') # Manual clean up
```

This can cause unexpected failures in the development environment when running headless functional tests after the unit tests.

Alternate solutions that I considered but rejected:
* Clear the memcache and redis queues before and after running functional tests
* Restart the memcache service (clearing it) before and after running functional tests
* Install a global pytest fixture that clears the cache before and after tests
* Add a fixture to each test that touches the cache to clear it (but every test that makes a request sets the zone remaps queue)

The ``CACHEBACK_CACHE_ALIAS`` change is sufficient to fix this particular issue, and the ``KEY_PREFIX`` change avoids unknown collisions on other cache items like rate limiting.