### PR TITLE
Bug 1127798: Kuma test suite depends on dict order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,6 @@ env:
           CREATE_DB=kuma
           INSTALL_PIPELINE=1
           INSTALL_ELASTICSEARCH=1
-          PYTHONHASHSEED=0
         - TOXENV=flake8
         - TOXENV=docs
         - TOXENV=locales
@@ -41,15 +40,7 @@ env:
           INSTALL_DOCKER_COMPOSE=1
           UID=0
         - TOXENV=stylelint
-        # TODO: make random hash seed the default when http://bugzil.la/1127798 is fixed
-        - TOXENV=py27
-          CREATE_DB=kuma
-          INSTALL_PIPELINE=1
-          INSTALL_ELASTICSEARCH=1
 
-matrix:
-    allow_failures:
-        - env: TOXENV=py27 CREATE_DB=kuma INSTALL_PIPELINE=1 INSTALL_ELASTICSEARCH=1
 install:
     - nvm install 6
     - nvm use 6

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -18,8 +18,7 @@ from statici18n.templatetags.statici18n import statici18n
 from urlobject import URLObject
 
 from ..urlresolvers import reverse, split_path
-from ..utils import format_date_time, urlparams
-
+from ..utils import format_date_time, order_params, urlparams
 
 htmlparser = HTMLParser.HTMLParser()
 
@@ -134,7 +133,7 @@ def add_utm(url_, campaign, source='developer.mozilla.org', medium='email'):
         'utm_campaign': campaign,
         'utm_source': source,
         'utm_medium': medium})
-    return str(url_obj)
+    return order_params(str(url_obj))
 
 
 @library.global_function

--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -1,7 +1,9 @@
+import pytest
 from django.test import TestCase
 
+from kuma.core.utils import order_params, smart_int
+
 from . import eq_
-from ..utils import smart_int
 
 
 class SmartIntTestCase(TestCase):
@@ -21,3 +23,13 @@ class SmartIntTestCase(TestCase):
     def test_wrong_type(self):
         eq_(0, smart_int(None))
         eq_(10, smart_int([], 10))
+
+
+@pytest.mark.parametrize(
+    'original,expected',
+    (('https://example.com', 'https://example.com'),
+     ('http://example.com?foo=bar&foo=', 'http://example.com?foo=&foo=bar'),
+     ('http://example.com?foo=bar&bar=baz', 'http://example.com?bar=baz&foo=bar'),
+     ))
+def test_order_params(original, expected):
+    assert order_params(original) == expected

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -23,6 +23,7 @@ from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 from polib import pofile
 from pytz import timezone
+from six.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
 from taggit.utils import split_strip
 
 from .cache import memcache
@@ -492,3 +493,13 @@ def add_shared_cache_control(response, **kwargs):
     cc_kwargs.update(kwargs)
 
     patch_cache_control(response, **cc_kwargs)
+
+
+def order_params(original_url):
+    """Standardize order of query parameters."""
+    bits = urlsplit(original_url)
+    qs = parse_qsl(bits.query, keep_blank_values=True)
+    qs.sort()
+    new_qs = urlencode(qs)
+    new_url = urlunsplit((bits.scheme, bits.netloc, bits.path, new_qs, bits.fragment))
+    return new_url

--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.utils import order_params
 
 from ..utils import QueryURLObject
 
@@ -36,16 +37,16 @@ class URLTests(KumaTestCase):
         original = 'http://example.com/?foo=&spam=eggs&foo=bar'
         url = QueryURLObject(original)
 
-        eq_(url.merge_query_param('foo', None),
-            'http://example.com/?foo=&foo=bar&spam=eggs')
+        merged_url = order_params(url.merge_query_param('foo', None))
+        assert merged_url == 'http://example.com/?foo=&foo=bar&spam=eggs'
 
-        eq_(url.merge_query_param('foo', [None]),
-            'http://example.com/?foo=&foo=bar&spam=eggs')
+        merged_url = order_params(url.merge_query_param('foo', [None]))
+        assert merged_url == 'http://example.com/?foo=&foo=bar&spam=eggs'
 
         # bug 930300
         url = QueryURLObject('http://example.com/en-US/search?q=javascript%20&&&highlight=false')
