### PR TITLE
bug 1401246: Fix test for raw file with 304

### DIFF
--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -229,12 +229,13 @@ def test_edit_attachment_post_with_vacant_file(admin_client, root_doc, tmpdir,
 
 def test_raw_file_requires_attachment_host(client, settings, file_attachment):
     settings.ATTACHMENT_HOST = 'demos'
+    settings.ALLOWED_HOSTS.append('demos')
     attachment = file_attachment['attachment']
     created = attachment.current_revision.created
     url = attachment.get_file_url()
 
     # Force the HOST header to look like something other than "demos".
-    response = client.get(url, HTTP_HOST='localhost')
+    response = client.get(url, HTTP_HOST='testserver')
     assert response.status_code == 301
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']
@@ -252,6 +253,7 @@ def test_raw_file_requires_attachment_host(client, settings, file_attachment):
 
 def test_raw_file_if_modified_since(client, settings, file_attachment):
     settings.ATTACHMENT_HOST = 'demos'
+    settings.ALLOWED_HOSTS.append('demos')
     attachment = file_attachment['attachment']
     created = attachment.current_revision.created
     url = attachment.get_file_url()
@@ -262,6 +264,8 @@ def test_raw_file_if_modified_since(client, settings, file_attachment):
         HTTP_IF_MODIFIED_SINCE=convert_to_http_date(created)
     )
     assert response.status_code == 304
+    if (settings.DJANGO_1_9 and not settings.DJANGO_1_11):
+        pytest.xfail("Streaming headers cleared in Django 1.9 and 1.10")
     assert response['Last-Modified'] == convert_to_http_date(created)
     assert 'public' in response['Cache-Control']
     assert 'max-age=900' in response['Cache-Control']


### PR DESCRIPTION
When the ``ConditionalGetMiddleware`` in 1.9 and 1.10 detects that a file attachment is unchanged, it returns a ``304 Not Modified`` response that removes caching headers and the ``Last-Modified`` header. The test is xfailed for these Django versions before the header check.

Django 1.11 retains the headers, so tests will pass like 1.9. The tests are modified to add the attachment host to ``ALLOWED_HOSTS``, which is checked in tests starting in 1.10.