### PR TITLE
bug 1240083: Remove eq_() from tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,10 +187,9 @@ seldom-updated code is more likely to have old-style tests. We expect a full
 conversion to take a few more years.
 
 We **avoid** old-style tests that use Django's
-[TestCase testing classes][testcase], [fixture files][fixture_files],
-[``eq_``][eq] test function and general-purpose factory
-functions like [get_user][get_user], [document][document], and
-[revision][revision].
+[TestCase testing classes][testcase], [fixture files][fixture_files] and
+general-purpose factory functions like [get_user][get_user], [document][document],
+and [revision][revision].
 
 We **prefer** test functions, a small number of global
 [pytest fixtures][pytest-fixtures] like [root_doc][root_doc] and

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -23,16 +23,6 @@ def assert_shared_cache_header(response):
     assert 's-maxage' in response['Cache-Control']
 
 
-def eq_(first, second, msg=None):
-    """Rough reimplementation of nose.tools.eq_
-
-    Note: This should be removed as soon as we no longer use it.
-
-    """
-    msg = msg or '%r != %r' % (first, second)
-    assert first == second, msg
-
-
 def get_user(username='testuser'):
     """Return a django user or raise FixtureMissingError"""
     User = get_user_model()

--- a/kuma/core/tests/test_decorators.py
+++ b/kuma/core/tests/test_decorators.py
@@ -7,7 +7,7 @@ from django.views.decorators.cache import never_cache
 
 from kuma.users.tests import UserTestCase
 
-from . import assert_no_cache_header, eq_, KumaTestCase
+from . import assert_no_cache_header, KumaTestCase
 from ..decorators import (block_user_agents, login_required,
                           logout_required, permission_required,
                           redirect_in_maintenance_mode,
@@ -27,22 +27,22 @@ class LogoutRequiredTestCase(UserTestCase):
         request.user = AnonymousUser()
         view = logout_required(simple_view)
         response = view(request)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
     def test_logged_in_default(self):
         request = self.rf.get('/foo')
         request.user = self.user_model.objects.get(username='testuser')
         view = logout_required(simple_view)
         response = view(request)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
 
     def test_logged_in_argument(self):
         request = self.rf.get('/foo')
         request.user = self.user_model.objects.get(username='testuser')
         view = logout_required('/bar')(simple_view)
         response = view(request)
-        eq_(302, response.status_code)
-        eq_('/bar', response['location'])
+        assert 302 == response.status_code
+        assert '/bar' == response['location']
 
 
 class LoginRequiredTestCase(UserTestCase):
@@ -53,7 +53,7 @@ class LoginRequiredTestCase(UserTestCase):
         request.user = AnonymousUser()
         view = login_required(simple_view)
         response = view(request)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
 
     def test_logged_in_default(self):
         """Active user login."""
@@ -61,7 +61,7 @@ class LoginRequiredTestCase(UserTestCase):
         request.user = self.user_model.objects.get(username='testuser')
         view = login_required(simple_view)
         response = view(request)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
     def test_logged_in_inactive(self):
         """Inactive user login not allowed by default."""
@@ -71,7 +71,7 @@ class LoginRequiredTestCase(UserTestCase):
         request.user = user
         view = login_required(simple_view)
         response = view(request)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
 
     def test_logged_in_inactive_allow(self):
         """Inactive user login explicitly allowed."""
@@ -81,7 +81,7 @@ class LoginRequiredTestCase(UserTestCase):
         request.user = user
         view = login_required(simple_view, only_active=False)
         response = view(request)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
 
 class PermissionRequiredTestCase(UserTestCase):
@@ -92,14 +92,14 @@ class PermissionRequiredTestCase(UserTestCase):
         request.user = AnonymousUser()
         view = permission_required('perm')(simple_view)
         response = view(request)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
 
     def test_logged_in_default(self):
         request = self.rf.get('/foo')
         request.user = self.user_model.objects.get(username='testuser')
         view = permission_required('perm')(simple_view)
         response = view(request)
-        eq_(403, response.status_code)
+        assert 403 == response.status_code
 
     def test_logged_in_inactive(self):
         """Inactive user is denied access."""
@@ -109,14 +109,14 @@ class PermissionRequiredTestCase(UserTestCase):
         request.user = user
         view = permission_required('perm')(simple_view)
         response = view(request)
-        eq_(403, response.status_code)
+        assert 403 == response.status_code
 
     def test_logged_in_admin(self):
         request = self.rf.get('/foo')
         request.user = self.user_model.objects.get(username='admin')
         view = permission_required('perm')(simple_view)
         response = view(request)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
 
 class TestBlockUserAgents(KumaTestCase):
@@ -129,7 +129,7 @@ class TestBlockUserAgents(KumaTestCase):
             'WOW64; rv:40.0) Gecko/20100101 Firefox/40.0'
         self.view = block_user_agents(simple_view)
         response = self.view(self.request)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
     def test_blocked_agents_forbidden(self):
         self.request.META['HTTP_USER_AGENT'] = 'curl/7.21.4 ' \
@@ -137,13 +137,13 @@ class TestBlockUserAgents(KumaTestCase):
             'zlib/1.2.5'
         self.view = block_user_agents(simple_view)
         response = self.view(self.request)
-        eq_(403, response.status_code)
+        assert 403 == response.status_code
 
         self.request.META['HTTP_USER_AGENT'] = 'Mozilla/5.0 (compatible; ' \
             'Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)'
         self.view = block_user_agents(simple_view)
         response = self.view(self.request)
-        eq_(403, response.status_code)
+        assert 403 == response.status_code
 
 
 @pytest.mark.parametrize("maintenance_mode", [False, True])

--- a/kuma/core/tests/test_form_fields.py
+++ b/kuma/core/tests/test_form_fields.py
@@ -1,6 +1,6 @@
 from django.utils import translation
 
-from . import eq_, KumaTestCase
+from . import KumaTestCase
 from ..form_fields import _format_decimal
 
 
@@ -9,27 +9,27 @@ class TestFormatDecimal(KumaTestCase):
     def test_default_locale(self):
         """Default locale just works"""
         num = _format_decimal(1234.567)
-        eq_('1,234.567', num)
+        assert '1,234.567' == num
 
     def test_fr_locale(self):
         """French locale returns french format"""
         translation.activate('fr')
         num = _format_decimal(1234.567)
-        eq_(u'1\xa0234,567', num)
+        assert u'1\xa0234,567' == num
 
     def test_xx_YY_locale(self):
         """Falls back to English for unknown Django locales"""
         translation.activate('xx-YY')
         # Note: this activation does not make Django attempt to use xx-YY
-        eq_('xx-yy', translation.get_language())
+        assert 'xx-yy' == translation.get_language()
         num = _format_decimal(1234.567)
-        eq_('1,234.567', num)
+        assert '1,234.567' == num
 
     def test_fy_NL_locale(self):
         """Falls back to English for unknown babel locales"""
         # Note: if this starts to fail for no apparent reason, it's probably
         # because babel learned about fy-NL since this test was written.
         translation.activate('fy-NL')
-        eq_('fy-nl', translation.get_language())
+        assert 'fy-nl' == translation.get_language()
         num = _format_decimal(1234.567)
-        eq_('1,234.567', num)
+        assert '1,234.567' == num

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.test import override_settings, RequestFactory, TestCase
 from soapbox.models import Message
 
-from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.tests import KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
@@ -22,10 +22,10 @@ from ..templatetags.jinja_helpers import (datetimeformat, get_soapbox_messages,
 class TestYesNo(KumaTestCase):
 
     def test_yesno(self):
-        eq_('Yes', yesno(True))
-        eq_('No', yesno(False))
-        eq_('Yes', yesno(1))
-        eq_('No', yesno(0))
+        assert 'Yes' == yesno(True)
+        assert 'No' == yesno(False)
+        assert 'Yes' == yesno(1)
+        assert 'No' == yesno(0)
 
 
 class TestSoapbox(KumaTestCase):
@@ -33,18 +33,18 @@ class TestSoapbox(KumaTestCase):
     def test_global_message(self):
         m = Message(message='Global', is_global=True, is_active=True, url='/')
         m.save()
-        eq_(m.message, get_soapbox_messages('/')[0].message)
-        eq_(m.message, get_soapbox_messages('/en-US/')[0].message)
+        assert m.message == get_soapbox_messages('/')[0].message
+        assert m.message == get_soapbox_messages('/en-US/')[0].message
 
     def test_subsection_message(self):
         m = Message(message='Search down', is_global=False, is_active=True,
                     url='/search')
         m.save()
-        eq_(0, len(get_soapbox_messages('/')))
-        eq_(0, len(get_soapbox_messages('/docs')))
-        eq_(0, len(get_soapbox_messages('/en-US/docs')))
-        eq_(m.message, get_soapbox_messages('/en-US/search')[0].message)
-        eq_(m.message, get_soapbox_messages('/de/search')[0].message)
+        assert 0 == len(get_soapbox_messages('/'))
+        assert 0 == len(get_soapbox_messages('/docs'))
+        assert 0 == len(get_soapbox_messages('/en-US/docs'))
+        assert m.message == get_soapbox_messages('/en-US/search')[0].message
+        assert m.message == get_soapbox_messages('/de/search')[0].message
 
     def test_message_with_url_is_link(self):
         m = Message(message='Go to http://bit.ly/sample-demo', is_global=True,
@@ -70,7 +70,7 @@ class TestDateTimeFormat(UserTestCase):
                                                      locale=u'en_US')
         value_returned = datetimeformat(self.context, date_today,
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_locale(self):
         """Expects shortdatetime in French."""
@@ -80,7 +80,7 @@ class TestDateTimeFormat(UserTestCase):
                                          locale=u'fr')
         value_returned = datetimeformat(self.context, value_test,
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_default(self):
         """Expects shortdatetime."""
@@ -89,7 +89,7 @@ class TestDateTimeFormat(UserTestCase):
                                          locale=u'en_US')
         value_returned = datetimeformat(self.context, value_test,
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_longdatetime(self):
         """Expects long format."""
@@ -100,7 +100,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='longdatetime',
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_date(self):
         """Expects date format."""
@@ -109,7 +109,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='date',
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_time(self):
         """Expects time format."""
@@ -118,7 +118,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='time',
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_datetime(self):
         """Expects datetime format."""
@@ -127,7 +127,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='datetime',
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
     def test_unknown_format(self):
         """Unknown format raises DateTimeFormatError."""
@@ -149,7 +149,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='datetime',
                                         output='json')
-        eq_(value_returned, value_english)
+        assert value_english == value_returned
 
     def test_invalid_value(self):
         """Passing invalid value raises ValueError."""
@@ -157,8 +157,8 @@ class TestDateTimeFormat(UserTestCase):
             datetimeformat(self.context, 'invalid')
 
     def test_json_helper(self):
-        eq_('false', jsonencode(False))
-        eq_('{"foo": "bar"}', jsonencode({'foo': 'bar'}))
+        assert 'false' == jsonencode(False)
+        assert '{"foo": "bar"}' == jsonencode({'foo': 'bar'})
 
     def test_user_timezone(self):
         """Shows time in user timezone."""
@@ -178,7 +178,7 @@ class TestDateTimeFormat(UserTestCase):
         value_returned = datetimeformat(self.context, value_test,
                                         format='longdatetime',
                                         output='json')
-        eq_(value_returned, value_expected)
+        assert value_expected == value_returned
 
 
 class TestInUtc(KumaTestCase):

--- a/kuma/core/tests/test_misc.py
+++ b/kuma/core/tests/test_misc.py
@@ -1,6 +1,6 @@
 from django.test import RequestFactory
 
-from . import eq_, KumaTestCase
+from . import KumaTestCase
 from ..context_processors import next_url
 
 
@@ -14,9 +14,9 @@ class TestNextUrl(KumaTestCase):
     def test_basic(self):
         path = '/one/two'
         request = self.rf.get(path)
-        eq_(next_url(request)['next_url'], path)
+        assert path == next_url(request)['next_url']
 
     def test_querystring(self):
         path = '/one/two?something'
         request = self.rf.get(path)
-        eq_(next_url(request)['next_url'], path)
+        assert path == next_url(request)['next_url']

--- a/kuma/core/tests/test_models.py
+++ b/kuma/core/tests/test_models.py
@@ -2,7 +2,6 @@ from datetime import date, timedelta
 
 from django.test import TestCase
 
-from . import eq_
 from ..models import IPBan
 
 
@@ -10,16 +9,16 @@ class RevisionIPTests(TestCase):
     def test_delete_older_than_default_30_days(self):
         old_date = date.today() - timedelta(days=31)
         IPBan(ip='127.0.0.1', created=old_date).save()
-        eq_(1, IPBan.objects.count())
+        assert 1 == IPBan.objects.count()
         IPBan.objects.delete_old()
-        eq_(0, IPBan.objects.count())
+        assert 0 == IPBan.objects.count()
 
     def test_delete_older_than_days_argument(self):
         ban_date = date.today() - timedelta(days=5)
         IPBan(ip='127.0.0.1', created=ban_date).save()
-        eq_(1, IPBan.objects.count())
+        assert 1 == IPBan.objects.count()
         IPBan.objects.delete_old(days=4)
-        eq_(0, IPBan.objects.count())
+        assert 0 == IPBan.objects.count()
 
     def test_delete_older_than_only_deletes_older_than(self):
         oldest_date = date.today() - timedelta(days=31)
@@ -30,6 +29,6 @@ class RevisionIPTests(TestCase):
 
         now_date = date.today()
         IPBan(ip='127.0.0.3', created=now_date).save()
-        eq_(3, IPBan.objects.count())
+        assert 3 == IPBan.objects.count()
         IPBan.objects.delete_old()
-        eq_(2, IPBan.objects.count())
+        assert 2 == IPBan.objects.count()

--- a/kuma/core/tests/test_pagination.py
+++ b/kuma/core/tests/test_pagination.py
@@ -1,7 +1,6 @@
 import pyquery
 from django.test import RequestFactory
 
-from . import eq_
 from ..templatetags.jinja_helpers import paginator
 from ..urlresolvers import reverse
 from ..utils import paginate, urlparams
@@ -13,8 +12,8 @@ def test_paginated_url():
     request = RequestFactory().get(url)
     queryset = [{}, {}]
     paginated = paginate(request, queryset)
-    eq_(paginated.url,
-        request.build_absolute_uri(request.path) + '?q=bookmarks')
+    assert (paginated.url ==
+            request.build_absolute_uri(request.path) + '?q=bookmarks')
 
 
 def test_invalid_page_param():
@@ -22,8 +21,8 @@ def test_invalid_page_param():
     request = RequestFactory().get(url)
     queryset = range(100)
     paginated = paginate(request, queryset)
-    eq_(paginated.url,
-        request.build_absolute_uri(request.path) + '?')
+    assert (paginated.url ==
+            request.build_absolute_uri(request.path) + '?')
 
 
 def test_paginator_filter_num_elements_start():
@@ -33,7 +32,7 @@ def test_paginator_filter_num_elements_start():
     pager = paginate(request, range(100), per_page=9)
     html = paginator(pager)
     doc = pyquery.PyQuery(html)
-    eq_(11, len(doc('li')))
+    assert 11 == len(doc('li'))
 
 
 def test_paginator_filter_num_elements_middle():
@@ -43,7 +42,7 @@ def test_paginator_filter_num_elements_middle():
     pager = paginate(request, range(200), per_page=10)
     html = paginator(pager)
     doc = pyquery.PyQuery(html)
-    eq_(13, len(doc('li')))
+    assert 13 == len(doc('li'))
 
 
 def test_paginator_filter_current_selected():
@@ -53,5 +52,5 @@ def test_paginator_filter_current_selected():
     pager = paginate(request, range(200), per_page=10)
     html = paginator(pager)
     doc = pyquery.PyQuery(html)
-    eq_(doc('li.selected a').attr('href'),
-        'http://testserver/en-US/search?page=10')
+    assert (doc('li.selected a').attr('href') ==
+            'http://testserver/en-US/search?page=10')

--- a/kuma/core/tests/test_templates.py
+++ b/kuma/core/tests/test_templates.py
@@ -8,7 +8,7 @@ from django.test import RequestFactory
 from django.utils import translation
 from pyquery import PyQuery as pq
 
-from . import eq_, KumaTestCase
+from . import KumaTestCase
 
 
 class MockRequestTests(KumaTestCase):
@@ -34,14 +34,14 @@ class BaseTemplateTests(MockRequestTests):
         html = render_to_string(self.template, request=self.request)
         doc = pq(html)
         dir_attr = doc('html').attr['dir']
-        eq_('ltr', dir_attr)
+        assert 'ltr' == dir_attr
 
     def test_rtl_dir_attribute(self):
         translation.activate('ar')
         html = render_to_string(self.template, request=self.request)
         doc = pq(html)
         dir_attr = doc('html').attr['dir']
-        eq_('rtl', dir_attr)
+        assert 'rtl' == dir_attr
 
     def test_lang_switcher(self):
         translation.activate("bn-BD")

--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -3,26 +3,24 @@ from django.test import TestCase
 
 from kuma.core.utils import order_params, smart_int
 
-from . import eq_
-
 
 class SmartIntTestCase(TestCase):
     def test_sanity(self):
-        eq_(10, smart_int('10'))
-        eq_(10, smart_int('10.5'))
+        assert 10 == smart_int('10')
+        assert 10 == smart_int('10.5')
 
     def test_int(self):
-        eq_(10, smart_int(10))
+        assert 10 == smart_int(10)
 
     def test_invalid_string(self):
-        eq_(0, smart_int('invalid'))
+        assert 0 == smart_int('invalid')
 
     def test_empty_string(self):
-        eq_(0, smart_int(''))
+        assert 0 == smart_int('')
 
     def test_wrong_type(self):
-        eq_(0, smart_int(None))
-        eq_(10, smart_int([], 10))
+        assert 0 == smart_int(None)
+        assert 10 == smart_int([], 10)
 
 
 @pytest.mark.parametrize(

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -10,7 +10,7 @@ from pyquery import PyQuery as pq
 from ratelimit.exceptions import Ratelimited
 from soapbox.models import Message
 
-from . import (assert_no_cache_header, assert_shared_cache_header, eq_,
+from . import (assert_no_cache_header, assert_shared_cache_header,
                KumaTestCase)
 from ..urlresolvers import reverse
 from ..views import handler500
@@ -66,14 +66,14 @@ class LoggingTests(KumaTestCase):
     def test_no_mail_handler(self):
         self.logger.handlers = [logging.NullHandler()]
         response = self.client.get(self.suspicous_path)
-        eq_(response.status_code, 400)
-        eq_(0, len(mail.outbox))
+        assert 400 == response.status_code
+        assert 0 == len(mail.outbox)
 
     def test_mail_handler(self):
         self.logger.handlers = [AdminEmailHandler()]
         response = self.client.get(self.suspicous_path)
-        eq_(response.status_code, 400)
-        eq_(1, len(mail.outbox))
+        assert 400 == response.status_code
+        assert 1 == len(mail.outbox)
 
         assert 'admin@example.com' in mail.outbox[0].to
         assert self.suspicous_path in mail.outbox[0].body
@@ -87,10 +87,10 @@ class SoapboxViewsTest(KumaTestCase):
 
         url = reverse('home')
         r = self.client.get(url, follow=True)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
 
         doc = pq(r.content)
-        eq_(m.message, doc.find('div.global-notice').text())
+        assert m.message == doc.find('div.global-notice').text()
 
     def test_subsection(self):
         m = Message(message='Search', is_global=False, is_active=True,
@@ -99,17 +99,17 @@ class SoapboxViewsTest(KumaTestCase):
 
         url = reverse('search')
         r = self.client.get(url, follow=True)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
 
         doc = pq(r.content)
-        eq_(m.message, doc.find('div.global-notice').text())
+        assert m.message == doc.find('div.global-notice').text()
 
         url = reverse('home')
         r = self.client.get(url, follow=True)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
 
         doc = pq(r.content)
-        eq_([], doc.find('div.global-notice'))
+        assert [] == doc.find('div.global-notice')
 
     def test_inactive(self):
         m = Message(message='Search', is_global=False, is_active=False,
@@ -118,10 +118,10 @@ class SoapboxViewsTest(KumaTestCase):
 
         url = reverse('search')
         r = self.client.get(url, follow=True)
-        eq_(200, r.status_code)
+        assert 200 == r.status_code
 
         doc = pq(r.content)
-        eq_([], doc.find('div.global-notice'))
+        assert [] == doc.find('div.global-notice')
 
 
 class EventsRedirectTest(KumaTestCase):
@@ -129,8 +129,8 @@ class EventsRedirectTest(KumaTestCase):
     def test_redirect_to_mozilla_org(self):
         url = '/en-US/events'
         response = self.client.get(url)
-        eq_(302, response.status_code)
-        eq_('https://mozilla.org/contribute/events', response['Location'])
+        assert 302 == response.status_code
+        assert 'https://mozilla.org/contribute/events' == response['Location']
 
 
 @pytest.mark.parametrize(

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -109,7 +109,7 @@ class SoapboxViewsTest(KumaTestCase):
         assert 200 == r.status_code
 
         doc = pq(r.content)
-        assert [] == doc.find('div.global-notice')
+        assert not doc.find('div.global-notice')
 
     def test_inactive(self):
         m = Message(message='Search', is_global=False, is_active=False,
@@ -121,7 +121,7 @@ class SoapboxViewsTest(KumaTestCase):
         assert 200 == r.status_code
 
         doc = pq(r.content)
-        assert [] == doc.find('div.global-notice')
+        assert not doc.find('div.global-notice')
 
 
 class EventsRedirectTest(KumaTestCase):

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -534,7 +534,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         assert (row_quarterly[daily_average_viewers] ==
                 '{:.1f}'.format(float(spam_views_quarter) / days_in_quarter))
         # The published spam: 1 this week, 2 this month, 3 this quarter
-        assert len([]) == int(row_daily[published_spam])
+        assert not int(row_daily[published_spam])
         assert len(spam_weekly) == int(row_weekly[published_spam])
         assert len(spam_monthly) == int(row_monthly[published_spam])
         assert len(spam_quarterly) == int(row_quarterly[published_spam])

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -13,7 +13,7 @@ from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_)
+                             assert_shared_cache_header)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html, urlparams
 from kuma.dashboards.forms import RevisionDashboardForm
@@ -303,16 +303,16 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))
 
         self.assertContains(response2, "Oops!", status_code=200)
         page = pq(response2.content)
         spam_trends_table = page.find('.spam-trends-table')
-        eq_(len(spam_trends_table), 1)
+        assert 1 == len(spam_trends_table)
         spam_events_table = page.find('.spam-events-table')
-        eq_(len(spam_events_table), 1)
+        assert 1 == len(spam_events_table)
 
     def test_recent_spam_revisions_show(self, mock_analytics_upageviews):
         """The correct spam revisions should show up."""
@@ -346,7 +346,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))
         page = pq(response2.content)
@@ -355,7 +355,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         for table_row in table_rows:
             table_row_text += table_row.text_content()
 
-        eq_(len(table_rows), len(created_revisions))
+        assert len(table_rows) == len(created_revisions)
         for revision in created_revisions:
             document_url = reverse(
                 'wiki.document',
@@ -368,12 +368,12 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))
         page = pq(response2.content)
         spam_trends_table = page.find('.spam-trends-table')
-        eq_(len(spam_trends_table), 1)
+        assert 1 == len(spam_trends_table)
 
     def test_spam_trends_stats(self, mock_analytics_upageviews):
         """Test that the correct stats show up on the spam trends dashboard."""
@@ -471,7 +471,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))
         page = pq(response2.content)
