### PR TITLE
bug 1401246: Use relative URIs for redirects in Django 1.9 and later

### DIFF
--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.core.cache import cache
 from django.test import TestCase
+from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
 from django.utils.translation import trans_real
 
 from ..cache import memcache
@@ -21,6 +22,31 @@ def assert_no_cache_header(response):
 def assert_shared_cache_header(response):
     assert 'public' in response['Cache-Control']
     assert 's-maxage' in response['Cache-Control']
+
+
+def assert_relative_uri(uri, expected_uri):
+    """
+    Assert that a URIs absolute portion matches.
+
+    Keyword Arguments:
+    uri - a URI like 'http://testserver/rel/path?foo=1'
+    relative_uri - The relative portion, like '/rel/path?foo=1'
+
+    This is a helper assertion for the transition to Django 1.9.
+    In Django 1.8 and earlier, redirects use RFC 2616 full URIs.
+    In Django 1.9 and later, redirects use RFC 7231 relative URIs.
+    After the transition to Django 1.11, these assertions can be
+    replaced with simple equality assertions.
+
+    See "HTTP redirects no longer forced to absolute URIs" in:
+    https://docs.djangoproject.com/en/2.0/releases/1.9/
+    """
+    if settings.DJANGO_1_9:
+        assert uri == expected_uri
+    else:
+        parts = urlsplit(uri)
+        relative_uri = urlunsplit(('', '') + parts[2:])
+        assert relative_uri == expected_uri
 
 
 def eq_(first, second, msg=None):

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -24,29 +24,32 @@ def assert_shared_cache_header(response):
     assert 's-maxage' in response['Cache-Control']
 
 
-def assert_relative_uri(uri, expected_uri):
+def assert_relative_reference(uri, expected_reference):
     """
-    Assert that a URIs absolute portion matches.
+    Assert that the relative reference of a URI matches.
 
     Keyword Arguments:
     uri - a URI like 'http://testserver/rel/path?foo=1'
-    relative_uri - The relative portion, like '/rel/path?foo=1'
+    expected_reference - The relative portion, like '/rel/path?foo=1'
 
     This is a helper assertion for the transition to Django 1.9.
     In Django 1.8 and earlier, redirects use RFC 2616 full URIs.
-    In Django 1.9 and later, redirects use RFC 7231 relative URIs.
+    In Django 1.9 and later, redirects use RFC 7231 relative references.
     After the transition to Django 1.11, these assertions can be
     replaced with simple equality assertions.
 
     See "HTTP redirects no longer forced to absolute URIs" in:
     https://docs.djangoproject.com/en/2.0/releases/1.9/
+
+    "Relative Reference" is defined in RFC 3986 Section 4.2:
+    https://tools.ietf.org/html/rfc3986#section-4.2
     """
     if settings.DJANGO_1_9:
-        assert uri == expected_uri
+        assert uri == expected_reference
     else:
         parts = urlsplit(uri)
         relative_uri = urlunsplit(('', '') + parts[2:])
-        assert relative_uri == expected_uri
+        assert relative_uri == expected_reference
 
 
 def eq_(first, second, msg=None):

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -1,7 +1,7 @@
 import pytest
 from django.conf import settings
 
-from . import assert_shared_cache_header
+from . import assert_relative_uri, assert_shared_cache_header
 
 
 # Simple Accept-Language headers, one term
@@ -46,7 +46,7 @@ def test_locale_middleware_picker(accept_language, locale, client, db):
     response = client.get('/', HTTP_ACCEPT_LANGUAGE=accept_language)
     assert response.status_code == 302
     url_locale = locale or 'en-US'
-    assert response['Location'] == 'http://testserver/%s/' % url_locale
+    assert_relative_uri(response['Location'], '/%s/' % url_locale)
     assert_shared_cache_header(response)
 
 
@@ -55,7 +55,7 @@ def test_locale_middleware_fixer(original, fixed, client, db):
     '''The LocaleMiddleware redirects for non-standard locale URLs.'''
     response = client.get('/%s/' % original)
     assert response.status_code == 302
-    assert response['Location'] == 'http://testserver/%s/' % fixed
+    assert_relative_uri(response['Location'], '/%s/' % fixed)
     assert_shared_cache_header(response)
 
 
@@ -70,7 +70,7 @@ def test_locale_middleware_language_cookie(client, db):
     client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
     response = client.get('/', HTTP_ACCEPT_LANGUAGE='fr')
     assert response.status_code == 302
