### PR TITLE
Remove ok_() from tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -188,7 +188,7 @@ conversion to take a few more years.
 
 We **avoid** old-style tests that use Django's
 [TestCase testing classes][testcase], [fixture files][fixture_files],
-test functions [``eq_``][eq] and [``ok_``][ok], and general-purpose factory
+[``eq_``][eq] test function and general-purpose factory
 functions like [get_user][get_user], [document][document], and
 [revision][revision].
 

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -33,16 +33,6 @@ def eq_(first, second, msg=None):
     assert first == second, msg
 
 
-def ok_(pred, msg=None):
-    """Rough reimplementation of nose.tools.ok_
-
-    Note: This should be removed as soon as we no longer use it.
-
-    """
-    msg = msg or '%r != True' % pred
-    assert pred, msg
-
-
 def get_user(username='testuser'):
     """Return a django user or raise FixtureMissingError"""
     User = get_user_model()

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.test import override_settings, RequestFactory, TestCase
 from soapbox.models import Message
 
-from kuma.core.tests import eq_, KumaTestCase, ok_
+from kuma.core.tests import eq_, KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
@@ -50,9 +50,8 @@ class TestSoapbox(KumaTestCase):
         m = Message(message='Go to http://bit.ly/sample-demo', is_global=True,
                     is_active=True, url='/')
         m.save()
-        ok_('Go to <a href="http://bit.ly/sample-demo" rel="noopener">'
-            'http://bit.ly/sample-demo</a>' in
-            soapbox_messages(get_soapbox_messages('/')))
+        assert 'Go to <a href="http://bit.ly/sample-demo" rel="noopener">' \
+               'http://bit.ly/sample-demo</a>' in soapbox_messages(get_soapbox_messages('/'))
 
 
 class TestDateTimeFormat(UserTestCase):

--- a/kuma/core/tests/test_templates.py
+++ b/kuma/core/tests/test_templates.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 from django.utils import translation
 from pyquery import PyQuery as pq
 
-from . import eq_, KumaTestCase, ok_
+from . import eq_, KumaTestCase
 
 
 class MockRequestTests(KumaTestCase):
@@ -49,7 +49,7 @@ class BaseTemplateTests(MockRequestTests):
         doc = pq(html)
         # Check default locale is in the first choice field
         first_field = doc("#language.autosubmit option")[0].text_content()
-        ok_(settings.LANGUAGE_CODE in first_field)
+        assert settings.LANGUAGE_CODE in first_field
 
 
 class ErrorListTests(MockRequestTests):

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -11,7 +11,7 @@ from ratelimit.exceptions import Ratelimited
 from soapbox.models import Message
 
 from . import (assert_no_cache_header, assert_shared_cache_header, eq_,
-               KumaTestCase, ok_)
+               KumaTestCase)
 from ..urlresolvers import reverse
 from ..views import handler500
 
@@ -74,8 +74,9 @@ class LoggingTests(KumaTestCase):
         response = self.client.get(self.suspicous_path)
         eq_(response.status_code, 400)
         eq_(1, len(mail.outbox))
-        ok_('admin@example.com' in mail.outbox[0].to)
-        ok_(self.suspicous_path in mail.outbox[0].body)
+
+        assert 'admin@example.com' in mail.outbox[0].to
+        assert self.suspicous_path in mail.outbox[0].body
 
 
 class SoapboxViewsTest(KumaTestCase):

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -13,7 +13,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_, ok_)
+                             assert_shared_cache_header, eq_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html, urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
@@ -361,7 +361,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
                 'wiki.document',
                 kwargs={'document_path': revision.document.slug}
             )
-            ok_(document_url in table_row_text)
+            assert document_url in table_row_text
 
     def test_spam_trends_show(self, mock_analytics_upageviews):
         """The spam trends table shows up."""

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,7 +1,7 @@
 from constance.test import override_config
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import eq_, KumaTestCase, ok_
+from kuma.core.tests import eq_, KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.search.models import Filter, FilterGroup
 
@@ -13,12 +13,12 @@ class HomeTests(KumaTestCase):
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
             response = self.client.get(url, follow=True)
             eq_(200, response.status_code)
-            ok_('ga(\'create' not in response.content)
+            assert 'ga(\'create' not in response.content
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
             response = self.client.get(url, follow=True)
             eq_(200, response.status_code)
-            ok_('ga(\'create' in response.content)
+            assert 'ga(\'create' in response.content
 
     def test_default_search_filters(self):
         url = reverse('home')

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -1,6 +1,6 @@
 from django.http import QueryDict
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.wiki.models import Document
 from kuma.wiki.signals import render_done
 
@@ -56,7 +56,7 @@ class FilterTests(ElasticTestCase):
         view = HighlightView.as_view()
         request = self.get_request('/en-US/search?q=article')
         response = view(request)
-        ok_('<mark>article</mark>' in response.data['documents'][0]['excerpt'])
+        assert '<mark>article</mark>' in response.data['documents'][0]['excerpt']
 
     def test_no_highlight_filter(self):
         class HighlightView(SearchView):
@@ -65,7 +65,7 @@ class FilterTests(ElasticTestCase):
         view = HighlightView.as_view()
         request = self.get_request('/en-US/search?q=article&highlight=false')
         response = view(request)
-        ok_('<mark>' not in response.data['documents'][0]['excerpt'])
+        assert '<mark>' not in response.data['documents'][0]['excerpt']
 
     def test_language_filter(self):
         class LanguageView(SearchView):

--- a/kuma/search/tests/test_indexes.py
+++ b/kuma/search/tests/test_indexes.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from elasticsearch_dsl.connections import connections
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.wiki.models import Document
 from kuma.wiki.search import WikiDocumentType
 
@@ -25,42 +25,42 @@ class TestIndexes(ElasticTestCase):
 
     def test_add_newindex(self):
         index = Index.objects.create()
-        ok_(not index.populated)
+        assert not index.populated
         index.populate()
         index = self._reload(index)
-        ok_(index.populated)
+        assert index.populated
         index.delete()
 
     def test_promote_index(self):
         index = Index.objects.create()
         index.populate()
         index = self._reload(index)
-        ok_(index.populated)
+        assert index.populated
         index.promote()
-        ok_(index.promoted)
+        assert index.promoted
 
         eq_(Index.objects.get_current().prefixed_name, index.prefixed_name)
 
         index.demote()
-        ok_(not index.promoted)
+        assert not index.promoted
 
     def test_there_can_be_only_one(self):
         """Tests that when one index is promoted, all others are demoted."""
         index1 = Index.objects.get_current()
-        ok_(index1.promoted)
+        assert index1.promoted
 
         index2 = Index.objects.create(name='second')
         index2.promote()
         index1 = self._reload(index1)
