### PR TITLE
bug 1431259: change cache TTL from 5min to 24hr (experiment)

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1682,4 +1682,4 @@ RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
 
 # Caching constants for the Cache-Control header.
 CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE = config(
-    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 5, cast=int)
+    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 60 * 24, cast=int)


### PR DESCRIPTION
**This PR should not be merged until we're ready to run [the experiment to extend the CDN caching TTL](https://github.com/mdn/sprints/issues/175).**

Changes the `s_maxage` setting of the `Cache-Control` header from 5 minutes to 24 hours for all of the endpoints with responses modified by `kuma.core.utils.add_shared_cache_control`. This setting is used in turn by MDN's CloudFront CDN to set the TTL period for its caching. This is an experiment, and will be reverted a short time (2-5 days) after it's merged and deployed.