### PR TITLE
bug 1468490: Update to Debian 9 (stretch) base image

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -1,17 +1,49 @@
-FROM python:2.7-slim-jessie
+FROM python:2.7-slim
 
-# extra python env
-ENV PYTHONDONTWRITEBYTECODE=1
-ENV PYTHONUNBUFFERED=1
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-# disable this when preparing for Django upgrade
-ENV PYTHONWARNINGS=ignore
+# Set the environment variables
+ENV NODE_VERSION=6.14.2 \
+    # extra python env
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # disable this when preparing for Django upgrade
+    PYTHONWARNINGS=ignore \
+    # Kuma Pipeline definitions
+    PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
+    PIPELINE_CLEANCSS_BINARY=/usr/local/bin/cleancss \
+    PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor \
+    PIPELINE_SASS_BINARY=/usr/local/bin/node-sass \
+    PIPELINE_UGLIFYJS_BINARY=/usr/local/bin/uglifyjs \
+    # gunicorn concurrency
+    WEB_CONCURRENCY=4
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        xz-utils \
+        gpg \
+        dirmngr \
+        libsasl2-modules \
+        gettext \
+        mime-support \
+        build-essential \
+        libtidy-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libffi-dev \
+        libjpeg-dev \
+        libmagic-dev \
+        default-libmysqlclient-dev \
+        mysql-client \
+    && rm -rf /var/lib/apt/lists/*
 
 # ----------------------------------------------------------------------------
-# add node.js 6.12, copied from:
-#     https://github.com/nodejs/docker-node/blob/master/6.12/slim/Dockerfile
-# but with curl added to the list of packages installed.
+# add node.js 6.x, copied from:
+#     https://github.com/nodejs/docker-node/blob/master/6/stretch/Dockerfile
+# but with package updates and version definitions moved above
 # ----------------------------------------------------------------------------
+
 RUN set -ex \
   && for key in \
     94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
@@ -23,15 +55,12 @@ RUN set -ex \
     56730D5401028683275BD23C23EFEFE93C4CFFFE \
     77984A986EBC2AA786BC0F66B01FBB92821C587A \
   ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
-ENV NODE_VERSION 6.12.0
-
-RUN buildDeps='xz-utils' \
-    && ARCH= && dpkgArch="$(dpkg --print-architecture)" \
+RUN ARCH=  && dpkgArch="$(dpkg --print-architecture)" \
     && case "${dpkgArch##*-}" in \
       amd64) ARCH='x64';; \
       ppc64el) ARCH='ppc64le';; \
@@ -41,53 +70,14 @@ RUN buildDeps='xz-utils' \
       i386) ARCH='x86';; \
       *) echo "unsupported architecture"; exit 1 ;; \
     esac \
-    && set -x \
-    && apt-get update && apt-get install -y curl $buildDeps --no-install-recommends \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
-    && curl -SLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
     && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
     && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
     && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
-    && apt-get purge -y --auto-remove $buildDeps \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
-
-ENV YARN_VERSION 1.3.2
-
-RUN set -ex \
-  && for key in \
-    6A010C5166006599AA17F08146C2130DFD2497F5 \
-  ; do \
-    gpg --keyserver pgp.mit.edu --recv-keys "$key" || \
-    gpg --keyserver keyserver.pgp.com --recv-keys "$key" || \
-    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key" ; \
-  done \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz" \
-  && curl -fSLO --compressed "https://yarnpkg.com/downloads/$YARN_VERSION/yarn-v$YARN_VERSION.tar.gz.asc" \
-  && gpg --batch --verify yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz \
-  && mkdir -p /opt/yarn \
-  && tar -xzf yarn-v$YARN_VERSION.tar.gz -C /opt/yarn --strip-components=1 \
-  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarn \
-  && ln -s /opt/yarn/bin/yarn /usr/local/bin/yarnpkg \
-  && rm yarn-v$YARN_VERSION.tar.gz.asc yarn-v$YARN_VERSION.tar.gz
 # ----------------------------------------------------------------------------
-
-RUN set -ex && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends \
-        gettext \
-        mime-support \
-        build-essential \
-        libtidy-dev \
-        libxml2-dev \
-        libxslt1-dev \
-        libffi-dev \
-        libjpeg-dev \
-        libmagic-dev \
-        libmysqlclient-dev \
-        mysql-client \
-    && rm -rf /var/lib/apt/lists/*
 
 # add non-priviledged user
 RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home kuma
@@ -104,12 +94,6 @@ RUN npm install -g \
         clean-css@3.4.23 \
         stylelint@7.10.1
 
-ENV PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
-    PIPELINE_CLEANCSS_BINARY=/usr/local/bin/cleancss \
-    PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor \
-    PIPELINE_SASS_BINARY=/usr/local/bin/node-sass \
-    PIPELINE_UGLIFYJS_BINARY=/usr/local/bin/uglifyjs
-
 COPY ./requirements /app/requirements
 RUN pip install --no-cache-dir -r requirements/dev.txt
 
@@ -119,5 +103,4 @@ RUN touch /usr/local/lib/python2.7/site-packages/backports/__init__.py
 
 USER kuma
 
-ENV WEB_CONCURRENCY=4
 CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--timeout=120", "--worker-class=meinheld.gmeinheld.MeinheldWorker", "kuma.wsgi:application"]


### PR DESCRIPTION
Update the Python base image from Debian 8 (jessie) to 9 (stretch), which is the current LTS release, along with some additional cleanup:

Move the `ENV` declarations to the top, to reduce the number of intermediate images.

Move all the package installation to the same section, to avoid refreshing the `apt-get` cache twice. Include the `gpg` package and dependencies, which is no longer in the default image. Update the names of the MySQL packages.

Update the `node.js` installation code to bump the minor version and use the current code for importing GPG signing keys. Drop the unused `yarn` install. The 8.x node.js update will come later.