-        ok_(index2.promoted)
-        ok_(not index1.promoted)
+        assert index2.promoted
+        assert not index1.promoted
 
     def test_outdated(self):
         # first create and populate an index
         main_index = Index.objects.create(name='first')
         main_index.populate()
         main_index = self._reload(main_index)
-        ok_(main_index.populated)
+        assert main_index.populated
         main_index.promote()
         eq_(Index.objects.get_current().prefixed_name,
             main_index.prefixed_name)

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -4,7 +4,7 @@ from django.utils import translation
 from rest_framework import serializers
 from rest_framework.test import APIRequestFactory
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 
 from . import ElasticTestCase
@@ -54,12 +54,12 @@ class SerializerTests(ElasticTestCase):
         doc_serializer = DocumentSerializer(result, many=True)
         list_data = doc_serializer.data
         eq_(len(list_data), 7)
-        ok_(isinstance(list_data, list))
-        ok_(1 in [data['id'] for data in list_data])
+        assert isinstance(list_data, list)
+        assert 1 in [data['id'] for data in list_data]
 
         doc_serializer = DocumentSerializer(result[0], many=False)
         dict_data = doc_serializer.data
-        ok_(isinstance(dict_data, dict))
+        assert isinstance(dict_data, dict)
         eq_(dict_data['id'], result[0].id)
 
     def test_excerpt(self):
@@ -97,4 +97,4 @@ class FieldTests(ElasticTestCase):
 
         field = SiteURLField('wiki.document', args=['slug'])
         value = field.to_representation(FakeValue())
-        ok_('/de/docs/Firefox' in value)
+        assert '/de/docs/Firefox' in value

--- a/kuma/search/tests/test_types.py
+++ b/kuma/search/tests/test_types.py
@@ -1,6 +1,6 @@
 from elasticsearch_dsl import query
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 
 from . import ElasticTestCase
@@ -12,11 +12,11 @@ class WikiDocumentTypeTests(ElasticTestCase):
     def test_get_excerpt_strips_html(self):
         self.refresh()
         results = WikiDocumentType.search().query('match', content='audio')
-        ok_(results.count() > 0)
+        assert results.count()
         for doc in results.execute():
             excerpt = doc.get_excerpt()
-            ok_('audio' in excerpt)
-            ok_('<strong>' not in excerpt)
+            assert 'audio' in excerpt
+            assert '<strong>' not in excerpt
 
     def test_current_locale_results(self):
         self.refresh()
@@ -30,14 +30,14 @@ class WikiDocumentTypeTests(ElasticTestCase):
     def test_get_excerpt_uses_summary(self):
         self.refresh()
         results = WikiDocumentType.search().query('match', content='audio')
-        ok_(results.count() > 0)
+        assert results.count()
         for doc in results.execute():
             excerpt = doc.get_excerpt()
-            ok_('the word for tough things' in excerpt)
-            ok_('extra content' not in excerpt)
+            assert 'the word for tough things' in excerpt
+            assert 'extra content' not in excerpt
 
     def test_hidden_slugs_get_indexable(self):
         self.refresh()
         title_list = WikiDocumentType.get_indexable().values_list('title',
                                                                   flat=True)
-        ok_('User:jezdez' not in title_list)
+        assert 'User:jezdez' not in title_list

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -4,7 +4,7 @@ import pytest
 from django import forms
 from django.test import RequestFactory
 