@@ -494,15 +494,15 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         true_negative_rate = 9
 
         # The periods are identified as 'Daily', 'Weekly', 'Monthly', 'Quarterly'
-        eq_(row_daily[period], 'Daily')
-        eq_(row_weekly[period], 'Weekly')
-        eq_(row_monthly[period], 'Monthly')
-        eq_(row_quarterly[period], 'Quarterly')
+        assert 'Daily' == row_daily[period]
+        assert 'Weekly' == row_weekly[period]
+        assert 'Monthly' == row_monthly[period]
+        assert 'Quarterly' == row_quarterly[period]
         # The start dates for each period are correct
-        eq_(row_daily[start_date], yesterday.strftime('%Y-%m-%d'))
-        eq_(row_weekly[start_date], weekly_start_date.strftime('%Y-%m-%d'))
-        eq_(row_monthly[start_date], monthly_start_date.strftime('%Y-%m-%d'))
-        eq_(row_quarterly[start_date], quarterly_start_date.strftime('%Y-%m-%d'))
+        assert yesterday.strftime('%Y-%m-%d') == row_daily[start_date]
+        assert weekly_start_date.strftime('%Y-%m-%d') == row_weekly[start_date]
+        assert monthly_start_date.strftime('%Y-%m-%d') == row_monthly[start_date]
+        assert quarterly_start_date.strftime('%Y-%m-%d') == row_quarterly[start_date]
         # The page views during the week, month, quarter
         spam_views_week = page_views[spam_rev_3_days_ago.id]
         spam_views_month = spam_views_week + page_views[spam_rev_10_days_ago.id]
@@ -516,38 +516,38 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         monthly_spam_change_percent = '{:.1%}'.format(
             float(spam_views_month - spam_views_quarter_exclude_month) / spam_views_quarter_exclude_month
         )
-        eq_(row_daily[spam_viewers_change_percent], '0.0%')
-        eq_(row_weekly[spam_viewers_change_percent], weekly_spam_change_percent)
-        eq_(row_monthly[spam_viewers_change_percent], monthly_spam_change_percent)
-        eq_(row_quarterly[spam_viewers_change_percent], '0.0%')
+        assert '0.0%' == row_daily[spam_viewers_change_percent]
+        assert weekly_spam_change_percent == row_weekly[spam_viewers_change_percent]
+        assert monthly_spam_change_percent == row_monthly[spam_viewers_change_percent]
+        assert '0.0%' == row_quarterly[spam_viewers_change_percent]
         # The spam viewers
-        eq_(int(row_daily[spam_viewers]), 0)
-        eq_(int(row_weekly[spam_viewers]), spam_views_week)
-        eq_(int(row_monthly[spam_viewers]), spam_views_month)
-        eq_(int(row_quarterly[spam_viewers]), spam_views_quarter)
+        assert 0 == int(row_daily[spam_viewers])
+        assert spam_views_week == int(row_weekly[spam_viewers])
+        assert spam_views_month == int(row_monthly[spam_viewers])
+        assert spam_views_quarter == int(row_quarterly[spam_viewers])
         # The daily average of spam viewers
-        eq_(float(row_daily[daily_average_viewers]), 0.0)
-        eq_(row_weekly[daily_average_viewers],
-            '{:.1f}'.format(float(spam_views_week) / days_in_week))
-        eq_(row_monthly[daily_average_viewers],
-            '{:.1f}'.format(float(spam_views_month) / days_in_month))
-        eq_(row_quarterly[daily_average_viewers],
-            '{:.1f}'.format(float(spam_views_quarter) / days_in_quarter))
+        assert float(row_daily[daily_average_viewers]) == 0.0
+        assert (row_weekly[daily_average_viewers] ==
+                '{:.1f}'.format(float(spam_views_week) / days_in_week))
+        assert (row_monthly[daily_average_viewers] ==
+                '{:.1f}'.format(float(spam_views_month) / days_in_month))
+        assert (row_quarterly[daily_average_viewers] ==
+                '{:.1f}'.format(float(spam_views_quarter) / days_in_quarter))
         # The published spam: 1 this week, 2 this month, 3 this quarter
-        eq_(int(row_daily[published_spam]), len([]))
-        eq_(int(row_weekly[published_spam]), len(spam_weekly))
-        eq_(int(row_monthly[published_spam]), len(spam_monthly))
-        eq_(int(row_quarterly[published_spam]), len(spam_quarterly))
+        assert len([]) == int(row_daily[published_spam])
+        assert len(spam_weekly) == int(row_weekly[published_spam])
+        assert len(spam_monthly) == int(row_monthly[published_spam])
+        assert len(spam_quarterly) == int(row_quarterly[published_spam])
         # The blocked spam: there were 2 correctly blocked spam attempts 3 days ago
-        eq_(int(row_daily[blocked_spam]), 0)
-        eq_(int(row_weekly[blocked_spam]), true_blocked_spam_num)
-        eq_(int(row_monthly[blocked_spam]), true_blocked_spam_num)
-        eq_(int(row_quarterly[blocked_spam]), true_blocked_spam_num)
+        assert 0 == int(row_daily[blocked_spam])
+        assert true_blocked_spam_num == int(row_weekly[blocked_spam])
+        assert true_blocked_spam_num == int(row_monthly[blocked_spam])
+        assert true_blocked_spam_num == int(row_quarterly[blocked_spam])
         # The blocked ham: there was 1 incorrectly blocked spam attempt 3 days ago