-        eq_(url.merge_query_param('topic', 'api'),
-            'http://example.com/en-US/search?q=javascript&topic=api&highlight=false')
+        merged_url = order_params(url.merge_query_param('topic', 'api'))
+        assert merged_url == 'http://example.com/en-US/search?highlight=false&q=javascript&topic=api'
 
     def test_clean_params(self):
         for url in ['http://example.com/?spam=',

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -168,8 +168,9 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         resp = e_info.value.response
         assert 'Banned by unit test.' in resp.content
         assert not resp.has_header('Vary')
-        never_cache = 'no-cache, no-store, must-revalidate, max-age=0'
-        assert resp['Cache-Control'] == never_cache
+
+        never_cache = ['no-cache', 'no-store', 'must-revalidate', 'max-age=0']
+        assert set(resp['Cache-Control'].split(", ")) == set(never_cache)
 
 
 class KumaAccountAdapterTestCase(UserTestCase):

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -15,17 +15,17 @@ from django_jinja import library
 from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
-from kuma.core.utils import urlparams
+from kuma.core.utils import order_params, urlparams
 
 from ..constants import DIFF_WRAP_COLUMN
 from ..utils import tidy_content
 
 
 def get_compare_url(doc, from_id, to_id):
-    return urlparams(
+    return order_params(urlparams(
         reverse('wiki.compare_revisions', args=[doc.slug], locale=doc.locale),
         **{'from': from_id, 'to': to_id}
-    )
+    ))
 
 
 @library.filter

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -422,13 +422,13 @@ class InjectSectionEditingLinksTests(TestCase):
             <p>test</p>
         """
         expected = """
-            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s1" href="/en-US/docs/some-slug$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>Head 1</h1>
+            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s1" href="/en-US/docs/some-slug$edit?edit_links=true&amp;section=s1" title="Edit section">Edit</a>Head 1</h1>
             <p>test</p>
             <p>test</p>
-            <h2 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s2" href="/en-US/docs/some-slug$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>Head 2</h2>
+            <h2 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s2" href="/en-US/docs/some-slug$edit?edit_links=true&amp;section=s2" title="Edit section">Edit</a>Head 2</h2>
             <p>test</p>
             <p>test</p>
-            <h3 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s3" href="/en-US/docs/some-slug$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>Head 3</h3>
+            <h3 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/some-slug?raw=true&amp;section=s3" href="/en-US/docs/some-slug$edit?edit_links=true&amp;section=s3" title="Edit section">Edit</a>Head 3</h3>
             <p>test</p>
             <p>test</p>
         """
@@ -436,7 +436,7 @@ class InjectSectionEditingLinksTests(TestCase):
                   .parse(doc_src)
                   .injectSectionEditingLinks('some-slug', 'en-US')
                   .serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 class CodeSyntaxFilterTests(TestCase):
@@ -1307,7 +1307,7 @@ def test_extractor_section(root_doc, annotate_links):
 def test_summary_section(markup, text, wrapper):
     content = wrapper.format(markup)
     assert get_seo_description(content, 'en-US') == text
-    assert get_seo_description(content, 'en-US', False) == markup
+    assert normalize_html(get_seo_description(content, 'en-US', False)) == normalize_html(markup)
 
 
 @pytest.mark.parametrize('wrapper', SUMMARY_WRAPPERS.values(),
@@ -1318,7 +1318,7 @@ def test_summary_section(markup, text, wrapper):
 def test_multiple_seo_summaries(markup, expected_markup, text, wrapper):
     content = wrapper.format(markup)
     assert get_seo_description(content, 'en-US') == text
-    assert get_seo_description(content, 'en-US', False) == expected_markup
+    assert normalize_html(get_seo_description(content, 'en-US', False)) == normalize_html(expected_markup)
 
 
 def test_empty_paragraph_content():

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -133,7 +133,7 @@ utm_source=developer.mozilla.org">View Page</a>
 utm_source=developer.mozilla.org">Edit Page</a>
     </td>
     <td>
-      <a href="/en-US/docs/Root$compare?to=%(to_id)s&from=%(from_id)s&\
+      <a href="/en-US/docs/Root$compare?from=%(from_id)s&to=%(to_id)s&\
 utm_campaign=feed&utm_medium=rss&utm_source=developer.mozilla.org">
         Show comparison
       </a>

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -703,7 +703,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         # cause notification emails to error
         # and stop being sent.
         time.sleep(1)
-        eq_(2, len(mail.outbox))
+        assert 2 == len(mail.outbox)
         first_edit_email = mail.outbox[0]
         expected_to = [config.EMAIL_LIST_SPAM_WATCH]
         expected_subject = (
@@ -712,20 +712,21 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
              'user': new_rev.creator.username,
              'title': self.d.title}
         )
-        eq_(expected_subject, first_edit_email.subject)
-        eq_(expected_to, first_edit_email.to)
+        assert expected_subject == first_edit_email.subject
+        assert expected_to == first_edit_email.to
 
         edited_email = mail.outbox[1]
         expected_to = [u'sam@example.com']
         expected_subject = (u'[MDN][en-US] Page "%s" changed by %s'
                             % (self.d.title, new_rev.creator))
-        eq_(expected_subject, edited_email.subject)
-        eq_(expected_to, edited_email.to)
-        ok_('%s changed %s.' % (unicode(self.username), unicode(self.d.title))
-            in edited_email.body)
-        ok_(u'https://testserver/en-US/docs/%s$history?utm_campaign=' %
-            self.d.slug
-            in edited_email.body)
+
+        assert expected_subject == edited_email.subject
+        assert expected_to == edited_email.to
+
+        assert '%s changed %s.' % (unicode(self.username), unicode(self.d.title)) in edited_email.body
+
+        assert u'https://testserver/en-US/docs/%s$history' % self.d.slug in edited_email.body
+        assert 'utm_campaign=' in edited_email.body
 
     @mock.patch.object(EditDocumentEvent, 'fire')
     @mock.patch.object(Site.objects, 'get_current')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -740,7 +740,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert 'public' not in resp['Cache-Control']
         assert 's-maxage' not in resp['Cache-Control']
         assert 'docs/new' in resp['Location']
-        assert ('?slug=%s' % local_slug) in resp['Location']
+        assert ('slug=%s' % local_slug) in resp['Location']
 
         # Ensure real 404 for visit to non-existent page with params common to
         # kumascript and raw content API.
@@ -2322,26 +2322,26 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             <h1 id="s1">s1</h1>
             <p>test</p>
             <p>test</p>
-
             <h1 id="s2">s2</h1>
             <p>test</p>
             <p>test</p>
-
             <h1 id="s3">s3</h1>
             <p>test</p>
             <p>test</p>
         """)