-    assert response['Location'] == 'http://testserver/bn-BD/'
+    assert_relative_uri(response['Location'], '/bn-BD/')
     assert_shared_cache_header(response)
 
 
@@ -81,7 +81,7 @@ def test_locale_middleware_lang_query_param(path, client):
     response = client.get('%s?lang=fr' % path,
                           HTTP_ACCEPT_LANGUAGE='en;q=0.9, fr;q=0.8')
     assert response.status_code == 302
-    assert response['Location'] == 'http://testserver/fr/'
+    assert_relative_uri(response['Location'], '/fr/')
     assert_shared_cache_header(response)
 
 
@@ -89,7 +89,7 @@ def test_locale_middleware_no_change(client, db):
     '''The LocaleMiddleware redirects on the same ?lang query.'''
     response = client.get('/fr/?lang=fr')
     assert response.status_code == 302
-    assert response['Location'] == 'http://testserver/fr/'
+    assert_relative_uri(response['Location'], '/fr/')
     assert_shared_cache_header(response)
 
 

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -1,7 +1,7 @@
 import pytest
 from django.conf import settings
 
-from . import assert_relative_uri, assert_shared_cache_header
+from . import assert_relative_reference, assert_shared_cache_header
 
 
 # Simple Accept-Language headers, one term
@@ -46,7 +46,7 @@ def test_locale_middleware_picker(accept_language, locale, client, db):
     response = client.get('/', HTTP_ACCEPT_LANGUAGE=accept_language)
     assert response.status_code == 302
     url_locale = locale or 'en-US'
-    assert_relative_uri(response['Location'], '/%s/' % url_locale)
+    assert_relative_reference(response['Location'], '/%s/' % url_locale)
     assert_shared_cache_header(response)
 
 
@@ -55,7 +55,7 @@ def test_locale_middleware_fixer(original, fixed, client, db):
     '''The LocaleMiddleware redirects for non-standard locale URLs.'''
     response = client.get('/%s/' % original)
     assert response.status_code == 302
-    assert_relative_uri(response['Location'], '/%s/' % fixed)
+    assert_relative_reference(response['Location'], '/%s/' % fixed)
     assert_shared_cache_header(response)
 
 
@@ -70,7 +70,7 @@ def test_locale_middleware_language_cookie(client, db):
     client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
     response = client.get('/', HTTP_ACCEPT_LANGUAGE='fr')
     assert response.status_code == 302
-    assert_relative_uri(response['Location'], '/bn-BD/')
+    assert_relative_reference(response['Location'], '/bn-BD/')
     assert_shared_cache_header(response)
 
 
@@ -81,7 +81,7 @@ def test_locale_middleware_lang_query_param(path, client):
     response = client.get('%s?lang=fr' % path,
                           HTTP_ACCEPT_LANGUAGE='en;q=0.9, fr;q=0.8')
     assert response.status_code == 302
-    assert_relative_uri(response['Location'], '/fr/')
+    assert_relative_reference(response['Location'], '/fr/')
     assert_shared_cache_header(response)
 
 
@@ -89,7 +89,7 @@ def test_locale_middleware_no_change(client, db):
     '''The LocaleMiddleware redirects on the same ?lang query.'''
     response = client.get('/fr/?lang=fr')
     assert response.status_code == 302
-    assert_relative_uri(response['Location'], '/fr/')
+    assert_relative_reference(response['Location'], '/fr/')
     assert_shared_cache_header(response)
 
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -31,6 +31,12 @@ class TupleCsv(Csv):
         return tuple((value, value) for value in split_values)
 
 
+# For the Django 1.11 update effort - Are we at least at this version?
+_dj_version = LooseVersion(get_version())
+DJANGO_1_9 = _dj_version >= LooseVersion('1.9')
+DJANGO_1_10 = _dj_version >= LooseVersion('1.10')
+DJANGO_1_11 = _dj_version >= LooseVersion('1.11')
+
 DEBUG = config('DEBUG', default=False, cast=bool)
 
 ROOT = dirname(dirname(dirname(os.path.abspath(__file__))))
@@ -447,7 +453,7 @@ SECRET_KEY = config('SECRET_KEY',
 
 # Django 1.9 and lower need protection from BREACH attacks
 # Django 1.10 include BREACH protection in CsrfViewMiddleware
-_NEED_DEBREACH = LooseVersion(get_version()) < LooseVersion('1.10')
+_NEED_DEBREACH = not DJANGO_1_10
 if _NEED_DEBREACH:
     _CSRF_CONTEXT_PROCESSOR = 'debreach.context_processors.csrf'
 else:

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -1,7 +1,4 @@
-from distutils.version import LooseVersion
-
 from decorator_include import decorator_include
-from django import get_version
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
@@ -73,7 +70,7 @@ else:
         url(r'^admin/wiki/document/purge/',
             purge_view,
             name='wiki.admin_bulk_purge')]