-        eq_(int(row_daily[blocked_ham]), 0)
-        eq_(int(row_weekly[blocked_ham]), false_blocked_spam_num)
-        eq_(int(row_monthly[blocked_ham]), false_blocked_spam_num)
-        eq_(int(row_quarterly[blocked_ham]), false_blocked_spam_num)
+        assert 0 == int(row_daily[blocked_ham])
+        assert false_blocked_spam_num == int(row_weekly[blocked_ham])
+        assert false_blocked_spam_num == int(row_monthly[blocked_ham])
+        assert false_blocked_spam_num == int(row_quarterly[blocked_ham])
         # The true positive rate == blocked_spam / total spam
         tpr_weekly = '{:.1%}'.format(
             true_blocked_spam_num / float(true_blocked_spam_num + len(spam_weekly))
@@ -558,10 +558,10 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         tpr_quarterly = '{:.1%}'.format(
             true_blocked_spam_num / float(true_blocked_spam_num + len(spam_quarterly))
         )
-        eq_(row_daily[true_positive_rate], '100.0%')
-        eq_(row_weekly[true_positive_rate], tpr_weekly)
-        eq_(row_monthly[true_positive_rate], tpr_monthly)
-        eq_(row_quarterly[true_positive_rate], tpr_quarterly)
+        assert '100.0%' == row_daily[true_positive_rate]
+        assert tpr_weekly == row_weekly[true_positive_rate]
+        assert tpr_monthly == row_monthly[true_positive_rate]
+        assert tpr_quarterly == row_quarterly[true_positive_rate]
         # The true negative rate == published ham / total ham
         tnr_weekly = '{:.1%}'.format(
             len(ham_weekly) / float(false_blocked_spam_num + len(ham_weekly))
@@ -572,10 +572,10 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         tnr_quarterly = '{:.1%}'.format(
             len(ham_quarterly) / float(false_blocked_spam_num + len(ham_quarterly))
         )
-        eq_(row_daily[true_negative_rate], '100.0%')
-        eq_(row_weekly[true_negative_rate], tnr_weekly)
-        eq_(row_monthly[true_negative_rate], tnr_monthly)
-        eq_(row_quarterly[true_negative_rate], tnr_quarterly)
+        assert '100.0%' == row_daily[true_negative_rate]
+        assert tnr_weekly == row_weekly[true_negative_rate]
+        assert tnr_monthly == row_monthly[true_negative_rate]
+        assert tnr_quarterly == row_quarterly[true_negative_rate]
 
 
 @pytest.mark.parametrize(

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -30,6 +30,6 @@ class HomeTests(KumaTestCase):
         response = self.client.get(url, follow=True)
         page = pq(response.content)
         filters = page.find('#home-search-form input[type=hidden]')
-        filter_vals = [p.val() for p in filters.items()]
+
         assert 'topic' == filters.eq(0).attr('name')
-        assert {'css', 'html', 'javascript'} == set(filter_vals)
+        assert set(p.val() for p in filters.items()) == {'css', 'html', 'javascript'}

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,7 +1,7 @@
 from constance.test import override_config
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.tests import KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.search.models import Filter, FilterGroup
 
@@ -12,12 +12,12 @@ class HomeTests(KumaTestCase):
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
             response = self.client.get(url, follow=True)
-            eq_(200, response.status_code)
+            assert 200 == response.status_code
             assert 'ga(\'create' not in response.content
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
             response = self.client.get(url, follow=True)
-            eq_(200, response.status_code)
+            assert 200 == response.status_code
             assert 'ga(\'create' in response.content
 
     def test_default_search_filters(self):
@@ -31,5 +31,5 @@ class HomeTests(KumaTestCase):
         page = pq(response.content)
         filters = page.find('#home-search-form input[type=hidden]')
         filter_vals = [p.val() for p in filters.items()]
-        eq_(filters.eq(0).attr('name'), 'topic')
-        eq_(sorted(filter_vals), ['css', 'html', 'javascript'])
+        assert 'topic' == filters.eq(0).attr('name')
+        assert {'css', 'html', 'javascript'} == set(filter_vals)

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -22,8 +22,7 @@ class FilterTests(ElasticTestCase):
         view = SearchQueryView.as_view()
         request = self.get_request('/en-US/search?q=article')
         response = view(request)
-        assert 4 == response.data['count']
-        assert 4 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 4
         assert 'CSS/article-title-3' == response.data['documents'][0]['slug']
         assert 'en-US' == response.data['documents'][0]['locale']
 
@@ -43,8 +42,7 @@ class FilterTests(ElasticTestCase):
         view = View.as_view()
         request = self.get_request('/en-US/search?css_classnames=eval')
         response = view(request)
-        assert 1 == response.data['count']
-        assert 1 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 1
         assert doc.slug == response.data['documents'][0]['slug']
         assert doc.locale == response.data['documents'][0]['locale']
 
@@ -75,15 +73,13 @@ class FilterTests(ElasticTestCase):
         assert 'fr' == request.LANGUAGE_CODE
         response = view(request)
 
-        assert 7 == response.data['count']
-        assert 7 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 7
         assert 'fr' == response.data['documents'][0]['locale']
 
         request = self.get_request('/en-US/search?q=article')
         assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
-        assert 6 == response.data['count']
-        assert 6 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 6
         assert 'en-US' == response.data['documents'][0]['locale']
 
     def test_language_filter_override(self):
@@ -96,15 +92,13 @@ class FilterTests(ElasticTestCase):
         assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
 
-        assert 1 == response.data['count']
-        assert 1 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 1
         assert 'fr' == response.data['documents'][0]['locale']
 
         request = self.get_request('/en-US/search?q=pipe')
         assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
-        assert 0 == response.data['count']
-        assert 0 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 0
 
     def test_database_filter(self):
         class DatabaseFilterView(SearchView):
@@ -113,8 +107,7 @@ class FilterTests(ElasticTestCase):
         view = DatabaseFilterView.as_view()
         request = self.get_request('/en-US/search?group=tagged')
         response = view(request)
-        assert 2 == response.data['count']
-        assert 2 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 2
         assert 'article-title' == response.data['documents'][0]['slug']
         assert [{
                 'name': 'Group',
@@ -134,8 +127,7 @@ class FilterTests(ElasticTestCase):
 
         request = self.get_request('/fr/search?group=non-existent')
         response = view(request)
-        assert 7 == response.data['count']
-        assert 7 == len(response.data['documents'])
+        assert len(response.data['documents']) == response.data['count'] == 7
 
     def test_get_filters(self):
         FilterGroup.objects.create(

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -1,6 +1,5 @@
 from django.http import QueryDict
 
-from kuma.core.tests import eq_
 from kuma.wiki.models import Document
 from kuma.wiki.signals import render_done
 
@@ -23,10 +22,10 @@ class FilterTests(ElasticTestCase):
         view = SearchQueryView.as_view()
         request = self.get_request('/en-US/search?q=article')
         response = view(request)
-        eq_(response.data['count'], 4)
-        eq_(len(response.data['documents']), 4)
-        eq_(response.data['documents'][0]['slug'], 'CSS/article-title-3')
-        eq_(response.data['documents'][0]['locale'], 'en-US')
+        assert 4 == response.data['count']
+        assert 4 == len(response.data['documents'])
+        assert 'CSS/article-title-3' == response.data['documents'][0]['slug']
+        assert 'en-US' == response.data['documents'][0]['locale']
 
     def test_advanced_search_query(self):
         """Test advanced search query filter."""
@@ -44,10 +43,10 @@ class FilterTests(ElasticTestCase):
         view = View.as_view()
         request = self.get_request('/en-US/search?css_classnames=eval')
         response = view(request)
-        eq_(response.data['count'], 1)
-        eq_(len(response.data['documents']), 1)
-        eq_(response.data['documents'][0]['slug'], doc.slug)
-        eq_(response.data['documents'][0]['locale'], doc.locale)
+        assert 1 == response.data['count']
+        assert 1 == len(response.data['documents'])
+        assert doc.slug == response.data['documents'][0]['slug']
+        assert doc.locale == response.data['documents'][0]['locale']
 
     def test_highlight_filter(self):
         class HighlightView(SearchView):
@@ -73,19 +72,19 @@ class FilterTests(ElasticTestCase):
 
         view = LanguageView.as_view()
         request = self.get_request('/fr/search?q=article')
-        eq_(request.LANGUAGE_CODE, 'fr')
+        assert 'fr' == request.LANGUAGE_CODE
         response = view(request)
 
-        eq_(response.data['count'], 7)
-        eq_(len(response.data['documents']), 7)
-        eq_(response.data['documents'][0]['locale'], 'fr')
+        assert 7 == response.data['count']
+        assert 7 == len(response.data['documents'])
+        assert 'fr' == response.data['documents'][0]['locale']
 
         request = self.get_request('/en-US/search?q=article')
-        eq_(request.LANGUAGE_CODE, 'en-US')
+        assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
-        eq_(response.data['count'], 6)
-        eq_(len(response.data['documents']), 6)
-        eq_(response.data['documents'][0]['locale'], 'en-US')
+        assert 6 == response.data['count']
+        assert 6 == len(response.data['documents'])
+        assert 'en-US' == response.data['documents'][0]['locale']
 
     def test_language_filter_override(self):
         """Ensure locale override can find the only 'fr' document."""
@@ -94,18 +93,18 @@ class FilterTests(ElasticTestCase):
 
         view = LanguageView.as_view()
         request = self.get_request('/en-US/search?q=pipe&locale=*')
-        eq_(request.LANGUAGE_CODE, 'en-US')
+        assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
 
-        eq_(response.data['count'], 1)
-        eq_(len(response.data['documents']), 1)
-        eq_(response.data['documents'][0]['locale'], 'fr')
+        assert 1 == response.data['count']
+        assert 1 == len(response.data['documents'])
+        assert 'fr' == response.data['documents'][0]['locale']
 
         request = self.get_request('/en-US/search?q=pipe')
-        eq_(request.LANGUAGE_CODE, 'en-US')
+        assert 'en-US' == request.LANGUAGE_CODE
         response = view(request)
-        eq_(response.data['count'], 0)
-        eq_(len(response.data['documents']), 0)
+        assert 0 == response.data['count']
+        assert 0 == len(response.data['documents'])
 
     def test_database_filter(self):
         class DatabaseFilterView(SearchView):
@@ -114,11 +113,10 @@ class FilterTests(ElasticTestCase):
         view = DatabaseFilterView.as_view()
         request = self.get_request('/en-US/search?group=tagged')
         response = view(request)
-        eq_(response.data['count'], 2)
-        eq_(len(response.data['documents']), 2)
-        eq_(response.data['documents'][0]['slug'], 'article-title')
-        eq_(response.data['filters'], [
-            {
+        assert 2 == response.data['count']
+        assert 2 == len(response.data['documents'])
+        assert 'article-title' == response.data['documents'][0]['slug']
+        assert [{
                 'name': 'Group',
                 'slug': 'group',
                 'options': [{
@@ -131,13 +129,13 @@ class FilterTests(ElasticTestCase):
                         'inactive': '/en-US/search',
                     },
                 }],
-            },
-        ])
+                },
+                ] == response.data['filters']
 
         request = self.get_request('/fr/search?group=non-existent')
         response = view(request)
-        eq_(response.data['count'], 7)
-        eq_(len(response.data['documents']), 7)
+        assert 7 == response.data['count']
+        assert 7 == len(response.data['documents'])
 
     def test_get_filters(self):
         FilterGroup.objects.create(
@@ -146,12 +144,12 @@ class FilterTests(ElasticTestCase):
             order=1)
         qd = QueryDict('q=test&topic=css,canvas,js')
         filters = get_filters(qd.getlist)
-        eq_(filters, [u'css,canvas,js'])
+        assert [u'css,canvas,js'] == filters
 
         qd = QueryDict('q=test&topic=css,js&none=none')
         filters = get_filters(qd.getlist)
-        eq_(filters, [u'none'])
+        assert [u'none'] == filters
 
         qd = QueryDict('q=test&none=none')
         filters = get_filters(qd.getlist)
-        eq_(filters, [u'none'])
+        assert [u'none'] == filters

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -31,7 +31,7 @@ class SerializerTests(ElasticTestCase):
         assert data['shortcut'] is None
         assert 'serializer' == data['slug']
         assert 1 == len(data['tags'])
-        assert u'tag' == data['tags'][0], u'tag'
+        assert u'tag' == data['tags'][0]
 
     @mock.patch('kuma.search.serializers.ugettext')
     def test_filter_serializer_with_translations(self, _mock):

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -4,7 +4,6 @@ from django.utils import translation
 from rest_framework import serializers
 from rest_framework.test import APIRequestFactory
 
-from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 
 from . import ElasticTestCase
@@ -25,17 +24,14 @@ class SerializerTests(ElasticTestCase):
         filter_.tags.add('tag')
         filter_serializer = FilterWithGroupSerializer(filter_)
         data = filter_serializer.data
-        eq_(data['group'], {
-            'order': 1L,
-            'name': u'Group',
-            'slug': u'group',
-        })
-        eq_(data['name'], u'Serializer')
-        eq_(data['operator'], 'OR')
-        eq_(data['shortcut'], None)
-        eq_(data['slug'], 'serializer')
-        eq_(len(data['tags']), 1)
-        eq_(data['tags'][0], u'tag')
+        assert ({'order': 1L, 'name': u'Group', 'slug': u'group'} ==
+                data['group'])
+        assert u'Serializer' == data['name']
+        assert 'OR' == data['operator']
+        assert data['shortcut'] is None
+        assert 'serializer' == data['slug']
+        assert 1 == len(data['tags'])
+        assert u'tag' == data['tags'][0], u'tag'
 
     @mock.patch('kuma.search.serializers.ugettext')
     def test_filter_serializer_with_translations(self, _mock):
@@ -43,24 +39,25 @@ class SerializerTests(ElasticTestCase):
         translation.activate('es')
         filter_ = Filter(name='Games', slug='games')
         serializer = FilterSerializer(filter_)
-        eq_(serializer.data, {
+        assert {
             'name': u'Juegos',
             'slug': u'games',
-            'shortcut': None})
+            'shortcut': None
+        } == serializer.data
 
     def test_document_serializer(self):
         search = WikiDocumentType.search()
         result = search.execute()
         doc_serializer = DocumentSerializer(result, many=True)
         list_data = doc_serializer.data
-        eq_(len(list_data), 7)
+        assert 7 == len(list_data)
         assert isinstance(list_data, list)
         assert 1 in [data['id'] for data in list_data]
 
         doc_serializer = DocumentSerializer(result[0], many=False)
         dict_data = doc_serializer.data
         assert isinstance(dict_data, dict)
-        eq_(dict_data['id'], result[0].id)
+        assert dict_data['id'] == result[0].id
 
     def test_excerpt(self):
         search = WikiDocumentType.search()
@@ -68,7 +65,7 @@ class SerializerTests(ElasticTestCase):
         search = search.highlight(*WikiDocumentType.excerpt_fields)
         result = search.execute()
         serializer = DocumentSerializer(result, many=True)
-        eq_(serializer.data[0]['excerpt'], u'A <em>CSS</em> article')
+        assert u'A <em>CSS</em> article' == serializer.data[0]['excerpt']
 
 
 class SearchQueryFieldSerializer(serializers.Serializer):
@@ -88,7 +85,7 @@ class FieldTests(ElasticTestCase):
             context={'request': request},
         )
         serializer.is_valid()
-        eq_(serializer.data, {'q': 'test'})
+        assert {'q': 'test'} == serializer.data
 
     def test_SiteURLField(self):
         class FakeValue(object):

--- a/kuma/search/tests/test_tasks.py
+++ b/kuma/search/tests/test_tasks.py
@@ -20,7 +20,7 @@ class TestLiveIndexing(ElasticTestCase):
         r.document.render()
 
         self.refresh()
-        assert count_before + 1, S().count()
+        assert count_before + 1 == S().count()
 
         r.document.delete()
         self.refresh()

--- a/kuma/search/tests/test_tasks.py
+++ b/kuma/search/tests/test_tasks.py
@@ -1,4 +1,3 @@
-from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 from kuma.wiki.tests import revision
 
@@ -21,10 +20,10 @@ class TestLiveIndexing(ElasticTestCase):
         r.document.render()
 
         self.refresh()
-        eq_(count_before + 1, S().count())
+        assert count_before + 1, S().count()
 
         r.document.delete()
         self.refresh()
         # TODO: Investigate this test failure. The ES debug output appears to
         # be doing the correct thing but the ES delete call is returning a 404.
-        eq_(count_before, S().count())
+        assert count_before == S().count()

--- a/kuma/search/tests/test_types.py
+++ b/kuma/search/tests/test_types.py
@@ -1,6 +1,5 @@
 from elasticsearch_dsl import query
 
-from kuma.core.tests import eq_
 from kuma.wiki.search import WikiDocumentType
 
 from . import ElasticTestCase
@@ -25,7 +24,7 @@ class WikiDocumentTypeTests(ElasticTestCase):
                                           query.Match(content='article'))
                                    .filter('term', locale='en-US'))
         for doc in results.execute():
-            eq_('en-US', doc.locale)
+            assert 'en-US' == doc.locale
 
     def test_get_excerpt_uses_summary(self):
         self.refresh()

--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.tests import KumaTestCase
 from kuma.core.utils import order_params
 
 from ..utils import QueryURLObject
@@ -12,27 +12,27 @@ class URLTests(KumaTestCase):
         original = 'http://example.com/?spam=eggs'
         url = QueryURLObject(original)
 
-        eq_(url.pop_query_param('spam', 'eggs'), 'http://example.com/')
-        eq_(url.pop_query_param('spam', 'spam'), original)
+        assert 'http://example.com/' == url.pop_query_param('spam', 'eggs')
+        assert original, url.pop_query_param('spam', 'spam')
 
         original = 'http://example.com/?spam=eggs&spam=spam'
         url = QueryURLObject(original)
-        eq_(url.pop_query_param('spam', 'eggs'),
-            'http://example.com/?spam=spam')
-        eq_(url.pop_query_param('spam', 'spam'),
-            'http://example.com/?spam=eggs')
+        assert ('http://example.com/?spam=spam' ==
+                url.pop_query_param('spam', 'eggs'))
+        assert ('http://example.com/?spam=eggs' ==
+                url.pop_query_param('spam', 'spam'))
 
         original = 'http://example.com/?spam=eggs&foo='
         url = QueryURLObject(original)
-        eq_(url.pop_query_param('spam', 'eggs'),
-            'http://example.com/?foo=')
+        assert ('http://example.com/?foo=' ==
+                url.pop_query_param('spam', 'eggs'))
 
     def test_merge_query_param(self):
         original = 'http://example.com/?spam=eggs'
         url = QueryURLObject(original)
 
-        eq_(url.merge_query_param('spam', 'eggs'), original)
-        eq_(url.merge_query_param('spam', 'spam'), original + '&spam=spam')
+        assert original == url.merge_query_param('spam', 'eggs')
+        assert original + '&spam=spam' == url.merge_query_param('spam', 'spam')
 
         original = 'http://example.com/?foo=&spam=eggs&foo=bar'
         url = QueryURLObject(original)
@@ -52,4 +52,4 @@ class URLTests(KumaTestCase):
         for url in ['http://example.com/?spam=',
                     'http://example.com/?spam']:
             url_object = QueryURLObject(url)
-            eq_(url_object.clean_params(url_object.query_dict), {})
+            assert {} == url_object.clean_params(url_object.query_dict)

--- a/kuma/search/tests/test_utils.py
+++ b/kuma/search/tests/test_utils.py
@@ -13,7 +13,7 @@ class URLTests(KumaTestCase):
         url = QueryURLObject(original)
 
         assert 'http://example.com/' == url.pop_query_param('spam', 'eggs')
-        assert original, url.pop_query_param('spam', 'spam')
+        assert original == url.pop_query_param('spam', 'spam')
 
         original = 'http://example.com/?spam=eggs&spam=spam'
         url = QueryURLObject(original)
@@ -52,4 +52,4 @@ class URLTests(KumaTestCase):
         for url in ['http://example.com/?spam=',
                     'http://example.com/?spam']:
             url_object = QueryURLObject(url)
-            assert {} == url_object.clean_params(url_object.query_dict)
+            assert not url_object.clean_params(url_object.query_dict)

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -5,7 +5,6 @@ from django.contrib import messages as django_messages
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 
-from kuma.core.tests import eq_
 from kuma.core.urlresolvers import reverse
 from kuma.users.adapters import KumaAccountAdapter, KumaSocialAccountAdapter
 from kuma.users.models import User, UserBan
@@ -42,10 +41,7 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         # Verify the social_login receiver over-writes the provider
         # stored in the session
         self.adapter.pre_social_login(request, sociallogin)
-        eq_(account.provider,
-            request.session['sociallogin_provider'],
-            "receiver should have over-written sociallogin_provider "
-            "session variable")
+        assert account.provider == request.session['sociallogin_provider']
 
     def test_pre_social_login_error_for_unmatched_login(self):
         """
@@ -74,8 +70,8 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         self.assertRaises(ImmediateHttpResponse,
                           self.adapter.pre_social_login, request, other_login)
         queued_messages = list(messages)
-        eq_(len(queued_messages), 1)
-        eq_(django_messages.ERROR, queued_messages[0].level)
+        assert len(queued_messages) == 1
+        assert queued_messages[0].level == django_messages.ERROR
 
     def test_pre_social_login_matched_login(self):
         """
@@ -111,7 +107,7 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         # stored in the session
         self.adapter.pre_social_login(request, github_login)
         session = request.session
-        eq_(session['sociallogin_provider'], 'github')
+        assert 'github' == session['sociallogin_provider']
 
     def test_pre_social_login_same_provider(self):
         """
@@ -140,7 +136,7 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         github2_login = SocialLogin(account=github2_account)
 
         self.adapter.pre_social_login(request, github2_login)
-        eq_(request.session['sociallogin_provider'], 'github')
+        assert 'github' == request.session['sociallogin_provider']
 
     def test_pre_social_login_banned_user(self):
         """A banned user is not allowed to login."""

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -4,7 +4,7 @@ import pytest
 from django import forms
 from django.test import RequestFactory
 
-from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.tests import KumaTestCase
 
 from . import user
 from ..adapters import (KumaAccountAdapter, USERNAME_CHARACTERS,
@@ -22,12 +22,12 @@ class TestUserEditForm(KumaTestCase):
             'username': test_user.username,
         }
         form = UserEditForm(data, instance=test_user)
-        eq_(True, form.is_valid())
+        assert form.is_valid()
 
         # let's try this with the username above
         test_user2 = user(save=True)
         form = UserEditForm(data, instance=test_user2)
-        eq_(False, form.is_valid())
+        assert not form.is_valid()
 
     def test_can_keep_legacy_username(self):
         test_user = user(username='legacy@example.com', save=True)
@@ -45,18 +45,18 @@ class TestUserEditForm(KumaTestCase):
             'username': 'mr.legacy@example.com'
         }
         form = UserEditForm(data, instance=test_user)
-        eq_(form.is_valid(), False)
-        eq_(form.errors, {'username': [USERNAME_CHARACTERS]})
+        assert not form.is_valid()
+        assert {'username': [USERNAME_CHARACTERS]} == form.errors
 
     def test_cannot_change_to_legacy_username(self):
         test_user = user(save=True)
-        eq_(test_user.has_legacy_username, False)
+        assert not test_user.has_legacy_username
         data = {
             'username': 'mr.legacy@example.com'
         }
         form = UserEditForm(data, instance=test_user)
-        eq_(form.is_valid(), False)
-        eq_(form.errors, {'username': [USERNAME_CHARACTERS]})
+        assert not form.is_valid(), False
+        assert {'username': [USERNAME_CHARACTERS]} == form.errors
 
     def test_blank_username_invalid(self):
         test_user = user(save=True)
@@ -64,8 +64,8 @@ class TestUserEditForm(KumaTestCase):
             'username': '',
         }
         form = UserEditForm(data, instance=test_user)
-        eq_(form.is_valid(), False)
-        eq_(form.errors, {'username': ['This field cannot be blank.']})
+        assert not form.is_valid()
+        assert {'username': ['This field cannot be blank.']} == form.errors
 
     def test_https_user_urls(self):
         """bug 733610: User URLs should allow https"""
@@ -111,7 +111,7 @@ class TestUserEditForm(KumaTestCase):
                 }
                 form = UserEditForm(data, instance=edit_user)
                 result_valid = form.is_valid()
-                eq_(expected_valid, result_valid)
+                assert expected_valid == result_valid
 
 
 @pytest.mark.parametrize('username', ('testuser@example.com', '@testuser'))

--- a/kuma/users/tests/test_forms.py
+++ b/kuma/users/tests/test_forms.py
@@ -55,7 +55,7 @@ class TestUserEditForm(KumaTestCase):
             'username': 'mr.legacy@example.com'
         }
         form = UserEditForm(data, instance=test_user)
-        assert not form.is_valid(), False
+        assert not form.is_valid()
         assert {'username': [USERNAME_CHARACTERS]} == form.errors
 
     def test_blank_username_invalid(self):

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -3,8 +3,6 @@ from hashlib import md5
 
 from django.conf import settings
 
-from kuma.core.tests import eq_
-
 from . import UserTestCase
 from ..templatetags.jinja_helpers import gravatar_url, public_email
 
@@ -25,9 +23,9 @@ class HelperTestCase(UserTestCase):
         assert md5(self.u.email).hexdigest() in gravatar_url(self.u.email)
 
     def test_public_email(self):
-        eq_('<span class="email">'
-            '&#109;&#101;&#64;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;'
-            '&#111;&#109;</span>', public_email('me@domain.com'))
-        eq_('<span class="email">'
-            '&#110;&#111;&#116;&#46;&#97;&#110;&#46;&#101;&#109;&#97;&#105;'
-            '&#108;</span>', public_email('not.an.email'))
+        assert ('<span class="email">'
+                '&#109;&#101;&#64;&#100;&#111;&#109;&#97;&#105;&#110;&#46;&#99;'
+                '&#111;&#109;</span>' == public_email('me@domain.com'))
+        assert ('<span class="email">'
+                '&#110;&#111;&#116;&#46;&#97;&#110;&#46;&#101;&#109;&#97;&#105;'
+                '&#108;</span>' == public_email('not.an.email'))

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -2,7 +2,6 @@ import pytest
 
 from django.core.exceptions import ValidationError
 
-from kuma.core.tests import eq_
 from kuma.wiki.tests import revision
 
 from . import UserTestCase
@@ -34,7 +33,7 @@ class TestUser(UserTestCase):
         user.save()
         user2 = self.user_model.objects.get(pk=user.pk)
         for name, url in test_sites.items():
-            eq_(getattr(user2, name), url)
+            assert url == getattr(user2, name)
 
     def test_linkedin_urls(self):
         user = self.user_model.objects.get(username='testuser')
@@ -49,7 +48,7 @@ class TestUser(UserTestCase):
             user.linkedin_url = url
             user.save()
             new_user = self.user_model.objects.get(pk=user.pk)
-            eq_(url, new_user.linkedin_url)
+            assert url == new_user.linkedin_url
 
     def test_stackoverflow_urls(self):
         """Bug 1306087: Accept two-letter country-localized stackoverflow
@@ -80,7 +79,7 @@ class TestUser(UserTestCase):
         Make sure it shows up."""
         user = self.user_model.objects.get(username='testuser')
         assert hasattr(user, 'irc_nickname')
-        eq_('testuser', user.irc_nickname)
+        assert 'testuser' == user.irc_nickname
 
     def test_unicode_email_gravatar(self):
         """Bug 689056: Unicode characters in email addresses shouldn't break
@@ -95,7 +94,7 @@ class TestUser(UserTestCase):
         assert hasattr(user, 'locale')
         assert user.locale == 'en-US'
         assert hasattr(user, 'timezone')
-        eq_(user.timezone, 'US/Pacific')
+        assert 'US/Pacific' == user.timezone
 
     def test_wiki_revisions(self):
         user = self.user_model.objects.get(username='testuser')

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1097,7 +1097,7 @@ def test_extractor_css_classnames(root_doc, wiki_user):
         document=root_doc, content=content, creator=wiki_user)
     root_doc.render()  # Also saves
     result = root_doc.extract.css_classnames()
-    assert set(result) == set(classes)
+    assert sorted(result) == sorted(classes)
 
 
 def test_extractor_html_attributes(root_doc, wiki_user):
@@ -1116,7 +1116,7 @@ def test_extractor_html_attributes(root_doc, wiki_user):
         document=root_doc, content=content, creator=wiki_user)
     root_doc.render()  # Also saves
     result = root_doc.extract.html_attributes()
