### PR TITLE
bug 1469029: keep two zone-related css classes

### DIFF
--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -183,3 +183,11 @@ Utility classes
         @extend %offscreen-placeholder;
     }
 }
+
+.bump-left-padding {
+    padding-left: $grid-spacing * 2;
+}
+
+.light-grey-background {
+	background-color: $grey-light;
+}

--- a/kuma/static/styles/base/utilities.scss
+++ b/kuma/static/styles/base/utilities.scss
@@ -189,5 +189,5 @@ Utility classes
 }
 
 .light-grey-background {
-	background-color: $grey-light;
+    background-color: $grey-light;
 }

--- a/kuma/static/styles/components/wiki/customcss.scss
+++ b/kuma/static/styles/components/wiki/customcss.scss
@@ -578,5 +578,31 @@ pre span.comment {
     display: inline;
 }
 
+/*
+  Zone-related classes kept after the removal of zones.
+  (See https://bugzilla.mozilla.org/show_bug.cgi?id=1469029)
+ */
+
+/*
+  reference-values:
+
+  This gives an extra indent to a dl, when it's embedded inside another dl,
+  which comes up sometimes in the reference pages. The extra indent indicates
+  that the embedded dl is part of an embedded list, not the main list.
+ */
+dd > dl.reference-values {
+    padding-left: 40px;
+}
+
+/*
+  webextension-api-sidebar:
+
+  This applies a background color to the piece of a sidebar containing the
+  api items relevant to the current page. It helps people orient themselves
+  within the sidebar.
+ */
+li.webextension-api-sidebar {
+    background-color: #f4f7f8;
+}
 
 /*end!*/

--- a/kuma/static/styles/components/wiki/customcss.scss
+++ b/kuma/static/styles/components/wiki/customcss.scss
@@ -586,23 +586,32 @@ pre span.comment {
 /*
   reference-values:
 
+  NOTE: This has been DEPRECATED. New work should use the utility
+        class "bump-left-padding" instead of "reference-values",
+        and this rule should be removed when it is no longer used
+        on any document pages.
+
   This gives an extra indent to a dl, when it's embedded inside another dl,
   which comes up sometimes in the reference pages. The extra indent indicates
   that the embedded dl is part of an embedded list, not the main list.
  */
 dd > dl.reference-values {
-    padding-left: 40px;
+    padding-left: $grid-spacing * 2;
 }
 
 /*
   webextension-api-sidebar:
+
+  TODO: Replace the use of "webextension-api-sidebar" with the utility class
+        "light-grey-background" within the "WebExtAPISidebar.ejs" Kumascript
+        macro and then remove this rule.
 
   This applies a background color to the piece of a sidebar containing the
   api items relevant to the current page. It helps people orient themselves
   within the sidebar.
  */
 li.webextension-api-sidebar {
-    background-color: #f4f7f8;
+    background-color: $grey-light;
 }
 
 /*end!*/


### PR DESCRIPTION
This is a companion PR to #4853. If/when that PR is merged/deployed, this PR should be merged/deployed as well.

The "death of zones" PR (#4853) removes all zone-related CSS. However, we'd actually like to keep two classes (see [bugzilla 1469029](https://bugzilla.mozilla.org/show_bug.cgi?id=1469029)). This PR adds those two classes into the mainstream CSS.

I wasn't sure of the best place for these two classes to live, so please suggest a different home if you don't like my choice.