### PR TITLE
bug 1401246: prepare spam tests for Django 1.9+

### DIFF
--- a/kuma/spam/tests/conftest.py
+++ b/kuma/spam/tests/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from waffle.models import Flag
+
+from ..constants import SPAM_CHECKS_FLAG
+
+
+@pytest.fixture
+def spam_check_everyone(db):
+    Flag.objects.update_or_create(
+        name=SPAM_CHECKS_FLAG,
+        defaults={'everyone': True}
+    )

--- a/kuma/spam/tests/test_akismet.py
+++ b/kuma/spam/tests/test_akismet.py
@@ -1,174 +1,167 @@
 import mock
 import pytest
 import requests
-import requests_mock
-from constance.test import override_config
-from django.test import SimpleTestCase
-from waffle.models import Flag
 
 from ..akismet import Akismet, AkismetError
-from ..constants import (CHECK_URL, HAM_URL, SPAM_CHECKS_FLAG,
-                         SPAM_URL, VERIFY_URL)
+from ..constants import CHECK_URL, HAM_URL, SPAM_URL, VERIFY_URL
 
 
-@pytest.mark.spam
-@override_config(AKISMET_KEY='api-key')
-class AkismetClientTests(SimpleTestCase):
+def test_verify_empty_key(spam_check_everyone, constance_config):
+    constance_config.AKISMET_KEY = ''
+    client = Akismet()
+    assert not client.ready
+    assert client.key == ''
 
-    def setUp(self):
-        super(AkismetClientTests, self).setUp()
-        Flag.objects.update_or_create(
-            name=SPAM_CHECKS_FLAG,
-            defaults={'everyone': True},
-        )
 
-    def tearDown(self):
-        super(AkismetClientTests, self).tearDown()
-        Flag.objects.update_or_create(
-            name=SPAM_CHECKS_FLAG,
-            defaults={'everyone': None},
-        )
+def test_verify_valid_key(spam_check_everyone, constance_config,
+                          mock_requests):
+    constance_config.AKISMET_KEY = 'api-key'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    assert not mock_requests.called
+    assert client.ready
+    assert mock_requests.call_count == 1
+    assert client.key == 'api-key'
 
-    @override_config(AKISMET_KEY='')
-    def test_verify_empty_key(self):
-        client = Akismet()
-        self.assertFalse(client.ready)
-        self.assertEqual(client.key, '')
 
