### PR TITLE
bug 1189160: Update to django-waffle 0.14.0

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -5,7 +5,7 @@ import requests_mock
 from django.conf import settings
 from django.core.cache import caches
 from django.utils.translation import activate
-from waffle.models import Flag
+from waffle.testutils import override_flag
 
 from kuma.wiki.models import Document, Revision
 
@@ -86,8 +86,8 @@ def user_client(client, wiki_user):
 
 @pytest.fixture
 def editor_client(user_client):
-    Flag.objects.create(name='kumaediting', everyone=True)
-    return user_client
+    with override_flag('kumaediting', True):
+        yield user_client
 
 
 @pytest.fixture

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -10,7 +10,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
 from pyquery import PyQuery as pq
-from waffle.models import Switch
+from waffle.testutils import override_switch
 
 from kuma.core.tests import (assert_no_cache_header,
                              assert_shared_cache_header, eq_, ok_)
@@ -105,10 +105,9 @@ def test_revisions_list_via_AJAX(dashboard_revisions, client):
 def test_revisions_show_ips_button(switch, is_admin, root_doc, user_client,
                                    admin_client):
     """Toggle IPs button appears for admins when the switch is active."""
-    if switch:
-        Switch.objects.create(name='store_revision_ips', active=True)
     client = admin_client if is_admin else user_client
-    response = client.get(reverse('dashboards.revisions'))
+    with override_switch('store_revision_ips', active=switch):
+        response = client.get(reverse('dashboards.revisions'))
     assert response.status_code == 200
     page = pq(response.content)
     ip_button = page.find('button#show_ips_btn')

--- a/kuma/spam/tests/conftest.py
+++ b/kuma/spam/tests/conftest.py
@@ -1,12 +1,10 @@
 import pytest
-from waffle.models import Flag
+from waffle.testutils import override_flag
 
 from ..constants import SPAM_CHECKS_FLAG
 
 
 @pytest.fixture
 def spam_check_everyone(db):
-    Flag.objects.update_or_create(
-        name=SPAM_CHECKS_FLAG,
-        defaults={'everyone': True}
-    )
+    with override_flag(SPAM_CHECKS_FLAG, True):
+        yield

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib import messages as django_messages
 from django.core import mail
 from django.test import RequestFactory, TestCase
-from waffle.models import Switch
+from waffle.testutils import override_switch
 
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
@@ -63,8 +63,8 @@ class TestWelcomeEmails(UserTestCase):
         send_welcome_email(testuser.pk, 'en-NZ')
         self.assertEqual(1, len(mail.outbox))
 
+    @override_switch('welcome_email', True)
     def test_welcome_mail_for_verified_email(self):
-        Switch.objects.get_or_create(name='welcome_email', active=True)
         testuser = user(username='welcome', email='welcome@tester.com',
                         password='welcome', save=True)
         request = self.setup_request_for_messages()
@@ -104,8 +104,8 @@ class TestWelcomeEmails(UserTestCase):
         self.assertEqual(django_messages.SUCCESS, queued_messages[0].level)
         self.assertTrue('getting started' in queued_messages[0].message)
 
+    @override_switch('welcome_email', True)
     def test_welcome_mail_for_unverified_email(self):
