### PR TITLE
bug 1461350: Update URLs for attachment host

### DIFF
--- a/kuma/urls_untrusted.py
+++ b/kuma/urls_untrusted.py
@@ -2,7 +2,9 @@ from django.conf import settings
 from django.conf.urls import include, url
 
 from kuma.core import views as core_views
+from kuma.core.urlresolvers import i18n_patterns
 from kuma.landing.views import robots_txt
+from kuma.wiki.urls_untrusted import lang_urlpatterns as wiki_lang_urlpatterns
 
 handler403 = core_views.handler403
 handler404 = core_views.handler404
@@ -10,7 +12,6 @@ handler500 = core_views.handler500
 
 urlpatterns = [
     url('', include('kuma.attachments.urls')),
-    url(r'^docs', include('kuma.wiki.urls_untrusted')),
     url(r'^robots.txt', robots_txt, name='robots_txt'),
 ]
 
@@ -19,3 +20,5 @@ if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):
     urlpatterns.append(
         url(r'^__debug__/', include(debug_toolbar.urls)),
     )
+
+urlpatterns += i18n_patterns(url(r'^docs/', include(wiki_lang_urlpatterns)))

--- a/kuma/wiki/urls_untrusted.py
+++ b/kuma/wiki/urls_untrusted.py
@@ -14,7 +14,7 @@ document_patterns = [
         name='wiki.code_sample'),
 ]
 
-urlpatterns = [
-    url(r'^/(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
+lang_urlpatterns = [
+    url(r'^(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
         include(document_patterns)),
 ]


### PR DESCRIPTION
Update the URLs for the attachment host to ensure that code samples and file attachments are processed with locale prefixes.

This adds a test ``test_code_sample_host_restricted_host`` that confirms that a code sample can be viewed with ``ENABLED_RESTRICTIONS_BY_HOST``. This test fails before this change. Other tests are split up so they test a single configuration.

The urls cache is set when the ``RestrictedEndpointsMiddleware`` overrides the urlconf. Django's [SimpleTestCase](https://github.com/django/django/blob/6a0dc2176f4ebf907e124d433411e52bba39a28e/django/test/testcases.py#L217-L228) has code to reset this cache, but pytest doesn't [unless mark.urls is used](https://github.com/pytest-dev/pytest-django/blob/a67ab3bd0eda8a2b76b4c5954b04482b4f27e20a/pytest_django/plugin.py#L447-L473). mark.urls is set to the default urlconf, the test sets it to the restricted urlconf, and pytest-django cleans it up.