### PR TITLE
bug 1461350: Remove extra reverse parameters

### DIFF
--- a/kuma/core/urlresolvers.py
+++ b/kuma/core/urlresolvers.py
@@ -49,8 +49,8 @@ def i18n_patterns(*args):
     return [LocaleRegexURLResolver(list(args))]
 
 
-def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
-            current_app=None, force_locale=False, locale=None, unprefixed=False):
+def reverse(viewname, urlconf=None, args=None, kwargs=None,
+            current_app=None, locale=None):
     """Wraps Django's reverse to prepend the requested locale.
     Keyword Arguments:
     * locale - Use this locale prefix rather than the current active locale.
@@ -60,10 +60,6 @@ def reverse(viewname, urlconf=None, args=None, kwargs=None, prefix=None,
     * args
     * kwargs
     * current_app
-    Legacy Keyword Arguments (TODO: remove from callers)
-    * prefix
-    * force_locale
-    * unprefixed
     """
     if locale:
         with translation.override(locale):

--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -220,6 +220,5 @@ class User(AbstractUser):
         uidb64 = urlsafe_base64_encode(force_bytes(self.pk))
         token = default_token_generator.make_token(self)
         link = reverse('users.recover',
-                       kwargs={'token': token, 'uidb64': uidb64},
-                       force_locale=True)
+                       kwargs={'token': token, 'uidb64': uidb64})
         return link

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -138,7 +138,7 @@ class SocialTestMixin(object):
         """
         login_url = reverse('github_login',
                             locale=settings.WIKI_DEFAULT_LANGUAGE)
-        callback_url = reverse('github_callback', unprefixed=True)
+        callback_url = reverse('github_callback')
 
         # Ensure GitHub is setup as an auth provider
         self.ensure_github_app()

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -992,8 +992,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         # section under "No actions taken"
         doc2_delete_url = reverse(
             'wiki.delete_document',
-            kwargs={'document_path': doc2.slug},
-            force_locale=True)
+            kwargs={'document_path': doc2.slug})
         doc2_delete_link = page.find('#already-spam a[href="{url}"]'.format(
             url=doc2_delete_url))
 
@@ -1034,8 +1033,7 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         delete_url = reverse(
             'wiki.delete_document',
-            kwargs={'document_path': self.document.slug},
-            force_locale=True)
+            kwargs={'document_path': self.document.slug})
         # TODO: PhaseV
         # delete_link_new_action_section = page.find('#new-actions-by-user a[href="{url}"]'.format(
         #     url=delete_url))
@@ -1093,12 +1091,10 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
 
         delete_url_already_spam = reverse(
             'wiki.delete_document',
-            kwargs={'document_path': doc1.slug},
-            force_locale=True)
+            kwargs={'document_path': doc1.slug})
         delete_url_reverted = reverse(
             'wiki.delete_document',
-            kwargs={'document_path': doc2.slug},
-            force_locale=True)
+            kwargs={'document_path': doc2.slug})
         # TODO: PhaseV
         # delete_url_new_action
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1756,20 +1756,6 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         )
 
         spam_message = render_to_string('wiki/includes/spam_error.html')
-        # The spam message is generated without a locale during this test, so we
-        # replace the url with a url with a locale
-        args = ['MDN/Contribute/Does_this_belong']
-        no_locale = reverse('wiki.document', args=args).encode('utf-8')
-        if translate_locale:
-            yes_locale = reverse(
-                'wiki.document', args=args, locale=translate_locale
-            ).encode('utf-8')
-        else:
-            yes_locale = reverse(
-                'wiki.document', args=args, force_locale=True
-            ).encode('utf-8')
-        spam_message = spam_message.replace(no_locale, yes_locale)
-        # Spam message appears in the JsonResponse content
         ok_(spam_message in json.loads(resp.content)['error_message'],
             "Spam message should appear")
 


### PR DESCRIPTION
Remove extra parameters from Kuma's reverse call:

* ``prefix`` - No one used this
* ``force_locale`` - Forced locale prefix in URL, now default
* ``unprefixed`` - Forced no locale prefix in URL, now default for non-prefixed URLs.

Some now-dead code in ``test_edit_spam_ajax`` that were using these parameters is also removed.