### PR TITLE
bug 1401246: Remove non-covered code branches

### DIFF
--- a/kuma/wiki/tests/test_views_delete.py
+++ b/kuma/wiki/tests/test_views_delete.py
@@ -39,8 +39,6 @@ def test_permission(root_doc, editor_client, endpoint):
     fixture, although logged in, does not have the proper permission.
     """
     args = [root_doc.slug]
-    if endpoint == 'revert_document':
-        args.append(root_doc.current_revision.id)
     url = reverse('wiki.{}'.format(endpoint), args=args)
     response = editor_client.get(url)
     assert response.status_code == 403

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -54,17 +54,15 @@ def get_content(content_case, data):
     if content_case == 'html-fragment':
         return 'text/html', data['content']
 
-    if content_case == 'html':
-        return 'text/html', """
-            <html>
-                <head>
-                    <title>%(title)s</title>
-                </head>
-                <body>%(content)s</body>
-            </html>
-        """ % data
-
-    raise ValueError('unsupported content case')
+    assert content_case == 'html'
+    return 'text/html', """
+        <html>
+            <head>
+                <title>%(title)s</title>
+            </head>
+            <body>%(content)s</body>
+        </html>
+    """ % data
 
 
 @pytest.fixture


### PR DESCRIPTION
These lines stood out when I looked at the report from ``make coveragetesthtml``. It should be rare to have uncovered lines in test code.