### PR TITLE
bug 1467513: Render server error page with minimal request

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -154,7 +154,7 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+    <script src="{{ statici18n(request.LANGUAGE_CODE or 'en-US') }}"></script>
     {% javascript 'main' %}
     <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -38,7 +38,7 @@
 
         {% if messages %}
             {% for message in messages %}
-                {% if 'wiki_redirect' not in message.tags or request.user.is_superuser %}
+                {% if 'wiki_redirect' not in message.tags or (request.user and request.user.is_superuser) %}
                     win.mdn.notifications.push({
                         message: "{{ message }}",
                         tags: "{{ message.tags }}",

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -11,7 +11,7 @@
         ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
 
-        {% if request.user.is_authenticated() %}
+        {% if request.user and request.user.is_authenticated() %}
             // dimension1 == 'Signed-In"
             ga('set', 'dimension1', 'Yes');
 
@@ -36,7 +36,7 @@
             ga('set', 'dimension12', '{{ analytics_page_revision }}');
         {%- endif %}
 
-        {%- if not request.user.is_authenticated() and
+        {%- if request.user and not request.user.is_authenticated() and
                content_experiment and
                content_experiment.selection_is_valid %}
             // dimension15 == “a/b test variation”, user scope

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -253,8 +253,8 @@ mysqlclient==1.3.7 \
 # Report performance metrics and exceptions to New Relic
 # Docs: https://docs.newrelic.com/docs/agents/python-agent/
 # Changes: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes
-newrelic==3.2.0.91 \
-    --hash=sha256:2d1cf00e105f423c5c5fa9ce3f6179773683e6ee52fb64016441abd225b43bf3
+newrelic==3.2.1.93 \
+    --hash=sha256:e60204f6d6b41741021d078ad5145414c759ff2482e2136ce22c9957654d9ca7
 
 # Compile .po files into .mo files, used in locale/compile-mo.sh
 polib==1.1.0 \


### PR DESCRIPTION
Make a few changes to try to handle the weird error in https://sentry.prod.mozaws.net/share/issue/37332e34333737383038/:

* Test that the server error page will render with a minimal ``request`` object.
* Test that ``request.user`` exists before calling ``request.user.is_authenticated()`` in templates included by ``500.html``.
* Update ``newrelic``, even though [the changes don't look relevant](https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes).