### PR TITLE
bug 1431497: Migrate from memcache to redis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ services:
     - docker
     - memcached
     - mysql
+    - redis
 env:
     global:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -33,11 +33,11 @@ services:
       - ./:/app
     command: sh -c "urlwait && py.test --nomigrations kuma --ignore=kuma/search"
     depends_on:
-      - memcached
       - mysql
+      - redis
     environment:
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
-      - MEMCACHE_SERVERS=memcached:11211
+      - REDIS_CACHE_SERVERS=redis://redis:6379/3
       - PYTHONDONTWRITEBYTECODE=1
       - URLWAIT_TIMEOUT=300
 
@@ -48,12 +48,12 @@ services:
       - ./:/app
     command: sh -c "urlwait && py.test --nomigrations --junit-xml=/app/test_results/django.xml kuma"
     depends_on:
-      - memcached
+      - redis
       - mysql
       - elasticsearch
     environment:
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
       - ES_URLS=elasticsearch:9200
-      - MEMCACHE_SERVERS=memcached:11211
+      - REDIS_CACHE_SERVERS=redis://redis:6379/3
       - PYTHONDONTWRITEBYTECODE=1
       - URLWAIT_TIMEOUT=300

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -37,7 +37,7 @@ services:
       - redis
     environment:
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
-      - REDIS_CACHE_SERVERS=redis://redis:6379/3
+      - REDIS_CACHE_SERVER=redis://redis:6379/3
       - PYTHONDONTWRITEBYTECODE=1
       - URLWAIT_TIMEOUT=300
 
@@ -54,6 +54,6 @@ services:
     environment:
       - DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
       - ES_URLS=elasticsearch:9200
-      - REDIS_CACHE_SERVERS=redis://redis:6379/3
+      - REDIS_CACHE_SERVER=redis://redis:6379/3
       - PYTHONDONTWRITEBYTECODE=1
       - URLWAIT_TIMEOUT=300

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - ES_URLS=elasticsearch:9200
       - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
-      - REDIS_CACHE_SERVERS=redis://redis:6379/3
+      - REDIS_CACHE_SERVER=redis://redis:6379/3
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=http://localhost:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     volumes:
       - ./:/app:z
     depends_on:
-      - memcached
       - mysql
       - elasticsearch
       - redis
@@ -28,7 +27,7 @@ services:
       - ES_URLS=elasticsearch:9200
       - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
-      - MEMCACHE_SERVERS=memcached:11211
+      - REDIS_CACHE_SERVERS=redis://redis:6379/3
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=http://localhost:8000
@@ -51,7 +50,6 @@ services:
     <<: *worker
     command: gunicorn -w 4 --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
     depends_on:
-      - memcached
       - mysql
       - elasticsearch
       - redis

--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:2.7-slim-stretch
 
 # Set the environment variables
 ENV NODE_VERSION=6.14.2 \

--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim-stretch
+FROM python:2.7-slim
 
 # Set the environment variables
 ENV NODE_VERSION=6.14.2 \

--- a/kuma/core/cache.py
+++ b/kuma/core/cache.py
@@ -1,4 +1,0 @@
-from django.core.cache import caches
-
-# just a helper to not have to redefine that all over the place
-redis = caches['redis']

--- a/kuma/core/cache.py
+++ b/kuma/core/cache.py
@@ -1,4 +1,4 @@
 from django.core.cache import caches
 
 # just a helper to not have to redefine that all over the place
-memcache = caches['memcache']
+redis = caches['redis']

--- a/kuma/core/tasks.py
+++ b/kuma/core/tasks.py
@@ -1,10 +1,10 @@
 from celery.task import task
 from constance import config
 from django.contrib.sessions.models import Session
+from django.core.cache import cache
 from django.db import connection
 from django.utils import timezone
 
-from .cache import redis
 from .decorators import skip_in_maintenance_mode
 from .models import IPBan
 
@@ -28,7 +28,7 @@ def clean_sessions():
     logger = clean_sessions.get_logger()
     chunk_size = config.SESSION_CLEANUP_CHUNK_SIZE
 
-    if redis.add(LOCK_ID, now.strftime('%c'), LOCK_EXPIRE):
+    if cache.add(LOCK_ID, now.strftime('%c'), LOCK_EXPIRE):
         total_count = get_expired_sessions(now).count()
         delete_count = 0
         logger.info('Deleting the %s of %s oldest expired sessions' %
@@ -44,13 +44,13 @@ def clean_sessions():
                 """, [chunk_size])
         finally:
             logger.info('Deleted %s expired sessions' % delete_count)
-            redis.delete(LOCK_ID)
+            cache.delete(LOCK_ID)
             expired_sessions = get_expired_sessions(now)
             if expired_sessions.exists():
                 clean_sessions.apply_async()
     else:
         logger.error('The clean_sessions task is already running since %s' %
-                     redis.get(LOCK_ID))
+                     cache.get(LOCK_ID))
 
 
 @task

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -7,8 +7,6 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.utils.translation import trans_real
 
-from ..cache import redis
-
 
 def assert_no_cache_header(response):
     assert 'max-age=0' in response['Cache-Control']
@@ -40,7 +38,6 @@ class KumaTestMixin(object):
 
         # Clean the slate.
         cache.clear()
-        redis.clear()
 
         trans_real.deactivate()
         trans_real._translations = {}  # Django fails to clear this cache.

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -7,7 +7,7 @@ from django.core.cache import cache
 from django.test import TestCase
 from django.utils.translation import trans_real
 
-from ..cache import memcache
+from ..cache import redis
 
 
 def assert_no_cache_header(response):
@@ -40,7 +40,7 @@ class KumaTestMixin(object):
 
         # Clean the slate.
         cache.clear()
-        memcache.clear()
+        redis.clear()
 
         trans_real.deactivate()
         trans_real._translations = {}  # Django fails to clear this cache.

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -132,11 +132,11 @@ def generate_filename_and_delete_previous(ffile, name, before_delete=None):
     return new_filename
 
 
-class RedisLockException(Exception):
+class CacheLockException(Exception):
     pass
 
 
-class RedisLock(object):
+class CacheLock(object):
     def __init__(self, key, attempts=1, expires=60 * 60 * 3):
         self.key = 'lock_%s' % key
         self.attempts = attempts
@@ -159,13 +159,13 @@ class RedisLock(object):
                 logging.debug('Sleeping for %s while trying to acquire key %s',
                               sleep_time, self.key)
                 time.sleep(sleep_time)
-        raise RedisLockException('Could not acquire lock for %s' % self.key)
+        raise CacheLockException('Could not acquire lock for %s' % self.key)
 
     def release(self):
         self.cache.delete(self.key)
 
 
-def redis_lock(prefix, expires=60 * 60):
+def cache_lock(prefix, expires=60 * 60):
     """
     Decorator that only allows one instance of the same command to run
     at a time.
@@ -174,14 +174,14 @@ def redis_lock(prefix, expires=60 * 60):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             name = '_'.join((prefix, func.__name__) + args)
-            lock = RedisLock(name, expires=expires)
+            lock = CacheLock(name, expires=expires)
             if lock.locked():
                 log.warning('Lock %s locked; ignoring call.' % name)
                 return
             try:
                 # Try to acquire the lock without blocking.
                 lock.acquire()
-            except RedisLockException:
+            except CacheLockException:
                 log.warning('Aborting %s; lock acquisition failed.' % name)
                 return
             else:

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -14,6 +14,7 @@ from itertools import islice
 from babel import dates, localedata
 from celery import chain, chord
 from django.conf import settings
+from django.core.cache import cache
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.http import QueryDict
 from django.shortcuts import _get_queryset
@@ -26,7 +27,6 @@ from pytz import timezone
 from six.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
 from taggit.utils import split_strip
 
-from .cache import redis
 from .exceptions import DateTimeFormatError
 
 
@@ -141,7 +141,7 @@ class CacheLock(object):
         self.key = 'lock_%s' % key
         self.attempts = attempts
         self.expires = expires
-        self.cache = redis
+        self.cache = cache
 
     def locked(self):
         return bool(self.cache.get(self.key))

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -3,7 +3,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from kuma.core.utils import memcache_lock
+from kuma.core.utils import redis_lock
 from kuma.feeder.utils import update_feeds
 
 
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             help='Fetch even disabled feeds.',
             action='store_true')
 
-    @memcache_lock('kuma_feeder')
+    @redis_lock('kuma_feeder')
     def handle(self, *args, **options):
         """
         Locked command handler to avoid running this command more than once

--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -3,7 +3,7 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from kuma.core.utils import redis_lock
+from kuma.core.utils import cache_lock
 from kuma.feeder.utils import update_feeds
 
 
@@ -16,7 +16,7 @@ class Command(BaseCommand):
             help='Fetch even disabled feeds.',
             action='store_true')
 
-    @redis_lock('kuma_feeder')
+    @cache_lock('kuma_feeder')
     def handle(self, *args, **options):
         """
         Locked command handler to avoid running this command more than once

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -19,7 +19,7 @@ def liveness(request):
     """
     A successful response from this endpoint simply proves
     that Django is up and running. It doesn't mean that its
-    supporting services (like MySQL, memcached, Celery) can
+    supporting services (like MySQL, redis, Celery) can
     be successfully used from within this service.
     """
     return HttpResponse(status=204)

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -19,7 +19,7 @@ def liveness(request):
     """
     A successful response from this endpoint simply proves
     that Django is up and running. It doesn't mean that its
-    supporting services (like MySQL, redis, Celery) can
+    supporting services (like MySQL, Redis, Celery) can
     be successfully used from within this service.
     """
     return HttpResponse(status=204)

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -1,18 +1,18 @@
 import mock
 import pytest
+from django.core.cache import cache
 from django.utils.six.moves.urllib.parse import urlparse
 from ratelimit.exceptions import Ratelimited
 
-from kuma.core.cache import redis
 from kuma.core.tests import assert_no_cache_header, assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
 
 
 @pytest.fixture()
-def cleared_redis_cache():
-    redis.clear()
-    yield redis
-    redis.clear()
+def cleared_cache():
+    cache.clear()
+    yield cache
+    cache.clear()
 
 
 def test_contribute_json(client, db):
@@ -28,12 +28,12 @@ def test_home(client, db):
     assert_shared_cache_header(response)
 
 
-def test_home_community_stats(client, db, cleared_redis_cache):
+def test_home_community_stats(client, db, cleared_cache):
     stats = {
         'contributors': 'so many, like more than 10,000',
         'locales': 'lots, maybe fifty'
     }
-    redis.set('community_stats', stats)
+    cache.set('community_stats', stats)
     response = client.get(reverse('home'), follow=True)
     assert response.status_code == 200
     assert_shared_cache_header(response)

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -3,16 +3,16 @@ import pytest
 from django.utils.six.moves.urllib.parse import urlparse
 from ratelimit.exceptions import Ratelimited
 
-from kuma.core.cache import memcache
+from kuma.core.cache import redis
 from kuma.core.tests import assert_no_cache_header, assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
 
 
 @pytest.fixture()
-def cleared_memcache():
-    memcache.clear()
-    yield memcache
-    memcache.clear()
+def cleared_redis_cache():
+    redis.clear()
+    yield redis
+    redis.clear()
 
 
 def test_contribute_json(client, db):
@@ -28,12 +28,12 @@ def test_home(client, db):
     assert_shared_cache_header(response)
 
 
-def test_home_community_stats(client, db, cleared_memcache):
+def test_home_community_stats(client, db, cleared_redis_cache):
     stats = {
         'contributors': 'so many, like more than 10,000',
         'locales': 'lots, maybe fifty'
     }
-    memcache.set('community_stats', stats)
+    redis.set('community_stats', stats)
     response = client.get(reverse('home'), follow=True)
     assert response.status_code == 200
     assert_shared_cache_header(response)

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.core.cache import cache
 from django.http import HttpResponse
 from django.shortcuts import redirect, render
 from django.views import static
@@ -6,7 +7,6 @@ from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 from ratelimit.decorators import ratelimit
 
-from kuma.core.cache import redis
 from kuma.core.decorators import shared_cache_control
 from kuma.feeder.models import Bundle
 from kuma.feeder.sections import SECTION_HACKS
@@ -27,7 +27,7 @@ def home(request):
     """Home page."""
     updates = list(Bundle.objects.recent_entries(SECTION_HACKS.updates)[:5])
 
-    community_stats = redis.get('community_stats')
+    community_stats = cache.get('community_stats')
 
     if not community_stats:
         community_stats = {'contributors': 5453, 'locales': 36}

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -6,7 +6,7 @@ from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 from ratelimit.decorators import ratelimit
 
-from kuma.core.cache import memcache
+from kuma.core.cache import redis
 from kuma.core.decorators import shared_cache_control
 from kuma.feeder.models import Bundle
 from kuma.feeder.sections import SECTION_HACKS
@@ -27,7 +27,7 @@ def home(request):
     """Home page."""
     updates = list(Bundle.objects.recent_entries(SECTION_HACKS.updates)[:5])
 
-    community_stats = memcache.get('community_stats')
+    community_stats = redis.get('community_stats')
 
     if not community_stats:
         community_stats = {'contributors': 5453, 'locales': 36}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -118,9 +118,8 @@ CACHES = {
         'BACKEND': 'django_redis.cache.RedisCache',
         'TIMEOUT': CACHE_COUNT_TIMEOUT * 60,
         'KEY_PREFIX': CACHE_PREFIX,
-        'LOCATION': config('REDIS_CACHE_SERVERS',
-                           default='127.0.0.1:6379',
-                           cast=Csv()),
+        'LOCATION': config('REDIS_CACHE_SERVER',
+                           default='127.0.0.1:6379'),
     }
 }
 