-    @requests_mock.mock()
-    def test_verify_valid_key(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        self.assertFalse(mock_requests.called)
-        self.assertTrue(client.ready)
-        self.assertEqual(mock_requests.call_count, 1)
-        self.assertEqual(client.key, 'api-key')
+def test_verify_invalid_key(spam_check_everyone, constance_config,
+                            mock_requests):
+    constance_config.AKISMET_KEY = 'api-key'
+    mock_requests.post(VERIFY_URL, content='invalid')
+    client = Akismet()
+    assert not mock_requests.called
+    assert not client.ready
+    assert mock_requests.call_count == 1
+    assert client.key == 'api-key'
 
-    @requests_mock.mock()
-    def test_verify_invalid_key(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='invalid')
-        client = Akismet()
-        self.assertFalse(mock_requests.called)
-        self.assertFalse(client.ready)
-        self.assertEqual(mock_requests.call_count, 1)
-        self.assertEqual(client.key, 'api-key')
 
-    @requests_mock.mock()
-    def test_verify_invalid_key_wrong_response(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='fail')
-        client = Akismet()
-        self.assertFalse(client.ready)
-        self.assertEqual(client.key, 'api-key')
-        self.assertFalse(client.verify_key())
-        self.assertEqual(mock_requests.call_count, 2)
+def test_verify_invalid_key_wrong_response(spam_check_everyone,
+                                           constance_config, mock_requests):
+    constance_config.AKISMET_KEY = 'api-key'
+    mock_requests.post(VERIFY_URL, content='fail')
+    client = Akismet()
+    assert not client.ready
+    assert client.key == 'api-key'
+    assert not client.verify_key()
+    assert mock_requests.call_count == 2
 
-    @requests_mock.mock()
-    @mock.patch('newrelic.agent.record_exception')
-    def test_exception_recording(self, mock_requests, mock_record_exception):
-        from requests.exceptions import HTTPError
 
-        exception = HTTPError('Nobody expects the Spanish inquisition')
-        mock_requests.post(VERIFY_URL, exc=exception)
-        client = Akismet()
-        self.assertFalse(client.ready)
-        self.assertTrue(mock_record_exception.called)
+@mock.patch('newrelic.agent.record_exception')
+def test_exception_recording(mock_record_exception, spam_check_everyone,
+                             constance_config, mock_requests):
+    from requests.exceptions import HTTPError
 
-    @override_config(AKISMET_KEY='comment')
-    @requests_mock.mock()
-    def test_exception_attributes(self, mock_requests):
-        mock_requests.post(
-            VERIFY_URL,
-            content='uh uh',
-            headers={'X-Akismet-Debug-Help': 'err0r!'},
-        )
+    constance_config.AKISMET_KEY = 'api-key'
+    exception = HTTPError('Nobody expects the Spanish inquisition')
+    mock_requests.post(VERIFY_URL, exc=exception)
+    client = Akismet()
+    assert not client.ready
+    assert mock_record_exception.called
 
-        client = Akismet()
-        assert not client.verify_key()
 
-    @override_config(AKISMET_KEY='comment')
-    @requests_mock.mock()
-    def test_check_comment_ham(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        self.assertTrue(client.ready)
+def test_exception_attributes(spam_check_everyone, constance_config,
+                              mock_requests):
+    constance_config.AKISMET_KEY = 'comment'
+    mock_requests.post(
+        VERIFY_URL,
+        content='uh uh',
+        headers={'X-Akismet-Debug-Help': 'err0r!'},
+    )
 
-        mock_requests.post(CHECK_URL, content='true')
-        valid = client.check_comment('0.0.0.0', 'Mozilla',
-                                     comment_content='yada yada')
-        self.assertTrue(valid)
-        request_body = mock_requests.request_history[1].body
-        self.assertIn('user_ip=0.0.0.0', request_body)
-        self.assertIn('user_agent=Mozilla', request_body)
-        self.assertIn('comment_content=yada+yada', request_body)
+    client = Akismet()
+    assert not client.verify_key()
 
-    @override_config(AKISMET_KEY='comment')
-    @requests_mock.mock()
-    def test_check_comment_spam(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        mock_requests.post(CHECK_URL, content='false')
-        client = Akismet()
-        valid = client.check_comment('0.0.0.0', 'Mozilla',
-                                     comment_content='yada yada')
-        self.assertFalse(valid)
 
-    @override_config(AKISMET_KEY='comment')
-    @requests_mock.mock()
-    def test_check_comment_wrong_response(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        mock_requests.post(CHECK_URL, content='wat', status_code=202)
-        with pytest.raises(AkismetError) as excinfo:
-            client.check_comment('0.0.0.0', 'Mozilla',
+def test_check_comment_ham(spam_check_everyone, constance_config,
+                           mock_requests):
+    constance_config.AKISMET_KEY = 'comment'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    assert client.ready
+
+    mock_requests.post(CHECK_URL, content='true')
+    valid = client.check_comment('0.0.0.0', 'Mozilla',
                                  comment_content='yada yada')
-        exc = excinfo.value
-        assert exc.status_code == 202
-        assert exc.debug_help == 'Not provided'
-        assert isinstance(exc.response, requests.Response)
+    assert valid
+    request_body = mock_requests.request_history[1].body
+    assert 'user_ip=0.0.0.0' in request_body
+    assert 'user_agent=Mozilla' in request_body
+    assert 'comment_content=yada+yada' in request_body
 
-    @override_config(AKISMET_KEY='spam')
-    @requests_mock.mock()
-    def test_submit_spam_success(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        mock_requests.post(SPAM_URL, content=client.submission_success)
-        result = client.submit_spam('0.0.0.0', 'Mozilla',
-                                    comment_content='spam. spam spam. spam.')
-        self.assertIsNone(result)
 
-    @override_config(AKISMET_KEY='spam')
-    @requests_mock.mock()
-    def test_submit_spam_failure(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        mock_requests.post(SPAM_URL, content='something completely different')
-        try:
-            client.submit_spam('0.0.0.0', 'Mozilla',
-                               comment_content='spam. eggs.')
-        except AkismetError as exc:
-            self.assertEqual(exc.status_code, 200)
-            self.assertEqual(exc.debug_help, 'Not provided')
-            self.assertIsInstance(exc.response, requests.Response)
+def test_check_comment_spam(spam_check_everyone, constance_config,
+                            mock_requests):
+    constance_config.AKISMET_KEY = 'comment'
+    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(CHECK_URL, content='false')
+    client = Akismet()
+    valid = client.check_comment('0.0.0.0', 'Mozilla',
+                                 comment_content='yada yada')
+    assert not valid
 
-    @override_config(AKISMET_KEY='spam')
-    @requests_mock.mock()
-    def test_submit_ham_success(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        mock_requests.post(HAM_URL, content=client.submission_success)
-        result = client.submit_ham('0.0.0.0', 'Mozilla',
-                                   comment_content='ham and bacon and pork.')
-        self.assertIsNone(result)
 
-    @override_config(AKISMET_KEY='spam')
-    @requests_mock.mock()
-    def test_submit_ham_failure(self, mock_requests):
-        mock_requests.post(VERIFY_URL, content='valid')
-        client = Akismet()
-        mock_requests.post(HAM_URL, content='something completely different')
-        try:
-            client.submit_ham('0.0.0.0', 'Mozilla',
-                              comment_content='eggs with ham. ham with eggs.')
-        except AkismetError as exc:
-            self.assertEqual(exc.status_code, 200)
-            self.assertEqual(exc.debug_help, 'Not provided')
-            self.assertIsInstance(exc.response, requests.Response)
+def test_check_comment_wrong_response(spam_check_everyone, constance_config,
+                                      mock_requests):
+    constance_config.AKISMET_KEY = 'comment'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    mock_requests.post(CHECK_URL, content='wat', status_code=202)
+    with pytest.raises(AkismetError) as excinfo:
+        client.check_comment('0.0.0.0', 'Mozilla',
+                             comment_content='yada yada')
+    exc = excinfo.value
+    assert exc.status_code == 202
+    assert exc.debug_help == 'Not provided'
+    assert isinstance(exc.response, requests.Response)
+
+
+def test_submit_spam_success(spam_check_everyone, constance_config,
+                             mock_requests):
+    constance_config.AKISMET_KEY = 'spam'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    mock_requests.post(SPAM_URL, content=client.submission_success)
+    result = client.submit_spam('0.0.0.0', 'Mozilla',
+                                comment_content='spam. spam spam. spam.')
+    assert result is None
+
+
+def test_submit_spam_failure(spam_check_everyone, constance_config,
+                             mock_requests):
+    constance_config.AKISMET_KEY = 'spam'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    mock_requests.post(SPAM_URL, content='something completely different')
+    with pytest.raises(AkismetError) as excinfo:
+        client.submit_spam('0.0.0.0', 'Mozilla',
+                           comment_content='spam. eggs.')
+    exc = excinfo.value
+    assert exc.status_code == 200
+    assert exc.debug_help == 'Not provided'
+    assert isinstance(exc.response, requests.Response)
+
+
+def test_submit_ham_success(spam_check_everyone, constance_config,
+                            mock_requests):
+    constance_config.AKISMET_KEY = 'spam'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    mock_requests.post(HAM_URL, content=client.submission_success)
+    result = client.submit_ham('0.0.0.0', 'Mozilla',
+                               comment_content='ham and bacon and pork.')
+    assert result is None
+
+
+def test_submit_ham_failure(spam_check_everyone, constance_config,
+                            mock_requests):
+    constance_config.AKISMET_KEY = 'spam'
+    mock_requests.post(VERIFY_URL, content='valid')
+    client = Akismet()
+    mock_requests.post(HAM_URL, content='something completely different')
+    with pytest.raises(AkismetError) as excinfo:
+        client.submit_ham('0.0.0.0', 'Mozilla',
+                          comment_content='eggs with ham. ham with eggs.')
+    exc = excinfo.value
+    assert exc.status_code == 200
+    assert exc.debug_help == 'Not provided'
+    assert isinstance(exc.response, requests.Response)

--- a/kuma/spam/tests/test_forms.py
+++ b/kuma/spam/tests/test_forms.py
@@ -1,8 +1,7 @@
 import pytest
 from django import forms
-from waffle.models import Flag
 
-from ..constants import CHECK_URL, SPAM_CHECKS_FLAG, VERIFY_URL
+from ..constants import CHECK_URL, VERIFY_URL
 from ..forms import AkismetCheckFormMixin
 
 
@@ -33,7 +32,7 @@ class AkismetContentTestForm(AkismetCheckTestForm):
 
 
 @pytest.fixture
-def spam_request(rf, db):
+def spam_request(spam_check_everyone, rf):
     """Create a spammy request and setup for spam checking."""
     request = rf.get(
         '/',
@@ -41,7 +40,6 @@ def spam_request(rf, db):
         HTTP_USER_AGENT='Mozilla Firefox',
         HTTP_REFERER='https://www.netscape.com/'
     )
-    Flag.objects.filter(name=SPAM_CHECKS_FLAG).update(everyone=True)
     return request
 
 


### PR DESCRIPTION
This PR prepares the tests under ~~`kuma/spam/tests/test_akismet.py::AkismetClientTests`~~ `kuma/spam/tests` for Django 1.9. It seems Django 1.9, with its new `allow_database_queries` class-level `SimpleTestCase` attribute, is better at detecting the DB writes from `constance.test.override_config`. The tests within `kuma/spam/tests/test_akismet.py::AkismetClientTests` should have sub-classed `django.test.TestCase` rather than `django.test.SimpleTestCase` all along.