### PR TITLE
bug 1401246: avoid error-handler exception-argument warnings

### DIFF
--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -33,9 +33,9 @@ def set_language(request):
     return response
 
 
-handler403 = lambda request: _error_page(request, 403)
-handler404 = lambda request: _error_page(request, 404)
-handler500 = lambda request: _error_page(request, 500)
+handler403 = lambda request, exception=None: _error_page(request, 403)
+handler404 = lambda request, exception=None: _error_page(request, 404)
+handler500 = lambda request, exception=None: _error_page(request, 500)
 
 
 @never_cache


### PR DESCRIPTION
This simple PR eliminates about 176 of the following warnings from the Django 1.9 test run:
```
RemovedInDjango20Warning: Error handlers should accept an exception parameter. Update your code as this parameter will be required in Django 2.0
```
I considered, and actually implemented, the option of simply removing all of the custom error handlers, since Django will automatically use our custom `403.html`, `404.html`, and `500.html` templates. I decided against that approach, at least for now, because we lost our custom `Cache-Control` header (set with the `never_cache` decorator) for those error responses. It is true that our CloudFront CDN is configured to never cache `403`s, `404`s, and `500`s, but it seems important to make that explicit in the `Cache-Control` header as well. We could add the `Cache-Control` header for those error responses via a middleware, but for now it didn't seem worth simplifying one thing only to complicate another. I'm happy changing that decision though, if desired.