### PR TITLE
bug 1431259: change cache TTL from 24hr back to 5min

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1682,4 +1682,4 @@ RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
 
 # Caching constants for the Cache-Control header.
 CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE = config(
-    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 60 * 24, cast=int)
+    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 5, cast=int)


### PR DESCRIPTION
**This PR ends [the experiment to extend the CDN caching TTL](https://github.com/mdn/sprints/issues/175).**

Reverts the `s_maxage` setting of the `Cache-Control` header from 24 hours back to 5 minutes (see #4845).