### PR TITLE
bug 1401246: fix test_views_document.py for Django 1.9+

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -390,7 +390,7 @@ LOCALE_PATHS = (
 #       needed, and should be deleted. Django's ConditionalGetMiddleware
 #       will take care of both computing/adding the ETag header and handling
 #       conditional requests (both only for GET requests).
-USE_ETAGS = True
+USE_ETAGS = not DJANGO_1_11
 
 # Absolute path to the directory that holds media.
 # Example: "/home/media/media.lawrence.com/"

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -16,7 +16,7 @@ from django.http import (Http404, HttpResponse, HttpResponseBadRequest,
 from django.http.multipartparser import MultiPartParser
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.cache import add_never_cache_headers, patch_vary_headers
-from django.utils.http import parse_etags
+from django.utils.http import parse_etags, quote_etag
 from django.utils.safestring import mark_safe
 from django.utils.translation import ugettext
 from django.views.decorators.cache import never_cache
@@ -892,6 +892,10 @@ def _document_api_PUT(request, document_slug, document_locale):
             except ValueError:
                 expected_etags = []
             current_etag = calculate_etag(doc.get_html(section_id))
+            if settings.DJANGO_1_11:
+                # Django's parse_etags returns a list of quoted rather than
+                # un-quoted ETags starting with version 1.11.
+                current_etag = quote_etag(current_etag)
             if current_etag not in expected_etags:
                 resp = HttpResponse()
                 resp.status_code = 412


### PR DESCRIPTION
This PR gets the `kuma/wiki/tests/test_views_document.py` tests running (or skipped) through to Django 1.11.
- PUT requests with an `If-Match` header (done via the `wiki.document.api` endpoint) are broken in 1.9 and 1.10, but work in 1.11 (with some minor additional changes). In Django 1.9 and 1.10, both the `ConditionalGetMiddleware` and the `CommonMiddleware` will incorrectly meddle with the response for conditional requests made with **any** HTTP method (they should only meddle with the response for conditional `GET`s, as is done starting in Django 1.11). So the `test_api_put_existing` tests using conditional `PUT`s are skipped in Django 1.9 and 1.10.
- Since conditional headers are only considered for `GET` requests starting in Django 1.11 (as long as `settings.USE_ETAGS` is False), I also modified the `test_api_safe` tests to avoid conditional requests for `HEAD`.
- Starting with Django 1.11, the `django.utils.http.parse_etags` function returns a quoted rather than un-quoted list of Etags, so the `If-Match` functionality with the `kuma.wiki.views.document._document_api_PUT` function has been modified accordingly.