### PR TITLE
Adds check for startMark before measure and beacon, bug 1468271

### DIFF
--- a/kuma/static/js/utils/post-message-handler.js
+++ b/kuma/static/js/utils/post-message-handler.js
@@ -33,17 +33,21 @@ function handlePerfMarks(perfData) {
         window.mdn.perf.setMark(perfData.markName);
     } else {
         window.mdn.perf.setMark(perfData.markName);
-        window.mdn.perf.setMeasure({
-            measureName: perfData.measureName,
-            startMark: perfData.startMark,
-            endMark: perfData.endMark
-        });
 
-        mdn.analytics.trackTiming({
-            category: 'RUM - Interactive Examples',
-            timingVar: perfData.measureName,
-            value: window.mdn.perf.getDuration(perfData.measureName)
-        });
+        // Ensure startMark exists before trying to measure and beacon
+        if (performance.getEntriesByName(perfData.startMark).length > 0) {
+            window.mdn.perf.setMeasure({
+                measureName: perfData.measureName,
+                startMark: perfData.startMark,
+                endMark: perfData.endMark
+            });
+
+            mdn.analytics.trackTiming({
+                category: 'RUM - Interactive Examples',
+                timingVar: perfData.measureName,
+                value: window.mdn.perf.getDuration(perfData.measureName)
+            });
+        }
     }
 }
 


### PR DESCRIPTION
@jwhitlock This error seems to be super hard to replicate. Safest is probably to just ensure the `startMark` exist before measuring and beaconing. r?