-from kuma.core.tests import eq_, KumaTestCase, ok_
+from kuma.core.tests import eq_, KumaTestCase
 
 from . import user
 from ..adapters import (KumaAccountAdapter, USERNAME_CHARACTERS,
@@ -31,16 +31,16 @@ class TestUserEditForm(KumaTestCase):
 
     def test_can_keep_legacy_username(self):
         test_user = user(username='legacy@example.com', save=True)
-        ok_(test_user.has_legacy_username)
+        assert test_user.has_legacy_username
         data = {
             'username': 'legacy@example.com'
         }
         form = UserEditForm(data, instance=test_user)
-        ok_(form.is_valid(), repr(form.errors))
+        assert form.is_valid(), repr(form.errors)
 
     def test_cannot_change_legacy_username(self):
         test_user = user(username='legacy@example.com', save=True)
-        ok_(test_user.has_legacy_username)
+        assert test_user.has_legacy_username
         data = {
             'username': 'mr.legacy@example.com'
         }

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -3,7 +3,7 @@ from hashlib import md5
 
 from django.conf import settings
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 
 from . import UserTestCase
 from ..templatetags.jinja_helpers import gravatar_url, public_email
@@ -17,12 +17,12 @@ class HelperTestCase(UserTestCase):
 
     def test_default_gravatar(self):
         d_param = urllib.urlencode({'d': settings.DEFAULT_AVATAR})
-        ok_(d_param in gravatar_url(self.u.email),
-            "Bad default avatar: %s" % gravatar_url(self.u.email))
+        assert d_param in gravatar_url(self.u.email), \
+            "Bad default avatar: %s" % gravatar_url(self.u.email)
 
     def test_gravatar_url(self):
         self.u.email = 'test@test.com'
-        ok_(md5(self.u.email).hexdigest() in gravatar_url(self.u.email))
+        assert md5(self.u.email).hexdigest() in gravatar_url(self.u.email)
 
     def test_public_email(self):
         eq_('<span class="email">'

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -2,7 +2,7 @@ import pytest
 
 from django.core.exceptions import ValidationError
 
-from kuma.core.tests import eq_, ok_
+from kuma.core.tests import eq_
 from kuma.wiki.tests import revision
 
 from . import UserTestCase
@@ -79,7 +79,7 @@ class TestUser(UserTestCase):
         """We've added IRC nickname as a profile field.
         Make sure it shows up."""
         user = self.user_model.objects.get(username='testuser')
-        ok_(hasattr(user, 'irc_nickname'))
+        assert hasattr(user, 'irc_nickname')
         eq_('testuser', user.irc_nickname)
 
     def test_unicode_email_gravatar(self):
@@ -92,15 +92,15 @@ class TestUser(UserTestCase):
     def test_locale_timezone_fields(self):
         """We've added locale and timezone fields. Verify defaults."""
         user = self.user_model.objects.get(username='testuser')
-        ok_(hasattr(user, 'locale'))
-        ok_(user.locale == 'en-US')
-        ok_(hasattr(user, 'timezone'))
+        assert hasattr(user, 'locale')
+        assert user.locale == 'en-US'
+        assert hasattr(user, 'timezone')
         eq_(user.timezone, 'US/Pacific')
 
     def test_wiki_revisions(self):
         user = self.user_model.objects.get(username='testuser')
         rev = revision(save=True, is_approved=True)
-        ok_(rev.pk in user.wiki_revisions().values_list('pk', flat=True))
+        assert rev.pk in user.wiki_revisions().values_list('pk', flat=True)
 
     def test_recovery_email(self):
         user = self.user_model.objects.get(username='testuser')
@@ -122,27 +122,27 @@ class BanTestCase(UserTestCase):
     def test_ban_user(self):
         testuser = self.user_model.objects.get(username='testuser')
         admin = self.user_model.objects.get(username='admin')
-        ok_(testuser.is_active)
+        assert testuser.is_active
         ban = UserBan(user=testuser,
                       by=admin,
                       reason='Banned by unit test')
         ban.save()
         testuser_banned = self.user_model.objects.get(username='testuser')
-        ok_(not testuser_banned.is_active)
-        ok_(testuser_banned.active_ban.by == admin)
+        assert not testuser_banned.is_active
+        assert testuser_banned.active_ban.by == admin
 
         ban.is_active = False
         ban.save()
         testuser_unbanned = self.user_model.objects.get(username='testuser')
-        ok_(testuser_unbanned.is_active)
+        assert testuser_unbanned.is_active
 
         ban.is_active = True
         ban.save()
         testuser_banned = self.user_model.objects.get(username='testuser')
-        ok_(not testuser_banned.is_active)
-        ok_(testuser_unbanned.active_ban)
+        assert not testuser_banned.is_active
+        assert testuser_unbanned.active_ban
 
         ban.delete()
         testuser_unbanned = self.user_model.objects.get(username='testuser')
-        ok_(testuser_unbanned.is_active)
-        ok_(testuser_unbanned.active_ban is None)
+        assert testuser_unbanned.is_active
+        assert testuser_unbanned.active_ban is None

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -10,7 +10,7 @@ from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
 
 import kuma.wiki.content
-from kuma.core.tests import eq_, KumaTestCase, ok_
+from kuma.core.tests import eq_, KumaTestCase
 
 from . import document, normalize_html
 from ..constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_TAGS
@@ -149,13 +149,13 @@ class InjectSectionIDsTests(TestCase):
             eq_(id, result_doc.find('.%s' % cls).attr('id'))
 
         # Then, ensure all elements in need of an ID now all have unique IDs.
-        ok_(len(SECTION_TAGS) > 0)
+        assert len(SECTION_TAGS)
         els = result_doc.find(', '.join(SECTION_TAGS))
         seen_ids = set()
         for i in range(0, len(els)):
             id = els.eq(i).attr('id')
-            ok_(id is not None)
-            ok_(id not in seen_ids)
+            assert id is not None
+            assert id not in seen_ids
             seen_ids.add(id)
 
     def test_incremented_section_ids(self):
@@ -495,7 +495,7 @@ class SectionIDFilterTests(TestCase):
         section_filter = SectionIDFilter('')
 
         for original, slugified in headers:
-            ok_(slugified == section_filter.slugify(original))
+            assert slugified == section_filter.slugify(original)
 
 
 @pytest.mark.toc

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 
 from kuma.attachments.models import Attachment, AttachmentRevision
 from kuma.core.exceptions import ProgrammingError
-from kuma.core.tests import eq_, get_user, ok_
+from kuma.core.tests import eq_, get_user
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
@@ -106,17 +106,17 @@ class DocumentTests(UserTestCase):
         # Check the parent document is in the first index of the list
         eq_(parent.pk, enfant.other_translations[0].pk)
         enfant_translation_pks = [trans.pk for trans in enfant.other_translations]
-        ok_(bambino.pk in enfant_translation_pks)
+        assert bambino.pk in enfant_translation_pks
         eq_(False, enfant.pk in enfant_translation_pks)
 
     def test_topical_parents(self):
         d1, d2 = create_topical_parents_docs()
-        ok_(d2.parents == [d1])
+        assert d2.parents == [d1]
 
         d3 = document(title='Smell accessibility')
         d3.parent_topic = d2
         d3.save()
-        ok_(d3.parents == [d1, d2])
+        assert d3.parents == [d1, d2]
 
     @pytest.mark.redirect
     def test_redirect_url_allows_site_url(self):
@@ -231,7 +231,7 @@ class UserDocumentTests(UserTestCase):
         trans = document(locale='fr', title='le test',
                          parent=orig, save=True)
 
-        ok_(trans.parent_topic)
+        assert trans.parent_topic
         eq_(trans.parent_topic.pk, trans_pt.pk)
 
     def test_default_topic_with_stub_creation(self):
@@ -246,12 +246,12 @@ class UserDocumentTests(UserTestCase):
 
         # There should be a translation topic parent
         trans_pt = trans.parent_topic
-        ok_(trans_pt)
+        assert trans_pt
         # The locale of the topic parent should match the new translation
         eq_(trans.locale, trans_pt.locale)
         # But, the translation's topic parent must *not* be the translation
         # parent's topic parent
-        ok_(trans_pt.pk != orig_pt.pk)
+        assert trans_pt.pk != orig_pt.pk
         # Still, since the topic parent is an autocreated stub, it shares its
         # title with the original.
         eq_(trans_pt.title, orig_pt.title)
@@ -288,21 +288,21 @@ class UserDocumentTests(UserTestCase):
         eq_(parents_5[0].pk, trans_0.pk)
         eq_(parents_5[1].locale, trans_5.locale)
         eq_(parents_5[1].title, docs[1].title)
-        ok_(parents_5[1].current_revision.pk != docs[1].current_revision.pk)
+        assert parents_5[1].current_revision.pk != docs[1].current_revision.pk
         eq_(parents_5[2].pk, trans_2.pk)
         eq_(parents_5[3].locale, trans_5.locale)
         eq_(parents_5[3].title, docs[3].title)
-        ok_(parents_5[3].current_revision.pk != docs[3].current_revision.pk)
+        assert parents_5[3].current_revision.pk != docs[3].current_revision.pk
         eq_(parents_5[4].locale, trans_5.locale)
         eq_(parents_5[4].title, docs[4].title)
-        ok_(parents_5[4].current_revision.pk != docs[4].current_revision.pk)
+        assert parents_5[4].current_revision.pk != docs[4].current_revision.pk
 
         for p in parents_5:
-            ok_(p.current_revision)
+            assert p.current_revision
             if p.pk not in (trans_0.pk, trans_2.pk, trans_5.pk):
-                ok_('NeedsTranslation' in p.current_revision.tags)
-                ok_('TopicStub' in p.current_revision.tags)
-                ok_(p.current_revision.localization_in_progress)
+                assert 'NeedsTranslation' in p.current_revision.tags
+                assert 'TopicStub' in p.current_revision.tags
+                assert p.current_revision.localization_in_progress
 
     def test_repair_breadcrumbs(self):
         english_top = document(locale=settings.WIKI_DEFAULT_LANGUAGE,
@@ -543,9 +543,9 @@ class RevisionTests(UserTestCase):
         rev.save()
 
         reverted = rev.document.revert(rev, rev.creator)
-        ok_('Revert to' in reverted.comment)
-        ok_('Test reverting' == reverted.content)
-        ok_(old_id != reverted.id)
+        assert 'Revert to' in reverted.comment
+        assert 'Test reverting' == reverted.content
+        assert old_id != reverted.id
 
     def test_revert_review_tags(self):
         rev = revision(is_approved=True, save=True,
@@ -562,8 +562,8 @@ class RevisionTests(UserTestCase):
 
         reverted = rev.document.revert(rev, rev.creator)
         reverted_tags = [t.name for t in reverted.review_tags.all()]
-        ok_('technical' in reverted_tags)
-        ok_('editorial' not in reverted_tags)
+        assert 'technical' in reverted_tags
+        assert 'editorial' not in reverted_tags
 
     def test_get_tidied_content_uses_model_field_first(self):
         content = '<h1>  Test get_tidied_content.  </h1>'
@@ -627,10 +627,10 @@ class DeferredRenderingTests(UserTestCase):
     def test_rendering_fields(self):
         """Defaults for model fields related to rendering should work as
         expected"""
-        ok_(not self.d1.rendered_html)
-        ok_(not self.d1.defer_rendering)
-        ok_(not self.d1.is_rendering_scheduled)
-        ok_(not self.d1.is_rendering_in_progress)
+        assert not self.d1.rendered_html
+        assert not self.d1.defer_rendering
+        assert not self.d1.is_rendering_scheduled
+        assert not self.d1.is_rendering_in_progress
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -641,11 +641,11 @@ class DeferredRenderingTests(UserTestCase):
 
         # First, try getting the rendered version of a document. It should
         # trigger a call to kumascript.
-        ok_(not self.d1.rendered_html)
-        ok_(not self.d1.render_started_at)
-        ok_(not self.d1.last_rendered_at)
+        assert not self.d1.rendered_html
+        assert not self.d1.render_started_at
+        assert not self.d1.last_rendered_at
         result_rendered, _ = self.d1.get_rendered(None, 'http://testserver/')
-        ok_(mock_kumascript_get.called)
+        assert mock_kumascript_get.called
         eq_(self.rendered_content, result_rendered)
         eq_(self.rendered_content, self.d1.rendered_html)
 
@@ -654,11 +654,11 @@ class DeferredRenderingTests(UserTestCase):
         # should be in the DB.
         d1_fresh = Document.objects.get(pk=self.d1.pk)
         eq_(self.rendered_content, d1_fresh.rendered_html)
-        ok_(d1_fresh.render_started_at)
-        ok_(d1_fresh.last_rendered_at)
+        assert d1_fresh.render_started_at
+        assert d1_fresh.last_rendered_at
         mock_kumascript_get.called = False
         result_rendered, _ = d1_fresh.get_rendered(None, 'http://testserver/')
-        ok_(not mock_kumascript_get.called)
+        assert not mock_kumascript_get.called
         eq_(self.rendered_content, result_rendered)
 
     @mock.patch('kuma.wiki.models.render_done')
@@ -669,11 +669,11 @@ class DeferredRenderingTests(UserTestCase):
         bug 875349
         """
         self.d1.save()
-        ok_(not mock_render_done.send.called)
+        assert not mock_render_done.send.called
         mock_render_done.reset()
 
         self.d1.render()
-        ok_(mock_render_done.send.called)
+        assert mock_render_done.send.called
 
     @mock.patch('kuma.wiki.kumascript.get')
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
@@ -682,14 +682,14 @@ class DeferredRenderingTests(UserTestCase):
         get_summary() should attempt to use rendered
         """
         mock_kumascript_get.return_value = ('<p>summary!</p>', None)
-        ok_(not self.d1.rendered_html)
+        assert not self.d1.rendered_html
         result_summary = self.d1.get_summary()
-        ok_(not mock_kumascript_get.called)
-        ok_(not self.d1.rendered_html)
+        assert not mock_kumascript_get.called
+        assert not self.d1.rendered_html
 
         self.d1.render()
-        ok_(self.d1.rendered_html)
-        ok_(mock_kumascript_get.called)
+        assert self.d1.rendered_html
+        assert mock_kumascript_get.called
         result_summary = self.d1.get_summary()
         eq_("summary!", result_summary)
 
@@ -730,11 +730,11 @@ class DeferredRenderingTests(UserTestCase):
 
         config.KUMA_DOCUMENT_FORCE_DEFERRED_TIMEOUT = 2.0
         self.d1.render('', 'http://testserver/')
-        ok_(not self.d1.defer_rendering)
+        assert not self.d1.defer_rendering
 
         config.KUMA_DOCUMENT_FORCE_DEFERRED_TIMEOUT = 0.5
         self.d1.render('', 'http://testserver/')
-        ok_(self.d1.defer_rendering)
+        assert self.d1.defer_rendering
         config.KUMASCRIPT_TIMEOUT = 0.0
 
     @mock.patch('kuma.wiki.kumascript.get')
@@ -745,13 +745,13 @@ class DeferredRenderingTests(UserTestCase):
         # Scheduling for a non-deferred render should happen on the spot.
         self.d1.defer_rendering = False
         self.d1.save()
-        ok_(not self.d1.render_scheduled_at)
-        ok_(not self.d1.last_rendered_at)
+        assert not self.d1.render_scheduled_at
+        assert not self.d1.last_rendered_at
         self.d1.schedule_rendering(None, 'http://testserver/')
-        ok_(self.d1.render_scheduled_at)
-        ok_(self.d1.last_rendered_at)
-        ok_(not mock_render_document_delay.called)
-        ok_(not self.d1.is_rendering_scheduled)
+        assert self.d1.render_scheduled_at
+        assert self.d1.last_rendered_at
+        assert not mock_render_document_delay.called
+        assert not self.d1.is_rendering_scheduled
 
         # Reset the significant fields and try a deferred render.
         self.d1.last_rendered_at = None
@@ -762,15 +762,15 @@ class DeferredRenderingTests(UserTestCase):
 
         # Scheduling for a deferred render should result in a queued task.
         self.d1.schedule_rendering(None, 'http://testserver/')
-        ok_(self.d1.render_scheduled_at)
-        ok_(not self.d1.last_rendered_at)
-        ok_(mock_render_document_delay.called)
+        assert self.d1.render_scheduled_at
+        assert not self.d1.last_rendered_at
+        assert mock_render_document_delay.called
 
         # And, since our mock delay() doesn't actually queue a task, this
         # document should appear to be scheduled for a pending render not yet
         # in progress.
-        ok_(self.d1.is_rendering_scheduled)
-        ok_(not self.d1.is_rendering_in_progress)
+        assert self.d1.is_rendering_scheduled
+        assert not self.d1.is_rendering_in_progress
 
     @mock.patch('kuma.wiki.kumascript.get')
     @mock.patch.object(tasks.render_document, 'delay')
@@ -807,7 +807,7 @@ class DeferredRenderingTests(UserTestCase):
         mock_kumascript_get.return_value = (self.rendered_content, errors)
 
         r_rendered, r_errors = self.d1.get_rendered(None, 'http://testserver/')
-        ok_(errors, r_errors)
+        assert errors, r_errors
 
 
 class RenderExpiresTests(UserTestCase):
@@ -850,8 +850,8 @@ class RenderExpiresTests(UserTestCase):
 
         # HACK: Exact time comparisons suck, because execution time.
         later = now + timedelta(seconds=max_age)
-        ok_(d1.render_expires > later - timedelta(seconds=1))
-        ok_(d1.render_expires < later + timedelta(seconds=1))
+        assert d1.render_expires > later - timedelta(seconds=1)
+        assert d1.render_expires < later + timedelta(seconds=1)
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -864,7 +864,7 @@ class RenderExpiresTests(UserTestCase):
         d1.save()
         d1.render()
 
-        ok_(not d1.render_expires)
+        assert not d1.render_expires
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -884,8 +884,8 @@ class RenderExpiresTests(UserTestCase):
         tasks.render_stale_documents()
 
         d1_fresh = Document.objects.get(pk=d1.pk)
-        ok_(not mock_render_document_delay.called)
-        ok_(d1_fresh.last_rendered_at > earlier)
+        assert not mock_render_document_delay.called
+        assert d1_fresh.last_rendered_at > earlier
 
 
 class PageMoveTests(UserTestCase):
@@ -959,7 +959,7 @@ class PageMoveTests(UserTestCase):
         ggc1.parent_topic = gc3
         ggc1.save()
 
-        ok_([c1, gc1, c2, gc2, gc3, ggc1] == top.get_descendants())
+        assert [c1, gc1, c2, gc2, gc3, ggc1] == top.get_descendants()
 
     @pytest.mark.move
     def test_circular_dependency(self):
@@ -972,7 +972,7 @@ class PageMoveTests(UserTestCase):
         child.parent_topic = parent
         child.save()
 
-        ok_(child.is_child_of(parent))
+        assert child.is_child_of(parent)
 
         # And at two levels removed.
         grandparent = document(title='Grandparent of '
@@ -980,7 +980,7 @@ class PageMoveTests(UserTestCase):
         parent.parent_topic = grandparent
         child.save()
 
-        ok_(child.is_child_of(grandparent))
+        assert child.is_child_of(grandparent)
 
     @pytest.mark.move
     def test_move_tree(self):
@@ -1046,36 +1046,30 @@ class PageMoveTests(UserTestCase):
         moved_top = Document.objects.get(pk=top_doc.id)
         eq_('new-prefix/first-level/parent',
             moved_top.current_revision.slug)
-        ok_(old_top_id != moved_top.current_revision.id)
-        ok_(moved_top.current_revision.slug in
-            Document.objects.get(slug='first-level/parent').get_redirect_url())
+        assert old_top_id != moved_top.current_revision.id
+        assert (moved_top.current_revision.slug in
+                Document.objects.get(slug='first-level/parent').get_redirect_url())
 
         moved_child1 = Document.objects.get(pk=child1_doc.id)
         eq_('new-prefix/first-level/parent/child1',
             moved_child1.current_revision.slug)
-        ok_(old_child1_id != moved_child1.current_revision.id)
-        ok_(moved_child1.current_revision.slug in
-            Document.objects.get(
-                slug='first-level/second-level/child1'
-            ).get_redirect_url())
+        assert old_child1_id != moved_child1.current_revision.id
+        assert moved_child1.current_revision.slug in Document.objects.get(
+            slug='first-level/second-level/child1').get_redirect_url()
 
         moved_child2 = Document.objects.get(pk=child2_doc.id)
         eq_('new-prefix/first-level/parent/child2',
             moved_child2.current_revision.slug)
-        ok_(old_child2_id != moved_child2.current_revision.id)
-        ok_(moved_child2.current_revision.slug in
-            Document.objects.get(
-                slug='first-level/second-level/child2'
-            ).get_redirect_url())
+        assert old_child2_id != moved_child2.current_revision.id
+        assert moved_child2.current_revision.slug in Document.objects.get(
+            slug='first-level/second-level/child2').get_redirect_url()
 
         moved_grandchild = Document.objects.get(pk=grandchild_doc.id)
         eq_('new-prefix/first-level/parent/child2/grandchild',
             moved_grandchild.current_revision.slug)
-        ok_(old_grandchild_id != moved_grandchild.current_revision.id)
-        ok_(moved_grandchild.current_revision.slug in
-            Document.objects.get(
-                slug='first-level/second-level/third-level/grandchild'
-            ).get_redirect_url())
+        assert old_grandchild_id != moved_grandchild.current_revision.id
+        assert moved_grandchild.current_revision.slug in Document.objects.get(
+            slug='first-level/second-level/third-level/grandchild').get_redirect_url()
 
     @pytest.mark.move
     def test_conflicts(self):
@@ -1218,10 +1212,10 @@ class PageMoveTests(UserTestCase):
         # note we have to refetch these to see any DB changes.
         grandma_moved = Document.objects.get(locale=grandma_doc.locale,
                                              slug='grandpa/grandma')
-        ok_(grandma_moved.parent_topic == grandpa_doc)
+        assert grandma_moved.parent_topic == grandpa_doc
         mom_moved = Document.objects.get(locale=mom_doc.locale,
                                          slug='grandpa/grandma/mom')
-        ok_(mom_moved.parent_topic == grandma_moved)
+        assert mom_moved.parent_topic == grandma_moved
 
     @pytest.mark.move
     def test_move_tree_no_new_parent(self):
@@ -1270,13 +1264,13 @@ class PageMoveTests(UserTestCase):
         page_child_doc = Document.objects.get(slug=page_child_slug)
         page_child_moved_doc = Document.objects.get(slug=page_child_moved_slug)
 
-        ok_('REDIRECT' in page_to_move_doc.html)
-        ok_(page_moved_slug in page_to_move_doc.html)
-        ok_(new_title in page_to_move_doc.html)
-        ok_(page_moved_doc)
-        ok_('REDIRECT' in page_child_doc.html)
-        ok_(page_moved_slug in page_child_doc.html)
-        ok_(page_child_moved_doc)
+        assert 'REDIRECT' in page_to_move_doc.html
+        assert page_moved_slug in page_to_move_doc.html
+        assert new_title in page_to_move_doc.html
+        assert page_moved_doc
+        assert 'REDIRECT' in page_child_doc.html
+        assert page_moved_slug in page_child_doc.html
+        assert page_child_moved_doc
         # TODO: Fix this assertion?
         # eq_('admin', page_moved_doc.current_revision.creator.username)
 
@@ -1318,13 +1312,13 @@ class PageMoveTests(UserTestCase):
 
         redirected_child = Document.objects.get(slug=child_slug)
         Document.objects.get(slug=moved_child_slug)
-        ok_('REDIRECT' in redirected_child.html)
-        ok_(moved_child_slug in redirected_child.html)
+        assert 'REDIRECT' in redirected_child.html
+        assert moved_child_slug in redirected_child.html
 
         redirected_grandchild = Document.objects.get(slug=grandchild_doc.slug)
         Document.objects.get(slug=moved_grandchild_slug)
-        ok_('REDIRECT' in redirected_grandchild.html)
-        ok_(moved_grandchild_slug in redirected_grandchild.html)
+        assert 'REDIRECT' in redirected_grandchild.html
+        assert moved_grandchild_slug in redirected_grandchild.html
 
     @pytest.mark.move
     def test_move_special(self):
@@ -1361,11 +1355,11 @@ class PageMoveTests(UserTestCase):
         # Appropriate redirects were left behind.
         root_redirect = Document.objects.get(locale=special_root.locale,
                                              slug=root_slug)
-        ok_(root_redirect.is_redirect)
+        assert root_redirect.is_redirect
         root_redirect_id = root_redirect.id
         child_redirect = Document.objects.get(locale=special_child.locale,
                                               slug=child_slug)
-        ok_(child_redirect.is_redirect)
+        assert child_redirect.is_redirect
         child_redirect_id = child_redirect.id
 
         # Moved documents still have the same IDs.
@@ -1382,18 +1376,18 @@ class PageMoveTests(UserTestCase):
         # Once again we left redirects behind.
         root_second_redirect = Document.objects.get(locale=special_root.locale,
                                                     slug=new_root_slug)
-        ok_(root_second_redirect.is_redirect)
+        assert root_second_redirect.is_redirect
         child_second_redirect = Document.objects.get(locale=special_child.locale,
                                                      slug='%s/child' % new_root_slug)
-        ok_(child_second_redirect.is_redirect)
+        assert child_second_redirect.is_redirect
 
         # The documents at the original URLs aren't redirects anymore.
         rerooted_root = Document.objects.get(locale=special_root.locale,
                                              slug=root_slug)
-        ok_(not rerooted_root.is_redirect)
+        assert not rerooted_root.is_redirect
         rerooted_child = Document.objects.get(locale=special_child.locale,
                                               slug=child_slug)
-        ok_(not rerooted_child.is_redirect)
+        assert not rerooted_child.is_redirect
 
         # The redirects created in the first move no longer exist in the DB.
         self.assertRaises(Document.DoesNotExist,
@@ -1453,7 +1447,7 @@ class PageMoveTests(UserTestCase):
                 'raise Exception("Requested move would overwrite a non-redirect page.")',
             ]
             for s in err_strings:
-                ok_(s in e.args[0])
+                assert s in e.args[0]
 
 
 class RevisionIPTests(UserTestCase):
@@ -1516,18 +1510,18 @@ class AttachmentTests(UserTestCase):
         doc = document(html=html, save=True)
         doc.populate_attachments()
 
-        ok_(doc.attached_files.all().exists())
+        assert doc.attached_files.all().exists()
         eq_(doc.attached_files.all().count(), 1)
         eq_(doc.attached_files.first().file, attachment)
 
     def test_popuplate_kuma_file_url(self):
         attachment, attachment_revision = self.new_attachment()
         doc = document(html=attachment.get_file_url(), save=True)
-        ok_(not doc.attached_files.all().exists())
+        assert not doc.attached_files.all().exists()
 
         populated = doc.populate_attachments()
         eq_(len(populated), 1)
-        ok_(doc.attached_files.all().exists())
+        assert doc.attached_files.all().exists()
         eq_(doc.attached_files.all().count(), 1)
         eq_(doc.attached_files.first().file, attachment)
 
@@ -1540,7 +1534,7 @@ class AttachmentTests(UserTestCase):
         populated = doc.populate_attachments()
         attachments = doc.attached_files.all()
         eq_(len(populated), 2)
-        ok_(attachments.exists())
+        assert attachments.exists()
         eq_(attachments.count(), 2)
         eq_(attachments[0].file, attachment)
         eq_(attachments[1].file, attachment2)

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from django.conf import settings
 
 from kuma.core.cache import memcache
-from kuma.core.tests import ok_
 from kuma.users.models import User
 from kuma.users.tests import user, UserTestCase
 
@@ -71,14 +70,14 @@ class SitemapsTestCase(UserTestCase):
             docs = Document.objects.filter_for_list(locale=locale)
 
             for doc in docs:
-                ok_(doc.modified.strftime('%Y-%m-%d') in sitemap_xml)
-                ok_(doc.slug in sitemap_xml)
+                assert doc.modified.strftime('%Y-%m-%d') in sitemap_xml
+                assert doc.slug in sitemap_xml
 
         sitemap_path = os.path.join(settings.MEDIA_ROOT, 'sitemap.xml')
         with open(sitemap_path, 'r') as sitemap_file:
             index_xml = sitemap_file.read()
         for loc in expected_sitemap_locs:
-            ok_(loc in index_xml)
+            assert loc in index_xml
 
 
 class DeleteOldDocumentSpamAttemptData(UserTestCase):

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -17,7 +17,7 @@ from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_, ok_)
+                             assert_shared_cache_header, eq_)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.models import User
@@ -114,12 +114,10 @@ class DocumentTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         eq_(d2.title, doc('main#content div.document-head h1').text())
         # HACK: fr doc has different message if locale/ is updated
-        ok_(
-            ("This article doesn't have approved content yet." in
-                doc('article#wikiArticle').text()) or
-            ("Cet article n'a pas encore de contenu" in
-                doc('article#wikiArticle').text())
-        )
+        assert (("This article doesn't have approved content yet." in
+                 doc('article#wikiArticle').text()) or
+                ("Cet article n'a pas encore de contenu" in
+                 doc('article#wikiArticle').text()))
 
     def test_document_fallback_with_translation(self):
         """The document template falls back to English if translation exists
@@ -230,13 +228,13 @@ class DocumentTests(UserTestCase, WikiTestCase):
         r = revision(save=True, content=doc_content, is_approved=True)
         response = self.client.get(r.document.get_absolute_url())
         eq_(200, response.status_code)
-        ok_('<div id="toc"' in response.content)
+        assert '<div id="toc"' in response.content
         new_r = revision(document=r.document, content=r.content,
                          toc_depth=0, is_approved=True)
         new_r.save()
         response = self.client.get(r.document.get_absolute_url())
         eq_(200, response.status_code)
-        ok_('<div class="page-toc">' not in response.content)
+        assert '<div class="page-toc">' not in response.content
 
     def test_lang_switcher_footer(self):
         """Test the language switcher footer"""
@@ -252,15 +250,15 @@ class DocumentTests(UserTestCase, WikiTestCase):
         options = doc(".languages.go select.wiki-l10n option")
 
         # The requeseted document language name should be at first
-        ok_(trans_pt_br.language in options[0].text)
-        ok_(parent.language not in options[0].text)
+        assert trans_pt_br.language in options[0].text
+        assert parent.language not in options[0].text
         # The parent document language should be at at second
-        ok_(parent.language in options[1].text)
-        ok_(trans_ar.language not in options[1].text)
+        assert parent.language in options[1].text
+        assert trans_ar.language not in options[1].text
         # Then should be ar, bn-BD, fr
-        ok_(trans_ar.language in options[2].text)
-        ok_(trans_bn_bd.language in options[3].text)
-        ok_(trans_fr.language in options[4].text)
+        assert trans_ar.language in options[2].text
+        assert trans_bn_bd.language in options[3].text
+        assert trans_fr.language in options[4].text
 
     def test_lang_switcher_button(self):
         parent = document(locale=settings.WIKI_DEFAULT_LANGUAGE, save=True)
@@ -275,13 +273,13 @@ class DocumentTests(UserTestCase, WikiTestCase):
         options = doc("#languages-menu-submenu ul#translations li a")
 
         # The requeseted document language name should not be at button
-        ok_(trans_pt_br.language not in options[0].text)
+        assert trans_pt_br.language not in options[0].text
         # Parent document language name should be at first
-        ok_(parent.language in options[0].text)
+        assert parent.language in options[0].text
         # Then should be ar, bn-BD, fr
-        ok_(trans_ar.language in options[1].text)
-        ok_(trans_bn_bd.language in options[2].text)
-        ok_(trans_fr.language in options[3].text)
+        assert trans_ar.language in options[1].text
+        assert trans_bn_bd.language in options[2].text
+        assert trans_fr.language in options[3].text
 
     def test_experiment_document_view(self):
         slug = EXPERIMENT_TITLE_PREFIX + 'Test'
@@ -518,7 +516,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
 
         # TODO: push test_strings functionality up into a test helper
         for test_string in test_strings:
-            ok_(test_string in response.content)
+            assert test_string in response.content
 
     def test_new_document_preview_button(self):
         """HTTP GET to new document URL shows preview button."""
@@ -526,7 +524,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(reverse('wiki.create'))
         eq_(200, response.status_code)
         doc = pq(response.content)
-        ok_(len(doc('.btn-preview')) > 0)
+        assert len(doc('.btn-preview'))
 
     def test_new_document_form_defaults(self):
         """The new document form should have all all 'Relevant to' options
@@ -583,8 +581,8 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
                                     follow=True)
         doc = pq(response.content)
         ul = doc('article ul.errorlist')
-        ok_(len(ul) > 0)
-        ok_('Please provide a title.' in ul('li').text())
+        assert len(ul)
+        assert 'Please provide a title.' in ul('li').text()
 
     def test_new_document_POST_empty_content(self):
         """Trigger required field validation for content."""

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,7 +17,7 @@ from waffle.testutils import override_flag, override_switch
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_, get_user, ok_)
+                             assert_shared_cache_header, eq_, get_user)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html
 from kuma.spam.constants import (
@@ -293,8 +293,8 @@ class ViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(rev.get_absolute_url())
         page = pq(resp.content)
         ct = to_html(page.find('#wikiArticle'))
-        ok_('<svg>' not in ct)
-        ok_('<a href="#">Hahaha</a>' in ct)
+        assert '<svg>' not in ct
+        assert '<a href="#">Hahaha</a>' in ct
 
     def test_article_revision_content(self):
         doc = document(title='Testing Article', slug='Article', save=True)
@@ -303,8 +303,8 @@ class ViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(r.get_absolute_url())
         page = pq(resp.content)
 
-        ok_('Revision Source' in resp.content)
-        ok_('Revision Content' in resp.content)
+        assert 'Revision Source' in resp.content
+        assert 'Revision Content' in resp.content
         eq_(page.find('#wikiArticle').parent().attr('open'), 'open')
         eq_(page.find('#doc-source').parent().attr('open'), None)
 
@@ -417,7 +417,7 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         """When kumascript timeout is non-zero, the service should be used"""
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.client.get(self.url, follow=False)
-        ok_(mock_kumascript_get.called, "kumascript should have been used")
+        assert mock_kumascript_get.called, "kumascript should have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=0.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -425,8 +425,7 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         """When disabled, the kumascript service should not be used"""
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.client.get(self.url, follow=False)
-        ok_(not mock_kumascript_get.called,
-            "kumascript not should have been used")
+        assert not mock_kumascript_get.called, "kumascript should not have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=0.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -435,31 +434,28 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         in rendering"""
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.doc.schedule_rendering('max-age=0')
-        ok_(not mock_kumascript_get.called,
-            "kumascript not should have been used")
+        assert not mock_kumascript_get.called, "kumascript should not have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
     def test_nomacros(self, mock_kumascript_get):
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.client.get('%s?nomacros' % self.url, follow=False)
-        ok_(not mock_kumascript_get.called,
-            "kumascript should not have been used")
+        assert not mock_kumascript_get.called, "kumascript should not have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
     def test_raw(self, mock_kumascript_get):
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.client.get('%s?raw' % self.url, follow=False)
-        ok_(not mock_kumascript_get.called,
-            "kumascript should not have been used")
+        assert not mock_kumascript_get.called, "kumascript should not have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
     def test_raw_macros(self, mock_kumascript_get):
         mock_kumascript_get.return_value = (self.doc.html, None)
         self.client.get('%s?raw&macros' % self.url, follow=False)
-        ok_(mock_kumascript_get.called, "kumascript should have been used")
+        assert mock_kumascript_get.called, "kumascript should have been used"
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=1234)
     @requests_mock.mock()
@@ -563,7 +559,7 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 
         # Third request to verify content was cached and served on a 304
         response = self.client.get(self.url)
-        ok_(expected_content in response.content)
+        assert expected_content in response.content
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=600)
     @requests_mock.mock()
@@ -618,7 +614,7 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
             response = self.client.get(reverse('wiki.document', args=[slug]))
             page = pq(response.content)
 
-            ok_(page.find('head > title').text() in aught_titles)
+            assert page.find('head > title').text() in aught_titles
 
         # Test nested document titles
         _make_doc('One', ['One | MDN'], 'one')
@@ -719,7 +715,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         for url in urls:
             page = pq(self.client.get(url).content)
             editor_src = page.find('#id_content').text()
-            ok_('onload' not in editor_src)
+            assert 'onload' not in editor_src
 
     def test_create_on_404(self):
         self.client.login(username='admin', password='testpass')
@@ -1176,9 +1172,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         new_en_json = json.loads(Document.objects.get(pk=en_doc.pk).json)
 
-        ok_('translations' in new_en_json)
-        ok_(translation_data['title'] in [t['title'] for t in
-                                          new_en_json['translations']])
+        assert 'translations' in new_en_json
+        assert (translation_data['title'] in
+                [t['title'] for t in new_en_json['translations']])
         es_translation_json = [t for t in new_en_json['translations'] if
                                t['title'] == translation_data['title']][0]
         eq_(es_translation_json['last_edit'],
@@ -1309,8 +1305,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert response['X-Robots-Tag'] == 'noindex'
         assert_no_cache_header(response)
         content = pq(response.content)
-        ok_(content('li.metadata-choose-parent'))
-        ok_(str(parent.id) in to_html(content))
+        assert content('li.metadata-choose-parent')
+        assert str(parent.id) in to_html(content)
 
     @pytest.mark.tags
     def test_tags_while_document_update(self):
@@ -1650,8 +1646,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             location_of_error = HTMLParser.HTMLParser().unescape(
                 resp.content[start_of_error: end_of_error]
             )
-        ok_(midair_collission_error in location_of_error,
-            "Midair collision message should appear")
+        assert midair_collission_error in location_of_error
 
     @pytest.mark.midair
     def test_edit_midair_collisions_ajax(self):
@@ -1720,8 +1715,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         )
 
         spam_message = render_to_string('wiki/includes/spam_error.html')
