### PR TITLE
bug 1401246: Fix query params in lang selector

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -54,7 +54,7 @@ class LangSelectorMiddleware(object):
         new_query = dict((smart_str(k), v) for
                          k, v in request.GET.iteritems() if k != 'lang')
         if new_query:
-            new_path = urlparams(new_path, new_query)
+            new_path = urlparams(new_path, **new_query)
         response = HttpResponseRedirect(new_path)
         add_shared_cache_control(response)
         return response


### PR DESCRIPTION
The ``LangSelectorMiddleware`` preserves query string parameters other than ``lang=<locale>``. PR #4807 (use relative references in redirect) introduced a bug, where extra querystring parameters would raise an ``AttributeError`` and return a 500 error. Add a test to exercise this branch, and fix the
bug.