### PR TITLE
bug 1401246: convert to new-style middleware

### DIFF
--- a/kuma/core/i18n.py
+++ b/kuma/core/i18n.py
@@ -193,3 +193,10 @@ def get_language_from_request(request):
 
 def get_language_mapping():
     return apps.get_app_config('core').language_mapping
+
+
+def activate_language_from_request(request):
+    """Activate the language, based on the request."""
+    language = get_language_from_request(request)
+    translation.activate(language)
+    request.LANGUAGE_CODE = language

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -7,8 +7,6 @@ from django.core.urlresolvers import get_script_prefix, resolve, Resolver404
 from django.http import (HttpResponseForbidden,
                          HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
-from django.utils import translation
-from django.utils.deprecation import MiddlewareMixin
 from django.utils.encoding import iri_to_uri, smart_str
 from django.utils.six.moves.urllib.parse import urlsplit
 from whitenoise.middleware import WhiteNoiseMiddleware
@@ -17,7 +15,8 @@ from kuma.wiki.views.legacy import (mindtouch_to_kuma_redirect,
                                     mindtouch_to_kuma_url)
 
 from .decorators import add_shared_cache_control
-from .i18n import (get_kuma_languages,
+from .i18n import (activate_language_from_request,
+                   get_kuma_languages,
                    get_language,
                    get_language_from_path,
                    get_language_from_request)
@@ -25,19 +24,26 @@ from .utils import is_untrusted, urlparams
 from .views import handler403
 
 
-class LangSelectorMiddleware(MiddlewareMixin):
+class MiddlewareBase(object):
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        super(MiddlewareBase, self).__init__()
+
+
+class LangSelectorMiddleware(MiddlewareBase):
     """
     Redirect requests with a ?lang= parameter.
 
     This should appear higher than LocaleMiddleware in the middleware list.
     """
 
-    def process_request(self, request):
+    def __call__(self, request):
         """Redirect if ?lang query parameter is valid."""
         query_lang = request.GET.get('lang')
         if not (query_lang and query_lang in get_kuma_languages()):
-            # Invalid language requested, don't redirect
-            return
+            # Invalid or no language requested, so don't redirect.
+            return self.get_response(request)
 
         # Check if the requested language is already embedded in URL
         language = get_language_from_request(request)
@@ -61,15 +67,17 @@ class LangSelectorMiddleware(MiddlewareMixin):
         return response
 
 
-class LocaleStandardizerMiddleware(MiddlewareMixin):
+class LocaleStandardizerMiddleware(MiddlewareBase):
     """
     Convert 404s with legacy locales to redirects.
 
     This should appear higher than LocaleMiddleware in the middleware list.
     """
 
-    def process_response(self, request, response):
+    def __call__(self, request):
         """Convert 404s into redirects to language-specific URLs."""
+
+        response = self.get_response(request)
 
         if response.status_code != 404:
             return response
@@ -104,12 +112,12 @@ class LocaleStandardizerMiddleware(MiddlewareMixin):
             redirect_response = HttpResponseRedirect(fixed_path)
             add_shared_cache_control(redirect_response)
             return redirect_response
-        else:
-            # No language fixup found, return the 404
-            return response
+
+        # No language fixup found, return the 404
+        return response
 
 
-class LocaleMiddleware(MiddlewareMixin):
+class LocaleMiddleware(MiddlewareBase):
     """
     This is a very simple middleware that parses a request
     and decides what translation object to install in the current
@@ -126,16 +134,14 @@ class LocaleMiddleware(MiddlewareMixin):
     * Don't include "Vary: Accept-Language" header
     * Add caching headers to locale redirects
     """
-    response_redirect_class = HttpResponseRedirect
 
-    def process_request(self, request):
-        """Activate the language, based on the request."""
-        language = get_language_from_request(request)
-        translation.activate(language)
-        request.LANGUAGE_CODE = language
+    def __call__(self, request):
+        # Activate the language, based on the request.
+        activate_language_from_request(request)
 
-    def process_response(self, request, response):
-        """Add Content-Language, convert some 404s to locale redirects."""
+        response = self.get_response(request)
+
+        # Add Content-Language, convert some 404s to locale redirects.
         language = get_language()
         language_from_path = get_language_from_path(request.path_info)
         if response.status_code == 404 and not language_from_path:
@@ -152,7 +158,7 @@ class LocaleMiddleware(MiddlewareMixin):
                     '%s%s/' % (script_prefix, language),
                     1
                 )
-                redirect = self.response_redirect_class(language_path)
+                redirect = HttpResponseRedirect(language_path)
                 add_shared_cache_control(redirect)
                 return redirect
 
@@ -162,15 +168,17 @@ class LocaleMiddleware(MiddlewareMixin):
         # instead. And a long comment.
         if 'Content-Language' not in response:  # pragma: no cover
             response['Content-Language'] = language
+
         return response
 
 
-class Forbidden403Middleware(MiddlewareMixin):
+class Forbidden403Middleware(MiddlewareBase):
     """
     Renders a 403.html page if response.status_code == 403.
     """
 
-    def process_response(self, request, response):
+    def __call__(self, request):
+        response = self.get_response(request)
         if isinstance(response, HttpResponseForbidden):
             return handler403(request)
         # If not 403, return response unmodified
@@ -193,7 +201,7 @@ def is_valid_path(request, path):
         return False
 
 
-class SlashMiddleware(MiddlewareMixin):
+class SlashMiddleware(MiddlewareBase):
     """
     Middleware that adds or removes a trailing slash if there was a 404.
 
@@ -208,7 +216,8 @@ class SlashMiddleware(MiddlewareMixin):
     makes it so that Django's is_valid_url returns True for all URLs.
     """
 
-    def process_response(self, request, response):
+    def __call__(self, request):
+        response = self.get_response(request)
         path = request.path_info
         if response.status_code == 404 and not is_valid_path(request, path):
             new_path = None
@@ -242,14 +251,14 @@ def safe_query_string(request):
         request.META['QUERY_STRING'] = qs
 
 
-class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
+class SetRemoteAddrFromForwardedFor(MiddlewareBase):
     """
     Middleware that sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, if the
     latter is set. This is useful if you're sitting behind a reverse proxy that
     causes each request's REMOTE_ADDR to be set to 127.0.0.1.
     """
 
-    def process_request(self, request):
+    def __call__(self, request):
         try:
             forwarded_for = request.META['HTTP_X_FORWARDED_FOR']
         except KeyError:
@@ -259,6 +268,8 @@ class SetRemoteAddrFromForwardedFor(MiddlewareMixin):
             # The client's IP will be the first one.
             forwarded_for = forwarded_for.split(',')[0].strip()
             request.META['REMOTE_ADDR'] = forwarded_for
+
+        return self.get_response(request)
 
 
 class ForceAnonymousSessionMiddleware(SessionMiddleware):
@@ -276,14 +287,13 @@ class ForceAnonymousSessionMiddleware(SessionMiddleware):
         return response
 
 
-class RestrictedEndpointsMiddleware(MiddlewareMixin):
+class RestrictedEndpointsMiddleware(MiddlewareBase):
+    """Restricts the accessible endpoints based on the host."""
 
-    def process_request(self, request):
-        """
-        Restricts the accessible endpoints based on the host.
-        """
+    def __call__(self, request):
         if settings.ENABLE_RESTRICTIONS_BY_HOST and is_untrusted(request):
             request.urlconf = 'kuma.urls_untrusted'
+        return self.get_response(request)
 
 
 class RestrictedWhiteNoiseMiddleware(WhiteNoiseMiddleware):
@@ -299,14 +309,12 @@ class RestrictedWhiteNoiseMiddleware(WhiteNoiseMiddleware):
         )
 
 
-class LegacyDomainRedirectsMiddleware(MiddlewareMixin):
+class LegacyDomainRedirectsMiddleware(MiddlewareBase):
+    """Permanently redirects all requests from legacy domains."""
 
-    def process_request(self, request):
-        """
-        Permanently redirects all requests from legacy domains.
-        """
+    def __call__(self, request):
         if request.get_host() in settings.LEGACY_HOSTS:
             return HttpResponsePermanentRedirect(
                 urljoin(settings.SITE_URL, request.get_full_path())
             )
-        return None
+        return self.get_response(request)

--- a/kuma/core/tests/test_middleware.py
+++ b/kuma/core/tests/test_middleware.py
@@ -1,4 +1,5 @@
 import pytest
+from django.core.exceptions import MiddlewareNotUsed
 from django.test import RequestFactory
 from mock import MagicMock, patch
 
@@ -81,10 +82,11 @@ def test_restricted_endpoints_middleware(rf, settings):
     middleware(request)
     assert not hasattr(request, 'urlconf')
 
+
+def test_restricted_endpoints_middleware_when_disabled(settings):
     settings.ENABLE_RESTRICTIONS_BY_HOST = False
-    request = rf.get('/foo', HTTP_HOST='demos')
-    middleware(request)
-    assert not hasattr(request, 'urlconf')
+    with pytest.raises(MiddlewareNotUsed):
+        RestrictedEndpointsMiddleware(lambda req: None)
 
 
 def test_restricted_whitenoise_middleware(rf, settings):

--- a/kuma/search/tests/__init__.py
+++ b/kuma/search/tests/__init__.py
@@ -5,7 +5,7 @@ from elasticsearch.exceptions import ConnectionError
 from elasticsearch_dsl.connections import connections
 from rest_framework.test import APIRequestFactory
 
-from kuma.core.middleware import LocaleMiddleware
+from kuma.core.i18n import activate_language_from_request
 from kuma.users.tests import UserTestCase
 from kuma.wiki.search import WikiDocumentType
 
@@ -75,5 +75,5 @@ class ElasticTestCase(UserTestCase):
     def get_request(self, *args, **kwargs):
         request = factory.get(*args, **kwargs)
         # setting request.LANGUAGE_CODE correctly
-        LocaleMiddleware().process_request(request)
+        activate_language_from_request(request)
         return request


### PR DESCRIPTION
I did some work on our Kuma middleware a short while ago, but when I realized it needed Django 1.11 in place, I shelved it. I thought it was useful, as it mostly embraced the new, ~~functional~~class-style of writing middleware (except `ReadOnlyMiddleware`), but it's real goal was to remove the dependency on `django.utils.deprecation.MiddlewareMixin` and go all-in with the new-style. I didn't want to lose the work, which wasn't totally finished, so I added what was missing and decided it was now or never. 