### PR TITLE
Add jinja helper for SVG. Fix issue 23 on sprints repo

### DIFF
--- a/jinja2/includes/footer/mdn-footer.html
+++ b/jinja2/includes/footer/mdn-footer.html
@@ -8,14 +8,12 @@
     <li><a href="{{ wiki_url('MDN/Feedback') }}">{{ _('Feedback') }}</a></li>
     <li class="footer-social">
         <a href="https://twitter.com/mozdevnet">
-            <!-- {{ _('Twitter') }} -->{# TODO: Add to SVG as translated title #}
-            {% include 'includes/icons/social/twitter.svg' %}
+            {{ include_svg('includes/icons/social/twitter.svg', _('Twitter')) }}
         </a>
     </li>
     <li class="footer-social">
         <a href="https://github.com/mdn/">
-            <!-- {{ _('GitHub') }} -->{# TODO: Add to SVG as translated title #}
-            {% include 'includes/icons/social/github.svg' %}
+            {{ include_svg('includes/icons/social/github.svg', _('GitHub')) }}
         </a>
     </li>
   </ul>

--- a/jinja2/includes/footer/moz-footer.html
+++ b/jinja2/includes/footer/moz-footer.html
@@ -7,20 +7,17 @@
     <li><a href="https://www.mozilla.org/firefox/?utm_source=developer.mozilla.org&utm_campaign=footer&utm_medium=referral">Firefox</a></li>
     <li class="footer-social">
         <a href="https://twitter.com/mozilla">
-            <!-- {{ _('Twitter') }} -->{# TODO: Add to SVG as translated title #}
-            {% include 'includes/icons/social/twitter.svg' %}
+            {{ include_svg('includes/icons/social/twitter.svg', _('Twitter')) }}
         </a>
     </li>
     <li class="footer-social">
         <a href="https://www.facebook.com/mozilla">
-            <!-- {{ _('Facebook') }} -->{# TODO: Add to SVG as translated title #}
-            {% include 'includes/icons/social/facebook.svg' %}
+            {{ include_svg('includes/icons/social/facebook.svg', _('Facebook')) }}
         </a>
     </li>
     <li class="footer-social">
         <a href="https://www.instagram.com/mozillagram/">
-            <!-- {{ _('Instagram') }} -->{# TODO: Add to SVG as translated title #}
-            {% include 'includes/icons/social/instagram.svg' %}
+            {{ include_svg('includes/icons/social/instagram.svg', _('Instagram')) }}
         </a>
     </li>
   </ul>

--- a/kuma/users/jinja2/socialaccount/snippets/login_service_icon.html
+++ b/kuma/users/jinja2/socialaccount/snippets/login_service_icon.html
@@ -1,4 +1,3 @@
 {% if request.session.sociallogin_provider == 'github' %}
-    <!-- {{ _('Signed in with GitHub') }} -->{# TODO: Add to SVG as translated title #}
-    {% include 'includes/icons/social/github.svg' %}
+    {{ include_svg('includes/icons/social/github.svg', _('Signed in with GitHub')) }}
 {% endif %}

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -3,7 +3,7 @@ import mock
 import pytest
 
 from django.contrib.sites.models import Site
-from jinja2 import TemplateNotFound
+from django.template import TemplateDoesNotExist
 from pyquery import PyQuery as pq
 
 from kuma.core.cache import memcache
@@ -45,7 +45,7 @@ class HelpTests(WikiTestCase):
 
 def test_include_svg_invalid_path():
     """An invalid SVG path raises an exception."""
-    with pytest.raises(TemplateNotFound):
+    with pytest.raises(TemplateDoesNotExist):
         include_svg('invalid.svg')
 
 


### PR DESCRIPTION
This adds the Jinja helper for SVG. Also applies the new helper to currently identified use cases. Open question is whether we should make `include_svg` the standard way to include SVG files in HTML or only use it when we want to pass a custom title.