### PR TITLE
bug 1468540: Prepend .interactive to tabbed editor classes to fix specificity bug

### DIFF
--- a/kuma/static/styles/components/wiki/interactive.scss
+++ b/kuma/static/styles/components/wiki/interactive.scss
@@ -36,16 +36,16 @@
 }
 
 /* custom sizing classes for the tabbed interactive editor */
-.tabbed-shorter {
+.interactive.tabbed-shorter {
     height: 375px;
 }
 
-.tabbed-standard {
+.interactive.tabbed-standard {
     height: 445px;
 }
 
-.tabbed-taller {
-    height: 745px;
+.interactive.tabbed-taller {
+    height: 655px;
 }
 
 @media #{$mq-small-desktop-and-up} {


### PR DESCRIPTION
Fixes a bug with specificity of the tabbed editor styles.