### PR TITLE
bug 1401246: upgrade to django-redirect-urls 1.0

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -11,8 +11,6 @@ from django.utils import translation
 from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import iri_to_uri, smart_str
 from django.utils.six.moves.urllib.parse import urlsplit
-from redirect_urls.middleware import (
-    RedirectsMiddleware as OriginalRedirectsMiddleware)
 from whitenoise.middleware import WhiteNoiseMiddleware
 
 from kuma.wiki.views.legacy import (mindtouch_to_kuma_redirect,
@@ -312,12 +310,3 @@ class LegacyDomainRedirectsMiddleware(MiddlewareMixin):
                 urljoin(settings.SITE_URL, request.get_full_path())
             )
         return None
-
-
-class RedirectsMiddleware(MiddlewareMixin, OriginalRedirectsMiddleware):
-    """
-    Enables the redirect_urls middleware to be used with both MIDDLEWARE
-    and MIDDLEWARE_CLASSES until a newer version of django-redirect-urls
-    is available that provides this "out of the box".
-    """
-    pass

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -455,7 +455,7 @@ MIDDLEWARE = (
     'kuma.core.middleware.LegacyDomainRedirectsMiddleware',
     'kuma.core.middleware.RestrictedWhiteNoiseMiddleware',
     # must come before LocaleMiddleware
-    'kuma.core.middleware.RedirectsMiddleware',
+    'redirect_urls.middleware.RedirectsMiddleware',
     'kuma.core.middleware.SetRemoteAddrFromForwardedFor',
     ('kuma.core.middleware.ForceAnonymousSessionMiddleware'
      if MAINTENANCE_MODE else

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -139,9 +139,10 @@ django-recaptcha==1.0.5 \
     --hash=sha256:d4d896dd399a1a0810af8e59a646bb5a1586b2cc8b8f32d16766ade5fba79475
 
 # Implement redirects in Django instead of Apache httpd
-django-redirect-urls==0.1 \
-    --hash=sha256:cd8499424e4920dc929bf1d64c5563349471353143af8e631033336570c42445 \
-    --hash=sha256:267f20cc44de96fc574b5b02e9efcd80f4aab4146539dea1f4228f62f34bb4f5
+# Code, Docs, Changes: https://github.com/pmac/django-redirect-urls
+django-redirect-urls==1.0 \
+    --hash=sha256:c4cd7818b06ccf0a5307656a33f3ecea47ee22f0cceb374ea559eb2d1402d5d8 \
+    --hash=sha256:e5b1dec666758c7d2621ce337458a09e4b3feeb06cb9ec5d43b17d66b87ea97d
 
 # RESTful API framework, used by search
 # Code: https://github.com/encode/django-rest-framework


### PR DESCRIPTION
Upgrade `django-redirect-urls` to version 1.0, which supports Django 1.11+. Thanks @pmclanahan!

Tested locally with:
```sh
VERSION=latest make build-base
docker-compose up -d
docker-compose exec web make lint test
pytest --base-url http://localhost:8000 tests/headless
```