-    assert set(result) == set(attributes)
+    assert sorted(result) == sorted(attributes)
 
 
 def test_extractor_macro_names(root_doc, wiki_user):
@@ -1131,7 +1131,7 @@ def test_extractor_macro_names(root_doc, wiki_user):
     root_doc.current_revision = Revision.objects.create(
         document=root_doc, content=content, creator=wiki_user)
     result = root_doc.extract.macro_names()
-    assert set(result) == set(macros)
+    assert sorted(result) == sorted(macros)
 
 
 @pytest.mark.parametrize('is_rendered', (True, False))

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -10,7 +10,7 @@ from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
 
 import kuma.wiki.content
-from kuma.core.tests import eq_, KumaTestCase
+from kuma.core.tests import KumaTestCase
 
 from . import document, normalize_html
 from ..constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_TAGS
@@ -104,7 +104,7 @@ class GetContentSectionsTests(TestCase):
         doc = document(title='Doc', locale=u'fr', slug=u'doc', save=True,
                        html='<!-- -->')
         res = get_content_sections(doc.html)
-        eq_(type(res).__name__, 'list')
+        assert 'list' == type(res).__name__
 
 
 class InjectSectionIDsTests(TestCase):
@@ -146,7 +146,7 @@ class InjectSectionIDsTests(TestCase):
             ('Quick_Links', 'Quick_Links'),
         )
         for cls, id in expected:
-            eq_(id, result_doc.find('.%s' % cls).attr('id'))
+            assert id == result_doc.find('.%s' % cls).attr('id')
 
         # Then, ensure all elements in need of an ID now all have unique IDs.
         assert len(SECTION_TAGS)
@@ -352,7 +352,7 @@ class ReplaceSectionTests(TestCase):
                   .parse(doc_src)
                   .replaceSection(id="s2", replace_src=replace_src)
                   .serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_ignore_heading_section_replace(self):
         doc_src = """
@@ -385,7 +385,7 @@ class ReplaceSectionTests(TestCase):
                                   replace_src=replace_src,
                                   ignore_heading=True)
                   .serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 class RemoveSectionTests(TestCase):
@@ -405,7 +405,7 @@ class RemoveSectionTests(TestCase):
                   .parse(doc_src)
                   .removeSection('here')
                   .serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 class InjectSectionEditingLinksTests(TestCase):
@@ -468,7 +468,7 @@ class CodeSyntaxFilterTests(TestCase):
         result = (kuma.wiki.content
                   .parse(doc_src)
                   .filter(CodeSyntaxFilter).serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 class SectionIDFilterTests(TestCase):
@@ -547,7 +547,7 @@ class TOCFilterTests(TestCase):
         result = (kuma.wiki.content
                   .parse(doc_src)
                   .filter(SectionTOCFilter).serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_generate_toc_h2(self):
         doc_src = """
