### PR TITLE
bug 1401246: make middleware work with MIDDLEWARE setting

### DIFF
--- a/kuma/core/tests/test_forms.py
+++ b/kuma/core/tests/test_forms.py
@@ -2,9 +2,9 @@
 #       since there would probably be no further need to confirm Django's
 #       handling of the "required" and "type" attributes when rendering
 #       a field as a widget.
+import pytest
 from django import forms
 from pyquery import PyQuery as pq
-import pytest
 
 from ..form_fields import StrippedCharField
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -476,12 +476,12 @@ _CONTEXT_PROCESSORS = (
 )
 
 
-MIDDLEWARE_CLASSES = (
+_MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
     'kuma.core.middleware.LegacyDomainRedirectsMiddleware',
     'kuma.core.middleware.RestrictedWhiteNoiseMiddleware',
     # must come before LocaleMiddleware
-    'redirect_urls.middleware.RedirectsMiddleware',
+    'kuma.core.middleware.RedirectsMiddleware',
     'kuma.core.middleware.SetRemoteAddrFromForwardedFor',
     ('kuma.core.middleware.ForceAnonymousSessionMiddleware'
      if MAINTENANCE_MODE else
@@ -506,10 +506,10 @@ if not MAINTENANCE_MODE:
     # to the Vary header, which in turn, kills caching.
 
     if _NEED_DEBREACH:
-        MIDDLEWARE_CLASSES += ('debreach.middleware.CSRFCryptMiddleware',)
-    MIDDLEWARE_CLASSES += ('django.middleware.csrf.CsrfViewMiddleware',)
+        _MIDDLEWARE += ('debreach.middleware.CSRFCryptMiddleware',)
+    _MIDDLEWARE += ('django.middleware.csrf.CsrfViewMiddleware',)
 
-MIDDLEWARE_CLASSES += (
+_MIDDLEWARE += (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     # TODO: In 1.10, SessionAuth*Middleware does nothing and can be removed
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
@@ -517,6 +517,11 @@ MIDDLEWARE_CLASSES += (
     'waffle.middleware.WaffleMiddleware',
     'kuma.core.middleware.RestrictedEndpointsMiddleware',
 )
+
+if DJANGO_1_10:
+    MIDDLEWARE = _MIDDLEWARE
+else:
+    MIDDLEWARE_CLASSES = _MIDDLEWARE
 
 # Auth
 AUTHENTICATION_BACKENDS = (

--- a/kuma/wiki/middleware.py
+++ b/kuma/wiki/middleware.py
@@ -1,6 +1,11 @@
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
+# TODO: Remove the try-except wrapper after move to Django 1.10+.
+try:
+    from django.utils.deprecation import MiddlewareMixin
+except ImportError:
+    MiddlewareMixin = object
 from django.views.decorators.cache import never_cache
 
 from kuma.core.i18n import get_kuma_languages
@@ -10,7 +15,7 @@ from .exceptions import ReadOnlyException
 from .jobs import DocumentZoneURLRemapsJob
 
 
-class ReadOnlyMiddleware(object):
+class ReadOnlyMiddleware(MiddlewareMixin):
     """
     Renders a 403.html page with a flag for a specific message.
     """
@@ -22,7 +27,7 @@ class ReadOnlyMiddleware(object):
         return None
 
 
-class DocumentZoneMiddleware(object):
+class DocumentZoneMiddleware(MiddlewareMixin):
     """
     For document zones with specified URL roots, this middleware modifies the
     incoming path_info to point at the internal wiki path

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -116,17 +116,23 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         eq_(200, response.status_code)
 
     def test_no_redirect(self):
-        middleware = DocumentZoneMiddleware()
+        if settings.DJANGO_1_10:
+            middleware = DocumentZoneMiddleware(lambda req: None)
+        else:
+            middleware = DocumentZoneMiddleware().process_request
         for endpoint in ['$subscribe', '$files']:
             request = self.rf.post('/en-US/docs/%s%s?raw' %
                                    (self.other_doc.slug, endpoint))
-            self.assertIsNone(middleware.process_request(request))
+            assert middleware(request) is None
 
     def test_skip_no_language_urls(self):
-        middleware = DocumentZoneMiddleware()
+        if settings.DJANGO_1_10:
+            middleware = DocumentZoneMiddleware(lambda req: None)
+        else:
+            middleware = DocumentZoneMiddleware().process_request
         for path in settings.LANGUAGE_URL_IGNORED_PATHS:
             request = self.rf.get('/' + path)
-            self.assertIsNone(middleware.process_request(request))
+            assert middleware(request) is None
 
     def test_zone_url_ends_with_slash(self):
         """Ensure urls only rewrite with a '/' at the end of url_root


### PR DESCRIPTION
Now that #4821 has been merged, this PR updates the Kuma middleware in `kuma.core.middleware` and `kuma.wiki.middleware` to handle both the [new style](https://docs.djangoproject.com/en/2.0/releases/1.10/#new-style-middleware) and original style. All of the third-party middleware we currently use is already compatible with both styles, except for [the middleware of `django-redirect-urls`](https://github.com/pmac/django-redirect-urls/blob/master/redirect_urls/middleware.py). I've created a temporary shim (`kuma.core.middleware.RedirectsMiddleware`) to handle that until a new version is available with middleware compatible with both the new and original style.

This has been tested locally with Django 1.8, 1.9, 1.10, and 1.11.

Once we're on Django 1.11, we may want to consider re-writing our Kuma middleware using [the functional style](https://docs.djangoproject.com/en/2.0/topics/http/middleware/#writing-your-own-middleware) (I already have a branch with this already done) so we can stop using `django.utils.deprecation.MiddlewareMixin`.