### PR TITLE
bug 1461350: Default to locale=en-US in tests

### DIFF
--- a/kuma/attachments/tests/test_templates.py
+++ b/kuma/attachments/tests/test_templates.py
@@ -17,8 +17,7 @@ def test_xss_file_attachment_title(admin_client, constance_config, root_doc,
     # use view to create new attachment
     file_for_upload = make_test_file()
     files_url = reverse('attachments.edit_attachment',
-                        kwargs={'document_path': root_doc.slug},
-                        locale='en-US')
+                        kwargs={'document_path': root_doc.slug})
     title = '"><img src=x onerror=prompt(navigator.userAgent);>'
     post_data = {
         'title': title,

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -29,8 +29,7 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
         self.revision = revision(save=True)
         self.document = self.revision.document
         self.files_url = reverse('attachments.edit_attachment',
-                                 kwargs={'document_path': self.document.slug},
-                                 locale='en-US')
+                                 kwargs={'document_path': self.document.slug})
 
     @transaction.atomic
     def _post_attachment(self):
@@ -135,8 +134,7 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
             'file': file_for_upload,
         }
         files_url = reverse('attachments.edit_attachment',
-                            kwargs={'document_path': doc.slug},
-                            locale='en-US')
+                            kwargs={'document_path': doc.slug})
         response = self.client.post(files_url, data=post_data)
         assert response.status_code == 302
         assert_no_cache_header(response)
@@ -167,8 +165,8 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
         revision.save()
         revision.make_current()
 
-        feed_url = reverse('attachments.feeds.recent_files', locale='en-US',
-                           args=(), kwargs={'format': 'json'})
+        feed_url = reverse('attachments.feeds.recent_files',
+                           kwargs={'format': 'json'})
         response = self.client.get(feed_url)
         assert_shared_cache_header(response)
         data = json.loads(response.content)
@@ -197,9 +195,7 @@ def test_legacy_redirect(client, file_attachment):
 def test_edit_attachment_get(admin_client, root_doc):
     url = reverse(
         'attachments.edit_attachment',
-        kwargs={'document_path': root_doc.slug},
-        locale='en-US'
-    )
+        kwargs={'document_path': root_doc.slug})
     response = admin_client.get(url)
     assert response.status_code == 302
     assert_no_cache_header(response)
@@ -224,8 +220,7 @@ def test_edit_attachment_post_with_vacant_file(admin_client, root_doc, tmpdir,
         expected = 'This field is required.'
 
     url = reverse('attachments.edit_attachment',
-                  kwargs={'document_path': root_doc.slug},
-                  locale='en-US')
+                  kwargs={'document_path': root_doc.slug})
     response = admin_client.post(url, data=post_data)
     assert response.status_code == 200
     doc = pq(response.content)

--- a/kuma/authkeys/tests/test_views.py
+++ b/kuma/authkeys/tests/test_views.py
@@ -54,7 +54,7 @@ class KeyViewsTest(RefetchingUserTestCase):
 
     def test_new_key(self):
         data = {"description": "This is meant for a test app"}
-        url = reverse('authkeys.new', locale='en-US')
+        url = reverse('authkeys.new')
 
         # Check out the creation page, look for the form.
         resp = self.client.get(url)
@@ -91,7 +91,7 @@ class KeyViewsTest(RefetchingUserTestCase):
 
     def test_list_key(self):
         """The current user's keys should be shown, but only that user's"""
-        url = reverse('authkeys.list', locale='en-US')
+        url = reverse('authkeys.list')
         resp = self.client.get(url)
         assert resp.status_code == 200
         assert_no_cache_header(resp)
@@ -118,8 +118,8 @@ class KeyViewsTest(RefetchingUserTestCase):
 
         # Iterate through 2 expected pages...
         for qs, offset in (('', 0), ('?page=2', ITEMS_PER_PAGE)):
-            url = '%s%s' % (reverse('authkeys.history', args=(self.key1.pk,),
-                                    locale='en-US'), qs)
+            url = '%s%s' % (reverse('authkeys.history', args=(self.key1.pk,)),
+                            qs)
             resp = self.client.get(url)
             assert resp.status_code == 200
             assert_no_cache_header(resp)
@@ -138,8 +138,7 @@ class KeyViewsTest(RefetchingUserTestCase):
 
     def test_delete_key(self):
         """User should be able to delete own keys, but no one else's"""
-        url = reverse('authkeys.delete', args=(self.key3.pk,),
-                      locale='en-US')
+        url = reverse('authkeys.delete', args=(self.key3.pk,))
         resp = self.client.get(url)
         assert resp.status_code == 403
         assert_no_cache_header(resp)
@@ -148,8 +147,7 @@ class KeyViewsTest(RefetchingUserTestCase):
         assert resp.status_code == 403
         assert_no_cache_header(resp)
 
-        url = reverse('authkeys.delete', args=(self.key1.pk,),
-                      locale='en-US')
+        url = reverse('authkeys.delete', args=(self.key1.pk,))
         resp = self.client.get(url)
         assert resp.status_code == 200
         assert_no_cache_header(resp)
@@ -176,7 +174,7 @@ class KeyViewsPermissionTest(RefetchingUserTestCase):
         self.client.login(username=username, password=password)
 
     def test_new_key_requires_permission(self):
-        url = reverse('authkeys.new', locale='en-US')
+        url = reverse('authkeys.new')
         resp = self.client.get(url)
         assert resp.status_code == 403
         assert_no_cache_header(resp)
@@ -193,7 +191,7 @@ class KeyViewsPermissionTest(RefetchingUserTestCase):
         self.key1 = Key(user=self.user, description='Test Key 1')
         self.key1.save()
 
-        url = reverse('authkeys.delete', locale='en-US', args=(self.key1.pk,))
+        url = reverse('authkeys.delete', args=(self.key1.pk,))
         resp = self.client.get(url)
         assert resp.status_code == 403
         assert_no_cache_header(resp)

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -4,9 +4,15 @@ import pytest
 import requests_mock
 from django.conf import settings
 from django.core.cache import caches
+from django.utils.translation import activate
 from waffle.models import Flag
 
 from kuma.wiki.models import Document, Revision
+
+
+@pytest.fixture(autouse=True)
+def set_default_language():
+    activate('en-US')
 
 
 @pytest.fixture()

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -219,7 +219,7 @@ def test_sitemaps_405s(client, db, method):
 
 def test_ratelimit_429(client, db):
     '''Custom 429 view is used for Ratelimited exception.'''