@@ -574,7 +574,7 @@ class TOCFilterTests(TestCase):
         result = (kuma.wiki.content
                   .parse(doc_src)
                   .filter(H2TOCFilter).serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_generate_toc_h3(self):
         doc_src = """
@@ -612,7 +612,7 @@ class TOCFilterTests(TestCase):
         result = (kuma.wiki.content
                   .parse(doc_src)
                   .filter(H3TOCFilter).serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_bug_925043(self):
         '''Bug 925043 - Redesign TOC has a bunch of empty <code> tags in markup'''
@@ -628,7 +628,7 @@ class TOCFilterTests(TestCase):
         result = (kuma.wiki.content
                   .parse(doc_src)
                   .filter(SectionTOCFilter).serialize())
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 class FilterOutNoIncludeTests(TestCase):
@@ -652,7 +652,7 @@ class FilterOutNoIncludeTests(TestCase):
             </dl>
         """
         result = (kuma.wiki.content.filter_out_noinclude(doc_src))
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_noinclude_empty_content(self):
         """Bug 777475: The noinclude filter and pyquery seems to really dislike
@@ -666,11 +666,11 @@ class BugizeTests(TestCase):
     def test_bugize_text(self):
         bad = 'Fixing bug #12345 again. <img src="http://davidwalsh.name" /> <a href="">javascript></a>'
         good = 'Fixing <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=12345" target="_blank">bug 12345</a> again. &lt;img src=&#34;http://davidwalsh.name&#34; /&gt; &lt;a href=&#34;&#34;&gt;javascript&gt;&lt;/a&gt;'
-        eq_(bugize_text(bad), Markup(good))
+        assert bugize_text(bad) == Markup(good)
 
         bad_upper = 'Fixing Bug #12345 again.'
         good_upper = 'Fixing <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=12345" target="_blank">Bug 12345</a> again.'
-        eq_(bugize_text(bad_upper), Markup(good_upper))
+        assert bugize_text(bad_upper) == Markup(good_upper)
 
 
 def test_filteriframe():
@@ -976,7 +976,7 @@ class FilterEditorSafetyTests(TestCase):
         result_src = (kuma.wiki.content.parse(doc_src)
                       .filterEditorSafety()
                       .serialize())
-        eq_(normalize_html(expected_src), normalize_html(result_src))
+        assert normalize_html(expected_src) == normalize_html(result_src)
 
 
 class AllowedHTMLTests(KumaTestCase):
@@ -1011,17 +1011,17 @@ class AllowedHTMLTests(KumaTestCase):
     def test_allowed_tags(self):
         for tag in self.simple_tags:
             html_str = '<%(tag)s></%(tag)s>' % {'tag': tag}
-            eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                       tags=ALLOWED_TAGS))
+            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
+                                            tags=ALLOWED_TAGS)
 
         for tag in self.unclose_tags:
             html_str = '<%s>' % tag
-            eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                       tags=ALLOWED_TAGS))
+            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
+                                            tags=ALLOWED_TAGS)
 
         for html_str in self.special_tags:
-            eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                       tags=ALLOWED_TAGS))
+            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
+                                            tags=ALLOWED_TAGS)
 
     def test_allowed_attributes(self):
         for tag in ('div', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'pre', 'code',
@@ -1030,12 +1030,12 @@ class AllowedHTMLTests(KumaTestCase):
                     'time', 'meter', 'output', 'progress', 'audio', 'details',
                     'datagrid', 'datalist', 'address'):
             html_str = '<%(tag)s id="foo"></%(tag)s>' % {'tag': tag}
-            eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                       tags=ALLOWED_TAGS))
+            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
+                                            tags=ALLOWED_TAGS)
 
         for html_str in self.special_attributes:
-            eq_(html_str, bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                       tags=ALLOWED_TAGS))
+            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
+                                            tags=ALLOWED_TAGS)
 
     def test_stripped_ie_comment(self):
         """bug 801046: strip IE conditional comments"""
@@ -1050,7 +1050,7 @@ class AllowedHTMLTests(KumaTestCase):
             <p>Goodbye</p>
         """
         result = Document.objects.clean_content(content)
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_iframe_in_script(self):
         """iframe in script should be filtered"""
@@ -1059,7 +1059,7 @@ class AllowedHTMLTests(KumaTestCase):
         expected = ('&lt;script&gt;&lt;iframe src="data:text/plain,foo"&gt;'
                     '&lt;/iframe&gt;&lt;/script&gt;')
         result = Document.objects.clean_content(content)
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_iframe_in_style(self):
         """iframe in style should be filtered"""
@@ -1068,7 +1068,7 @@ class AllowedHTMLTests(KumaTestCase):
         expected = ('&lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;'
                     '&lt;/iframe&gt;&lt;/style&gt;')
         result = Document.objects.clean_content(content)
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
     def test_iframe_in_textarea(self):
         """
@@ -1081,7 +1081,7 @@ class AllowedHTMLTests(KumaTestCase):
             <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
         """
         result = Document.objects.clean_content(content)
-        eq_(normalize_html(expected), normalize_html(result))
+        assert normalize_html(expected) == normalize_html(result)
 
 
 def test_extractor_css_classnames(root_doc, wiki_user):
@@ -1097,7 +1097,7 @@ def test_extractor_css_classnames(root_doc, wiki_user):
         document=root_doc, content=content, creator=wiki_user)
     root_doc.render()  # Also saves
     result = root_doc.extract.css_classnames()
-    assert sorted(result) == sorted(classes)
+    assert set(result) == set(classes)
 
 
 def test_extractor_html_attributes(root_doc, wiki_user):
@@ -1116,7 +1116,7 @@ def test_extractor_html_attributes(root_doc, wiki_user):
         document=root_doc, content=content, creator=wiki_user)
     root_doc.render()  # Also saves
     result = root_doc.extract.html_attributes()
-    assert sorted(result) == sorted(attributes)
+    assert set(result) == set(attributes)
 
 
 def test_extractor_macro_names(root_doc, wiki_user):
@@ -1131,7 +1131,7 @@ def test_extractor_macro_names(root_doc, wiki_user):
     root_doc.current_revision = Revision.objects.create(
         document=root_doc, content=content, creator=wiki_user)
     result = root_doc.extract.macro_names()
-    assert sorted(result) == sorted(macros)
+    assert set(result) == set(macros)
 
 
 @pytest.mark.parametrize('is_rendered', (True, False))

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -5,7 +5,6 @@ import pytest
 from django.contrib.sites.models import Site
 
 from kuma.core.cache import memcache
-from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
 from . import document, revision, WikiTestCase
@@ -20,25 +19,25 @@ from ..templatetags.jinja_helpers import (absolutify,
 class HelpTests(WikiTestCase):
 
     def test_tojson(self):
-        eq_(tojson({'title': '<script>alert("Hi!")</script>'}),
-            '{"title": "&lt;script&gt;alert(&quot;Hi!&quot;)&lt;/script&gt;"}')
+        assert (tojson({'title': '<script>alert("Hi!")</script>'}) ==
+                '{"title": "&lt;script&gt;alert(&quot;Hi!&quot;)&lt;/script&gt;"}')
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_absolutify(self, get_current):
         get_current.return_value.domain = 'testserver'
 
-        eq_(absolutify(''), 'https://testserver/')
-        eq_(absolutify('/'), 'https://testserver/')
-        eq_(absolutify('//'), 'https://testserver/')
-        eq_(absolutify('/foo/bar'), 'https://testserver/foo/bar')
-        eq_(absolutify('http://domain.com'), 'http://domain.com')
+        assert absolutify('') == 'https://testserver/'
+        assert absolutify('/') == 'https://testserver/'
+        assert absolutify('//') == 'https://testserver/'
+        assert absolutify('/foo/bar') == 'https://testserver/foo/bar'
+        assert absolutify('http://domain.com') == 'http://domain.com'
 
         site = Site(domain='otherserver')
-        eq_(absolutify('/woo', site), 'https://otherserver/woo')
+        assert absolutify('/woo', site) == 'https://otherserver/woo'
 
-        eq_(absolutify('/woo?var=value'), 'https://testserver/woo?var=value')
-        eq_(absolutify('/woo?var=value#fragment'),
-            'https://testserver/woo?var=value#fragment')
+        assert absolutify('/woo?var=value') == 'https://testserver/woo?var=value'
+        assert (absolutify('/woo?var=value#fragment') ==
+                'https://testserver/woo?var=value#fragment')
 
 
 class RevisionsUnifiedDiffTests(UserTestCase, WikiTestCase):
@@ -132,8 +131,8 @@ class DocumentZoneTests(UserTestCase, WikiTestCase):
         ]
         for (user, doc, add, change) in cases:
             result_links = document_zone_management_links(user, doc)
-            eq_(add, result_links['add'] is not None, (user, doc))
-            eq_(change, result_links['change'] is not None)
+            assert add == (result_links['add'] is not None)
+            assert change == (result_links['change'] is not None)
 
 
 class SelectorContentFindTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -8,8 +8,6 @@ import pytest
 from elasticsearch import TransportError
 from elasticsearch_dsl.connections import connections
 
-from kuma.core.tests import eq_
-
 from . import WikiTestCase
 from .. import kumascript
 from .. constants import KUMASCRIPT_BASE_URL
@@ -52,8 +50,8 @@ class KumascriptClientTests(WikiTestCase):
 
         # Ensure the env vars intended for kumascript match expected values.
         for n in ('title', 'slug', 'locale', 'path'):
-            eq_(env_vars[n], result_vars[n])
-        eq_(sorted([u'foo', u'bar', u'baz']), sorted(result_vars['tags']))
+            assert env_vars[n] == result_vars[n]
+        assert {u'foo', u'bar', u'baz'} == set(result_vars['tags'])
 
 
 def test_macro_sources(mock_requests):

--- a/kuma/wiki/tests/test_middleware.py
+++ b/kuma/wiki/tests/test_middleware.py
@@ -3,7 +3,6 @@ from django.conf import settings
 from django.test import RequestFactory
 
 from kuma.core.cache import memcache
-from kuma.core.tests import eq_
 from kuma.users.tests import UserTestCase
 
 from . import document, revision, WikiTestCase
@@ -73,21 +72,21 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
 
         url = '/en-US/%s?raw' % self.zone_root
         response = self.client.get(url, follow=False)
-        eq_(200, response.status_code)
-        eq_(self.zone_root_content, response.content)
+        assert 200 == response.status_code
+        assert self.zone_root_content == response.content
 
         url = '/en-US/%s/Middle/SubPage?raw' % self.zone_root
         response = self.client.get(url, follow=False)
-        eq_(200, response.status_code)
-        eq_(self.sub_doc.html, response.content)
+        assert 200 == response.status_code
+        assert self.sub_doc.html == response.content
 
         self.root_zone.url_root = 'NewRoot'
         self.root_zone.save()
 
         url = '/en-US/%s/Middle/SubPage?raw' % 'NewRoot'
         response = self.client.get(url, follow=False)
-        eq_(200, response.status_code)
-        eq_(self.sub_doc.html, response.content)
+        assert 200 == response.status_code
+        assert self.sub_doc.html == response.content
 
     def test_actual_wiki_url_redirect(self):
         """
@@ -96,7 +95,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
         """
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
         assert response['Location'] == '/en-US/ExtraWiki/Middle?raw=1'
 
         self.root_zone.url_root = 'NewRoot'
@@ -104,14 +103,14 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
 
         url = '/en-US/docs/%s?raw=1' % self.middle_doc.slug
         response = self.client.get(url, follow=False)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
         assert response['Location'] == '/en-US/NewRoot/Middle?raw=1'
 
     def test_blank_url_root(self):
         """Ensure a blank url_root does not trigger URL remap"""
         url = '/en-US/docs/%s?raw=1' % self.other_doc.slug
         response = self.client.get(url, follow=False)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
     def test_no_redirect(self):
         middleware = DocumentZoneMiddleware(lambda req: None)
@@ -152,7 +151,7 @@ class DocumentZoneMiddlewareTestCase(UserTestCase, WikiTestCase):
 
         url = '/en-US/docs/%s' % non_zone_doc.slug
         response = self.client.get(url, follow=False)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
 
 class DocumentZoneWithLocaleTestCase(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -11,7 +11,7 @@ from django.core.exceptions import ValidationError
 
 from kuma.attachments.models import Attachment, AttachmentRevision
 from kuma.core.exceptions import ProgrammingError
-from kuma.core.tests import eq_, get_user
+from kuma.core.tests import get_user
 from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
@@ -51,10 +51,10 @@ class DocumentTests(UserTestCase):
         d = document()
         d.save()
         d.tags.add('grape')
-        eq_(1, TaggedDocument.objects.count())
+        assert 1 == TaggedDocument.objects.count()
 
         d.delete()
-        eq_(0, TaggedDocument.objects.count())
+        assert 0 == TaggedDocument.objects.count()
 
     def test_only_localizable_allowed_children(self):
         """You can't have children for a non-localizable document."""
@@ -100,14 +100,14 @@ class DocumentTests(UserTestCase):
         children = (Document.objects.filter(parent=parent)
                                     .order_by('locale')
                                     .values_list('pk', flat=True))
-        eq_(list(children),
-            [trans.pk for trans in parent.other_translations])
+        assert (list(children) ==
+                [trans.pk for trans in parent.other_translations])
 
         # Check the parent document is in the first index of the list
-        eq_(parent.pk, enfant.other_translations[0].pk)
+        assert parent.pk == enfant.other_translations[0].pk
         enfant_translation_pks = [trans.pk for trans in enfant.other_translations]
         assert bambino.pk in enfant_translation_pks
-        eq_(False, enfant.pk in enfant_translation_pks)
+        assert (enfant.pk in enfant_translation_pks) is False
 
     def test_topical_parents(self):
         d1, d2 = create_topical_parents_docs()
@@ -124,7 +124,7 @@ class DocumentTests(UserTestCase):
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
         d = document(is_redirect=True, html=html)
-        eq_(href, d.get_redirect_url())
+        assert href == d.get_redirect_url()
 
     @pytest.mark.redirect
     def test_redirect_url_allows_domain_relative_url(self):
@@ -132,7 +132,7 @@ class DocumentTests(UserTestCase):
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
         d = document(is_redirect=True, html=html)
-        eq_(href, d.get_redirect_url())
+        assert href == d.get_redirect_url()
 
     @pytest.mark.redirect
     def test_redirect_url_rejects_protocol_relative_url(self):
@@ -140,7 +140,7 @@ class DocumentTests(UserTestCase):
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
         d = document(is_redirect=True, html=html)
-        eq_(None, d.get_redirect_url())
+        assert d.get_redirect_url() is None
 
     @pytest.mark.redirect
     def test_redirect_url_works_for_home_path(self):
@@ -149,11 +149,11 @@ class DocumentTests(UserTestCase):
         title = "Mozilla"
         html = REDIRECT_CONTENT % {'href': href, 'title': title}
         d = document(is_redirect=True, html=html)
-        eq_(href, d.get_redirect_url())
+        assert href == d.get_redirect_url()
 
     def test_get_full_url(self):
         doc = document()
-        eq_(doc.get_full_url(), absolutify(doc.get_absolute_url()))
+        assert doc.get_full_url() == absolutify(doc.get_absolute_url())
 
     def test_from_url(self):
         created_doc = document(save=True)
@@ -232,7 +232,7 @@ class UserDocumentTests(UserTestCase):
                          parent=orig, save=True)
 
         assert trans.parent_topic
