### PR TITLE
bug 1461350: Simplify test client

### DIFF
--- a/docs/tests.rst
+++ b/docs/tests.rst
@@ -133,10 +133,6 @@ new functionality. All apps have a ``tests`` module where tests should go. They
 will be discovered automatically by the test runner as long as the look like a
 test.
 
-If you're expecting ``reverse`` to return locales in the URL
-(``/en-US/docs/Mozilla`` versus ``/docs/Mozilla``), use ``LocalizingClient``
-instead of the default client for the ``TestCase`` class.
-
 Changing tests
 ==============
 Unless the current behavior, and thus the test that verifies that behavior is

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -1,12 +1,10 @@
 import os
-from importlib import import_module
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.cache import cache
 from django.test import TestCase
-from django.test.client import Client
 from django.utils.translation import trans_real
 
 from ..cache import memcache
@@ -51,36 +49,10 @@ def get_user(username='testuser'):
     return User.objects.get(username=username)
 
 
-class SessionAwareClient(Client):
-    """
-    Just a small override to patch the session property to be able to
-    use the sessions.
-    """
-    @property
-    def session(self):
-        """
-        Obtains the current session variables.
-
-        Backported the else clause from Django 1.7 to make sure there
-        is a session available during tests.
-        """
-        assert 'django.contrib.sessions' in settings.INSTALLED_APPS
-        engine = import_module(settings.SESSION_ENGINE)
-        cookie = self.cookies.get(settings.SESSION_COOKIE_NAME, None)
-        if cookie:
-            return engine.SessionStore(cookie.value)
-        else:
-            session = engine.SessionStore()
-            session.save()
-            self.cookies[settings.SESSION_COOKIE_NAME] = session.session_key
-            return session
-
-
 JINJA_INSTRUMENTED = False
 
 
 class KumaTestMixin(object):
-    client_class = SessionAwareClient
     skipme = False
 
     def _pre_setup(self):

--- a/kuma/search/tests/__init__.py
+++ b/kuma/search/tests/__init__.py
@@ -6,18 +6,13 @@ from elasticsearch_dsl.connections import connections
 from rest_framework.test import APIRequestFactory
 
 from kuma.core.middleware import LocaleMiddleware
-from kuma.core.tests import LocalizingMixin
 from kuma.users.tests import UserTestCase
 from kuma.wiki.search import WikiDocumentType
 
 from ..models import Index
 
 
-class LocalizingAPIRequestFactory(LocalizingMixin, APIRequestFactory):
-    pass
-
-
-factory = LocalizingAPIRequestFactory()
+factory = APIRequestFactory()
 
 
 class ElasticTestCase(UserTestCase):

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -173,7 +173,6 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
 
 
 class KumaAccountAdapterTestCase(UserTestCase):
-    localizing_client = True
     rf = RequestFactory()
     message_template = 'socialaccount/messages/account_connected.txt'
 

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -23,7 +23,6 @@ from ..models import User, UserBan
 
 
 class SignupTests(UserTestCase, SocialTestMixin):
