### PR TITLE
add handler for interactive examples load end event, bug 1468271

### DIFF
--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -29,55 +29,51 @@
     /* Ensure there is an iframe present and that performance is
        supported before gathering performance metric */
     if (iframe && performance !== undefined) {
-        document.addEventListener('readystatechange', function(event) {
-            if (event.target.readyState === 'complete') {
-                var interactiveExamplesPerfEntry = {};
-                var perfEntries = performance.getEntriesByType('resource');
-                var mainFetchStart = 0;
-                var iframeFetchStart = 0;
-                var iframeFetchStartSinceUnixEpoch = 0;
-                var timeToIframeFetchStart = 0;
+        window.addEventListener('load', function() {
+            var interactiveExamplesPerfEntry = {};
+            var perfEntries = performance.getEntriesByType('resource');
+            var mainNavigationStart = 0;
+            var iframeFetchStart = 0;
+            var iframeFetchStartSinceUnixEpoch = 0;
+            var timeToIframeFetchStart = 0;
 
-                if (perfEntries === undefined || perfEntries.length <= 0) {
-                    console.info('No performance entries was returned');
-                    return;
-                }
+            if (perfEntries === undefined || perfEntries.length <= 0) {
+                console.info('No performance entries was returned');
+                return;
+            }
 
-                interactiveExamplesPerfEntry = getInteractiveExamplesPerfEntry(
-                    perfEntries
+            interactiveExamplesPerfEntry = getInteractiveExamplesPerfEntry(
+                perfEntries
+            );
+
+            // ensure that the iframe was found in the array of performance entries
+            if (interactiveExamplesPerfEntry !== undefined) {
+                mainNavigationStart = performance.timing.navigationStart;
+                iframeFetchStart = Math.round(
+                    interactiveExamplesPerfEntry.fetchStart
                 );
+                iframeFetchStartSinceUnixEpoch =
+                    mainNavigationStart + iframeFetchStart;
 
-                // ensure that the iframe was found in the array of performance entries
-                if (interactiveExamplesPerfEntry !== undefined) {
-                    mainFetchStart = performance.timing.fetchStart;
-                    iframeFetchStart = Math.round(
-                        interactiveExamplesPerfEntry.fetchStart
-                    );
-                    iframeFetchStartSinceUnixEpoch =
-                        mainFetchStart + iframeFetchStart;
+                timeToIframeFetchStart =
+                    new Date(iframeFetchStartSinceUnixEpoch) -
+                    new Date(mainNavigationStart);
 
-                    timeToIframeFetchStart =
-                        new Date(iframeFetchStartSinceUnixEpoch) -
-                        new Date(mainFetchStart);
+                // one of hitType: event
+                mdn.analytics.trackEvent({
+                    category: 'Interactive Examples',
+                    action: 'Time to iframe fetch start',
+                    label:
+                        new Date().getTime() + '-' + mdn.utils.randomString(5),
+                    value: timeToIframeFetchStart
+                });
 
-                    // one of hitType: event
-                    mdn.analytics.trackEvent({
-                        category: 'Interactive Examples',
-                        action: 'Time to iframe fetch start',
-                        label:
-                            new Date().getTime() +
-                            '-' +
-                            mdn.utils.randomString(5),
-                        value: timeToIframeFetchStart
-                    });
-
-                    // one of hitType: timing
-                    mdn.analytics.trackTiming({
-                        category: 'Interactive Examples',
-                        timingVar: 'Time to iframe fetch start',
-                        value: timeToIframeFetchStart
-                    });
-                }
+                // one of hitType: timing
+                mdn.analytics.trackTiming({
+                    category: 'Interactive Examples',
+                    timingVar: 'Time to iframe fetch start',
+                    value: timeToIframeFetchStart
+                });
             }
         });
     }

--- a/kuma/static/js/utils/post-message-handler.js
+++ b/kuma/static/js/utils/post-message-handler.js
@@ -8,14 +8,14 @@ function handlePerformanceEvents(data) {
         category: data.category,
         action: data.action,
         label: new Date().getTime() + '-' + mdn.utils.randomString(5),
-        value: data.value - performance.timing.fetchStart
+        value: data.value - performance.timing.navigationStart
     });
 
     // one of hitType: timing
     mdn.analytics.trackTiming({
         category: data.category,
         timingVar: data.action,
-        value: data.value - performance.timing.fetchStart
+        value: data.value - performance.timing.navigationStart
     });
 }
 
@@ -51,7 +51,7 @@ function handlePerfMarks(perfData) {
  * Called by `handlePerfMarks` when a `markName` contains the
  * string `ie-load-event-end`. This sets a new mark, and a new
  * measure. It then uses this information to expose the total
- * duration from `fetchStart` of the parent document, until the
+ * duration from `navigationStart` of the parent document, until the
  * interactive example has reached `loadEventEnd`
  * @param {Object} perfData - Object containing performance mark/measure information
  */
@@ -59,8 +59,8 @@ function setLoadEventEnd(perfData) {
     var measureName = perfData.markName + '-measure';
     // set a mark
     window.mdn.perf.setMark(perfData.markName);
-    /* set a performance measure that is the duration from
-       fetchStart until the interactive editor loaded */
+    /* Set a performance measure that is the duration from
+       navigationStart until the interactive editor loaded */
     window.mdn.perf.setMeasure({
         measureName: measureName,
         startMark: 'navigationStart',


### PR DESCRIPTION
@jwhitlock @tkadlec Here is the Kuma side of the final metric we want to track for now.

## GA Debug info

<img width="1172" alt="screen shot 2018-06-28 at 13 45 14" src="https://user-images.githubusercontent.com/10350960/42032534-2820d9c6-7ada-11e8-9f9e-df24db82b195.png">

## User Timing in Devtools

<img width="1194" alt="screen shot 2018-06-28 at 13 47 57" src="https://user-images.githubusercontent.com/10350960/42032543-304d7082-7ada-11e8-994f-e31357912c8f.png">
