### PR TITLE
bug 1401246: Pin Django app migrations

### DIFF
--- a/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
+++ b/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
@@ -15,8 +15,8 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('contenttypes', '__latest__'),
-        ('sites', '__latest__'),
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('sites', '0001_initial'),
         ('waffle', '0001_initial'),
         ('attachments', '0001_squashed_0008_attachment_on_delete'),
         ('users', '0001_squashed_0008_update_locales_tz_help'),


### PR DESCRIPTION
Django 1.9 adds a migration for the sites app, which means that there is a new latest migration, and attempting to run migrations raises an error:

```
django.db.migrations.exceptions.InconsistentMigrationHistory: Migration wiki.0001_squashed_0036_update_locales is applied before its dependency sites.0002_alter_domain_unique on database 'default'.
```

Instead of using ``__latest__``, use the actual migration names from Django 1.8, so that migrations will run without errors.