### PR TITLE
bug 1467518: Add Python 3.6 build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ cache:
       - node_modules
       - downloads
 language: python
-python:
-    - "2.7"
 services:
     - docker
     - memcached
@@ -26,21 +24,49 @@ env:
         - PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor
         - PIPELINE_SASS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/node-sass
         - PIPELINE_UGLIFYJS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/uglifyjs
-    matrix:
-        - TOXENV=py27
-          CREATE_DB=kuma
-          INSTALL_PIPELINE=1
-          INSTALL_ELASTICSEARCH=1
-        - TOXENV=flake8
-        - TOXENV=docs
-        - TOXENV=locales
-          CREATE_DB=kuma
-          INSTALL_PIPELINE=1
-        - TOXENV=docker
-          INSTALL_DOCKER_COMPOSE=1
-          UID=0
-        - TOXENV=stylelint
 
+matrix:
+    include:
+        - python: "2.7"
+          env:
+            TOXENV=pytest
+            CREATE_DB=kuma
+            INSTALL_PIPELINE=1
+            INSTALL_ELASTICSEARCH=1
+        - python: "2.7"
+          env:
+            TOXENV=flake8
+        - python: "2.7"
+          env:
+            TOXENV=docs
+        - python: "2.7"
+          env:
+            TOXENV=locales
+            CREATE_DB=kuma
+            INSTALL_PIPELINE=1
+        - python: "2.7"
+          env:
+            TOXENV=docker
+            INSTALL_DOCKER_COMPOSE=1
+            UID=0
+        - python: "2.7"
+          env:
+            TOXENV=stylelint
+        - python: "3.6"
+          env:
+            TOXENV=pytest
+            CREATE_DB=kuma
+            INSTALL_PIPELINE=1
+            INSTALL_ELASTICSEARCH=1
+            PYTHONHASHSEED=0
+    allow_failures:
+        - python: "3.6"
+          env:
+            TOXENV=pytest
+            CREATE_DB=kuma
+            INSTALL_PIPELINE=1
+            INSTALL_ELASTICSEARCH=1
+            PYTHONHASHSEED=0
 install:
     - nvm install 6
     - nvm use 6

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -116,11 +116,34 @@ click==6.7 \
     --hash=sha256:f15516df478d5a56180fbf80e68f206010e6d160fc39fa508b65e035fd75130b
 
 # django-allauth
+#
+# Implementation of the OAuth request-signing logic
+# Code: https://github.com/oauthlib/oauthlib
+# Changes: https://github.com/oauthlib/oauthlib/blob/master/CHANGELOG.rst
+# Docs: https://oauthlib.readthedocs.io/en/latest/index.html
 oauthlib==2.0.4 \
     --hash=sha256:514e293cb356dd53d596692207d48d9231b997995c9a4167eefa868583d74d13
+# XML bomb protection for Python stdlib modules
+# Code: https://github.com/tiran/defusedxml
+# Changes: https://github.com/tiran/defusedxml/blob/master/CHANGES.txt
+defusedxml==0.5.0 \
+    --hash=sha256:24d7f2f94f7f3cb6061acb215685e5125fbcdc40a857eff9de22518820b0a4f4 \
+    --hash=sha256:702a91ade2968a82beb0db1e0766a6a273f33d4616a6ce8cde475d8e09853b20
+# OpenID library for Python 2
+# Code: https://github.com/openid/python-openid
 python-openid==2.2.5 \
     --hash=sha256:92c51c3ecec846cbec4aeff11f9ff47303d4a63f93b0e6ac0ec02a091fed70ef \
     --hash=sha256:c2d133e47e0a7705c9272eef00d7a09c174f5bf17a127fed8e2c6499556cc782
+# OpenID library for Python 3
+# Code: https://github.com/necaris/python3-openid
+# Changes: https://github.com/necaris/python3-openid/blob/master/CHANGES.md
+python3-openid==3.1.0 \
+    --hash=sha256:0086da6b6ef3161cfe50fb1ee5cceaf2cda1700019fda03c2c5c440ca6abe4fa \
+    --hash=sha256:628d365d687e12da12d02c6691170f4451db28d6d68d050007e4a40065868502
+# OAuth library support for Requests
+# Code: https://github.com/requests/requests-oauthlib
+# Changes: https://github.com/requests/requests-oauthlib/blob/master/HISTORY.rst
+# Docs: https://requests-oauthlib.readthedocs.io/en/latest/
 requests-oauthlib==0.8.0 \
     --hash=sha256:883ac416757eada6d3d07054ec7092ac21c7f35cb1d2cf82faf205637081f468 \
     --hash=sha256:50a8ae2ce8273e384895972b56193c7409601a66d4975774c60c2aed869639ca

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -221,12 +221,6 @@ gunicorn==19.7.1 \
     --hash=sha256:75af03c99389535f218cc596c7de74df4763803f7b63eb09d77e92b3956b36c6 \
     --hash=sha256:eee1169f0ca667be05db3351a0960765620dad53f53434262ff8901b68a1b622
 
-# String-based Python imports
-importlib==1.0.3 \
-    --hash=sha256:7cbb514a352f821c69b8e8bdaa6b2e59728547a8965503c758652c2826d157b5 \
-    --hash=sha256:01fc0a2a1e01990a97b096615c11328fa4306ced1733c98d884160387760d479 \
-    --hash=sha256:65f342a604a2e1028707c5e055266ab2431c26e20fe10780b423320870884dac
-
 # Improved template engine
 # Code: https://github.com/pallets/jinja
 # Changes: http://jinja.pocoo.org/docs/2.10/changelog/

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
-envlist = py27, flake8, docs, dennis, docker, stylelint
+envlist = pytest, flake8, docs, locales, docker, stylelint
 skipsdist = True
 
-[testenv:py27]
+[testenv:pytest]
 whitelist_externals = make
 deps =
     -rrequirements/dev.txt


### PR DESCRIPTION
Add a optional TravisCI build that runs the tests under Python 3.6. This requires changing the way the builds are configured so that most will continue to run under Python 2.7.

Clean up the tox.ini configuration to call this build "pytest" rather than "py27", and fix the locales target.

Update requirements so that they install without errors:
* ``importlib`` isn't needed in Python 2.7, and fails to install in 3.6 - remove it
* ``django-allauth`` requires ``python3-openid``, which requires ``defusexml``, under Python 3.x

Tests don't even run, due to non-compat code in a library, but this is a starting point so @MatonAnthony and others can start iterating on Python 3 changes.