-    localizing_client = False
     profile_create_strings = (
         'Create your MDN profile to continue',
         'choose a username',
@@ -103,7 +102,6 @@ def test_account_email_page_multiple_emails(wiki_user, user_client):
 class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
     existing_email = 'testuser@test.com'
     existing_username = 'testuser'
-    localizing_client = False
 
     def test_auth_failure(self):
         """A failed GitHub auth shows the sign in failure page."""

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -57,7 +57,6 @@ def test_old_profile_url_gone(db, client):
 
 @pytest.mark.bans
 class BanTestCase(UserTestCase):
-    localizing_client = True
 
     def test_ban_permission(self):
         """The ban permission controls access to the ban view."""
@@ -212,7 +211,6 @@ class BanTestCase(UserTestCase):
 
 @pytest.mark.bans
 class BanAndCleanupTestCase(UserTestCase):
-    localizing_client = True
 
     def test_ban_permission(self):
         """The ban permission controls access to the ban and cleanup view."""
@@ -256,7 +254,6 @@ class BanAndCleanupTestCase(UserTestCase):
 
 @pytest.mark.bans
 class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
-    localizing_client = True
 
     def setUp(self):
         super(BanUserAndCleanupSummaryTestCase, self).setUp()
@@ -1100,7 +1097,6 @@ def test_404_already_logged_in(user_client):
 
 
 class KumaGitHubTests(UserTestCase, SocialTestMixin):
-    localizing_client = False
 
     def setUp(self):
         self.signup_url = reverse('socialaccount_signup',

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -496,7 +496,6 @@ def test_revision_template(root_doc, client):
 
 class NewDocumentTests(UserTestCase, WikiTestCase):
     """Tests for the New Document template"""
-    localizing_client = True
 
     def test_new_document_GET_with_perm(self):
         """HTTP GET to new document URL renders the form."""
@@ -634,7 +633,6 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
 
 class NewRevisionTests(UserTestCase, WikiTestCase):
     """Tests for the New Revision template"""
-    localizing_client = True
 
     def setUp(self):
         super(NewRevisionTests, self).setUp()
@@ -792,7 +790,6 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
 
 class DocumentEditTests(UserTestCase, WikiTestCase):
     """Test the editing of document level fields."""
-    localizing_client = True
 
     def setUp(self):
         super(DocumentEditTests, self).setUp()
@@ -1200,7 +1197,6 @@ def _test_form_maintains_based_on_rev(client, doc, view, post_data,
 
 class ArticlePreviewTests(UserTestCase, WikiTestCase):
     """Tests for preview view and template."""
-    localizing_client = True
 
     def setUp(self):
         super(ArticlePreviewTests, self).setUp()

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -39,7 +39,6 @@ from ..views.document import _get_seo_parent_title
 
 class RedirectTests(UserTestCase, WikiTestCase):
     """Tests for the REDIRECT wiki directive"""
-    localizing_client = True
 
     def test_redirect_suppression(self):
         """The document view shouldn't redirect when passed redirect=no."""
@@ -87,7 +86,6 @@ class RedirectTests(UserTestCase, WikiTestCase):
 
 class ViewTests(UserTestCase, WikiTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
-    localizing_client = True
 
     def test_json_view(self):
         """bug 875349"""
@@ -320,7 +318,6 @@ class ViewTests(UserTestCase, WikiTestCase):
 
 class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
     """Tests for conditional GET on document view"""
-    localizing_client = True
 
     def test_deleted_doc_returns_404(self):
         """Requesting a deleted doc returns 404"""
@@ -356,7 +353,6 @@ class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
 class ReadOnlyTests(UserTestCase, WikiTestCase):
     """Tests readonly scenarios"""
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
-    localizing_client = True
 
     def setUp(self):
         super(ReadOnlyTests, self).setUp()
@@ -401,7 +397,6 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
     Note that these tests really just check whether or not the service was
     used, and are not integration tests meant to exercise the real service.
     """
-    localizing_client = True
 
     def setUp(self):
         super(KumascriptIntegrationTests, self).setUp()
@@ -613,7 +608,6 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 
 class DocumentSEOTests(UserTestCase, WikiTestCase):
     """Tests for the document seo logic"""
-    localizing_client = True
 
     def test_get_seo_parent_doesnt_throw_404(self):
         """bug 1190212"""
@@ -717,7 +711,6 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
 
 class DocumentEditingTests(UserTestCase, WikiTestCase):
     """Tests for the document-editing view"""
-    localizing_client = True
 
     def test_editor_safety_filter(self):
         """Safety filter should be applied before rendering editor
@@ -826,8 +819,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # Move the document to new slug
         root_doc._move_tree(new_slug="moved_doc")
 
-        zoned_child_full_slug = zoned_doc.url_root + "/" + "children_document"
-        response = self.client.get(zoned_child_full_slug)
+        zoned_child_full_path = ('/en-US/' + zoned_doc.url_root + "/" +
+                                 "children_document")
+        response = self.client.get(zoned_child_full_path)
         assert response.status_code == 302
         assert 'public' not in response['Cache-Control']
         assert 'no-cache' in response['Cache-Control']
@@ -2313,7 +2307,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
 
 class SectionEditingResourceTests(UserTestCase, WikiTestCase):
-    localizing_client = True
 
     def test_raw_source(self):
         """The raw source for a document can be requested"""
@@ -2799,7 +2792,6 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
     # out from the ones the legacy MindTouch handling will emit, so
     # instead we just test that A) we did issue a redirect and B) the
     # URL we constructed is enough for the document views to go on.
-    localizing_client = True
 
     server_prefix = 'http://testserver/%s/docs' % settings.WIKI_DEFAULT_LANGUAGE
     namespace_urls = (
@@ -2860,7 +2852,6 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
 @override_config(KUMASCRIPT_TIMEOUT=5.0, KUMASCRIPT_MAX_AGE=600)
 class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
     """Tests for the deferred rendering system and interaction with views"""
-    localizing_client = True
 
     def setUp(self):
         super(DeferredRenderingViewTests, self).setUp()
@@ -2977,7 +2968,6 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
 
 
 class PageMoveTests(UserTestCase, WikiTestCase):
-    localizing_client = True
 
     def setUp(self):
         super(PageMoveTests, self).setUp()


### PR DESCRIPTION
With the ``LocaleMiddleware``, the default is to include the locale prefix in URLs, so the ``LocalizingMixin`` and ``LocalizingClient`` are no longer needed.

The ``SessionAwareClient`` included code from Django 1.7, and was probably added when MDN was on Django 1.4 or earlier, and is included in the default 1.8 test client:

https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/test/client.py#L411-L426
