### PR TITLE
bug 1468414: update cdn tests to reflect new cdn config

### DIFF
--- a/tests/headless/test_cdn.py
+++ b/tests/headless/test_cdn.py
@@ -362,7 +362,6 @@ LOCALE_SELECTORS = {
      '/profile',
      '/promote',
      '/profiles/sheppy',
-     '/users/signin',
      '/unsubscribe/1',
      '/docs.json?slug=Web/HTML',
      '/docs/Web/HTML',
@@ -436,7 +435,8 @@ def test_locale_selection_cached(base_url, is_behind_cdn, is_local_url, slug,
                          LOCALE_SELECTORS.values(),
                          ids=LOCALE_SELECTORS.keys())
 @pytest.mark.parametrize(
-    'slug', ['/docs/Web/HTML$edit',
+    'slug', ['/users/signin',
+             '/docs/Web/HTML$edit',
              '/docs/Web/HTML$move',
              '/docs/Web/HTML$files',
              '/docs/Web/HTML$purge',


### PR DESCRIPTION
When submitting https://github.com/mdn/infra/pull/5 and https://github.com/mdn/infra/pull/6, I failed to update the headless CDN tests to reflect the addition of the `users*` behavior. This change affected the 4 locale-selection tests for the `/users/signin` slug. This PR updates the tests to reflect the CloudFront CDN changes on stage and production.