-        ok_(spam_message in json.loads(resp.content)['error_message'],
-            "Spam message should appear")
+        assert spam_message in json.loads(resp.content)['error_message']
 
     def test_multiple_edits_ajax(self, translate_locale=None):
         """Tests multiple sequential attempted valid edits that occur as Ajax POSTs."""
@@ -1784,7 +1778,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # For Ajax requests the response is a JsonResponse
         for resp in [resp1, resp2]:
             eq_(json.loads(resp.content)['error'], False)
-            ok_('error_message' not in json.loads(resp.content).keys())
+            assert 'error_message' not in json.loads(resp.content).keys()
 
     def test_multiple_translation_edits_ajax(self):
         """Tests multiple sequential valid transalation edits that occur as Ajax POSTs."""
@@ -1810,7 +1804,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         rev = revision(is_approved=True, save=True)
         doc = rev.document
         data = new_document_data()
-        ok_(Document.objects.get(slug=doc.slug, locale=doc.locale).show_toc)
+        assert Document.objects.get(slug=doc.slug, locale=doc.locale).show_toc
         data['form-type'] = 'rev'
         data['toc_depth'] = 0
         data['slug'] = doc.slug
@@ -2623,8 +2617,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
             'wiki.document_revisions',
             kwargs={'document_path': rev.document.slug})
         midair_collission_error = (unicode(MIDAIR_COLLISION) % {'url': history_url}).encode('utf-8')