-        eq_(trans.parent_topic.pk, trans_pt.pk)
+        assert trans_pt.pk == trans.parent_topic.pk
 
     def test_default_topic_with_stub_creation(self):
         orig_pt = document(locale=settings.WIKI_DEFAULT_LANGUAGE,
@@ -248,16 +248,16 @@ class UserDocumentTests(UserTestCase):
         trans_pt = trans.parent_topic
         assert trans_pt
         # The locale of the topic parent should match the new translation
-        eq_(trans.locale, trans_pt.locale)
+        assert trans_pt.locale == trans.locale
         # But, the translation's topic parent must *not* be the translation
         # parent's topic parent
         assert trans_pt.pk != orig_pt.pk
         # Still, since the topic parent is an autocreated stub, it shares its
         # title with the original.
-        eq_(trans_pt.title, orig_pt.title)
+        assert trans_pt.title == orig_pt.title
         # Oh, and it should point to the original parent topic as its
         # translation parent
-        eq_(trans_pt.parent, orig_pt)
+        assert trans_pt.parent == orig_pt
 
     def test_default_topic_with_path_gaps(self):
         # Build a path of docs in en-US
@@ -281,20 +281,20 @@ class UserDocumentTests(UserTestCase):
         revision(document=trans_5, title='le ;eaf', tags="LeTest!", save=True)
 
         # Make sure trans_2 got the right parent
-        eq_(trans_2.parents[0].pk, trans_0.pk)
+        assert trans_2.parents[0].pk == trans_0.pk
 
         # Ensure the translated parents and stubs appear properly in the path
         parents_5 = trans_5.parents
-        eq_(parents_5[0].pk, trans_0.pk)
-        eq_(parents_5[1].locale, trans_5.locale)
-        eq_(parents_5[1].title, docs[1].title)
+        assert parents_5[0].pk == trans_0.pk
+        assert parents_5[1].locale == trans_5.locale
+        assert parents_5[1].title == docs[1].title
         assert parents_5[1].current_revision.pk != docs[1].current_revision.pk
-        eq_(parents_5[2].pk, trans_2.pk)
-        eq_(parents_5[3].locale, trans_5.locale)
-        eq_(parents_5[3].title, docs[3].title)
+        assert parents_5[2].pk == trans_2.pk
+        assert parents_5[3].locale == trans_5.locale
+        assert parents_5[3].title == docs[3].title
         assert parents_5[3].current_revision.pk != docs[3].current_revision.pk
-        eq_(parents_5[4].locale, trans_5.locale)
-        eq_(parents_5[4].title, docs[4].title)
+        assert parents_5[4].locale == trans_5.locale
+        assert parents_5[4].title == docs[4].title
         assert parents_5[4].current_revision.pk != docs[4].current_revision.pk
 
         for p in parents_5:
@@ -333,8 +333,8 @@ class UserDocumentTests(UserTestCase):
         french_bottom.repair_breadcrumbs()
         french_bottom_fixed = Document.objects.get(locale='fr',
                                                    title=french_bottom.title)
-        eq_(french_mid.id, french_bottom_fixed.parent_topic.id)
-        eq_(french_top.id, french_bottom_fixed.parent_topic.parent_topic.id)
+        assert french_mid.id == french_bottom_fixed.parent_topic.id
+        assert french_top.id == french_bottom_fixed.parent_topic.parent_topic.id
 
     def test_code_sample_extraction(self):
         """Make sure sample extraction works from the model.
@@ -354,9 +354,9 @@ class UserDocumentTests(UserTestCase):
 
         rev = revision(is_approved=True, save=True, content=doc_src)
         result = rev.document.extract.code_sample('s2')
-        eq_(sample_html.strip(), result['html'].strip())
-        eq_(sample_css.strip(), result['css'].strip())
-        eq_(sample_js.strip(), result['js'].strip())
+        assert sample_html.strip() == result['html'].strip()
+        assert sample_css.strip() == result['css'].strip()
+        assert sample_js.strip() == result['js'].strip()
 
     def test_tree_is_watched_by(self):
         rev = revision()
@@ -383,22 +383,22 @@ class TaggedDocumentTests(UserTestCase):
         """Change tags on Document by creating Revisions"""
         rev = revision(is_approved=True, save=True, content='Sample document')
 
-        eq_(0, Document.objects.filter(tags__name='foo').count())
-        eq_(0, Document.objects.filter(tags__name='alpha').count())
+        assert 0 == Document.objects.filter(tags__name='foo').count()
+        assert 0 == Document.objects.filter(tags__name='alpha').count()
 
         r = revision(document=rev.document, content='Update to document',
                      is_approved=True, tags="foo, bar, baz")
         r.save()
 
-        eq_(1, Document.objects.filter(tags__name='foo').count())
-        eq_(0, Document.objects.filter(tags__name='alpha').count())
+        assert 1 == Document.objects.filter(tags__name='foo').count()
+        assert 0 == Document.objects.filter(tags__name='alpha').count()
 
         r = revision(document=rev.document, content='Another update',
                      is_approved=True, tags="alpha, beta, gamma")
         r.save()
 
-        eq_(0, Document.objects.filter(tags__name='foo').count())
-        eq_(1, Document.objects.filter(tags__name='alpha').count())
+        assert 0 == Document.objects.filter(tags__name='foo').count()
+        assert 1 == Document.objects.filter(tags__name='alpha').count()
 
     def test_duplicate_tags_with_creation(self):
         rev = revision(
@@ -456,7 +456,7 @@ class RevisionTests(UserTestCase):
         """Revision containing unicode characters is saved successfully."""
         content = u'Firefox informa\xe7\xf5es \u30d8\u30eb'
         rev = revision(is_approved=True, save=True, content=content)
-        eq_(content, rev.content)
+        assert content == rev.content
 
     def test_save_bad_based_on(self):
         """Saving a Revision with a bad based_on value raises an error."""
@@ -470,7 +470,7 @@ class RevisionTests(UserTestCase):
         r = revision()
         r.based_on = revision()  # Revision of some other unrelated Document
         self.assertRaises(ValidationError, r.clean)
-        eq_(None, r.based_on)
+        assert r.based_on is None
 
     def test_correct_based_on_to_current_revision(self):
         """Assure Revision.clean() defaults based_on value to the English
@@ -487,7 +487,7 @@ class RevisionTests(UserTestCase):
         # Set based_on to a de rev to simulate fixing broken translation source
         de_rev.based_on = de_rev
         de_rev.clean()
-        eq_(en_rev.document.current_revision, de_rev.based_on)
+        assert en_rev.document.current_revision == de_rev.based_on
 
     def test_previous(self):
         """Revision.previous should return this revision's document's
@@ -570,18 +570,18 @@ class RevisionTests(UserTestCase):
         fake_tidied = '<h1>  Fake tidied.  </h1>'
         rev = revision(is_approved=True, save=True, content=content,
                        tidied_content=fake_tidied)
-        eq_(fake_tidied, rev.get_tidied_content())
+        assert fake_tidied == rev.get_tidied_content()
 
     def test_get_tidied_content_tidies_in_process_by_default(self):
         content = '<h1>  Test get_tidied_content.  </h1>'
         rev = revision(is_approved=True, save=True, content=content)
         tidied_content, errors = tidy_content(content)
-        eq_(tidied_content, rev.get_tidied_content())
+        assert tidied_content == rev.get_tidied_content()
 
     def test_get_tidied_content_returns_none_on_allow_none(self):
         rev = revision(is_approved=True, save=True,
                        content='Test get_tidied_content can return None.')
-        eq_(None, rev.get_tidied_content(allow_none=True))
+        assert rev.get_tidied_content(allow_none=True) is None
 
 
 class GetCurrentOrLatestRevisionTests(UserTestCase):
@@ -590,20 +590,20 @@ class GetCurrentOrLatestRevisionTests(UserTestCase):
     def test_single_approved(self):
         """Get approved revision."""
         rev = revision(is_approved=True, save=True)
-        eq_(rev, rev.document.current_or_latest_revision())
+        assert rev == rev.document.current_or_latest_revision()
 
     def test_multiple_approved(self):
         """When multiple approved revisions exist, return the most recent."""
         r1 = revision(is_approved=True, save=True)
         r2 = revision(is_approved=True, save=True, document=r1.document)
-        eq_(r2, r2.document.current_or_latest_revision())
+        assert r2 == r2.document.current_or_latest_revision()
 
     def test_latest(self):
         """Return latest revision when no current exists."""
         r1 = revision(is_approved=False, save=True,
                       created=datetime.now() - timedelta(days=1))
         r2 = revision(is_approved=False, save=True, document=r1.document)
-        eq_(r2, r1.document.current_or_latest_revision())
+        assert r2 == r1.document.current_or_latest_revision()
 
 
 @override_config(
@@ -646,20 +646,20 @@ class DeferredRenderingTests(UserTestCase):
         assert not self.d1.last_rendered_at
         result_rendered, _ = self.d1.get_rendered(None, 'http://testserver/')
         assert mock_kumascript_get.called
-        eq_(self.rendered_content, result_rendered)
-        eq_(self.rendered_content, self.d1.rendered_html)
+        assert self.rendered_content == result_rendered
+        assert self.rendered_content == self.d1.rendered_html
 
         # Next, get a fresh copy of the document and try getting a rendering.
         # It should *not* call out to kumascript, because the rendered content
         # should be in the DB.
         d1_fresh = Document.objects.get(pk=self.d1.pk)
-        eq_(self.rendered_content, d1_fresh.rendered_html)
+        assert self.rendered_content == d1_fresh.rendered_html
         assert d1_fresh.render_started_at
         assert d1_fresh.last_rendered_at
         mock_kumascript_get.called = False
         result_rendered, _ = d1_fresh.get_rendered(None, 'http://testserver/')
         assert not mock_kumascript_get.called
-        eq_(self.rendered_content, result_rendered)
+        assert self.rendered_content == result_rendered
 
     @mock.patch('kuma.wiki.models.render_done')
     def test_build_json_on_render(self, mock_render_done):
@@ -691,7 +691,7 @@ class DeferredRenderingTests(UserTestCase):
         assert self.d1.rendered_html
         assert mock_kumascript_get.called
         result_summary = self.d1.get_summary()
-        eq_("summary!", result_summary)
+        assert 'summary!' == result_summary
 
     @mock.patch('kuma.wiki.kumascript.get')
     def test_one_render_at_a_time(self, mock_kumascript_get):
@@ -832,8 +832,8 @@ class RenderExpiresTests(UserTestCase):
         d3.save()
 
         stale_docs = Document.objects.get_by_stale_rendering()
-        eq_(sorted([d2.pk, d3.pk]),
-            sorted([x.pk for x in stale_docs]))
+        assert (sorted([d2.pk, d3.pk]) ==
+                sorted([x.pk for x in stale_docs]))
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get')
@@ -903,7 +903,7 @@ class PageMoveTests(UserTestCase):
         d3.parent_topic = d1
         d3.save()
 
-        eq_([d2, d3], d1.get_descendants())
+        assert [d2, d3] == d1.get_descendants()
 
     def test_get_descendants_limited(self):
         """Tests limiting of descendant levels"""
@@ -921,12 +921,12 @@ class PageMoveTests(UserTestCase):
         _make_doc('Great GrandChild 1', grandchild)
 
         # Test descendant counts
-        eq_(len(parent.get_descendants()), 4)  # All
-        eq_(len(parent.get_descendants(1)), 2)
-        eq_(len(parent.get_descendants(2)), 3)
-        eq_(len(parent.get_descendants(0)), 0)
-        eq_(len(child2.get_descendants(10)), 0)
-        eq_(len(grandchild.get_descendants(4)), 1)
+        assert 4 == len(parent.get_descendants())  # All
+        assert 2 == len(parent.get_descendants(1))
+        assert 3 == len(parent.get_descendants(2))
+        assert 0 == len(parent.get_descendants(0))
+        assert 0 == len(child2.get_descendants(10))
+        assert 1 == len(grandchild.get_descendants(4))
 
     def test_children_complex(self):
         """A slightly more complex tree, with multiple children, some
@@ -1044,29 +1044,29 @@ class PageMoveTests(UserTestCase):
         # 2. A new revision was created when the page moved.
         # 3. A redirect was created.
         moved_top = Document.objects.get(pk=top_doc.id)
-        eq_('new-prefix/first-level/parent',
-            moved_top.current_revision.slug)
+        assert ('new-prefix/first-level/parent' ==
+                moved_top.current_revision.slug)
         assert old_top_id != moved_top.current_revision.id
         assert (moved_top.current_revision.slug in
                 Document.objects.get(slug='first-level/parent').get_redirect_url())
 
         moved_child1 = Document.objects.get(pk=child1_doc.id)
-        eq_('new-prefix/first-level/parent/child1',
-            moved_child1.current_revision.slug)
+        assert ('new-prefix/first-level/parent/child1' ==
+                moved_child1.current_revision.slug)
         assert old_child1_id != moved_child1.current_revision.id
         assert moved_child1.current_revision.slug in Document.objects.get(
             slug='first-level/second-level/child1').get_redirect_url()
 
         moved_child2 = Document.objects.get(pk=child2_doc.id)
-        eq_('new-prefix/first-level/parent/child2',
-            moved_child2.current_revision.slug)
+        assert ('new-prefix/first-level/parent/child2' ==
+                moved_child2.current_revision.slug)
         assert old_child2_id != moved_child2.current_revision.id
         assert moved_child2.current_revision.slug in Document.objects.get(
             slug='first-level/second-level/child2').get_redirect_url()
 
         moved_grandchild = Document.objects.get(pk=grandchild_doc.id)
-        eq_('new-prefix/first-level/parent/child2/grandchild',
-            moved_grandchild.current_revision.slug)
+        assert('new-prefix/first-level/parent/child2/grandchild' ==
+               moved_grandchild.current_revision.slug)
         assert old_grandchild_id != moved_grandchild.current_revision.id
         assert moved_grandchild.current_revision.slug in Document.objects.get(
             slug='first-level/second-level/third-level/grandchild').get_redirect_url()
@@ -1093,8 +1093,8 @@ class PageMoveTests(UserTestCase):
                                 is_approved=True,
                                 save=True)
 
-        eq_([top_conflict.document],
-            top_doc._tree_conflicts('moved/test-move-conflict-detection'))
+        assert([top_conflict.document] ==
+               top_doc._tree_conflicts('moved/test-move-conflict-detection'))
 
         # Or if it will involve a child document.
         child_conflict = revision(title='Conflicting child for move conflict detection',
@@ -1102,8 +1102,8 @@ class PageMoveTests(UserTestCase):
                                   is_approved=True,
                                   save=True)
 
-        eq_([top_conflict.document, child_conflict.document],
-            top_doc._tree_conflicts('moved/test-move-conflict-detection'))
+        assert ([top_conflict.document, child_conflict.document] ==
+                top_doc._tree_conflicts('moved/test-move-conflict-detection'))
 
         # But a redirect should not trigger a conflict.
         revision(title='Conflicting document for move conflict detection',
@@ -1113,8 +1113,8 @@ class PageMoveTests(UserTestCase):
                  is_approved=True,
                  save=True)
 