+
         expected = """
-            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s1" href="/en-US/docs/%(slug)s$edit?section=s1&amp;edit_links=true" title="Edit section">Edit</a>s1</h1>
+            <h1 id="s1"><a class="edit-section" data-section-id="s1" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s1" href="/en-US/docs/%(slug)s$edit?edit_links=true&amp;section=s1" title="Edit section">Edit</a>s1</h1>
             <p>test</p>
             <p>test</p>
-            <h1 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s2" href="/en-US/docs/%(slug)s$edit?section=s2&amp;edit_links=true" title="Edit section">Edit</a>s2</h1>
+            <h1 id="s2"><a class="edit-section" data-section-id="s2" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s2" href="/en-US/docs/%(slug)s$edit?edit_links=true&amp;section=s2" title="Edit section">Edit</a>s2</h1>
             <p>test</p>
             <p>test</p>
-            <h1 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s3" href="/en-US/docs/%(slug)s$edit?section=s3&amp;edit_links=true" title="Edit section">Edit</a>s3</h1>
+            <h1 id="s3"><a class="edit-section" data-section-id="s3" data-section-src-url="/en-US/docs/%(slug)s?raw=true&amp;section=s3" href="/en-US/docs/%(slug)s$edit?edit_links=true&amp;section=s3" title="Edit section">Edit</a>s3</h1>
             <p>test</p>
             <p>test</p>
         """ % {'slug': rev.document.slug}
+
         response = self.client.get('%s?raw=true&edit_links=true' %
                                    reverse('wiki.document',
                                            args=[rev.document.slug]),


### PR DESCRIPTION
The kuma suite currently depends on dict order.

This is an attempt to remove this dependency, which would allow us to remove a considerable chunk of configuration and a better mirror of the real usage of the code.