-    url = reverse('home', locale='en-US')
+    url = reverse('home')
     with mock.patch('kuma.landing.views.render') as render:
         render.side_effect = Ratelimited()
         response = client.get(url)

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -26,14 +26,14 @@ def test_home_when_rate_limited(mock_render, client, db):
     Cloudfront CDN's don't cache 429's, but let's test this anyway.
     """
     mock_render.side_effect = Ratelimited()
-    response = client.get(reverse('home', locale='en-US'))
+    response = client.get(reverse('home'))
     assert response.status_code == 429
     assert_no_cache_header(response)
 
 
 @pytest.mark.parametrize('mode', ['maintenance', 'normal'])
 def test_maintenance_mode(db, client, settings, mode):
-    url = reverse('maintenance_mode', locale='en-US')
+    url = reverse('maintenance_mode')
     settings.MAINTENANCE_MODE = (mode == 'maintenance')
     response = client.get(url)
     if settings.MAINTENANCE_MODE:

--- a/kuma/search/store.py
+++ b/kuma/search/store.py
@@ -34,7 +34,7 @@ def get_search_url_from_referer(request):
     if (referer is None or url is None or
             url.scheme != 'https' or
             url.netloc != current_site.domain or
-            reverse('search', locale=request.LANGUAGE_CODE) != url.path):
+            reverse('search') != url.path):
         return None
     return referer
 

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -210,7 +210,7 @@ class ViewTests(ElasticTestCase):
 
     def test_tokenize_camelcase_titles(self):
         for q in ('get', 'element', 'by', 'id'):
-            response = self.client.get('/en-US/search?q=' + q)
+            response = self.client.get('/en-US/search', {'q': q})
             assert response.status_code == 200
             assert 'camel-case-test' in response.content
 

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -86,8 +86,7 @@ class KumaAccountAdapter(DefaultAccountAdapter):
             # as it would be misleading
             # Bug 1229906#c2 - need from "create new account" page
             user_url = reverse('users.user_edit',
-                               kwargs={'username': request.user.username},
-                               locale=request.LANGUAGE_CODE)
+                               kwargs={'username': request.user.username})
             next_url = request.session.get('sociallogin_next_url', None)
             if next_url != user_url:
                 return
@@ -205,8 +204,7 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         """
         assert request.user.is_authenticated()
         user_url = reverse('users.user_edit',
-                           kwargs={'username': request.user.username},
-                           locale=request.LANGUAGE_CODE)
+                           kwargs={'username': request.user.username})
         return user_url
 
     def save_user(self, request, sociallogin, form):

--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -32,8 +32,7 @@ class KumaOAuth2LoginView(OAuth2LoginView):
 
     def dispatch(self, request):
         next_url = (get_next_redirect_url(request) or
-                    reverse('users.my_edit_page',
-                            locale=request.LANGUAGE_CODE))
+                    reverse('users.my_edit_page'))
         request.session['sociallogin_next_url'] = next_url
         request.session.modified = True
         return super(KumaOAuth2LoginView, self).dispatch(request)

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -2,7 +2,6 @@ import requests_mock
 from allauth.socialaccount.models import SocialApp
 from allauth.socialaccount.providers import registry
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.utils.crypto import get_random_string
 from django.utils.six.moves.urllib_parse import parse_qs, urlparse