-        eq_([child_conflict.document],
-            top_doc._tree_conflicts('moved/test-move-conflict-detection'))
+        assert ([child_conflict.document] ==
+                top_doc._tree_conflicts('moved/test-move-conflict-detection'))
 
     @pytest.mark.move
     def test_additional_conflicts(self):
@@ -1139,8 +1139,7 @@ class PageMoveTests(UserTestCase):
         child2_doc = child2.document
         child2_doc.parent_topic = top_doc
         child2_doc.save()
-        eq_([],
-            top_doc._tree_conflicts('NativeRTC'))
+        assert [] == top_doc._tree_conflicts('NativeRTC')
 
     @pytest.mark.move
     def test_preserve_tags(self):
@@ -1163,9 +1162,9 @@ class PageMoveTests(UserTestCase):
 
             moved_doc = Document.objects.get(pk=doc.id)
             new_rev = moved_doc.current_revision
-            eq_(tags, new_rev.tags)
-            eq_(['technical'],
-                [str(tag) for tag in new_rev.review_tags.all()])
+            assert tags == new_rev.tags
+            assert (['technical'] ==
+                    [str(tag) for tag in new_rev.review_tags.all()])
 
     @pytest.mark.move
     def test_move_tree_breadcrumbs(self):
@@ -1272,7 +1271,7 @@ class PageMoveTests(UserTestCase):
         assert page_moved_slug in page_child_doc.html
         assert page_child_moved_doc
         # TODO: Fix this assertion?
-        # eq_('admin', page_moved_doc.current_revision.creator.username)
+        # assert 'admin' == page_moved_doc.current_revision.creator.username)
 
     @pytest.mark.move
     def test_mid_move(self):
@@ -1365,10 +1364,10 @@ class PageMoveTests(UserTestCase):
         # Moved documents still have the same IDs.
         moved_root = Document.objects.get(locale=special_root.locale,
                                           slug=new_root_slug)
-        eq_(original_root_id, moved_root.id)
+        assert original_root_id == moved_root.id
         moved_child = Document.objects.get(locale=special_child.locale,
                                            slug='%s/child' % new_root_slug)
-        eq_(original_child_id, moved_child.id)
+        assert original_child_id == moved_child.id
 
         # Second move, back to original slug.
         moved_root._move_tree(root_slug)
@@ -1455,17 +1454,17 @@ class RevisionIPTests(UserTestCase):
         old_date = date.today() - timedelta(days=31)
         r = revision(created=old_date, save=True)
         RevisionIP.objects.create(revision=r, ip='127.0.0.1').save()
-        eq_(1, RevisionIP.objects.all().count())
+        assert 1 == RevisionIP.objects.all().count()
         RevisionIP.objects.delete_old()
-        eq_(0, RevisionIP.objects.all().count())
+        assert 0 == RevisionIP.objects.all().count()
 
     def test_delete_older_than_days_argument(self):
         rev_date = date.today() - timedelta(days=5)
         r = revision(created=rev_date, save=True)
         RevisionIP.objects.create(revision=r, ip='127.0.0.1').save()
-        eq_(1, RevisionIP.objects.all().count())
+        assert 1 == RevisionIP.objects.all().count()
         RevisionIP.objects.delete_old(days=4)
-        eq_(0, RevisionIP.objects.all().count())
+        assert 0 == RevisionIP.objects.all().count()
 
     def test_delete_older_than_only_deletes_older_than(self):
         oldest_date = date.today() - timedelta(days=31)
@@ -1479,9 +1478,9 @@ class RevisionIPTests(UserTestCase):
         now_date = date.today()
         r2 = revision(created=now_date, save=True)
         RevisionIP.objects.create(revision=r2, ip='127.0.0.1').save()
-        eq_(3, RevisionIP.objects.all().count())
+        assert 3 == RevisionIP.objects.all().count()
         RevisionIP.objects.delete_old()
-        eq_(2, RevisionIP.objects.all().count())
+        assert 2 == RevisionIP.objects.all().count()
 
 
 class AttachmentTests(UserTestCase):
@@ -1511,8 +1510,8 @@ class AttachmentTests(UserTestCase):
         doc.populate_attachments()
 
         assert doc.attached_files.all().exists()
-        eq_(doc.attached_files.all().count(), 1)
-        eq_(doc.attached_files.first().file, attachment)
+        assert 1 == doc.attached_files.all().count()
+        assert attachment == doc.attached_files.first().file
 
     def test_popuplate_kuma_file_url(self):
         attachment, attachment_revision = self.new_attachment()
@@ -1520,10 +1519,10 @@ class AttachmentTests(UserTestCase):
         assert not doc.attached_files.all().exists()
 
         populated = doc.populate_attachments()
-        eq_(len(populated), 1)
+        assert 1 == len(populated)
         assert doc.attached_files.all().exists()
-        eq_(doc.attached_files.all().count(), 1)
-        eq_(doc.attached_files.first().file, attachment)
+        assert 1 == doc.attached_files.all().count()
+        assert attachment == doc.attached_files.first().file
 
     def test_popuplate_multiple_attachments(self):
         attachment, attachment_revision = self.new_attachment()
@@ -1533,8 +1532,8 @@ class AttachmentTests(UserTestCase):
         doc = document(html=html, save=True)
         populated = doc.populate_attachments()
         attachments = doc.attached_files.all()
-        eq_(len(populated), 2)
+        assert 2 == len(populated)
         assert attachments.exists()
-        eq_(attachments.count(), 2)
-        eq_(attachments[0].file, attachment)
-        eq_(attachments[1].file, attachment2)
+        assert 2 == attachments.count()
+        assert attachment == attachments[0].file
+        assert attachment2 == attachments[1].file

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -107,7 +107,7 @@ class DocumentTests(UserTestCase):
         assert parent.pk == enfant.other_translations[0].pk
         enfant_translation_pks = [trans.pk for trans in enfant.other_translations]
         assert bambino.pk in enfant_translation_pks
-        assert (enfant.pk in enfant_translation_pks) is False
+        assert enfant.pk not in enfant_translation_pks
 
     def test_topical_parents(self):
         d1, d2 = create_topical_parents_docs()
@@ -1139,7 +1139,7 @@ class PageMoveTests(UserTestCase):
         child2_doc = child2.document
         child2_doc.parent_topic = top_doc
         child2_doc.save()