-    if LooseVersion(get_version()) >= LooseVersion('1.9'):
+    if settings.DJANGO_1_9:
         # We don't worry about decorating the views within django.contrib.admin
         # with "never_cache", since most have already been decorated, and the
         # remaining can be safely cached.

--- a/kuma/wiki/feeds.py
+++ b/kuma/wiki/feeds.py
@@ -1,9 +1,7 @@
 """Feeds for documents"""
 import datetime
 import json
-from distutils.version import LooseVersion
 
-from django import get_version
 from django.conf import settings
 from django.contrib.syndication.views import Feed
 from django.db.models import F
@@ -110,7 +108,7 @@ class DocumentsFeed(Feed):
 class DocumentJSONFeedGenerator(SyndicationFeed):
     """JSON feed generator for Documents
     TODO: Someday maybe make this into a JSON Activity Stream?"""
-    if LooseVersion(get_version()) >= LooseVersion('1.9'):
+    if settings.DJANGO_1_9:
         content_type = 'application/json'
     else:
         mime_type = 'application/json'

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.test import RequestFactory
 
 from kuma.core.cache import memcache
-from kuma.core.tests import assert_relative_uri, eq_
+from kuma.core.tests import assert_relative_reference, eq_
 from kuma.users.tests import UserTestCase
 
 from . import document, revision, WikiTestCase
@@ -97,8 +97,8 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
-        assert_relative_uri(response['Location'],
-                            '/en-US/ExtraWiki/Middle?raw=1')
+        assert_relative_reference(response['Location'],
+                                  '/en-US/ExtraWiki/Middle?raw=1')
 
         self.root_zone.url_root = 'NewRoot'
         self.root_zone.save()
@@ -106,8 +106,8 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
-        assert_relative_uri(response['Location'],
-                            '/en-US/NewRoot/Middle?raw=1')
+        assert_relative_reference(response['Location'],
+                                  '/en-US/NewRoot/Middle?raw=1')
 
     def test_blank_url_root(self):
         """Ensure a blank url_root does not trigger URL remap"""
@@ -212,7 +212,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         response = self.client.get(url, follow=True)
         assert len(response.redirect_chain) == 1
         redirect_url, status_code = response.redirect_chain[0]
-        assert_relative_uri(redirect_url, '/en-US/Firefox')
+        assert_relative_reference(redirect_url, '/en-US/Firefox')
         assert status_code == 302
 
     def test_docs_zone_with_default_locale(self):
@@ -237,8 +237,8 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         assert len(response.redirect_chain) == 2
         url1, status_code_1 = response.redirect_chain[0]
         url2, status_code_2 = response.redirect_chain[1]
-        assert_relative_uri(url1, '/fr/docs/Firefox')
-        assert_relative_uri(url2, '/fr/Firefox')
+        assert_relative_reference(url1, '/fr/docs/Firefox')
+        assert_relative_reference(url2, '/fr/Firefox')
         assert status_code_1 == status_code_2 == 302
 
     def test_zone_document_with_implied_default_locale(self):
@@ -248,7 +248,7 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         response = self.client.get(url, follow=True)
         assert len(response.redirect_chain) == 1
         redirect_url, status_code = response.redirect_chain[0]
-        assert_relative_uri(redirect_url, '/en-US/Firefox')
+        assert_relative_reference(redirect_url, '/en-US/Firefox')
         assert status_code == 302
 
     def test_zone_document_with_default_locale(self):

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.test import RequestFactory
 
 from kuma.core.cache import memcache
-from kuma.core.tests import eq_
+from kuma.core.tests import assert_relative_uri, eq_
 from kuma.users.tests import UserTestCase
 
 from . import document, revision, WikiTestCase
@@ -97,8 +97,8 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/ExtraWiki/Middle?raw=1',
-            response['Location'])
+        assert_relative_uri(response['Location'],
+                            '/en-US/ExtraWiki/Middle?raw=1')
 
         self.root_zone.url_root = 'NewRoot'
         self.root_zone.save()
@@ -106,8 +106,8 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
         eq_(302, response.status_code)
-        eq_('http://testserver/en-US/NewRoot/Middle?raw=1',
-            response['Location'])
+        assert_relative_uri(response['Location'],
+                            '/en-US/NewRoot/Middle?raw=1')
 
     def test_blank_url_root(self):
         """Ensure a blank url_root does not trigger URL remap"""