-        ok_(midair_collission_error in json.loads(resp.content)['error_message'],
-            "Midair collision message should appear")
+        assert midair_collission_error in json.loads(resp.content)['error_message']
 
     def test_raw_include_option(self):
         doc_src = u"""
@@ -2686,7 +2679,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                          {"form-type": "rev", "slug": rev.document.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
-        ok_(rev.id != changed.id)
+        assert rev.id != changed.id
         eq_(1, changed.toc_depth)
 
     def test_section_edit_review_tags(self):
@@ -2719,7 +2712,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                          {"form-type": "rev", "slug": rev.document.slug, "content": replace},
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
-        ok_(rev.id != changed.id)
+        assert rev.id != changed.id
         eq_(set(tags_to_save),
             set([t.name for t in changed.review_tags.all()]))
 
@@ -2823,8 +2816,8 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(self.url, follow=False)
         p = pq(resp.content)
         txt = p.find('#wikiArticle').text()
-        ok_(self.rendered_content in txt)
-        ok_(self.raw_content not in txt)
+        assert self.rendered_content in txt
+        assert self.raw_content not in txt
 
         eq_(0, p.find('#doc-rendering-in-progress').length)
         eq_(0, p.find('#doc-render-raw-fallback').length)
@@ -2840,8 +2833,8 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
 
         # Even though a rendering looks like it's in progress, ensure the
         # last-known render is displayed.
-        ok_(self.rendered_content in txt)
-        ok_(self.raw_content not in txt)
+        assert self.rendered_content in txt
+        assert self.raw_content not in txt
         eq_(0, p.find('#doc-rendering-in-progress').length)
 
         # Only for logged-in users, ensure the render-in-progress warning is
@@ -2868,8 +2861,8 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(self.url, follow=False)
         p = pq(resp.content)
         txt = p.find('#wikiArticle').text()
-        ok_(self.rendered_content not in txt)
-        ok_(self.raw_content in txt)
+        assert self.rendered_content not in txt
+        assert self.raw_content in txt
         eq_(0, p.find('#doc-render-raw-fallback').length)
 
         # Only for logged-in users, ensure that a warning is displayed about
@@ -2896,7 +2889,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         edit_url = reverse('wiki.edit', args=[self.doc.slug])
         resp = self.client.post(edit_url, data)
         eq_(302, resp.status_code)
-        ok_(mock_document_schedule_rendering.called)
+        assert mock_document_schedule_rendering.called
 
         mock_document_schedule_rendering.reset_mock()
 


### PR DESCRIPTION
This PR remove the `ok_()` method that is no longer necessary.

## Actions to take before merging this PR
- Open a bug (or find an existing bug) to link this.
- Reword the commit to include details in the commit title and message.