@@ -136,8 +135,7 @@ class SocialTestMixin(object):
         email_data - GitHub email data, or None for default
         process - 'login', 'connect', or 'redirect'
         """
-        login_url = reverse('github_login',
-                            locale=settings.WIKI_DEFAULT_LANGUAGE)
+        login_url = reverse('github_login')
         callback_url = reverse('github_callback')
 
         # Ensure GitHub is setup as an auth provider

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -213,16 +213,14 @@ class KumaAccountAdapterTestCase(UserTestCase):
     def test_account_connected_message_user_edit(self):
         """Connection message appears if the profile edit is the next page."""
         next_url = reverse('users.user_edit',
-                           kwargs={'username': self.user.username},
-                           locale='en-US')
+                           kwargs={'username': self.user.username})
         messages = self.test_account_connected_message(next_url, True)
         assert messages[0].tags == 'account success'
 
     def test_extra_tags(self):
         """Extra tags can be added to the message."""
         next_url = reverse('users.user_edit',
-                           kwargs={'username': self.user.username},
-                           locale='en-US')
+                           kwargs={'username': self.user.username})
         messages = self.test_account_connected_message(next_url, True,
                                                        extra_tags='congrats')
         assert messages[0].tags == 'congrats account success'

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -127,8 +127,7 @@ class TestWelcomeEmails(UserTestCase):
         self.assertTrue('Confirm' in confirm_email.subject)
 
         # Click on a similar confirm link (HMAC has timestamp, changes)
-        link = reverse('account_confirm_email', locale='en-US',
-                       args=[confirmation.key])
+        link = reverse('account_confirm_email', args=[confirmation.key])
         resp = self.client.get(link)
         assert resp.status_code == 200
         assert_no_cache_header(resp)
@@ -157,8 +156,7 @@ class TestWelcomeEmails(UserTestCase):
         self.assertTrue('Confirm' in confirm_email2.subject)
 
         # Confirm the second email address
-        link2 = reverse('account_confirm_email', locale='en-US',
-                        args=[confirmation2.key])
+        link2 = reverse('account_confirm_email', args=[confirmation2.key])
         resp = self.client.get(link2)
         assert resp.status_code == 200
         assert_no_cache_header(resp)

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -66,7 +66,7 @@ class BanTestCase(UserTestCase):
         # testuser doesn't have ban permission, can't ban.
         self.client.login(username='testuser',
                           password='testpass')
-        ban_url = reverse('users.ban_user', locale='en-US',
+        ban_url = reverse('users.ban_user',
                           kwargs={'username': admin.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 302
@@ -77,7 +77,7 @@ class BanTestCase(UserTestCase):
         # admin has ban permission, can ban.
         self.client.login(username='admin',
                           password='testpass')
-        ban_url = reverse('users.ban_user', locale='en-US',
+        ban_url = reverse('users.ban_user',
                           kwargs={'username': testuser.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
@@ -133,7 +133,7 @@ class BanTestCase(UserTestCase):
 
         self.client.login(username='admin', password='testpass')
 
-        ban_url = reverse('users.ban_user', locale='en-US',
+        ban_url = reverse('users.ban_user',
                           kwargs={'username': testuser.username})
 
         # POST without data kwargs
@@ -160,7 +160,7 @@ class BanTestCase(UserTestCase):
     def test_bug_811751_banned_user(self):
         """A banned user should not be viewable"""
         testuser = self.user_model.objects.get(username='testuser')
-        url = reverse('users.user_detail', locale='en-US',
+        url = reverse('users.user_detail',
                       args=(testuser.username,))
 
         # User viewable if not banned
@@ -220,7 +220,7 @@ class BanAndCleanupTestCase(UserTestCase):
         # testuser doesn't have ban permission, can't ban.
         self.client.login(username='testuser',
                           password='testpass')
-        ban_url = reverse('users.ban_user_and_cleanup', locale='en-US',
+        ban_url = reverse('users.ban_user_and_cleanup',
                           kwargs={'username': admin.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 302
@@ -231,7 +231,7 @@ class BanAndCleanupTestCase(UserTestCase):
         # admin has ban permission, can ban.
         self.client.login(username='admin',
                           password='testpass')
-        ban_url = reverse('users.ban_user_and_cleanup', locale='en-US',
+        ban_url = reverse('users.ban_user_and_cleanup',
                           kwargs={'username': testuser.username})
         resp = self.client.get(ban_url)
         assert resp.status_code == 200
@@ -785,8 +785,7 @@ def test_user_detail_view(wiki_user, client):
     """A user can be viewed."""
     wiki_user.irc_nickname = 'wooki'
     wiki_user.save()
-    url = reverse('users.user_detail', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_detail', args=(wiki_user.username,))
     response = client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -801,7 +800,7 @@ def test_user_detail_view(wiki_user, client):
 
 
 def test_my_user_page(wiki_user, user_client):
-    resp = user_client.get(reverse('users.my_detail_page', locale='en-US'))
+    resp = user_client.get(reverse('users.my_detail_page'))
     assert resp.status_code == 302
     assert_no_cache_header(resp)
     assert resp['Location'].endswith(reverse('users.user_detail',
@@ -810,8 +809,7 @@ def test_my_user_page(wiki_user, user_client):
 
 def test_bug_698971(wiki_user, client):
     """A non-numeric page number should not raise an error."""
-    url = reverse('users.user_detail', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_detail', args=(wiki_user.username,))
 
     response = client.get(url, dict(page='asdf'))
     assert response.status_code == 200
@@ -819,16 +817,14 @@ def test_bug_698971(wiki_user, client):
 
 
 def test_user_edit(wiki_user, client, user_client):
-    url = reverse('users.user_detail', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_detail', args=(wiki_user.username,))
     response = client.get(url, follow=True)
     assert response.status_code == 200
     assert_no_cache_header(response)
     doc = pq(response.content)
     assert doc.find('#user-head .edit .button').length == 0
 
-    url = reverse('users.user_detail', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_detail', args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -878,7 +874,7 @@ def test_user_edit(wiki_user, client, user_client):
 
 
 def test_my_user_edit(wiki_user, user_client):
-    response = user_client.get(reverse('users.my_edit_page', locale='en-US'))
+    response = user_client.get(reverse('users.my_edit_page'))
     assert response.status_code == 302
     assert_no_cache_header(response)
     assert response['Location'].endswith(
@@ -887,8 +883,7 @@ def test_my_user_edit(wiki_user, user_client):
 
 def test_user_edit_beta(wiki_user, wiki_user_github_account,
                         beta_testers_group, user_client):
-    url = reverse('users.user_edit', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_edit', args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -911,8 +906,7 @@ def test_user_edit_beta(wiki_user, wiki_user_github_account,
 
 
 def test_user_edit_websites(wiki_user, wiki_user_github_account, user_client):
-    url = reverse('users.user_edit', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_edit', args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -976,8 +970,7 @@ def test_user_edit_websites(wiki_user, wiki_user_github_account, user_client):
 
 
 def test_user_edit_interests(wiki_user, wiki_user_github_account, user_client):
-    url = reverse('users.user_edit', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_edit', args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -1023,8 +1016,7 @@ def test_user_edit_interests(wiki_user, wiki_user_github_account, user_client):
 
 def test_bug_709938_interests(wiki_user, wiki_user_github_account,
                               user_client):
-    url = reverse('users.user_edit', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_edit', args=(wiki_user.username,))
     response = user_client.get(url)
     doc = pq(response.content)
 
@@ -1061,8 +1053,7 @@ def test_user_edit_github_is_public(wiki_user, wiki_user_github_account,
                                     user_client):
     """A user can set that they want their GitHub to be public."""
     assert not wiki_user.is_github_url_public
-    url = reverse('users.user_edit', locale='en-US',
-                  args=(wiki_user.username,))
+    url = reverse('users.user_edit', args=(wiki_user.username,))
     response = user_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -1099,8 +1090,7 @@ def test_404_already_logged_in(user_client):
 class KumaGitHubTests(UserTestCase, SocialTestMixin):
 
     def setUp(self):
-        self.signup_url = reverse('socialaccount_signup',
-                                  locale=settings.WIKI_DEFAULT_LANGUAGE)
+        self.signup_url = reverse('socialaccount_signup')
 
     def test_login(self):
         resp = self.github_login()
@@ -1332,8 +1322,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
 
 def test_missing_user_is_missing(db, client):
     assert not User.objects.filter(username='missing').exists()
-    url = reverse('users.user_delete', locale='en-US',
-                  kwargs={'username': 'missing'})
+    url = reverse('users.user_delete', kwargs={'username': 'missing'})
     response = client.get(url)
     assert response.status_code == 404
     assert_no_cache_header(response)
@@ -1347,8 +1336,7 @@ def test_user_can_delete(wiki_user, wiki_user_2, user_client, user_case):
     else:
         user = wiki_user
         expected_status = 200
-    url = reverse('users.user_delete', locale='en-US',
-                  kwargs={'username': user.username})
+    url = reverse('users.user_delete', kwargs={'username': user.username})
     response = user_client.get(url)
     assert response.status_code == expected_status
     assert_no_cache_header(response)
@@ -1359,7 +1347,7 @@ def test_user_can_delete(wiki_user, wiki_user_2, user_client, user_case):
     [('test@example.com', 302), ('not an email', 400)],
     ids=('good_email', 'bad_email'))
 def test_send_recovery_email(db, client, email, expected_status):
-    url = reverse('users.send_recovery_email', locale='en-US')
+    url = reverse('users.send_recovery_email')
     response = client.post(url, {'email': email})
     assert response.status_code == expected_status
     assert_no_cache_header(response)

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -110,9 +110,7 @@ def redirect_doc(wiki_user, root_doc):
         document=redirect_doc,
         creator=wiki_user,
         content=REDIRECT_CONTENT % {
-            'href': reverse('wiki.document',
-                            args=(root_doc.slug,),
-                            locale=root_doc.locale),
+            'href': reverse('wiki.document', args=(root_doc.slug,)),
             'title': root_doc.title,
         },
         title='Redirect Document',

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -167,7 +167,7 @@ def extract_description(feed_item):
 
 def test_recent_revisions(create_revision, edit_revision, client):
     """The revisions feed includes recent revisions."""
-    feed_url = reverse('wiki.feeds.recent_revisions', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_revisions',
                        kwargs={'format': 'rss'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -188,7 +188,7 @@ def test_recent_revisions(create_revision, edit_revision, client):
 
 def test_recent_revisions_pages(create_revision, edit_revision, client):
     """The revisions feed can be paginated."""
-    feed_url = reverse('wiki.feeds.recent_revisions', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_revisions',
                        kwargs={'format': 'rss'})
     resp = client.get(feed_url, {'limit': 1})
     assert resp.status_code == 200
@@ -219,7 +219,7 @@ def test_recent_revisions_limit_0(edit_revision, client):
     TODO: the limit should probably be MAX_FEED_ITEMS instead, and applied
     before the start and finish positions are picked.
     """
-    feed_url = reverse('wiki.feeds.recent_revisions', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_revisions',
                        kwargs={'format': 'rss'})
     resp = client.get(feed_url, {'limit': 0})
     assert resp.status_code == 200
