### PR TITLE
bug 1401246: Fix management commands for Django 1.11

### DIFF
--- a/kuma/core/management/commands/anonymize.py
+++ b/kuma/core/management/commands/anonymize.py
@@ -1,13 +1,16 @@
+import os.path
+
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.db import connection
-from manage import path
 
 
 class Command(BaseCommand):
     help = 'Anonymize the database. Will wipe out some data.'
 
     def handle(self, *arg, **kwargs):
-        with open(path('scripts/anonymize.sql')) as fp:
-            sql = fp.read()
-            cursor = connection.cursor()
-            cursor.execute(sql)
+        path = os.path.join(settings.ROOT, 'scripts/anonymize.sql')
+        sql = open(path).read()
+        assert sql
+        cursor = connection.cursor()
+        cursor.execute(sql)

--- a/kuma/core/management/commands/delete_old_ip_bans.py
+++ b/kuma/core/management/commands/delete_old_ip_bans.py
@@ -1,20 +1,20 @@
 """
 Delete old revision IPs
 """
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
-from .tasks import delete_old_ip_bans
+from kuma.core.tasks import delete_old_ip_bans
 
 
 class Command(BaseCommand):
     help = "Delete old IP Bans"
-    option_list = BaseCommand.option_list + (
-        make_option('--days', dest="days", default=30, type=int,
-                    help="How many days 'old' (Default 30)"),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            help="How many days 'old' (default 30)",
+            default=30,
+            type=int)
 
     def handle(self, *args, **options):
-        self.options = options
         delete_old_ip_bans(days=options['days'])

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from optparse import make_option
 
 from django.core.management.base import BaseCommand
 
@@ -11,10 +10,11 @@ from kuma.feeder.utils import update_feeds
 class Command(BaseCommand):
     """Update all registered RSS/Atom feeds."""
 
-    option_list = BaseCommand.option_list + (
-        make_option('--force', '-f', dest='force', action='store_true',
-                    default=False, help='Fetch even disabled feeds.'),
-    )
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--force', '-f',
+            help='Fetch even disabled feeds.',
+            action='store_true')
 
     @memcache_lock('kuma_feeder')
     def handle(self, *args, **options):
