### PR TITLE
bug 1301116, 1401246: Dockerfile updates for Django update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ KUMASCRIPT_IMAGE_NAME ?= kumascript
 REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= mozmar
 BASE_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:${VERSION}
+BASE_IMAGE_1_9 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.9
+BASE_IMAGE_1_10 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.10
+BASE_IMAGE_1_11 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.11
 BASE_IMAGE_LATEST ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:latest
 IMAGE ?= $(BASE_IMAGE_LATEST)
 KUMA_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${KUMA_IMAGE_NAME}\:${VERSION}
@@ -101,6 +104,15 @@ pull-latest: pull-base-latest pull-kuma-latest
 
 build-base:
 	docker build -f docker/images/kuma_base/Dockerfile -t ${BASE_IMAGE} .
+
+build-base-1.9:
+	docker build -f docker/images/kuma_base/Dockerfile-1.9 -t ${BASE_IMAGE_1_9} .
+
+build-base-1.10:
+	docker build -f docker/images/kuma_base/Dockerfile-1.10 -t ${BASE_IMAGE_1_10} .
+
+build-base-1.11:
+	docker build -f docker/images/kuma_base/Dockerfile-1.11 -t ${BASE_IMAGE_1_11} .
 
 build-kuma:
 	docker build --build-arg REVISION_HASH=${KUMA_REVISION_HASH} \

--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -95,9 +95,6 @@ RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home kuma
 WORKDIR /app
 EXPOSE 8000
 
-# bug 1301116
-RUN pip install setuptools==26.1.1
-
 RUN npm install -g \
         fibers@1.0.15 \
         csslint@0.10.0 \

--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -113,6 +113,10 @@ ENV PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
 COPY ./requirements /app/requirements
 RUN pip install --no-cache-dir -r requirements/dev.txt
 
+# Import issue with configparser 3.5.0
+# https://bitbucket.org/ambv/configparser/issues/20/importwarning-missing-__init__py
+RUN touch /usr/local/lib/python2.7/site-packages/backports/__init__.py
+
 USER kuma
 
 ENV WEB_CONCURRENCY=4

--- a/docker/images/kuma_base/Dockerfile-1.10
+++ b/docker/images/kuma_base/Dockerfile-1.10
@@ -1,0 +1,6 @@
+FROM quay.io/mozmar/kuma_base:latest
+
+USER root
+RUN pip install "Django>1.10,<1.11"
+ENV PYTHONWARNINGS=all
+USER kuma

--- a/docker/images/kuma_base/Dockerfile-1.11
+++ b/docker/images/kuma_base/Dockerfile-1.11
@@ -1,0 +1,6 @@
+FROM quay.io/mozmar/kuma_base:latest
+
+USER root
+RUN pip install "Django>1.11,<1.12"
+ENV PYTHONWARNINGS=all
+USER kuma

--- a/docker/images/kuma_base/Dockerfile-1.9
+++ b/docker/images/kuma_base/Dockerfile-1.9
@@ -1,0 +1,6 @@
+FROM quay.io/mozmar/kuma_base:latest
+
+USER root
+RUN pip install "Django>1.9,<1.10"
+ENV PYTHONWARNINGS=all
+USER kuma


### PR DESCRIPTION
[bug 1301116](https://bugzilla.mozilla.org/show_bug.cgi?id=1301116) was about an issue running ``./manage.py extract`` with the Ubuntu image. Now that we're on a Python image and two years have passed, it appears it is no longer needed.

There's a gross warning about ``/usr/local/lib/python2.7/site-packages/backports/__init__.py`` that is caused by configparser 3.5.0 (see https://bitbucket.org/ambv/configparser/issues/20/importwarning-missing-__init__py and https://bitbucket.org/brandon/backports/issues/5/missing-__init__py). Until it is fixed, it is easy enough to avoid it by touching that file.

I'm often creating a Docker image with Django 1.9 and 1.11 in it, by changing the Django version in ``requirements/default.txt``, and running ``VERSION=django-1.9 make build-base``. I'm adding a nicer version here, so that you can make it with ``make build-base-1.9``, etc. You can then create environments for testing with Django versions, such as https://gist.github.com/jwhitlock/a643cf804746be7d23baba5b16d8fa53. 

I think these alternate Dockerfiles will be useful for the upgrade effort, and then should be deleted. Or, maybe replaced with one for Python 3, Django 2.0, etc.