### PR TITLE
bug 1401246: Move leading slashes for authkey URLs

### DIFF
--- a/kuma/authkeys/urls.py
+++ b/kuma/authkeys/urls.py
@@ -3,16 +3,13 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url(r'^$',
-        views.list,
-        name='authkeys.list'),
-    url(r'^/new$',
+    url(r'^new$',
         views.new,
         name='authkeys.new'),
-    url(r'^/(?P<pk>\d+)/history$',
+    url(r'^(?P<pk>\d+)/history$',
         views.history,
         name='authkeys.history'),
-    url(r'^/(?P<pk>\d+)/delete$',
+    url(r'^(?P<pk>\d+)/delete$',
         views.delete,
         name='authkeys.delete'),
 ]

--- a/kuma/users/urls.py
+++ b/kuma/users/urls.py
@@ -5,6 +5,7 @@ from allauth.socialaccount import providers, views as socialaccount_views
 from django.conf.urls import include, url
 from django.views.decorators.csrf import csrf_exempt
 
+from kuma.authkeys.views import list as list_keys
 from kuma.core.decorators import redirect_in_maintenance_mode
 
 from . import views
@@ -33,7 +34,8 @@ account_patterns = [
         redirect_in_maintenance_mode(account_views.confirm_email),
         name='account_confirm_email'),
     # Auth keys
-    url(r'^keys', include('kuma.authkeys.urls')),
+    url(r'^keys$', list_keys, name='authkeys.list'),
+    url(r'^keys/', include('kuma.authkeys.urls')),
 ]
 
 


### PR DESCRIPTION
This eliminates a warning when running management commands under Django 1.11.

I missed this during PR #4764, because wow I wasn't expecting the user app to include URLs from the apices app.