@@ -210,8 +210,10 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         # zoned url with locale in a single redirect.
         url = '/docs/Firefox'
         response = self.client.get(url, follow=True)
-        self.assertEqual(response.redirect_chain,
-                         [('http://testserver/en-US/Firefox', 302)])
+        assert len(response.redirect_chain) == 1
+        redirect_url, status_code = response.redirect_chain[0]
+        assert_relative_uri(redirect_url, '/en-US/Firefox')
+        assert status_code == 302
 
     def test_docs_zone_with_default_locale(self):
         # This url has a locale and a wiki path, and gets redirected to the
@@ -232,17 +234,22 @@ class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):
         # the zoned url and then as requested by the ?lang parameter.
         url = '/docs/Firefox'
         response = self.client.get(url, {'lang': 'fr'}, follow=True)
-        self.assertEqual(response.redirect_chain,
-                         [('http://testserver/fr/docs/Firefox', 302),
-                          ('http://testserver/fr/Firefox', 302)])
+        assert len(response.redirect_chain) == 2
+        url1, status_code_1 = response.redirect_chain[0]
+        url2, status_code_2 = response.redirect_chain[1]
+        assert_relative_uri(url1, '/fr/docs/Firefox')
+        assert_relative_uri(url2, '/fr/Firefox')
+        assert status_code_1 == status_code_2 == 302
 
     def test_zone_document_with_implied_default_locale(self):
         # This url has no locale and a wiki path, and gets redirected to the
         # zoned url with locale in a single step.
         url = '/docs/Mozilla/Firefox'
         response = self.client.get(url, follow=True)
