### PR TITLE
bug 1401246: Don't email Django errors to admins

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1543,6 +1543,8 @@ LOGGING['formatters']['default'] = {
 }
 # Switch log level
 LOGGING['handlers']['console']['level'] = LOG_LEVEL
+# Don't email Django errors, we have Sentry
+LOGGING['loggers']['django']['handlers'] = ['console']
 # Add our loggers
 LOGGING['loggers'].update({
     'kuma': {


### PR DESCRIPTION
The default for Django errors (the "django" log) is to send them to the console and to mail admin. Set the handler for Django errors to just send them to the console.