### PR TITLE
bug 1401246: Use random seed in Django 1.9+ jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,23 +51,26 @@ env:
           CREATE_DB=kuma
           INSTALL_PIPELINE=1
           INSTALL_ELASTICSEARCH=1
+          PYTHONHASHSEED=0
         # TODO: remove after Django 1.11 upgrade
         - TOXENV=django-1.10
           CREATE_DB=kuma
           INSTALL_PIPELINE=1
           INSTALL_ELASTICSEARCH=1
+          PYTHONHASHSEED=0
         # TODO: remove after Django 1.11 upgrade
         - TOXENV=django-1.11
           CREATE_DB=kuma
           INSTALL_PIPELINE=1
           INSTALL_ELASTICSEARCH=1
+          PYTHONHASHSEED=0
 
 matrix:
     allow_failures:
         - env: TOXENV=py27 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
-        - env: TOXENV=django-1.9 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
-        - env: TOXENV=django-1.10 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
-        - env: TOXENV=django-1.11 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
+        - env: TOXENV=django-1.9 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1 PYTHONHASHSEED=0
+        - env: TOXENV=django-1.10 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1 PYTHONHASHSEED=0
+        - env: TOXENV=django-1.11 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1 PYTHONHASHSEED=0
 install:
     - nvm install 6
     - nvm use 6


### PR DESCRIPTION
Use ``PYTHONHASHSEED=0`` in the Django 1.9, 1.10, and 1.11 jobs, to mirror the standard 1.8 build. This avoids test failures due to random behavior, such as key order in dictionaries, which are covered by a different optional TravisCI build.

Related to PR #4806.