@@ -1203,16 +1202,15 @@ CELERYD_MAX_TASKS_PER_CHILD = config(
 
 if MAINTENANCE_MODE:
     # In maintenance mode, we're going to avoid using the database, and
-    # use Celery's default beat-scheduler as well as redis for storing
+    # use Celery's default beat-scheduler as well as Redis for storing
     # any results. In both normal and maintenance mode we use djcelery's
     # loader (see djcelery.setup_loader() above) so we, among other things,
     # acquire the Celery settings from among Django's settings.
     CELERYBEAT_SCHEDULER = 'celery.beat.PersistentScheduler'
     DEFAULT_CELERY_RESULT_BACKEND = (
         'redis://' + ';'.join(
-            config('REDIS_CACHE_SERVERS',
-                   default='127.0.0.1:6379',
-                   cast=Csv())
+            config('REDIS_CACHE_SERVER',
+                   default='127.0.0.1:6379')
         )
     )
 else:

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -110,11 +110,6 @@ CACHE_COUNT_TIMEOUT = 60  # in seconds
 
 CACHES = {
     'default': {
-        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
-        'TIMEOUT': CACHE_COUNT_TIMEOUT,
-        'KEY_PREFIX': CACHE_PREFIX,
-    },
-    'redis': {
         'BACKEND': 'django_redis.cache.RedisCache',
         'TIMEOUT': CACHE_COUNT_TIMEOUT * 60,
         'KEY_PREFIX': CACHE_PREFIX,
@@ -123,7 +118,7 @@ CACHES = {
     }
 }
 
-CACHEBACK_CACHE_ALIAS = 'redis'
+CACHEBACK_CACHE_ALIAS = 'default'
 
 # Email
 vars().update(config('EMAIL_URL',
@@ -1336,7 +1331,7 @@ CONSTANCE_BACKEND = ('kuma.core.backends.ReadOnlyConstanceDatabaseBackend'
                      if MAINTENANCE_MODE else
                      'constance.backends.database.DatabaseBackend')
 # must be an entry in the CACHES setting!
-CONSTANCE_DATABASE_CACHE_BACKEND = 'redis'
+CONSTANCE_DATABASE_CACHE_BACKEND = 'default'
 
 # Settings and defaults controllable by Constance in admin
 CONSTANCE_CONFIG = dict(
@@ -1620,7 +1615,7 @@ with open(ce_path, 'r') as ce_file:
 
 # django-ratelimit
 RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=True, cast=bool)
-RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='redis')
+RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='default')
 RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
 
 # Caching constants for the Cache-Control header.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1202,12 +1202,8 @@ if MAINTENANCE_MODE:
     # loader (see djcelery.setup_loader() above) so we, among other things,
     # acquire the Celery settings from among Django's settings.
     CELERYBEAT_SCHEDULER = 'celery.beat.PersistentScheduler'
-    DEFAULT_CELERY_RESULT_BACKEND = (
-        'redis://' + ';'.join(
-            config('REDIS_CACHE_SERVER',
-                   default='127.0.0.1:6379')
-        )
-    )
+    DEFAULT_CELERY_RESULT_BACKEND = config('REDIS_CACHE_SERVER')
+
 else:
     CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'
     DEFAULT_CELERY_RESULT_BACKEND = 'djcelery.backends.database:DatabaseBackend'

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -114,17 +114,17 @@ CACHES = {
         'TIMEOUT': CACHE_COUNT_TIMEOUT,
         'KEY_PREFIX': CACHE_PREFIX,
     },
-    'memcache': {
-        'BACKEND': 'memcached_hashring.backend.MemcachedHashRingCache',
+    'redis': {
+        'BACKEND': 'django_redis.cache.RedisCache',
         'TIMEOUT': CACHE_COUNT_TIMEOUT * 60,
         'KEY_PREFIX': CACHE_PREFIX,
-        'LOCATION': config('MEMCACHE_SERVERS',
-                           default='127.0.0.1:11211',
+        'LOCATION': config('REDIS_CACHE_SERVERS',
+                           default='127.0.0.1:6379',
                            cast=Csv()),
-    },
+    }
 }
 
-CACHEBACK_CACHE_ALIAS = 'memcache'
+CACHEBACK_CACHE_ALIAS = 'redis'
 
 # Email
 vars().update(config('EMAIL_URL',
@@ -1203,15 +1203,15 @@ CELERYD_MAX_TASKS_PER_CHILD = config(
 
 if MAINTENANCE_MODE:
     # In maintenance mode, we're going to avoid using the database, and
-    # use Celery's default beat-scheduler as well as memcached for storing
+    # use Celery's default beat-scheduler as well as redis for storing
     # any results. In both normal and maintenance mode we use djcelery's
     # loader (see djcelery.setup_loader() above) so we, among other things,
     # acquire the Celery settings from among Django's settings.
     CELERYBEAT_SCHEDULER = 'celery.beat.PersistentScheduler'
     DEFAULT_CELERY_RESULT_BACKEND = (
-        'cache+memcached://' + ';'.join(
-            config('MEMCACHE_SERVERS',
-                   default='127.0.0.1:11211',
+        'redis://' + ';'.join(
+            config('REDIS_CACHE_SERVERS',
+                   default='127.0.0.1:6379',
                    cast=Csv())
         )
     )
@@ -1338,7 +1338,7 @@ CONSTANCE_BACKEND = ('kuma.core.backends.ReadOnlyConstanceDatabaseBackend'
                      if MAINTENANCE_MODE else
                      'constance.backends.database.DatabaseBackend')
 # must be an entry in the CACHES setting!
-CONSTANCE_DATABASE_CACHE_BACKEND = 'memcache'
+CONSTANCE_DATABASE_CACHE_BACKEND = 'redis'
 
 # Settings and defaults controllable by Constance in admin
 CONSTANCE_CONFIG = dict(
@@ -1622,7 +1622,7 @@ with open(ce_path, 'r') as ce_file:
 
 # django-ratelimit
 RATELIMIT_ENABLE = config('RATELIMIT_ENABLE', default=True, cast=bool)
-RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='memcache')
+RATELIMIT_USE_CACHE = config('RATELIMIT_USE_CACHE', default='redis')
 RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
 
 # Caching constants for the Cache-Control header.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1202,7 +1202,7 @@ if MAINTENANCE_MODE:
     # loader (see djcelery.setup_loader() above) so we, among other things,
     # acquire the Celery settings from among Django's settings.
     CELERYBEAT_SCHEDULER = 'celery.beat.PersistentScheduler'
-    DEFAULT_CELERY_RESULT_BACKEND = config('REDIS_CACHE_SERVER')
+    DEFAULT_CELERY_RESULT_BACKEND = CACHES['default']['LOCATION']
 
 else:
     CELERYBEAT_SCHEDULER = 'djcelery.schedulers.DatabaseScheduler'

--- a/kuma/settings/prod.py
+++ b/kuma/settings/prod.py
@@ -14,7 +14,7 @@ SERVER_EMAIL = config(
 )
 
 # Cache
-CACHES['redis']['TIMEOUT'] = 60 * 60 * 24
+CACHES['default']['TIMEOUT'] = 60 * 60 * 24
 
 MEDIA_URL = config('MEDIA_URL', default='https://developer.cdn.mozilla.net/media/')
 

--- a/kuma/settings/prod.py
+++ b/kuma/settings/prod.py
@@ -14,7 +14,7 @@ SERVER_EMAIL = config(
 )
 
 # Cache
-CACHES['memcache']['TIMEOUT'] = 60 * 60 * 24
+CACHES['redis']['TIMEOUT'] = 60 * 60 * 24
 
 MEDIA_URL = config('MEDIA_URL', default='https://developer.cdn.mozilla.net/media/')
 

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -14,7 +14,7 @@ from django.contrib.sites.models import Site
 from elasticsearch import TransportError
 from elasticsearch_dsl import Search
 
-from kuma.core.cache import memcache
+from kuma.core.cache import redis
 
 from .constants import KUMASCRIPT_BASE_URL, KUMASCRIPT_TIMEOUT_ERROR
 
@@ -147,7 +147,7 @@ def get(document, cache_control, base_url, timeout=None):
         add_env_headers(headers, env_vars)
 
         # Set up for conditional GET, if we have the details cached.
-        cached_meta = memcache.get_many([etag_key, modified_key])
+        cached_meta = redis.get_many([etag_key, modified_key])
         if etag_key in cached_meta:
             headers['If-None-Match'] = cached_meta[etag_key]
         if modified_key in cached_meta:
@@ -158,7 +158,7 @@ def get(document, cache_control, base_url, timeout=None):
 
         if response.status_code == 304:
             # Conditional GET was a pass, so use the cached content.
-            result = memcache.get_many([body_key, errors_key])
+            result = redis.get_many([body_key, errors_key])
             body = result.get(body_key, '').decode('utf-8')
             errors = result.get(errors_key, None)
 
@@ -169,11 +169,11 @@ def get(document, cache_control, base_url, timeout=None):
             # Cache the request for conditional GET, but use the max_age for
             # the cache timeout here too.
             headers = response.headers
-            memcache.set(etag_key, headers.get('etag'), timeout=max_age)
-            memcache.set(modified_key, headers.get('last-modified'), timeout=max_age)
-            memcache.set(body_key, body.encode('utf-8'), timeout=max_age)
+            redis.set(etag_key, headers.get('etag'), timeout=max_age)
+            redis.set(modified_key, headers.get('last-modified'), timeout=max_age)
+            redis.set(body_key, body.encode('utf-8'), timeout=max_age)
             if errors:
-                memcache.set(errors_key, errors, timeout=max_age)
+                redis.set(errors_key, errors, timeout=max_age)
 
         elif response.status_code is None:
             errors = KUMASCRIPT_TIMEOUT_ERROR

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -11,10 +11,9 @@ import requests
 from constance import config
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.core.cache import cache
 from elasticsearch import TransportError
 from elasticsearch_dsl import Search
-
-from kuma.core.cache import redis
 
 from .constants import KUMASCRIPT_BASE_URL, KUMASCRIPT_TIMEOUT_ERROR
 
@@ -147,7 +146,7 @@ def get(document, cache_control, base_url, timeout=None):
         add_env_headers(headers, env_vars)
 
         # Set up for conditional GET, if we have the details cached.
-        cached_meta = redis.get_many([etag_key, modified_key])
+        cached_meta = cache.get_many([etag_key, modified_key])
         if etag_key in cached_meta:
             headers['If-None-Match'] = cached_meta[etag_key]
         if modified_key in cached_meta:
@@ -158,7 +157,7 @@ def get(document, cache_control, base_url, timeout=None):
 
         if response.status_code == 304:
             # Conditional GET was a pass, so use the cached content.
-            result = redis.get_many([body_key, errors_key])
+            result = cache.get_many([body_key, errors_key])
             body = result.get(body_key, '').decode('utf-8')
             errors = result.get(errors_key, None)
 
@@ -169,11 +168,11 @@ def get(document, cache_control, base_url, timeout=None):
             # Cache the request for conditional GET, but use the max_age for
             # the cache timeout here too.
             headers = response.headers
-            redis.set(etag_key, headers.get('etag'), timeout=max_age)
-            redis.set(modified_key, headers.get('last-modified'), timeout=max_age)
-            redis.set(body_key, body.encode('utf-8'), timeout=max_age)
+            cache.set(etag_key, headers.get('etag'), timeout=max_age)
+            cache.set(modified_key, headers.get('last-modified'), timeout=max_age)
+            cache.set(body_key, body.encode('utf-8'), timeout=max_age)
             if errors:
-                redis.set(errors_key, errors, timeout=max_age)
+                cache.set(errors_key, errors, timeout=max_age)
 
         elif response.status_code is None:
             errors = KUMASCRIPT_TIMEOUT_ERROR

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -17,9 +17,9 @@ from django.utils.encoding import smart_str
 from djcelery_transactions import task as transaction_task
 from lxml import etree
 
-from kuma.core.cache import memcache
+from kuma.core.cache import redis
 from kuma.core.decorators import skip_in_maintenance_mode
-from kuma.core.utils import chord_flow, chunked, MemcacheLock
+from kuma.core.utils import chord_flow, chunked, RedisLock
 from kuma.search.models import Index
 
 from .events import first_edit_email
@@ -31,7 +31,7 @@ from .utils import tidy_content
 
 
 log = logging.getLogger('kuma.wiki.tasks')
-render_lock = MemcacheLock('render-stale-documents-lock', expires=60 * 60)
+render_lock = RedisLock('render-stale-documents-lock', expires=60 * 60)
 
 
 @task(rate_limit='60/m')
@@ -296,7 +296,7 @@ def update_community_stats():
     if 0 in community_stats.values():
         community_stats = None
 
-    memcache.set('community_stats', community_stats, 86400)
+    redis.set('community_stats', community_stats, 86400)
 
 
 @task

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -19,7 +19,7 @@ from lxml import etree
 
 from kuma.core.cache import redis
 from kuma.core.decorators import skip_in_maintenance_mode
-from kuma.core.utils import chord_flow, chunked, RedisLock
+from kuma.core.utils import CacheLock, chord_flow, chunked
 from kuma.search.models import Index
 
 from .events import first_edit_email
@@ -31,7 +31,7 @@ from .utils import tidy_content
 
 
 log = logging.getLogger('kuma.wiki.tasks')
-render_lock = RedisLock('render-stale-documents-lock', expires=60 * 60)
+render_lock = CacheLock('render-stale-documents-lock', expires=60 * 60)
 
 
 @task(rate_limit='60/m')

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -10,6 +10,7 @@ from celery import chord, task
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sitemaps import GenericSitemap
+from django.core.cache import cache
 from django.core.mail import mail_admins, send_mail
 from django.db import connection, transaction
 from django.template.loader import render_to_string
@@ -17,7 +18,6 @@ from django.utils.encoding import smart_str
 from djcelery_transactions import task as transaction_task
 from lxml import etree
 
-from kuma.core.cache import redis
 from kuma.core.decorators import skip_in_maintenance_mode
 from kuma.core.utils import CacheLock, chord_flow, chunked
 from kuma.search.models import Index
@@ -296,7 +296,7 @@ def update_community_stats():
     if 0 in community_stats.values():
         community_stats = None
 
-    redis.set('community_stats', community_stats, 86400)
+    cache.set('community_stats', community_stats, 86400)
 
 
 @task

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -4,8 +4,8 @@ import os
 from datetime import datetime
 
 from django.conf import settings
+from django.core.cache import cache
 
-from kuma.core.cache import redis
 from kuma.users.models import User
 from kuma.users.tests import user, UserTestCase
 
@@ -20,7 +20,7 @@ class UpdateCommunityStatsTests(UserTestCase):
 
     def setUp(self):
         super(UpdateCommunityStatsTests, self).setUp()
-        self.cache = redis
+        self.cache = cache
 
     def test_empty_community_stats(self):
         update_community_stats()

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 from django.conf import settings
 
-from kuma.core.cache import memcache
+from kuma.core.cache import redis
 from kuma.users.models import User
 from kuma.users.tests import user, UserTestCase
 
@@ -20,7 +20,7 @@ class UpdateCommunityStatsTests(UserTestCase):
 
     def setUp(self):
         super(UpdateCommunityStatsTests, self).setUp()
-        self.cache = memcache
+        self.cache = redis
 
     def test_empty_community_stats(self):
         update_community_stats()

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -169,14 +169,6 @@ django-appconf==1.0.2 \
     --hash=sha256:6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261 \
     --hash=sha256:ddab987d14b26731352c01ee69c090a4ebfc9141ed223bef039d79587f22acd9
 
-# django-memcached-hashring
-hash-ring==1.3.1 \
-    --hash=sha256:67b05e6c753a982cda85e4b1c010493b159e53ab112c3ac3b1c8fb6734f050d7 \
-    --hash=sha256:f86b96517bc5cb7dbf34bbbc51cdd5968170877b43bc1ab7c9eb39345cff4dd7
-python-memcached==1.54 \
-    --hash=sha256:df21d1431424c512901ecc3cd244039833aebc4bc7d345af403d4abdace20081 \
-    --hash=sha256:67e1c18b6b99ca4c2c8e4a02e0a96174bf7068919a5aff52836600974c1ef4d8
-
 # django-pipeline
 futures==3.0.5 \
     --hash=sha256:f7f16b6bf9653a918a03f1f2c2d62aac0cd64b1bc088e93ea279517f6b61120b \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -106,11 +106,6 @@ django-jinja==2.4.1 \
     --hash=sha256:8a49d73de616a12075eee14c6d3bbab936261a463457d40348d8b8e2995cfbed \
     --hash=sha256:ceaa0eeebc4d91a5800967e50f4f087f0b6457503e3c2af85dc199bed8732a9a
 
-# Use consistent hashes despite adding or removing servers
-django-memcached-hashring==0.1.2 \
-    --hash=sha256:f71f99d60e704cc239bddbbe336dcdc5bb8a487b65a1b0b6c7ce0f4af5848442 \
-    --hash=sha256:14c2dc29bc693feaf114dea8c871f4d25daca72bba8f37b159d552fed4ab6337
-
 # Allow Django to use MySQL-specific features
 django-mysql==1.0.4 \
     --hash=sha256:a90eaaff1b9cfca374e565a873ba98b20209753e774ee136c526d1c4dd641561 \
@@ -143,6 +138,13 @@ django-recaptcha==1.0.5 \
 django-redirect-urls==1.0 \
     --hash=sha256:c4cd7818b06ccf0a5307656a33f3ecea47ee22f0cceb374ea559eb2d1402d5d8 \
     --hash=sha256:e5b1dec666758c7d2621ce337458a09e4b3feeb06cb9ec5d43b17d66b87ea97d
+
+# Provide a caching provider to use Redis as a cache in Django
+# Code: https://github.com/niwinz/django-redis
+# Docs: http://niwinz.github.io/django-redis/latest/
+django-redis==4.9.0 \
+    --hash=sha256:15b47faef6aefaa3f47135a2aeb67372da300e4a4cf06809c66ab392686a2155 \
+    --hash=sha256:a90343c33a816073b735f0bed878eaeec4f83b75fcc0dce2432189b8ea130424
 
 # RESTful API framework, used by search
 # Code: https://github.com/encode/django-rest-framework


### PR DESCRIPTION
Redis is a better suited cache than memcache for our usage.

We have hit the memcache technical limitations such as:
    - 1MB values
    - Simple string storage
    - Lack of key introspections

All those features are provided by Redis while also providing the same
feature set as memcache.

Redis is already used by Kuma and removing memcache also means reducing
our infrastructure costs.

## Kumascript
To be able to entirely remove `memcache` from MDN infrastructure, we need to switch mdn/kumascript to `redis` too.

This PR is not done at this stage and I'm currently not specifically working on it.

## Python 3
Removing `memcache` is having the expected side-effects of remove `memcache_hashring` non-compatibility with Python 3.