@@ -231,8 +231,7 @@ def test_recent_revisions_limit_0(edit_revision, client):
 
 def test_recent_revisions_all_locales(trans_edit_revision, client):
     """The ?all_locales parameter returns mixed locales (bug 869301)."""
-    feed_url = reverse('wiki.feeds.recent_revisions', locale='en-US',
-                       kwargs={'format': 'rss'})
+    feed_url = reverse('wiki.feeds.recent_revisions', kwargs={'format': 'rss'})
     resp = client.get(feed_url, {'all_locales': ''},
                       HTTP_HOST='example.com',
                       HTTP_X_FORWARDED_PROTO='https')
@@ -269,8 +268,7 @@ def test_recent_revisions_diff_includes_tags(create_revision, client):
         tags='"NewTag"'
     )
     new_revision.review_tags.add('editorial')
-    feed_url = reverse('wiki.feeds.recent_revisions', locale='en-US',
-                       kwargs={'format': 'rss'})
+    feed_url = reverse('wiki.feeds.recent_revisions', kwargs={'format': 'rss'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
     assert_shared_cache_header(resp)
@@ -290,7 +288,7 @@ def test_recent_revisions_diff_includes_tags(create_revision, client):
 
 def test_recent_revisions_feed_ignores_render(edit_revision, client):
     """Re-rendering a document does not update the feed."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        args=(), kwargs={'format': 'rss'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -314,7 +312,7 @@ def test_recent_revisions_feed_ignores_render(edit_revision, client):
 
 def test_recent_revisions_feed_omits_docs_without_rev(edit_revision, client):
     """Documents without a current revision are omitted from the feed."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        args=(), kwargs={'format': 'rss'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -365,7 +363,7 @@ def test_recent_documents_feed_filter_by_locale(locale, trans_edit_revision,
 
 def test_recent_documents_atom_feed(root_doc, client):
     """The recent documents feed can be formatted as an Atom feed."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        kwargs={'format': 'atom'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -375,7 +373,7 @@ def test_recent_documents_atom_feed(root_doc, client):
 
 def test_recent_documents_as_jsonp(root_doc, client):
     """The recent documents feed can be called with a JSONP wrapper."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        kwargs={'format': 'json'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -397,7 +395,7 @@ def test_recent_documents_as_jsonp(root_doc, client):
 
 def test_recent_documents_optional_items(create_revision, client):
     """The recent documents JSON feed includes some items if set."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        kwargs={'format': 'json'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -425,7 +423,7 @@ def test_recent_documents_optional_items(create_revision, client):
 
 def test_recent_documents_feed_filter_by_tag(edit_revision, client):
     """The recent documents feed can be filtered by tag."""
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        kwargs={'format': 'json', 'tag': 'TheTag'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -481,7 +479,7 @@ def test_recent_documents_handles_ambiguous_time(root_doc, client):
         content='<p>Happy Daylight Savings Time!</p>',
         title=root_doc.title,
         created=ambiguous)
-    feed_url = reverse('wiki.feeds.recent_documents', locale='en-US',
+    feed_url = reverse('wiki.feeds.recent_documents',
                        kwargs={'format': 'json'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
@@ -492,8 +490,7 @@ def test_recent_documents_handles_ambiguous_time(root_doc, client):
 
 def test_list_review(edit_revision, client):
     """The documents needing review feed shows documents needing any review."""
-    feed_url = reverse('wiki.feeds.list_review', locale='en-US',
-                       kwargs={'format': 'json'})
+    feed_url = reverse('wiki.feeds.list_review', kwargs={'format': 'json'})
     resp = client.get(feed_url)
     assert resp.status_code == 200
     assert_shared_cache_header(resp)
@@ -509,7 +506,7 @@ def test_list_review(edit_revision, client):
 
 def test_list_review_tag(edit_revision, client):
     """The documents needing editorial review feed works."""
-    feed_url = reverse('wiki.feeds.list_review_tag', locale='en-US',
+    feed_url = reverse('wiki.feeds.list_review_tag',
                        kwargs={'format': 'json', 'tag': 'editorial'})
     resp = client.get(feed_url)
     assert resp.status_code == 200

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -474,7 +474,7 @@ class GoogleAnalyticsTests(UserTestCase, WikiTestCase):
 def test_revision_template(root_doc, client):
     """Verify the revision template."""
     rev = root_doc.current_revision
-    url = reverse('wiki.revision', args=[root_doc.slug, rev.id], locale=root_doc.locale)
+    url = reverse('wiki.revision', args=[root_doc.slug, rev.id])
     response = client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
@@ -684,7 +684,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
             'based_on': self.d.current_revision.id,
             'form-type': 'rev',
         }
-        edit_url = reverse('wiki.edit', locale='en-US', args=[self.d.slug])
+        edit_url = reverse('wiki.edit', args=[self.d.slug])
         response = self.client.post(edit_url, data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
@@ -742,8 +742,8 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         tags = ['tag1', 'tag2', 'tag3']
         data = new_document_data(tags)
         data['form-type'] = 'rev'
-        response = self.client.post(reverse('wiki.edit', locale='en-US',
-                                    args=[self.d.slug]), data)
+        response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
+                                    data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
         assert_no_cache_header(response)
@@ -767,8 +767,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         tags = [u'tag1', u'tag4']
         data = new_document_data(tags)
         data['form-type'] = 'rev'
-        response = self.client.post(reverse('wiki.edit', locale='en-US',
-                                            args=[self.d.slug]),
+        response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
@@ -802,8 +801,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         _create_document(title='Document Prueba', parent=self.d,
                          locale='es')
         # Make sure is_localizable hidden field is rendered
-        response = self.client.get(reverse('wiki.edit', locale='en-US',
-                                           args=[self.d.slug]))
+        response = self.client.get(reverse('wiki.edit', args=[self.d.slug]))
         assert response.status_code == 200
         assert response['X-Robots-Tag'] == 'noindex'
         assert_no_cache_header(response)
@@ -813,8 +811,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         data.update(title=new_title)
         data['form-type'] = 'doc'
         data.update(is_localizable='True')
-        response = self.client.post(reverse('wiki.edit', locale='en-US',
-                                            args=[self.d.slug]),
+        response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
@@ -827,8 +824,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         new_slug = 'Test-Document'
         data.update(slug=new_slug)
         data['form-type'] = 'doc'
-        response = self.client.post(reverse('wiki.edit', locale='en-US',
-                                            args=[self.d.slug]),
+        response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
@@ -841,8 +837,7 @@ class DocumentEditTests(UserTestCase, WikiTestCase):
         new_title = 'TeST DoCuMent'
         data.update(title=new_title)
         data['form-type'] = 'doc'
-        response = self.client.post(reverse('wiki.edit', locale='en-US',
-                                            args=[self.d.slug]),
+        response = self.client.post(reverse('wiki.edit', args=[self.d.slug]),
                                     data)
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
@@ -855,8 +850,8 @@ def test_compare_revisions(edit_revision, client):
     doc = edit_revision.document
     first_revision = doc.revisions.first()
     params = {'from': first_revision.id, 'to': edit_revision.id}
-    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug],
-                            locale=doc.locale), **params)
+    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug]),
+                    **params)
 
     response = client.get(url)
     assert response.status_code == 200
@@ -870,8 +865,7 @@ def test_compare_revisions(edit_revision, client):
     assert change_link.text() == 'Change Revisions'
     change_href = change_link.attr('href')
     bits = urlparse(change_href)
-    assert bits.path == reverse('wiki.document_revisions', args=[doc.slug],
-                                locale=doc.locale)
+    assert bits.path == reverse('wiki.document_revisions', args=[doc.slug])
     assert parse_qs(bits.query) == {'locale': [doc.locale],
                                     'origin': ['compare']}
 
@@ -879,15 +873,13 @@ def test_compare_revisions(edit_revision, client):
     assert rev_from_link.text() == 'Revision %d:' % first_revision.id
     from_href = rev_from_link.attr('href')
     assert from_href == reverse('wiki.revision',
-                                args=[doc.slug, first_revision.id],
-                                locale=doc.locale)
+                                args=[doc.slug, first_revision.id])
 
     rev_to_link = page('div.rev-to h3 a')
     assert rev_to_link.text() == 'Revision %d:' % edit_revision.id
     to_href = rev_to_link.attr('href')
     assert to_href == reverse('wiki.revision',
-                              args=[doc.slug, edit_revision.id],
-                              locale=doc.locale)
+                              args=[doc.slug, edit_revision.id])
 
 
 def test_compare_first_translation(trans_revision, client):
@@ -941,9 +933,7 @@ class TranslateTests(UserTestCase, WikiTestCase):
         self.client.login(username='admin', password='testpass')
 
     def _translate_uri(self):
-        translate_uri = reverse('wiki.translate',
-                                locale='en-US',
-                                args=[self.d.slug])
+        translate_uri = reverse('wiki.translate', args=[self.d.slug])
         return '%s?tolocale=%s' % (translate_uri, 'es')
 
     def test_translate_GET_logged_out(self):
@@ -953,7 +943,7 @@ class TranslateTests(UserTestCase, WikiTestCase):
         response = self.client.get(translate_uri)
         assert response.status_code == 302
         assert_no_cache_header(response)
-        expected_url = '%s?next=%s' % (reverse('account_login', locale='en-US'),
+        expected_url = '%s?next=%s' % (reverse('account_login'),
                                        urlquote(translate_uri))
         assert expected_url in response['Location']
 
@@ -1204,13 +1194,13 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
 
     def test_preview_GET_405(self):
         """Preview with HTTP GET results in 405."""
-        response = self.client.get(reverse('wiki.preview', locale='en-US'))
+        response = self.client.get(reverse('wiki.preview'))
         assert response.status_code == 405
         assert_no_cache_header(response)
 
     def test_preview(self):
         """Preview the wiki syntax content."""
-        response = self.client.post(reverse('wiki.preview', locale='en-US'),
+        response = self.client.post(reverse('wiki.preview'),
                                     {'content': '<h1>Test Content</h1>'})
         assert response.status_code == 200
         assert_no_cache_header(response)
@@ -1245,7 +1235,6 @@ class SelectLocaleTests(UserTestCase, WikiTestCase):
     def test_page_renders_locales(self):
         """Load the page and verify it contains all the locales for l10n."""
         response = self.client.get(reverse('wiki.select_locale',
-                                           locale='en-US',
                                            args=[self.d.slug]))
         assert response.status_code == 200
         assert_no_cache_header(response)

--- a/kuma/wiki/tests/test_views_akismet.py
+++ b/kuma/wiki/tests/test_views_akismet.py
@@ -50,7 +50,7 @@ def enable_akismet_submissions(constance_config):
     'http_method', ['get', 'put', 'delete', 'options', 'head'])
 def test_disallowed_methods(db, client, http_method):
     """HTTP methods other than POST are not allowed."""
-    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    url = reverse('wiki.submit_akismet_spam')
     response = getattr(client, http_method)(url)
     assert response.status_code == 405
     assert_no_cache_header(response)
@@ -60,7 +60,7 @@ def test_disallowed_methods(db, client, http_method):
 def test_spam_valid_response(create_revision, akismet_wiki_user, user_client,
                              enable_akismet_submissions,
                              akismet_mock_requests):
-    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    url = reverse('wiki.submit_akismet_spam')
     response = user_client.post(url, data={'revision': create_revision.id})
     assert response.status_code == 201
     assert_no_cache_header(response)
@@ -96,7 +96,7 @@ def test_spam_with_many_response(create_revision, akismet_wiki_user,
     assert ras.count() == 1
 
     # Create another Akismet revision via the endpoint.
-    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    url = reverse('wiki.submit_akismet_spam')
     response = user_client.post(url, data={'revision': create_revision.id})
     assert response.status_code == 201
     assert_no_cache_header(response)
@@ -115,7 +115,7 @@ def test_spam_with_many_response(create_revision, akismet_wiki_user,
 @pytest.mark.spam
 def test_spam_no_permission(create_revision, wiki_user, user_client,
                             enable_akismet_submissions, akismet_mock_requests):
-    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    url = reverse('wiki.submit_akismet_spam')
     response = user_client.post(url, data={'revision': create_revision.id})
     # Redirects to login page when without permission.
     assert response.status_code == 302
@@ -137,7 +137,7 @@ def test_spam_revision_does_not_exist(create_revision, akismet_wiki_user,
     revision_id = create_revision.id
     create_revision.delete()
 
-    url = reverse('wiki.submit_akismet_spam', locale='en-US')
+    url = reverse('wiki.submit_akismet_spam')
     response = user_client.post(url, data={'revision': revision_id})
     assert response.status_code == 400
     assert_no_cache_header(response)

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -30,7 +30,7 @@ def code_sample_doc(root_doc, wiki_user):
 def test_code_sample(code_sample_doc, constance_config, client, settings):
     """The raw source for a document can be requested."""
     Switch.objects.create(name='application_ACAO', active=True)
-    url = reverse('wiki.code_sample', locale='en-US',
+    url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
     constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*testserver'
     response = client.get(
@@ -62,7 +62,7 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
 def test_code_sample_host_restriction(code_sample_doc, constance_config,
                                       client):
     """Users are not allowed to view samples on a restricted domain."""
-    url = reverse('wiki.code_sample', locale='en-US',
+    url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
     constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*sampleserver'
     response = client.get(url, HTTP_HOST='testserver')
@@ -77,7 +77,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
                               wiki_user, admin_client):
 
     # Upload an attachment
-    upload_url = reverse('attachments.edit_attachment', locale='en-US',
+    upload_url = reverse('attachments.edit_attachment',
                          kwargs={'document_path': code_sample_doc.slug})
     file_for_upload = make_test_file(content='Something something unique')
     post_data = {
@@ -90,8 +90,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     constance_config.WIKI_ATTACHMENT_ALLOWED_TYPES = 'text/plain'
     response = admin_client.post(upload_url, data=post_data)
     assert response.status_code == 302
-    edit_url = reverse('wiki.edit', locale='en-US',
-                       args=(code_sample_doc.slug,))
+    edit_url = reverse('wiki.edit', args=(code_sample_doc.slug,))
     assert response.url == 'http://testserver' + edit_url
 
     # Add a relative reference to the sample content
@@ -108,7 +107,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     code_sample_doc.save()
 
     # URL is in the sample
-    sample_url = reverse('wiki.code_sample', locale='en-US',
+    sample_url = reverse('wiki.code_sample',
                          args=[code_sample_doc.slug, 'sample1'])
 
     response = admin_client.get(sample_url)
@@ -118,7 +117,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     assert 'max-age=86400' in response['Cache-Control']
 
     # Getting the URL redirects to the attachment
-    file_url = reverse('wiki.raw_code_sample_file', locale='en-US',
+    file_url = reverse('wiki.raw_code_sample_file',
                        args=(code_sample_doc.slug, 'sample1', attachment.id,
                              filename))
     response = admin_client.get(file_url)

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -62,13 +62,13 @@ def add_doc_client(editor_client, wiki_user, permission_add_document):
 
 
 def test_check_read_only_mode(user_client):
-    response = user_client.get(reverse('wiki.create', locale='en-US'))
+    response = user_client.get(reverse('wiki.create'))
     assert response.status_code == 403
     assert_no_cache_header(response)
 
 
 def test_user_add_document_permission(editor_client):
-    response = editor_client.get(reverse('wiki.create', locale='en-US'))
+    response = editor_client.get(reverse('wiki.create'))
     assert response.status_code == 403
     assert response['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(response)
@@ -76,7 +76,7 @@ def test_user_add_document_permission(editor_client):
 
 @pytest.mark.toc
 def test_get(add_doc_client):
-    response = add_doc_client.get(reverse('wiki.create', locale='en-US'))
+    response = add_doc_client.get(reverse('wiki.create'))
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(response)
@@ -91,8 +91,7 @@ def test_get(add_doc_client):
             assert opt_element.attr('value') == str(Revision.TOC_DEPTH_H4)
     assert found_selected, 'No ToC depth initially selected.'
     # Check discard button.
-    assert (page.find('.btn-discard').attr('href') ==
-            reverse('wiki.create', locale='en-US'))
+    assert (page.find('.btn-discard').attr('href') == reverse('wiki.create'))
 
 
 @pytest.mark.tags
@@ -111,14 +110,13 @@ def test_create_valid(add_doc_client):
         comment='This is foobar.',
         toc_depth=1,
     )
-    url = reverse('wiki.create', locale='en-US')
+    url = reverse('wiki.create')
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 302
     assert resp['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(resp)
-    assert resp['Location'].endswith(
-        reverse('wiki.document', locale='en-US', args=(slug,)))
-    doc = Document.objects.get(slug=slug, locale='en-US')
+    assert resp['Location'].endswith(reverse('wiki.document', args=(slug,)))
+    doc = Document.objects.get(slug=slug)
     for name in (set(data.keys()) - set(('tags', 'review_tags'))):
         assert getattr(doc.current_revision, name) == data[name]
     assert (sorted(doc.tags.all().values_list('name', flat=True)) ==
@@ -147,7 +145,7 @@ def test_create_invalid(add_doc_client, slug):
         comment='This is foobar.',
         toc_depth=1,
     )
-    url = reverse('wiki.create', locale='en-US')
+    url = reverse('wiki.create')
     resp = add_doc_client.post(url, data)
     assert resp.status_code == 200
     assert resp['X-Robots-Tag'] == 'noindex'
@@ -174,7 +172,7 @@ def test_create_child_valid(root_doc, add_doc_client, slug):
         comment='This is foobar.',
         toc_depth=1,
     )
-    url = reverse('wiki.create', locale='en-US')
+    url = reverse('wiki.create')
     url += '?parent={}'.format(root_doc.id)
     full_slug = '{}/{}'.format(root_doc.slug, slug)
     resp = add_doc_client.post(url, data)
@@ -182,7 +180,7 @@ def test_create_child_valid(root_doc, add_doc_client, slug):
     assert resp['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(resp)
     assert resp['Location'].endswith(
-        reverse('wiki.document', locale='en-US', args=(full_slug,)))
+        reverse('wiki.document', args=(full_slug,)))
     assert root_doc.children.count() == 1
     doc = Document.objects.get(slug=full_slug, locale='en-US')
     skip_keys = set(('tags', 'review_tags', 'parent_topic'))
@@ -215,7 +213,7 @@ def test_create_child_invalid(root_doc, add_doc_client, slug):
         comment='This is foobar.',
         toc_depth=1,
     )
-    url = reverse('wiki.create', locale='en-US')
+    url = reverse('wiki.create')
     url += '?parent={}'.format(root_doc.id)
     full_slug = '{}/{}'.format(root_doc.slug, slug)
     resp = add_doc_client.post(url, data)
@@ -230,7 +228,7 @@ def test_create_child_invalid(root_doc, add_doc_client, slug):
 
 
 def test_clone_get(root_doc, add_doc_client):
-    url = reverse('wiki.create', locale='en-US')
+    url = reverse('wiki.create')
     url += '?clone={}'.format(root_doc.id)
     response = add_doc_client.get(url)
     assert response.status_code == 200

--- a/kuma/wiki/tests/test_views_delete.py
+++ b/kuma/wiki/tests/test_views_delete.py
@@ -24,7 +24,7 @@ def test_login(root_doc, client, endpoint):
     args = [root_doc.slug]
     if endpoint == 'revert_document':
         args.append(root_doc.current_revision.id)
-    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    url = reverse('wiki.{}'.format(endpoint), args=args)
     response = client.get(url)
     assert response.status_code == 302
     assert 'en-US/users/signin?' in response['Location']
@@ -41,7 +41,7 @@ def test_permission(root_doc, editor_client, endpoint):
     args = [root_doc.slug]
     if endpoint == 'revert_document':
         args.append(root_doc.current_revision.id)
-    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    url = reverse('wiki.{}'.format(endpoint), args=args)
     response = editor_client.get(url)
     assert response.status_code == 403
     assert_no_cache_header(response)
@@ -53,14 +53,14 @@ def test_read_only_mode(root_doc, user_client, endpoint):
     args = [root_doc.slug]
     if endpoint == 'revert_document':
         args.append(root_doc.current_revision.id)
-    url = reverse('wiki.{}'.format(endpoint), locale='en-US', args=args)
+    url = reverse('wiki.{}'.format(endpoint), args=args)
     response = user_client.get(url)
     assert response.status_code == 403
     assert_no_cache_header(response)
 
 
 def test_delete_get(root_doc, delete_client):
-    url = reverse('wiki.delete_document', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.delete_document', args=[root_doc.slug])
     response = delete_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -70,7 +70,7 @@ def test_delete_get(root_doc, delete_client):
                           ' (see bugzilla 1197390).')
 def test_purge_get(root_doc, delete_client):
     root_doc.delete()
-    url = reverse('wiki.purge_document', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.purge_document', args=[root_doc.slug])
     response = delete_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
@@ -80,8 +80,7 @@ def test_restore_get(root_doc, delete_client):
     root_doc.delete()
     with pytest.raises(Document.DoesNotExist):
         Document.objects.get(slug=root_doc.slug, locale=root_doc.locale)
-    url = reverse('wiki.restore_document', locale='en-US',
-                  args=[root_doc.slug])
+    url = reverse('wiki.restore_document', args=[root_doc.slug])
     response = delete_client.get(url)
     assert response.status_code == 302
     assert response['Location'].endswith(root_doc.get_absolute_url())
@@ -90,7 +89,7 @@ def test_restore_get(root_doc, delete_client):
 
 
 def test_revert_get(root_doc, delete_client):
-    url = reverse('wiki.revert_document', locale='en-US',
+    url = reverse('wiki.revert_document',
                   args=[root_doc.slug, root_doc.current_revision.id])
     response = delete_client.get(url)
     assert response.status_code == 200
@@ -98,7 +97,7 @@ def test_revert_get(root_doc, delete_client):
 
 
 def test_delete_post(root_doc, delete_client):
-    url = reverse('wiki.delete_document', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.delete_document', args=[root_doc.slug])
     response = delete_client.post(url, data=dict(reason='test'))
     assert response.status_code == 302
     assert response['Location'].endswith(root_doc.get_absolute_url())
@@ -114,7 +113,7 @@ def test_delete_post(root_doc, delete_client):
 
 def test_purge_post(root_doc, delete_client):
     root_doc.delete()
-    url = reverse('wiki.purge_document', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.purge_document', args=[root_doc.slug])
     response = delete_client.post(url, data=dict(confirm='true'))
     assert response.status_code == 302
     assert response['Location'].endswith(root_doc.get_absolute_url())
@@ -127,7 +126,7 @@ def test_revert_post(edit_revision, delete_client):
     root_doc = edit_revision.document
     assert len(root_doc.revisions.all()) == 2
     first_revision = root_doc.revisions.first()
-    url = reverse('wiki.revert_document', locale='en-US',
+    url = reverse('wiki.revert_document',
                   args=[root_doc.slug, first_revision.id])
     response = delete_client.post(url, data=dict(comment='test'))
     assert response.status_code == 302

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -7,7 +7,7 @@ from kuma.core.urlresolvers import reverse
 
 
 def test_edit_get(editor_client, root_doc):
-    url = reverse('wiki.edit', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.edit', args=[root_doc.slug])
     response = editor_client.get(url)
     assert response.status_code == 200
     assert response['X-Robots-Tag'] == 'noindex'
@@ -19,7 +19,7 @@ def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
                                     cleared_cacheback_cache):
     ip = '127.0.0.1'
     IPBan.objects.create(ip=ip)
-    url = reverse('wiki.edit', locale='en-US', args=[root_doc.slug])
+    url = reverse('wiki.edit', args=[root_doc.slug])
     caller = getattr(editor_client, method.lower())
     response = caller(url, REMOTE_ADDR=ip)
     assert response.status_code == 403

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -20,7 +20,7 @@ def test_disallowed_methods(db, client, http_method, endpoint):
     kwargs = None
     if endpoint in ('tag', 'list_review_tag', 'list_with_localization_tag'):
         kwargs = dict(tag='tag')
-    url = reverse('wiki.{}'.format(endpoint), locale='en-US', kwargs=kwargs)
+    url = reverse('wiki.{}'.format(endpoint), kwargs=kwargs)
     resp = getattr(client, http_method)(url)
     assert resp.status_code == 405
     assert_shared_cache_header(resp)
@@ -28,8 +28,7 @@ def test_disallowed_methods(db, client, http_method, endpoint):
 
 def test_revisions(root_doc, client):
     """$history of English doc works."""
-    url = reverse('wiki.document_revisions', args=(root_doc.slug,),
-                  locale=root_doc.locale)
+    url = reverse('wiki.document_revisions', args=(root_doc.slug,))
     resp = client.get(url)
     assert resp.status_code == 200
     assert_shared_cache_header(resp)
@@ -75,8 +74,7 @@ def test_revisions_of_translated_doc_with_no_based_on(trans_revision, client):
 
 def test_revisions_bad_slug_is_not_found(db, client):
     """$history of unknown page returns 404."""
-    url = reverse('wiki.document_revisions', args=('not_found',),
-                  locale='en-US')
+    url = reverse('wiki.document_revisions', args=('not_found',))
     resp = client.get(url)
     assert resp.status_code == 404
 
@@ -84,16 +82,14 @@ def test_revisions_bad_slug_is_not_found(db, client):
 def test_revisions_doc_without_revisions_is_not_found(db, client):
     """$history of half-created document returns 404."""
     doc = Document.objects.create(locale='en-US', slug='half_created')
-    url = reverse('wiki.document_revisions', args=(doc.slug,),
-                  locale=doc.locale)
+    url = reverse('wiki.document_revisions', args=(doc.slug,))
     resp = client.get(url)
     assert resp.status_code == 404
 
 
 def test_revisions_all_params_as_anon_user_is_forbidden(root_doc, client):
     """Anonymous users are forbidden to request all revisions."""
-    url = reverse('wiki.document_revisions', args=(root_doc.slug,),
-                  locale=root_doc.locale)
+    url = reverse('wiki.document_revisions', args=(root_doc.slug,))
     all_url = urlparams(url, limit='all')
     resp = client.get(all_url)
     assert resp.status_code == 403
@@ -102,8 +98,7 @@ def test_revisions_all_params_as_anon_user_is_forbidden(root_doc, client):
 
 def test_revisions_all_params_as_user_is_allowed(root_doc, wiki_user, client):
     """Users are allowed to request all revisions."""
-    url = reverse('wiki.document_revisions', args=(root_doc.slug,),
-                  locale=root_doc.locale)
+    url = reverse('wiki.document_revisions', args=(root_doc.slug,))
     all_url = urlparams(url, limit='all')
     wiki_user.set_password('password')
     wiki_user.save()
@@ -116,8 +111,7 @@ def test_revisions_request_tiny_pages(edit_revision, client):
     """$history will paginate the revisions."""
     doc = edit_revision.document
     assert doc.revisions.count() > 1
-    url = reverse('wiki.document_revisions', args=(doc.slug,),
-                  locale=doc.locale)
+    url = reverse('wiki.document_revisions', args=(doc.slug,))
     limit_url = urlparams(url, limit=1)
     resp = client.get(limit_url)
     assert resp.status_code == 200
@@ -128,8 +122,7 @@ def test_revisions_request_tiny_pages(edit_revision, client):
 def test_revisions_request_large_pages(root_doc, client):
     """$history?limit=(more than revisions) works, removes pagination."""
     rev_count = root_doc.revisions.count()
-    url = reverse('wiki.document_revisions', args=(root_doc.slug,),
-                  locale=root_doc.locale)
+    url = reverse('wiki.document_revisions', args=(root_doc.slug,))
     limit_url = urlparams(url, limit=rev_count + 1)
     resp = client.get(limit_url)
     assert resp.status_code == 200
@@ -139,15 +132,14 @@ def test_revisions_request_large_pages(root_doc, client):
 
 def test_revisions_request_invalid_pages(root_doc, client):
     """$history?limit=nonsense uses the default pagination."""
-    url = reverse('wiki.document_revisions', args=(root_doc.slug,),
-                  locale=root_doc.locale)
+    url = reverse('wiki.document_revisions', args=(root_doc.slug,))
     limit_url = urlparams(url, limit='nonsense')
     resp = client.get(limit_url)
     assert resp.status_code == 200
 
 
 def test_list_no_redirects(redirect_doc, doc_hierarchy_with_zones, client):
-    url = reverse('wiki.all_documents', locale='en-US')
+    url = reverse('wiki.all_documents')
     resp = client.get(url)
     assert resp.status_code == 200
     assert_shared_cache_header(resp)
@@ -162,7 +154,7 @@ def test_list_no_redirects(redirect_doc, doc_hierarchy_with_zones, client):
 def test_tags(root_doc, client):
     """Test list of all tags."""
     root_doc.tags.set('foobar', 'blast')
-    url = reverse('wiki.list_tags', locale=root_doc.locale)
+    url = reverse('wiki.list_tags')
     resp = client.get(url)
     assert resp.status_code == 200
     assert 'foobar' in resp.content

--- a/kuma/wiki/tests/test_views_misc.py
+++ b/kuma/wiki/tests/test_views_misc.py
@@ -14,14 +14,14 @@ from kuma.core.urlresolvers import reverse
     'endpoint', ['ckeditor_config', 'autosuggest_documents'])
 def test_disallowed_methods(db, client, http_method, endpoint):
     """HTTP methods other than GET & HEAD are not allowed."""
-    url = reverse('wiki.{}'.format(endpoint), locale='en-US')
+    url = reverse('wiki.{}'.format(endpoint))
     response = getattr(client, http_method)(url)
     assert response.status_code == 405
     assert_shared_cache_header(response)
 
 
 def test_ckeditor_config(db, client):
-    response = client.get(reverse('wiki.ckeditor_config', locale='en-US'))
+    response = client.get(reverse('wiki.ckeditor_config'))
     assert response.status_code == 200
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'application/x-javascript'
@@ -62,7 +62,7 @@ def test_autosuggest(client, redirect_doc, doc_hierarchy_with_zones,
                                'Middle-Top Document', 'Middle-Bottom Document',
                                'Bottom Document'))
 
-    url = reverse('wiki.autosuggest_documents', locale='en-US')
+    url = reverse('wiki.autosuggest_documents')
     if params:
         url += '?{}'.format(urlencode(params))
     response = client.get(url)

--- a/kuma/wiki/tests/test_views_revision.py
+++ b/kuma/wiki/tests/test_views_revision.py
@@ -17,8 +17,8 @@ def test_compare_revisions(edit_revision, client, raw):
     params = {'from': first_revision.id, 'to': edit_revision.id}
     if raw:
         params['raw'] = '1'
-    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug],
-                            locale=doc.locale), **params)
+    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug]),
+                    **params)
 
     response = client.get(url)
     assert response.status_code == 200
@@ -58,8 +58,8 @@ def test_compare_revisions_without_tidied_content(edit_revision, client, raw):
     params = {'from': first_revision.id, 'to': edit_revision.id}
     if raw:
         params['raw'] = '1'
-    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug],
-                            locale=doc.locale), **params)
+    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug]),
+                    **params)
 
     response = client.get(url)
     assert response.status_code == 200
@@ -73,8 +73,7 @@ def test_compare_revisions_without_tidied_content(edit_revision, client, raw):
                           ])
 def test_compare_revisions_invalid_ids(root_doc, client, id1, id2):
     """Comparing badly-formed revision parameters return 404, not error."""
-    url = urlparams(reverse('wiki.compare_revisions', args=[root_doc.slug],
-                            locale=root_doc.locale),
+    url = urlparams(reverse('wiki.compare_revisions', args=[root_doc.slug]),
                     **{'from': id1, 'to': id2})
     response = client.get(url)
     assert response.status_code == 404
@@ -84,8 +83,7 @@ def test_compare_revisions_invalid_ids(root_doc, client, id1, id2):
 def test_compare_revisions_only_one_param(create_revision, client, param):
     """If a compare query parameter is missing, a 404 is returned."""
     doc = create_revision.document
-    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug],
-                            locale=doc.locale),
+    url = urlparams(reverse('wiki.compare_revisions', args=[doc.slug]),
                     **{param: create_revision.id})
     response = client.get(url)
     assert response.status_code == 404
@@ -97,8 +95,7 @@ def test_compare_revisions_wrong_document(edit_revision, client):
     first_revision = doc.revisions.first()
     other_doc = Document.objects.create(locale='en-US', slug='Other',
                                         title='Other Document')
-    url = urlparams(reverse('wiki.compare_revisions', args=[other_doc.slug],
-                            locale=other_doc.locale),
+    url = urlparams(reverse('wiki.compare_revisions', args=[other_doc.slug]),
                     **{'from': first_revision.id, 'to': edit_revision.id})
     response = client.get(url)
     assert response.status_code == 404

--- a/kuma/wiki/tests/test_views_translate.py
+++ b/kuma/wiki/tests/test_views_translate.py
@@ -22,8 +22,7 @@ def trans_doc_client(editor_client, wiki_user, permission_change_document):
 def test_translate_get(root_doc, trans_doc_client):
     """Test GET on the translate view."""
 
-    url = reverse(
-        'wiki.translate', args=(root_doc.slug,), locale=root_doc.locale)
+    url = reverse('wiki.translate', args=(root_doc.slug,))
     url += '?tolocale=fr'
 
     response = trans_doc_client.get(url)
@@ -45,8 +44,7 @@ def test_translate_post(root_doc, trans_doc_client):
         'toc_depth': 1
     }
 
-    url = reverse(
-        'wiki.translate', args=(root_doc.slug,), locale=root_doc.locale)
+    url = reverse('wiki.translate', args=(root_doc.slug,))
     url += '?tolocale=fr'
 
     response = trans_doc_client.post(url, data)


### PR DESCRIPTION
When using Kuma's ``reverse``, don't pass ``locale="en-US"`` (common in tests to avoid a redirect) or ``locale=request.LANGUAGE_CODE`` (used in app code to avoid a redirect), but instead rely on the default behavior of including the active language.
    
Continue passing the locale parameter for non-default locales, or if the test makes a request that sets the active language (usually by making a request to a non-default locale).
    
The active language is reset to en-US at the start of each test with an always-run fixture ``set_default_language``.