### PR TITLE
bug 1462479: Use non-permanent redirects for zones

### DIFF
--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import HttpResponsePermanentRedirect, HttpResponseRedirect
+from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 
@@ -72,7 +72,7 @@ class DocumentZoneMiddleware(object):
                 query = request.GET.copy()
                 new_path = urlparams(new_path, query_dict=query)
 
-                return HttpResponsePermanentRedirect(new_path)
+                return HttpResponseRedirect(new_path)
 
             elif path.startswith(new_path):
                 # Is this a request for the relocated wiki path? If so, rewrite

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -211,21 +211,21 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         url = '/docs/Firefox'
         response = self.client.get(url, follow=True)
         self.assertEqual(response.redirect_chain,
-                         [('http://testserver/en-US/Firefox', 301)])
+                         [('http://testserver/en-US/Firefox', 302)])
 
     def test_docs_zone_with_default_locale(self):
         # This url has a locale and a wiki path, and gets redirected to the
         # zoned url.
         url = '/en-US/docs/Firefox'
         response = self.client.get(url, follow=False)
-        self.assertRedirects(response, '/en-US/Firefox', status_code=301)
+        self.assertRedirects(response, '/en-US/Firefox', status_code=302)
 
     def test_docs_zone_with_non_default_locale(self):
         # This url has a non-default locale and a wiki path, and gets
         # redirected to the correct zoned url.
         url = '/fr/docs/Firefox'
         response = self.client.get(url, follow=False)
-        self.assertRedirects(response, '/fr/Firefox', status_code=301)
+        self.assertRedirects(response, '/fr/Firefox', status_code=302)
 
     def test_docs_zone_with_get_param_locale(self):
         # This url has no locale and a wiki path, and gets redirected first to
@@ -234,7 +234,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         response = self.client.get(url, {'lang': 'fr'}, follow=True)
         self.assertEqual(response.redirect_chain,
                          [('http://testserver/fr/docs/Firefox', 302),
-                          ('http://testserver/fr/Firefox', 301)])
+                          ('http://testserver/fr/Firefox', 302)])
 
     def test_zone_document_with_implied_default_locale(self):
         # This url has no locale and a wiki path, and gets redirected to the


### PR DESCRIPTION
As a first step to retiring zoned URLs, use a ``302 Found`` redirect rather than a ``301 Permanently Moved`` redirect, so that we can prepare browsers and search engines for the change.