@@ -22,11 +22,10 @@ class Command(BaseCommand):
         Locked command handler to avoid running this command more than once
         simultaneously.
         """
-        force = options.get('force', False)
+        force = options['force']
         verbosity = int(options['verbosity'])
 
         # Setup logging
-        verbosity = int(options['verbosity'])
         console = logging.StreamHandler(self.stderr)
         level = [logging.WARNING,
                  logging.INFO,

--- a/kuma/scrape/management/commands/sample_mdn.py
+++ b/kuma/scrape/management/commands/sample_mdn.py
@@ -23,11 +23,15 @@ class Command(ScrapeCommand):
                             action='store_false',
                             default='true',
                             dest='ssl')
+        parser.add_argument('--force',
+                            help='Update existing records',
+                            action='store_true')
 
     def handle(self, *arg, **options):
         self.setup_logging(options['verbosity'])
         host = options['host']
         ssl = options['ssl']
+        force = options['force']
         scraper = self.make_scraper(host=host, ssl=ssl)
         with open(options['spec']) as spec_file:
             data = json.load(spec_file)
@@ -39,6 +43,8 @@ class Command(ScrapeCommand):
         # Scrape data from MDN
         for source_spec in data.get('sources', []):
             source_name, param, source_args = source_spec
+            if force:
+                source_args['force'] = True
             scraper.add_source(source_name, param, **source_args)
         sources = scraper.scrape()
         incomplete = 0

--- a/kuma/search/management/commands/reindex.py
+++ b/kuma/search/management/commands/reindex.py
@@ -1,5 +1,4 @@
 import logging
-from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 
@@ -8,13 +7,20 @@ from kuma.wiki.search import WikiDocumentType
 
 class Command(BaseCommand):
     help = 'Reindex the database for Elastic.'
-    option_list = BaseCommand.option_list + (
-        make_option('-c', '--chunk', type='int', dest='chunk_size', default=1000,
-                    help='Chunk size when reindexing. Lower is better for '
-                         'slow computers with little memory'),
-        make_option('-p', '--percent', type='int', dest='percent', default=100,
-                    help='the percentage of the db to index (1 to 100)'),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '-c', '--chunk',
+            help='Chunk size when reindexing (default 100). Lower is better'
+                 'for slow computers with little memory',
+            type=int,
+            dest='chunk_size',
+            default=1000)
+        parser.add_argument(
+            '-p', '--percent',
+            help='the percentage of the db to index (1 to 100) (default 100)',
+            type=int,
+            default=100)
 
     def handle(self, *args, **options):
         logging.basicConfig(level=logging.INFO)

--- a/kuma/wiki/management/commands/delete_old_revision_ips.py
+++ b/kuma/wiki/management/commands/delete_old_revision_ips.py
@@ -1,8 +1,6 @@
 """
 Delete old revision IPs
 """
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from kuma.wiki.tasks import delete_old_revision_ips
@@ -10,11 +8,13 @@ from kuma.wiki.tasks import delete_old_revision_ips
 
 class Command(BaseCommand):
     help = "Delete old Revision IPs"
-    option_list = BaseCommand.option_list + (
-        make_option('--days', dest="days", default=30, type=int,
-                    help="How many days 'old'"),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            help="How many days 'old' (default 30)",
+            default=30,
+            type=int)
 
     def handle(self, *args, **options):
-        self.options = options
         delete_old_revision_ips(days=options['days'])

--- a/kuma/wiki/management/commands/delete_old_spam_attempt_data.py
+++ b/kuma/wiki/management/commands/delete_old_spam_attempt_data.py
@@ -1,8 +1,6 @@
 """
 Delete old DocumentSpamAttempt data
 """
-from optparse import make_option
-
 from django.core.management.base import BaseCommand
 
 from kuma.wiki.tasks import delete_old_documentspamattempt_data
@@ -10,10 +8,13 @@ from kuma.wiki.tasks import delete_old_documentspamattempt_data
 
 class Command(BaseCommand):
     help = "Delete old DocumentSpamAttempt.data"
-    option_list = BaseCommand.option_list + (
-        make_option('--days', dest='days', default=30, type=int,
-                    help="How many days 'old'"),
-    )
 
-    def handle(self, days, *args, **options):
-        delete_old_documentspamattempt_data(days=days)
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            help="How many days 'old' (default 30)",
+            default=30,
+            type=int)
+
+    def handle(self, *args, **options):
+        delete_old_documentspamattempt_data(days=options['days'])

--- a/kuma/wiki/management/commands/refresh_wiki_caches.py
+++ b/kuma/wiki/management/commands/refresh_wiki_caches.py
@@ -7,7 +7,6 @@ Kuma and other services like Kumascript.
 import hashlib
 import logging
 import urlparse
-from optparse import make_option
 
 import requests
 
@@ -27,14 +26,14 @@ PAGE_EXISTS_TIMEOUT = getattr(settings, 'wiki_page_exists_timeout',
 class Command(BaseCommand):
 
     help = "Refresh cached wiki data"
-    option_list = BaseCommand.option_list + (
-        make_option('--baseurl', dest="baseurl",
-                    default=False,
-                    help="Base URL to site"),
-    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--baseurl',
+            help="Base URL to site",
+            default='')
 
     def handle(self, *args, **options):
-
         to_prefetch = []
         logging.info("Querying all Documents...")
         doc_cnt, doc_total = 0, Document.objects.count()

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -85,9 +85,9 @@ django-decorator-include==1.3 \
 # Code: https://github.com/django-extensions/django-extensions
 # Changes: https://github.com/django-extensions/django-extensions/blob/master/CHANGELOG.md
 # Docs: http://django-extensions.readthedocs.io/en/latest/
-django-extensions==2.0.6 \
-    --hash=sha256:bc9f2946c117bb2f49e5e0633eba783787790ae810ea112fe7fd82fa64de2ff1 \
-    --hash=sha256:37a543af370ee3b0721ff50442d33c357dd083e6ea06c5b94a199283b6f9e361
+django-extensions==2.0.7 \
+    --hash=sha256:3be3debf53c77ca795bdf713726c923aa3c3f895e1a42e2e31a68c1a562346a4 \
+    --hash=sha256:94bfac99eb262c5ac27e53eda96925e2e53fe0b331af7dde37012d07639a649c
 
 # Modern flat theme for Django admin
 django-flat-theme==1.1.3 \


### PR DESCRIPTION
Several management commands are broken in Django 1.11, because the compatibility layer for the ``optparse`` to ``argparse`` transition was removed in Django 1.10.  Other commands were broken for a very long time. One command, ``./manage.py pop``, never worked. Finally, ``./manage.py pipchecker`` requires a third-party update.


Safe verification:

```
./manage.py anonymize --help
./manage.py delete_old_ip_bans --help
./manage.py delete_old_revision_ips --help
./manage.py delete_old_spam_attempt_data --help
./manage.py pipchecker --help
./manage.py refresh_wiki_caches --help
./manage.py reindex --help
./manage.py render_document --help
./manage.py update_feeds --help
```
Sort of safe:
```
./manage.py delete_old_ip_bans
./manage.py delete_old_revision_ips
./manage.py delete_old_spam_attempt_data
./manage.py pipchecker
./manage.py refresh_wiki_caches
./manage.py reindex
./manage.py render_document
./manage.py update_feeds
```

Much less safe:
```
./manage.py anonymize  # Will anonymize your database
```