-        Switch.objects.get_or_create(name='welcome_email', active=True)
         testuser = user(username='welcome2', email='welcome2@tester.com',
                         password='welcome2', save=True)
         email_address = EmailAddress.objects.create(user=testuser,

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -263,10 +263,17 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
         self.ban_testuser2_url = reverse('users.ban_user_and_cleanup_summary',
                                          kwargs={'username': self.testuser2.username})
         self.client.login(username='admin', password='testpass')
+        self.submissions_flag = None
+
+    def tearDown(self):
+        super(BanUserAndCleanupSummaryTestCase, self).tearDown()
+        if self.submissions_flag:
+            self.submissions_flag.delete()
 
     def enable_akismet_and_mock_requests(self, mock_requests):
         """Enable Akismet and mock calls to it. Return the mock object."""
-        Flag.objects.create(name=SPAM_SUBMISSIONS_FLAG, everyone=True)
+        self.submissions_flag = Flag.objects.create(
+            name=SPAM_SUBMISSIONS_FLAG, everyone=True)
         mock_requests.post(VERIFY_URL, content='valid')
         mock_requests.post(SPAM_URL, content=Akismet.submission_success)
         return mock_requests

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -20,6 +20,10 @@ class WikiTestCase(KumaTestCase):
         self.kumaediting_flag, created = Flag.objects.get_or_create(
             name='kumaediting', everyone=True)
 
+    def tearDown(self):
+        super(WikiTestCase, self).setUp()
+        self.kumaediting_flag.delete()
+
 
 # Model makers. These make it clearer and more concise to create objects in
 # test cases. They allow the significant attribute values to stand out rather

--- a/kuma/wiki/tests/test_views_admin.py
+++ b/kuma/wiki/tests/test_views_admin.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 import pytest
-from waffle.models import Flag
+from waffle.testutils import override_flag
 
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
@@ -11,8 +11,8 @@ from ..models import Document, Revision
 
 @pytest.fixture
 def purge_client(admin_client):
-    Flag.objects.create(name='kumaediting', everyone=True)
-    return admin_client
+    with override_flag('kumaediting', True):
+        yield admin_client
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_views_akismet.py
+++ b/kuma/wiki/tests/test_views_akismet.py
@@ -2,7 +2,7 @@ import json
 
 import pytest
 from django.contrib.auth.models import Permission
-from waffle.models import Flag
+from waffle.testutils import override_flag
 
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
@@ -41,8 +41,8 @@ def akismet_mock_requests(mock_requests):
 @pytest.fixture
 def enable_akismet_submissions(constance_config):
     constance_config.AKISMET_KEY = 'dashboard'
-    Flag.objects.create(name=SPAM_SUBMISSIONS_FLAG, everyone=True)
-    return constance_config
+    with override_flag(SPAM_SUBMISSIONS_FLAG, True):
+        yield constance_config
 
 
 @pytest.mark.spam

--- a/kuma/wiki/tests/test_views_misc.py
+++ b/kuma/wiki/tests/test_views_misc.py
@@ -2,7 +2,7 @@ import json
 from urllib import urlencode
 
 import pytest
-from waffle.models import Switch
+from waffle.testutils import override_switch
 
 from kuma.core.tests import assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
@@ -35,8 +35,6 @@ def test_ckeditor_config(db, client):
      'non-english-locale', 'exclude-current-locale'])
 def test_autosuggest(client, redirect_doc, doc_hierarchy_with_zones,
                      locale_case, term):
-    Switch.objects.create(name='application_ACAO', active=True)
-
     params = {}
     expected_status_code = 200
     if term:
@@ -65,7 +63,8 @@ def test_autosuggest(client, redirect_doc, doc_hierarchy_with_zones,
     url = reverse('wiki.autosuggest_documents')
     if params:
         url += '?{}'.format(urlencode(params))
-    response = client.get(url)
+    with override_switch('application_ACAO', True):
+        response = client.get(url)
     assert response.status_code == expected_status_code
     assert_shared_cache_header(response)
     assert 'Access-Control-Allow-Origin' in response

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -189,9 +189,12 @@ django-tidings==2.0.1 \
     --hash=sha256:a144628acdd9ddafdc921cdb70fb8ee297886b1dc38b00fab8fffbbf46163012
 
 # Support segmented user experiences
-django-waffle==0.11 \
-    --hash=sha256:9cd9e3a976849a3cd816830d7811b93543c1dc9da9f3cb1ccc2f9da831b8b025 \
-    --hash=sha256:914b4b874fa6250a0897bc30b67e02034d92a7235ab72a91bf6da49b71751de4
+# Code: https://github.com/jsocol/django-waffle
+# Changes: https://github.com/jsocol/django-waffle/blob/master/CHANGES
+# Docs: https://waffle.readthedocs.io/en/stable/
+django-waffle==0.14.0 \
+    --hash=sha256:f243a56db80bd28601222b1a8a0b1fa4e7e6ac1bbf809952c3725cb4cc0012d9 \
+    --hash=sha256:f3db39cc17d6e388a485230b6029095e5d6fba4ceaff8d4fcc21f95c47fe2e97
 
 # Configure Django DATABASES settings from an environment variable
 dj-database-url==0.4.0 \


### PR DESCRIPTION
* django-waffle 0.11 → 0.14.0: Significant caching improvements, fixes for management commands, update Django and Python support.

[Bug 1189160](https://bugzilla.mozilla.org/show_bug.cgi?id=1189160) was listed as a blocker (by me) for the Django 1.11 update, when I was hoping to get all the requirements up to date. I was expecting some breakage with this update, but tests pass, and browsing in the development environment appears to work. There doesn't appear to be any downside to this update. 