-        assert [] == top_doc._tree_conflicts('NativeRTC')
+        assert not top_doc._tree_conflicts('NativeRTC')
 
     @pytest.mark.move
     def test_preserve_tags(self):

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -17,7 +17,7 @@ from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_)
+                             assert_shared_cache_header)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.models import User
@@ -50,25 +50,25 @@ class DocumentTests(UserTestCase, WikiTestCase):
         """Load the document view page and verify the title and content."""
         r = revision(save=True, content='Some text.', is_approved=True)
         response = self.client.get(r.document.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(r.document.title, doc('main#content div.document-head h1').text())
-        eq_(r.document.html, doc('article#wikiArticle').text())
+        assert doc('main#content div.document-head h1').text() == r.document.title
+        assert doc('article#wikiArticle').text() == r.document.html
 
     @pytest.mark.breadcrumbs
     def test_document_no_breadcrumbs(self):
         """Create docs with topical parent/child rel, verify no breadcrumbs."""
         d1, d2 = create_topical_parents_docs()
         response = self.client.get(d1.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(d1.title, doc('main#content div.document-head h1').text())
+        assert doc('main#content div.document-head h1').text() == d1.title
         assert len(doc('nav.crumbs')) == 0
 
         response = self.client.get(d2.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(d2.title, doc('main#content div.document-head h1').text())
+        assert doc('main#content div.document-head h1').text() == d2.title
         assert len(doc('nav.crumbs')) == 0
 
     @pytest.mark.breadcrumbs
@@ -97,11 +97,11 @@ class DocumentTests(UserTestCase, WikiTestCase):
         """Load an English document with no approved content."""
         r = revision(save=True, content='Some text.', is_approved=False)
         response = self.client.get(r.document.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(r.document.title, doc('main#content div.document-head h1').text())
-        eq_("This article doesn't have approved content yet.",
-            doc('article#wikiArticle').text())
+        assert doc('main#content div.document-head h1').text() == r.document.title
+        assert ("This article doesn't have approved content yet." ==
+                doc('article#wikiArticle').text())
 
     def test_translation_document_no_approved_content(self):
         """Load a non-English document with no approved content, with a parent
@@ -110,9 +110,9 @@ class DocumentTests(UserTestCase, WikiTestCase):
         d2 = document(parent=r.document, locale='fr', slug='french', save=True)
         revision(document=d2, save=True, content='Moartext', is_approved=False)
         response = self.client.get(d2.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(d2.title, doc('main#content div.document-head h1').text())
+        assert doc('main#content div.document-head h1').text() == d2.title
         # HACK: fr doc has different message if locale/ is updated
         assert (("This article doesn't have approved content yet." in
                  doc('article#wikiArticle').text()) or
@@ -227,13 +227,13 @@ class DocumentTests(UserTestCase, WikiTestCase):
         """
         r = revision(save=True, content=doc_content, is_approved=True)
         response = self.client.get(r.document.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         assert '<div id="toc"' in response.content
         new_r = revision(document=r.document, content=r.content,
                          toc_depth=0, is_approved=True)
         new_r.save()
         response = self.client.get(r.document.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         assert '<div class="page-toc">' not in response.content
 
     def test_lang_switcher_footer(self):
@@ -245,7 +245,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         trans_fr = document(parent=parent, locale="fr", save=True)
 
         response = self.client.get(trans_pt_br.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200, response.status_code
         doc = pq(response.content)
         options = doc(".languages.go select.wiki-l10n option")
 
@@ -268,7 +268,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         trans_fr = document(parent=parent, locale="fr", save=True)
 
         response = self.client.get(trans_pt_br.get_absolute_url())
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
         options = doc("#languages-menu-submenu ul#translations li a")
 
@@ -499,9 +499,9 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         """HTTP GET to new document URL renders the form."""
         self.client.login(username='admin', password='testpass')
         response = self.client.get(reverse('wiki.create'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
-        eq_(1, len(doc('form#wiki-page-edit input[name="title"]')))
+        assert 1 == len(doc('form#wiki-page-edit input[name="title"]'))
 
     def test_new_document_includes_review_block(self):
         """
@@ -512,7 +512,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(reverse('wiki.create'))
 
         test_strings = ['Review needed?', 'Technical', 'Editorial']
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
 
         # TODO: push test_strings functionality up into a test helper
         for test_string in test_strings:
@@ -522,7 +522,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         """HTTP GET to new document URL shows preview button."""
         self.client.login(username='admin', password='testpass')
         response = self.client.get(reverse('wiki.create'))
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
         assert len(doc('.btn-preview'))
 
@@ -532,7 +532,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         self.client.login(username='admin', password='testpass')
         response = self.client.get(reverse('wiki.create'))
         doc = pq(response.content)
-        eq_("Name Your Article", doc('input#id_title').attr('placeholder'))
+        assert "Name Your Article" == doc('input#id_title').attr('placeholder')
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_new_document_POST(self, get_current):
@@ -549,12 +549,12 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         redirect_uri, status_code = response.redirect_chain[0]
         assert redirect_uri == ('/en-US/docs/%s' % d.slug)
         assert status_code == 302
-        eq_(settings.WIKI_DEFAULT_LANGUAGE, d.locale)
-        eq_(tags, sorted(t.name for t in d.tags.all()))
+        assert settings.WIKI_DEFAULT_LANGUAGE == d.locale
+        assert tags == sorted(t.name for t in d.tags.all())
         r = d.revisions.all()[0]
-        eq_(data['keywords'], r.keywords)
-        eq_(data['summary'], r.summary)
-        eq_(data['content'], r.content)
+        assert data['keywords'] == r.keywords
+        assert data['summary'] == r.summary
+        assert data['content'] == r.content
 
     @mock.patch.object(Site.objects, 'get_current')
     def test_new_document_other_locale(self, get_current):
@@ -570,7 +570,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         self.client.post(reverse('wiki.create', locale=locale),
                          data, follow=True)
         d = Document.objects.get(title=data['title'])
-        eq_(locale, d.locale)
+        assert locale == d.locale
 
     def test_new_document_POST_empty_title(self):
         """Trigger required field validation for title."""
@@ -593,8 +593,8 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
                                     follow=True)
         doc = pq(response.content)
         ul = doc('article ul.errorlist')
-        eq_(1, len(ul))
-        eq_('Please provide content.', ul('li').text())
+        assert 1 == len(ul)
+        assert 'Please provide content.' == ul('li').text()
 
     def test_slug_collision_validation(self):
         """Trying to create document with existing locale/slug should
@@ -604,12 +604,12 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         data['slug'] = d.slug
         response = self.client.post(reverse('wiki.create'), data)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         doc = pq(response.content)
         ul = doc('article ul.errorlist')
-        eq_(1, len(ul))
-        eq_('Document with this Slug and Locale already exists.',
-            ul('li').text())
+        assert 1 == len(ul)
+        assert ('Document with this Slug and Locale already exists.' ==
+                ul('li').text())
 
     def test_title_no_collision(self):
         """Only slugs and not titles are required to be unique per
@@ -619,7 +619,7 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         data['slug'] = '%s-once-more-with-feeling' % d.slug
         response = self.client.post(reverse('wiki.create'), data)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
 
     def test_slug_3_chars(self):
         """Make sure we can create a slug with only 3 characters."""
@@ -627,8 +627,8 @@ class NewDocumentTests(UserTestCase, WikiTestCase):
         data = new_document_data()
         data['slug'] = 'ask'
         response = self.client.post(reverse('wiki.create'), data)
-        eq_(302, response.status_code)
-        eq_('ask', Document.objects.all()[0].slug)
+        assert 302 == response.status_code
+        assert 'ask' == Document.objects.all()[0].slug
 
 
 class NewRevisionTests(UserTestCase, WikiTestCase):
@@ -764,7 +764,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
         self.d.tags.add(*tags)
         result_tags = list(self.d.tags.names())
         result_tags.sort()
-        eq_(tags, result_tags)
+        assert tags == result_tags
         tags = [u'tag1', u'tag4']
         data = new_document_data(tags)
         data['form-type'] = 'rev'
@@ -1221,7 +1221,7 @@ class ArticlePreviewTests(UserTestCase, WikiTestCase):
         doc = pq(response.content)
         link = doc('#doc-content a')
         assert link.text() == 'Prueba'
-        eq_('/es/docs/prueba', link[0].attrib['href'])
+        assert '/es/docs/prueba' == link[0].attrib['href']
 
 
 class SelectLocaleTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -245,7 +245,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         trans_fr = document(parent=parent, locale="fr", save=True)
 
         response = self.client.get(trans_pt_br.get_absolute_url())
-        assert 200, response.status_code
+        assert 200 == response.status_code
         doc = pq(response.content)
         options = doc(".languages.go select.wiki-l10n option")
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1777,7 +1777,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # For Ajax requests the response is a JsonResponse
         for resp in [resp1, resp2]:
-            assert json.loads(resp.content)['error'] is False
+            assert not json.loads(resp.content)['error']
             assert 'error_message' not in json.loads(resp.content).keys()
 
     def test_multiple_translation_edits_ajax(self):
@@ -1953,7 +1953,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                            locale=foreign_doc.locale))
         assert (pq(response.content).find('.btn-discard').attr('href') ==
                 reverse('wiki.document', args=[foreign_doc.slug],
-                locale=foreign_doc.locale))
+                        locale=foreign_doc.locale))
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get',
@@ -2600,7 +2600,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         resp = self.client.post('%s?section=s2&raw=true' %
                                 reverse('wiki.edit', args=[rev.document.slug]),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        assert json.loads(resp.content)['error'] is False
+        assert not json.loads(resp.content)['error']
 
         # Edit #1 submits, but since it's the same section, there's a collision
         data.update({
@@ -2713,8 +2713,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
         assert rev.id != changed.id
-        assert (set(tags_to_save) ==
-                set([t.name for t in changed.review_tags.all()]))
+        assert set(tags_to_save) == set(t.name for t in changed.review_tags.all())
 
 
 class MindTouchRedirectTests(UserTestCase, WikiTestCase):
@@ -2870,7 +2869,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.url, follow=False)
         p = pq(resp.content)
-        assert 1, p.find('#doc-render-raw-fallback').length
+        assert 1 == p.find('#doc-render-raw-fallback').length
 
     @mock.patch.object(Document, 'schedule_rendering')
     @mock.patch('kuma.wiki.kumascript.get')

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,7 +17,7 @@ from waffle.testutils import override_flag, override_switch
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, eq_, get_user)
+                             assert_shared_cache_header, get_user)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html
 from kuma.spam.constants import (
@@ -77,7 +77,7 @@ class RedirectTests(UserTestCase, WikiTestCase):
         revision(document=doc, content=html, is_approved=True, save=True)
 
         response = self.client.get(doc.get_absolute_url(), follow=True)
-        eq_(200, response.status_code)
+        assert 200 == response.status_code
         response_html = pq(response.content)
         article_body = to_html(response_html.find('#wikiArticle'))
         self.assertHTMLEqual(html, article_body)
@@ -305,8 +305,8 @@ class ViewTests(UserTestCase, WikiTestCase):
 
         assert 'Revision Source' in resp.content
         assert 'Revision Content' in resp.content
-        eq_(page.find('#wikiArticle').parent().attr('open'), 'open')
-        eq_(page.find('#doc-source').parent().attr('open'), None)
+        assert 'open' == page.find('#wikiArticle').parent().attr('open')
+        assert page.find('#doc-source').parent().attr('open') is None
 
 
 class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
@@ -322,7 +322,7 @@ class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
                                            reason="test")
         response = self.client.get(rev.document.get_absolute_url(),
                                    follow=False)
-        eq_(404, response.status_code)
+        assert 404 == response.status_code
         assert 'Reason for Deletion' not in response.content
 
     def test_deleted_doc_returns_404_and_content(self):
@@ -339,7 +339,7 @@ class GetDeletedDocumentTests(UserTestCase, WikiTestCase):
         DocumentDeletionLog.objects.create(locale=doc.locale, slug=doc.slug,
                                            user=rev.creator, reason="test")
         response = self.client.get(doc.get_absolute_url(), follow=False)
-        eq_(404, response.status_code)
+        assert 404 == response.status_code
         assert 'Reason for Deletion' in response.content
 
 
@@ -472,14 +472,14 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         )
 
         self.client.get(self.url, follow=False, HTTP_CACHE_CONTROL='no-cache')
-        eq_(mock_requests.request_history[0].headers['Cache-Control'],
-            'max-age=1234')
+        assert ('max-age=1234' ==
+                mock_requests.request_history[0].headers['Cache-Control'])
 
         self.client.login(username='admin', password='testpass')
         self.client.get(self.url, follow=False,
                         HTTP_CACHE_CONTROL='no-cache')
-        eq_(mock_requests.request_history[1].headers['Cache-Control'],
-            'no-cache')
+        assert ('no-cache' ==
+                mock_requests.request_history[1].headers['Cache-Control'])
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=1234)
     @requests_mock.mock()
@@ -496,13 +496,13 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
         )
 
         self.client.get(self.url, follow=False, HTTP_CACHE_CONTROL='no-cache')
-        eq_(mock_requests.request_history[0].headers['Cache-Control'],
-            'max-age=1234')
+        assert ('max-age=1234' ==
+                mock_requests.request_history[0].headers['Cache-Control'])
 
         self.client.login(username='admin', password='testpass')
         self.client.get(self.url, follow=False, HTTP_CACHE_CONTROL='no-cache')
-        eq_(mock_requests.request_history[1].headers['Cache-Control'],
-            'no-cache')
+        assert ('no-cache' ==
+                mock_requests.request_history[1].headers['Cache-Control'])
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0, KUMASCRIPT_MAX_AGE=1234)
     @requests_mock.mock()
@@ -552,10 +552,10 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 
         # Second request to verify the view sends them back
         response = self.client.get(self.url)
-        eq_(expected_etag,
-            mock_requests.request_history[1].headers['If-None-Match'])
-        eq_(expected_modified,
-            mock_requests.request_history[1].headers['If-Modified-Since'])
+        assert (expected_etag ==
+                mock_requests.request_history[1].headers['If-None-Match'])
+        assert (expected_modified ==
+                mock_requests.request_history[1].headers['If-Modified-Since'])
 
         # Third request to verify content was cached and served on a 304
         response = self.client.get(self.url)
@@ -643,14 +643,14 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
             data = new_document_data()
             data.update({'title': 'blah', 'slug': slug, 'content': content})
             response = self.client.post(reverse('wiki.create'), data)
-            eq_(302, response.status_code)
+            assert 302 == response.status_code
 
             # Connect to newly created page
             response = self.client.get(reverse('wiki.document', args=[slug]))
             page = pq(response.content)
             meta_content = page.find('meta[name=description]').attr('content')
-            eq_(str(meta_content).decode('utf-8'),
-                str(aught_preview).decode('utf-8'))
+            assert (str(meta_content).decode('utf-8') ==
+                    str(aught_preview).decode('utf-8'))
 
         # Test pages - very basic
         good = 'This is the content which should be chosen, man.'
@@ -1050,7 +1050,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         translate_url = reverse('wiki.document', args=[child_data['slug']])
         response = self.client.post(translate_url + '$translate?tolocale=es',
                                     child_data)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
         url = reverse('wiki.document', args=[child_data['slug']], locale='es')
         params = {'rev_saved': ''}
         url = '%s?%s' % (url, urlencode(params))
@@ -1059,7 +1059,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         translate_url = reverse('wiki.document', args=['length/length'])
         response = self.client.post(translate_url + '$translate?tolocale=es',
                                     child_data)
-        eq_(302, response.status_code)
+        assert 302 == response.status_code
         slug = 'length/' + child_data['slug']
         url = reverse('wiki.document', args=[slug], locale='es')
         params = {'rev_saved': ''}
@@ -1097,9 +1097,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert_no_cache_header(response)
 
         de_child_doc = Document.objects.get(locale='de', slug='de-child')
-        eq_(en_child_doc, de_child_doc.parent)
-        eq_(de_doc, de_child_doc.parent_topic)
-        eq_('New translation', de_child_doc.current_revision.content)
+        assert en_child_doc == de_child_doc.parent
+        assert de_doc == de_child_doc.parent_topic
+        assert 'New translation' == de_child_doc.current_revision.content
 
     def test_translate_keeps_toc_depth(self):
         self.client.login(username='admin', password='testpass')
@@ -1132,7 +1132,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.assertRedirects(response, doc_url)
 
         es_d = Document.objects.get(locale=foreign_locale, slug=foreign_slug)
-        eq_(r.toc_depth, es_d.current_revision.toc_depth)
+        assert r.toc_depth == es_d.current_revision.toc_depth
 
     def test_translate_rebuilds_source_json(self):
         self.client.login(username='admin', password='testpass')
@@ -1177,8 +1177,8 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                 [t['title'] for t in new_en_json['translations']])
         es_translation_json = [t for t in new_en_json['translations'] if
                                t['title'] == translation_data['title']][0]
-        eq_(es_translation_json['last_edit'],
-            es_doc.current_revision.created.isoformat())
+        assert (es_translation_json['last_edit'] ==
+                es_doc.current_revision.created.isoformat())
 
     def test_slug_translate(self):
         """Editing a translated doc keeps the correct slug"""
@@ -1219,7 +1219,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
                                            args=[foreign_slug],
                                            locale=foreign_locale))
         page = pq(response.content)
-        eq_(page.find('input[name=slug]')[0].value, foreign_slug)
+        assert page.find('input[name=slug]')[0].value == foreign_slug
 
         # Create an English child now
         en_doc = document(title='Child Eng Doc',
@@ -1777,7 +1777,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         # For Ajax requests the response is a JsonResponse
         for resp in [resp1, resp2]:
-            eq_(json.loads(resp.content)['error'], False)
+            assert json.loads(resp.content)['error'] is False
             assert 'error_message' not in json.loads(resp.content).keys()
 
     def test_multiple_translation_edits_ajax(self):
@@ -1935,15 +1935,15 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # Test that the 'discard' button on an edit goes to the original page
         doc = _create_doc('testdiscarddoc', settings.WIKI_DEFAULT_LANGUAGE)
         response = self.client.get(reverse('wiki.edit', args=[doc.slug]))
-        eq_(pq(response.content).find('.btn-discard').attr('href'),
-            reverse('wiki.document', args=[doc.slug]))
+        assert (pq(response.content).find('.btn-discard').attr('href') ==
+                reverse('wiki.document', args=[doc.slug]))
 
         # Test that the 'discard button on a new translation goes
         # to the en-US page'
         response = self.client.get(reverse('wiki.translate', args=[doc.slug]),
                                    {'tolocale': 'es'})
-        eq_(pq(response.content).find('.btn-discard').attr('href'),
-            reverse('wiki.document', args=[doc.slug]))
+        assert (pq(response.content).find('.btn-discard').attr('href') ==
+                reverse('wiki.document', args=[doc.slug]))
 
         # Test that the 'discard' button on an existing translation goes
         # to the 'es' page
@@ -1951,9 +1951,9 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         response = self.client.get(reverse('wiki.edit',
                                            args=[foreign_doc.slug],
                                            locale=foreign_doc.locale))
-        eq_(pq(response.content).find('.btn-discard').attr('href'),
-            reverse('wiki.document', args=[foreign_doc.slug],
-                    locale=foreign_doc.locale))
+        assert (pq(response.content).find('.btn-discard').attr('href') ==
+                reverse('wiki.document', args=[foreign_doc.slug],
+                locale=foreign_doc.locale))
 
     @override_config(KUMASCRIPT_TIMEOUT=1.0)
     @mock.patch('kuma.wiki.kumascript.get',
@@ -2600,7 +2600,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         resp = self.client.post('%s?section=s2&raw=true' %
                                 reverse('wiki.edit', args=[rev.document.slug]),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(False, json.loads(resp.content)['error'])
+        assert json.loads(resp.content)['error'] is False
 
         # Edit #1 submits, but since it's the same section, there's a collision
         data.update({
@@ -2611,7 +2611,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         resp = self.client.post('%s?section=s2&raw=true' %
                                 reverse('wiki.edit', args=[rev.document.slug]),
                                 data, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
-        eq_(200, resp.status_code)
+        assert 200 == resp.status_code
         # We receive the midair collission message
         history_url = reverse(
             'wiki.document_revisions',
@@ -2680,7 +2680,7 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
         assert rev.id != changed.id
-        eq_(1, changed.toc_depth)
+        assert 1 == changed.toc_depth
 
     def test_section_edit_review_tags(self):
         """review tags are preserved in section editing."""
@@ -2713,8 +2713,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
                          follow=True, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
         changed = Document.objects.get(pk=rev.document.id).current_revision
         assert rev.id != changed.id
-        eq_(set(tags_to_save),
-            set([t.name for t in changed.review_tags.all()]))
+        assert (set(tags_to_save) ==
+                set([t.name for t in changed.review_tags.all()]))
 
 
 class MindTouchRedirectTests(UserTestCase, WikiTestCase):
@@ -2760,7 +2760,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         new_doc.save()
         for namespace_test in self.namespace_urls:
             resp = self.client.get(namespace_test['mindtouch'], follow=False)
-            eq_(301, resp.status_code)
+            assert 301 == resp.status_code
             assert resp['Location'] == namespace_test['kuma']
 
     def test_document_urls(self):
@@ -2784,7 +2784,7 @@ class MindTouchRedirectTests(UserTestCase, WikiTestCase):
         d.save()
         mt_url = '/en-US/%s?view=edit' % (d.slug,)
         resp = self.client.get(mt_url)
-        eq_(301, resp.status_code)
+        assert 301 == resp.status_code
         expected_url = d.get_absolute_url('wiki.edit')
         assert resp['Location'] == expected_url
 
@@ -2819,8 +2819,8 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         assert self.rendered_content in txt
         assert self.raw_content not in txt
 
-        eq_(0, p.find('#doc-rendering-in-progress').length)
-        eq_(0, p.find('#doc-render-raw-fallback').length)
+        assert 0 == p.find('#doc-rendering-in-progress').length
+        assert 0 == p.find('#doc-render-raw-fallback').length
 
     def test_rendering_in_progress_warning(self):
         # Make the document look like there's a rendering in progress.
@@ -2835,14 +2835,14 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         # last-known render is displayed.
         assert self.rendered_content in txt
         assert self.raw_content not in txt
-        eq_(0, p.find('#doc-rendering-in-progress').length)
+        assert 0 == p.find('#doc-rendering-in-progress').length
 
         # Only for logged-in users, ensure the render-in-progress warning is
         # displayed.
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.url, follow=False)
         p = pq(resp.content)
-        eq_(1, p.find('#doc-rendering-in-progress').length)
+        assert 1 == p.find('#doc-rendering-in-progress').length
 
     @mock.patch('kuma.wiki.kumascript.get')
     def test_raw_content_during_initial_render(self, mock_kumascript_get):
@@ -2863,14 +2863,14 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
         txt = p.find('#wikiArticle').text()
         assert self.rendered_content not in txt
         assert self.raw_content in txt
-        eq_(0, p.find('#doc-render-raw-fallback').length)
+        assert 0 == p.find('#doc-render-raw-fallback').length
 
         # Only for logged-in users, ensure that a warning is displayed about
         # the fallback
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.url, follow=False)
         p = pq(resp.content)
-        eq_(1, p.find('#doc-render-raw-fallback').length)
+        assert 1, p.find('#doc-render-raw-fallback').length
 
     @mock.patch.object(Document, 'schedule_rendering')
     @mock.patch('kuma.wiki.kumascript.get')
@@ -2888,7 +2888,7 @@ class DeferredRenderingViewTests(UserTestCase, WikiTestCase):
 
         edit_url = reverse('wiki.edit', args=[self.doc.slug])
         resp = self.client.post(edit_url, data)
-        eq_(302, resp.status_code)
+        assert 302 == resp.status_code
         assert mock_document_schedule_rendering.called
 
         mock_document_schedule_rendering.reset_mock()


### PR DESCRIPTION
The `eq_()` function is a reliquat of the transition from nose to
pytest.

It does not provide anything except clutter for the current codebase.

This commit removes all references to `eq_()` and replace it with
`assert`