### PR TITLE
bug 1419532: Delete dev emails with make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ install:
 	@ pip install $(requirements)
 
 clean:
-	rm -rf .coverage build/
+	rm -rf .coverage build/ tmp/emails/*.log
 	find . \( -name \*.pyc -o -name \*.pyo -o -name __pycache__ \) -delete
 	mkdir -p build/locale
 


### PR DESCRIPTION
Clear out the development emails with ``make clean``, which saves a small bit of disk space (for me, 20 MB over 6+ months) and makes it easier to find the latest email when debugging.