### PR TITLE
[Bug 1401246] Fixing select_related to select only foreignkey fields

### DIFF
--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -241,16 +241,18 @@ def _get_doc_and_fallback_reason(document_locale, document_slug):
     doc = None
     fallback_reason = None
 
+    # Optimizing the queryset to fetch the required values only
+    related_fields = ['current_revision', 'current_revision__creator',
+                      'parent', 'parent__current_revision', 'parent__topic']
     current_revision_fields = ['current_revision__{}'.format(field) for field in
                                ('toc_depth', 'created', 'creator__id', 'creator__username', 'creator__is_active')]
     parent_fields = ['parent__{}'.format(field) for field in ('locale', 'slug', 'current_revision__slug')]
     parent_topic_fields = ['parent_topic__{}'.format(field) for field in ('id', 'title', 'slug')]
 
-    related_fields = current_revision_fields + parent_fields + parent_topic_fields
-
-    fields = ['html', 'rendered_html', 'zone_subnav_local_html', 'body_html',
-              'locale', 'slug', 'title', 'is_localizable', 'rendered_errors',
-              'toc_html', 'summary_html', 'summary_text', 'quick_links_html'] + related_fields
+    fields = (['html', 'rendered_html', 'zone_subnav_local_html', 'body_html',
+               'locale', 'slug', 'title', 'is_localizable', 'rendered_errors',
+               'toc_html', 'summary_html', 'summary_text', 'quick_links_html']
+              + current_revision_fields + parent_fields + parent_topic_fields)
 
     try:
         doc = (Document.objects.only(*fields).select_related(*related_fields)

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -243,16 +243,17 @@ def _get_doc_and_fallback_reason(document_locale, document_slug):
 
     # Optimizing the queryset to fetch the required values only
     related_fields = ['current_revision', 'current_revision__creator',
-                      'parent', 'parent__current_revision', 'parent__topic']
+                      'parent', 'parent__current_revision', 'parent_topic']
     current_revision_fields = ['current_revision__{}'.format(field) for field in
                                ('toc_depth', 'created', 'creator__id', 'creator__username', 'creator__is_active')]
     parent_fields = ['parent__{}'.format(field) for field in ('locale', 'slug', 'current_revision__slug')]
     parent_topic_fields = ['parent_topic__{}'.format(field) for field in ('id', 'title', 'slug')]
 
-    fields = (['html', 'rendered_html', 'zone_subnav_local_html', 'body_html',
-               'locale', 'slug', 'title', 'is_localizable', 'rendered_errors',
-               'toc_html', 'summary_html', 'summary_text', 'quick_links_html']
-              + current_revision_fields + parent_fields + parent_topic_fields)
+    document_fields = ['html', 'rendered_html', 'zone_subnav_local_html', 'body_html',
+                       'locale', 'slug', 'title', 'is_localizable', 'rendered_errors',
+                       'toc_html', 'summary_html', 'summary_text', 'quick_links_html']
+
+    fields = document_fields + current_revision_fields + parent_fields + parent_topic_fields
 
     try:
         doc = (Document.objects.only(*fields).select_related(*related_fields)

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -161,7 +161,7 @@ def revisions(request, document_slug, document_locale):
                  .only('id', 'locale', 'slug', 'title',
                        'current_revision_id',
                        'parent__slug', 'parent__locale')
-                 .select_related('parent__slug', 'parent__locale')
+                 .select_related('parent')
                  .exclude(current_revision__isnull=True)
                  .filter(locale=locale, slug=document_slug))
     document = get_object_or_404(doc_query)
@@ -210,10 +210,7 @@ def revisions(request, document_slug, document_locale):
                           .only('id', 'slug', 'created', 'comment',
                                 'document__slug', 'document__locale',
                                 'creator__username', 'creator__is_active')
-                          .select_related('document__slug',
-                                          'document__locale',
-                                          'creator__is_active',
-                                          'creator__username')
+                          .select_related('document', 'creator')
                           .filter(id__in=selected_revision_ids))
     revisions = {rev.id: rev for rev in selected_revisions}
 


### PR DESCRIPTION
Fixing all the `select_related` queryset to get compataibility with django 1.9+.
It seems to be a bug in django code that let selecting non related fields by `select_related` as it was fetching the whole object instead of the fields only.

The actual use case would be using `only` for limiting fetch fields instead of full object. In all of our use case, it seems that we are covered with `only`.

@jwhitlock @escattone r?