-        self.assertEqual(response.redirect_chain,
-                         [('http://testserver/en-US/Firefox', 302)])
+        assert len(response.redirect_chain) == 1
+        redirect_url, status_code = response.redirect_chain[0]
+        assert_relative_uri(redirect_url, '/en-US/Firefox')
+        assert status_code == 302
 
     def test_zone_document_with_default_locale(self):
         # This url is the canonical one for our English document, so it should

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -16,7 +16,7 @@ from django.utils.http import urlquote
 from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import (assert_no_cache_header,
+from kuma.core.tests import (assert_no_cache_header, assert_relative_uri,
                              assert_shared_cache_header, eq_, ok_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
@@ -547,8 +547,10 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.post(reverse('wiki.create'), data,
                                     follow=True)
         d = Document.objects.get(title=data['title'])
-        eq_([('http://testserver/en-US/docs/%s' % d.slug, 302)],
-            response.redirect_chain)
+        assert len(response.redirect_chain) == 1
+        redirect_uri, status_code = response.redirect_chain[0]
+        assert_relative_uri(redirect_uri, '/en-US/docs/%s' % d.slug)
+        assert status_code == 302
         eq_(settings.WIKI_DEFAULT_LANGUAGE, d.locale)
         eq_(tags, sorted(t.name for t in d.tags.all()))
         r = d.revisions.all()[0]
@@ -1055,8 +1057,8 @@ class TranslateTests(UserTestCase, WikiTestCase):
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
         assert_no_cache_header(response)
-        assert (response['location'] ==
-                'http://testserver/es/docs/un-test-articulo?rev_saved=')
+        assert_relative_uri(response['Location'],
+                            '/es/docs/un-test-articulo?rev_saved=')
         doc = Document.objects.get(slug=data['slug'])
         rev = doc.revisions.filter(content=data['content'])[0]
         assert rev.keywords == data['keywords']

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -16,7 +16,7 @@ from django.utils.http import urlquote
 from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import (assert_no_cache_header, assert_relative_uri,
+from kuma.core.tests import (assert_no_cache_header, assert_relative_reference,
                              assert_shared_cache_header, eq_, ok_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
@@ -549,7 +549,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         d = Document.objects.get(title=data['title'])
         assert len(response.redirect_chain) == 1
         redirect_uri, status_code = response.redirect_chain[0]
-        assert_relative_uri(redirect_uri, '/en-US/docs/%s' % d.slug)
+        assert_relative_reference(redirect_uri, '/en-US/docs/%s' % d.slug)
         assert status_code == 302
         eq_(settings.WIKI_DEFAULT_LANGUAGE, d.locale)
         eq_(tags, sorted(t.name for t in d.tags.all()))
@@ -1057,8 +1057,8 @@ class TranslateTests(UserTestCase, WikiTestCase):
         assert response.status_code == 302
         assert response['X-Robots-Tag'] == 'noindex'
         assert_no_cache_header(response)
-        assert_relative_uri(response['Location'],
-                            '/es/docs/un-test-articulo?rev_saved=')
+        assert_relative_reference(response['Location'],
+                                  '/es/docs/un-test-articulo?rev_saved=')
         doc = Document.objects.get(slug=data['slug'])
         rev = doc.revisions.filter(content=data['content'])[0]
         assert rev.keywords == data['keywords']

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,7 +17,7 @@ from waffle.models import Flag, Switch
 from waffle.testutils import override_flag
 
 from kuma.core.templatetags.jinja_helpers import add_utm
-from kuma.core.tests import (assert_no_cache_header, assert_relative_uri,
+from kuma.core.tests import (assert_no_cache_header, assert_relative_reference,
                              assert_shared_cache_header, eq_, get_user, ok_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html
@@ -2770,7 +2770,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         for namespace_test in self.namespace_urls:
             resp = self.client.get(namespace_test['mindtouch'], follow=False)
             eq_(301, resp.status_code)
-            assert_relative_uri(resp['Location'], namespace_test['kuma'])
+            assert_relative_reference(resp['Location'], namespace_test['kuma'])
 
     def test_document_urls(self):
         """Check the url redirect to proper document when the url like
@@ -2783,7 +2783,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
 
         # Check the last redirect chain url is correct document url
         last_url = resp.redirect_chain[-1][0]
-        assert_relative_uri(last_url, d.get_absolute_url())
+        assert_relative_reference(last_url, d.get_absolute_url())
 
     def test_view_param(self):
         d = document()
@@ -2795,7 +2795,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         resp = self.client.get(mt_url)
         eq_(301, resp.status_code)
         expected_url = d.get_absolute_url('wiki.edit')
-        assert_relative_uri(resp['Location'], expected_url)
+        assert_relative_reference(resp['Location'], expected_url)
 
 
 @override_config(KUMASCRIPT_TIMEOUT=5.0, KUMASCRIPT_MAX_AGE=600)

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -3,6 +3,7 @@ from waffle.models import Switch
 
 from kuma.attachments.models import Attachment
 from kuma.attachments.tests import make_test_file
+from kuma.core.tests import assert_relative_uri
 from kuma.core.urlresolvers import reverse
 
 from . import normalize_html
@@ -91,7 +92,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     response = admin_client.post(upload_url, data=post_data)
     assert response.status_code == 302
     edit_url = reverse('wiki.edit', args=(code_sample_doc.slug,))
-    assert response.url == 'http://testserver' + edit_url
+    assert_relative_uri(response.url, edit_url)
 
     # Add a relative reference to the sample content
     attachment = Attachment.objects.get(title='An uploaded file')

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -3,7 +3,7 @@ from waffle.models import Switch
 
 from kuma.attachments.models import Attachment
 from kuma.attachments.tests import make_test_file
-from kuma.core.tests import assert_relative_uri
+from kuma.core.tests import assert_relative_reference
 from kuma.core.urlresolvers import reverse
 
 from . import normalize_html
@@ -92,7 +92,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     response = admin_client.post(upload_url, data=post_data)
     assert response.status_code == 302
     edit_url = reverse('wiki.edit', args=(code_sample_doc.slug,))
-    assert_relative_uri(response.url, edit_url)
+    assert_relative_reference(response.url, edit_url)
 
     # Add a relative reference to the sample content
     attachment = Attachment.objects.get(title='An uploaded file')


### PR DESCRIPTION
This PR centralizes Django version detection in settings, because I was getting tired of duplicating the same two imports across the code. If desired, this can be pulled into a new PR, or removed.

In Django 1.9, [HTTP redirects are no longer converted to absolute URIs](https://docs.djangoproject.com/en/2.0/releases/1.9/#http-redirects-no-longer-forced-to-absolute-uris). Absolute URIs, such as ``https://developer.mozilla.org/en-US/docs/Web/JavaScript``, were a requirement with [RFC 2616](https://tools.ietf.org/html/rfc2616.html). Relative URIs, such as ``/en-US/docs/Web/JavaScript``, are allowed in the ``Location`` header with [RFC 7231](https://docs.djangoproject.com/en/2.0/releases/1.9/#http-redirects-no-longer-forced-to-absolute-uris). Django 1.8 still forces absolute URIs.

This PR changes our code that generates redirects to use relative URIs. A function ``assert_relative_uri`` is used to test the Django 1.8 and Django 1.9 behavior, and can be replaced with an equality assert after the upgrade.