### PR TITLE
bug 1401246: Update development docs

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -106,7 +106,7 @@ Database migrations
 ===================
 Apps are migrated using Django's migration system. To run the migrations::
 
-    manage.py migrate
+    ./manage.py migrate
 
 If your changes include schema modifications, see the Django documentation for
 the `migration workflow`_.
@@ -139,9 +139,14 @@ Front-end dependencies are managed by Bower_ and checked into the repository.
 Follow these steps to add or upgrade a dependency:
 
 #. On the host, update ``bower.json``.
-#. (*Docker only*) In the container, install ``git`` (``apt-get install -y git``).
-#. (*Docker only*) In the container, install ``bower-installer`` (``npm install -g bower-installer``).
-#. In the VM or container, install the dependency (``bower-installer``).
+#. Start a root Docker container shell ``docker-compose run -u root web bash``
+#. (*Docker only*) In the root container shell, run::
+
+    apt-get update
+    apt-get install -y git
+    npm install -g bower-installer
+    bower-installer
+
 #. On the host, prepare the dependency to be committed (``git add path/to/dependency``).
 
 Front-end dependencies that are not already managed by Bower should begin using

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -277,6 +277,10 @@ HTTPS.
 
 Deis Workflow Demo instances
 ============================
+**Note**: Deis workflow demo instances are unused, and
+`Deis Workflow is no longer active`_. These docs and supporting code
+will be removed. See `bug 1465829`_.
+
 You can deploy a hosted demo instance of Kuma by following these steps:
 
 #. Create a new branch, you cannot create a demo from the ``master`` branch.
@@ -304,6 +308,9 @@ to the MySQL instance::
 **Note**: if you copy and paste the code above into a bash terminal and are
 wondering why the commands don't appear in your bash history, it's because there's
 whitespace at the beginning of the line.
+
+.. _`Deis Workflow is no longer active`: https://deis.com/blog/2017/deis-workflow-final-release/
+.. _`bug 1465829`: https://bugzilla.mozilla.org/show_bug.cgi?id=1465829
 
 .. _maintenance-mode:
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -2,7 +2,7 @@
 Docker
 ======
 
-Docker__ is used for development and (soon) for deployment.
+Docker__ is used for development and for deployment.
 
 .. __: https://www.docker.com
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -36,7 +36,7 @@ transitioning to Docker containers for deployment as well.
 .. _`quay.io`: https://quay.io/repository/mozmar/kuma_base?tab=tags
 .. _TravisCI: https://travis-ci.org/mozilla/kuma/
 .. _Jenkins: https://ci.us-west.moz.works/view/MDN/job/mdn_multibranch_pipeline/
-.. _discourse: https://discourse.mozilla.org/c/MDN
+.. _discourse: https://discourse.mozilla.org/c/mdn
 
 Docker setup
 ============
@@ -46,14 +46,14 @@ Docker setup
    `Linux distribution`_.  Linux users will also want to install
    `Docker Compose`_ and follow `post-install instructions`_ to confirm that
    the development user can run Docker commmands.
-   
+
    To confirm that Docker is installed correctly, run::
 
         docker run hello-world
-        
+
    If you find any error using docker commands without ``sudo`` visit using 
    `docker as non-root`_ user.
-   
+
 #. Clone the kuma Git repository, if you haven't already::
 
         git clone --recursive https://github.com/mozilla/kuma.git
@@ -163,15 +163,15 @@ A few thousand lines will be printed, like::
     processing language ar
     ...
     ## Compiling (Sass), collecting, and building static files ##
-    Copying '/app/build/locale/jsi18n/af/javascript.js'
-    Copying '/app/build/locale/jsi18n/ar/javascript.js'
-    Copying '/app/build/locale/jsi18n/az/javascript.js'
+    Copying '/app/kuma/static/img/embed/promos/survey.svg'
+    Copying '/app/kuma/static/styles/components/home/column-callout.scss'
+    Copying '/app/build/locale/jsi18n/fy-NL/javascript.js'
     ...
-    Post-processed 'build/styles/wiki.css' as 'build/styles/wiki.css'
-    Post-processed 'build/styles/error-404.css' as 'build/styles/error-404.css'
-    Post-processed 'build/styles/mdn.css' as 'build/styles/mdn.css'
+    Post-processed 'build/styles/editor-locale-ar.css' as 'build/styles/editor-locale-ar.css'
+    Post-processed 'build/styles/locale-ln.css' as 'build/styles/locale-ln.css'
+    Post-processed 'build/styles/editor-locale-pt-BR.css' as 'build/styles/editor-locale-pt-BR.css'
     ....
-    1687 static files copied to '/app/static', 1773 post-processed
+    1870 static files copied to '/app/static', 125 post-processed.
 
 Visit the Homepage
 ==================


### PR DESCRIPTION
I skimmed the development documentation, running most of the commands against images with Django 1.11, by loading the django-1.11 branch, running ``VERSION=latest make build-base``, and [reseting my containers](https://kuma.readthedocs.io/en/latest/troubleshooting.html#reset-a-corrupt-database), including starting from a fresh MySQL. There were a few documentation issues I found while reviewing the docs, and I took the opportunity to fix them.

It appears that all of our development processes work with Django 1.11, after fixing an issue running migrations with Django 1.11 on a fresh database (PR #4827).  I also found some non-critical problems. There are non-covered lines in tests (PR #4825), and warnings about the URL patterns in the ``authkeys`` app (PR #4826).

We have some documentation on creating demo deployments with Deis Workflow, that might work, but that I didn't run, since [Deis Workflow reached end-of-maintenance](https://deis.com/blog/2017/deis-workflow-final-release/). I opened [bug 1465829](https://bugzilla.mozilla.org/show_bug.cgi?id=1465829) and added a note that it is deprecated. It should be easy enough to remove all the Deis Workflow support stuff, but it is not a blocker for Django 1.11, so I'm saving it for future work.