### PR TITLE
bug 1401246: upgrade django-babel and puente

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -265,9 +265,12 @@ polib==1.1.0 \
     --hash=sha256:fad87d13696127ffb27ea0882d6182f1a9cf8a5e2b37a587751166c51e5a332a
 
 # String extraction and l10n tools
-puente==0.4.1 \
-    --hash=sha256:bc5ee85521127577d23430832e2f827686efdb7ce95b232f54fbeb5b9166397c \
-    --hash=sha256:84f769c0ea607829c77bd8b3d6d6fbc16589cd7a5d4e5023f717cd3d5de54473
+# Code: https://github.com/mozilla/puente
+# Changes: https://github.com/mozilla/puente/blob/master/HISTORY.rst
+# Docs: https://puente.readthedocs.io/en/latest/
+puente==0.5.0 \
+    --hash=sha256:7ba1d07f9cee9657adf874bd94879b343fea81a783fdfa8e53885520477bf1ea \
+    --hash=sha256:4a17958f7d6a83cb9ff92593c40f34911abafaec6ad959916b754aaa3869f11f
 
 # Translate environment variables into native Python types
 python-decouple==3.0 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,9 +2,12 @@
 -r default.txt
 
 # Extract messages from Django templates
-django-babel==0.4.0 \
---hash=sha256:0cf070be3fc0d8628b008da697aa5c0f89bd62c8dd9238283d5bcdbce70bbec6 \
---hash=sha256:b328dae0e594031d7b0ffded51fd6df60677d4509aee3677013a3a2f76da4e70
+# Code: https://github.com/python-babel/django-babel
+# Docs: http://django-babel.readthedocs.io/en/latest/
+# Changes: https://github.com/python-babel/django-babel/blob/master/CHANGELOG.rst
+django-babel==0.6.2 \
+    --hash=sha256:b62084a6f0cbf2e7af719bd129abfe54608a52645c0677aff5a728f586873af7 \
+    --hash=sha256:1e621b198e1f98ae4f93e43463cf78cbedbace475eb6e0853ba1e2567f3b8119
 
 # Analyze Django performance during request
 django-debug-toolbar==1.8 \


### PR DESCRIPTION
Upgrade `puente` and `django-babel` to the latest versions (0.5.0 and 0.6.2, respectively). This has been tested locally such that `docker-compose exec web ./manage.py extract` works all of the way to Django 1.11 (ensure the `django.pot` and `javascript.pot` files remain unchanged).