### PR TITLE
bug 1467518: Cleanup Django update images, add Python 3 image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ KUMASCRIPT_IMAGE_NAME ?= kumascript
 REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= mozmar
 BASE_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:${VERSION}
+BASE_IMAGE_PY3 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:py3
 BASE_IMAGE_LATEST ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:latest
 IMAGE ?= $(BASE_IMAGE_LATEST)
 KUMA_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${KUMA_IMAGE_NAME}\:${VERSION}
@@ -101,6 +102,9 @@ pull-latest: pull-base-latest pull-kuma-latest
 
 build-base:
 	docker build -f docker/images/kuma_base/Dockerfile -t ${BASE_IMAGE} .
+
+build-base-py3:
+	docker build -f docker/images/kuma_base/Dockerfile-py3 -t ${BASE_IMAGE_PY3} .
 
 build-kuma:
 	docker build --build-arg REVISION_HASH=${KUMA_REVISION_HASH} \

--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ KUMASCRIPT_IMAGE_NAME ?= kumascript
 REGISTRY ?= quay.io/
 IMAGE_PREFIX ?= mozmar
 BASE_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:${VERSION}
-BASE_IMAGE_1_9 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.9
-BASE_IMAGE_1_10 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.10
-BASE_IMAGE_1_11 ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:django-1.11
 BASE_IMAGE_LATEST ?= ${REGISTRY}${IMAGE_PREFIX}/${BASE_IMAGE_NAME}\:latest
 IMAGE ?= $(BASE_IMAGE_LATEST)
 KUMA_IMAGE ?= ${REGISTRY}${IMAGE_PREFIX}/${KUMA_IMAGE_NAME}\:${VERSION}
@@ -104,15 +101,6 @@ pull-latest: pull-base-latest pull-kuma-latest
 
 build-base:
 	docker build -f docker/images/kuma_base/Dockerfile -t ${BASE_IMAGE} .
-
-build-base-1.9:
-	docker build -f docker/images/kuma_base/Dockerfile-1.9 -t ${BASE_IMAGE_1_9} .
-
-build-base-1.10:
-	docker build -f docker/images/kuma_base/Dockerfile-1.10 -t ${BASE_IMAGE_1_10} .
-
-build-base-1.11:
-	docker build -f docker/images/kuma_base/Dockerfile-1.11 -t ${BASE_IMAGE_1_11} .
 
 build-kuma:
 	docker build --build-arg REVISION_HASH=${KUMA_REVISION_HASH} \

--- a/docker/images/kuma_base/Dockerfile-1.10
+++ b/docker/images/kuma_base/Dockerfile-1.10
@@ -1,6 +1,0 @@
-FROM quay.io/mozmar/kuma_base:latest
-
-USER root
-RUN pip install "Django>1.10,<1.11"
-ENV PYTHONWARNINGS=all
-USER kuma

--- a/docker/images/kuma_base/Dockerfile-1.11
+++ b/docker/images/kuma_base/Dockerfile-1.11
@@ -1,6 +1,0 @@
-FROM quay.io/mozmar/kuma_base:latest
-
-USER root
-RUN pip install "Django>1.11,<1.12"
-ENV PYTHONWARNINGS=all
-USER kuma

--- a/docker/images/kuma_base/Dockerfile-1.9
+++ b/docker/images/kuma_base/Dockerfile-1.9
@@ -1,6 +1,0 @@
-FROM quay.io/mozmar/kuma_base:latest
-
-USER root
-RUN pip install "Django>1.9,<1.10"
-ENV PYTHONWARNINGS=all
-USER kuma

--- a/docker/images/kuma_base/Dockerfile-py3
+++ b/docker/images/kuma_base/Dockerfile-py3
@@ -1,0 +1,102 @@
+FROM python:3.6-slim
+
+# Set the environment variables
+ENV NODE_VERSION=6.14.2 \
+    # extra python env
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    # disable this when preparing for Django upgrade
+    PYTHONWARNINGS=ignore \
+    # Kuma Pipeline definitions
+    PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
+    PIPELINE_CLEANCSS_BINARY=/usr/local/bin/cleancss \
+    PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor \
+    PIPELINE_SASS_BINARY=/usr/local/bin/node-sass \
+    PIPELINE_UGLIFYJS_BINARY=/usr/local/bin/uglifyjs \
+    # gunicorn concurrency
+    WEB_CONCURRENCY=4
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+        curl \
+        xz-utils \
+        gpg \
+        dirmngr \
+        libsasl2-modules \
+        gettext \
+        mime-support \
+        build-essential \
+        libtidy-dev \
+        libxml2-dev \
+        libxslt1-dev \
+        libffi-dev \
+        libjpeg-dev \
+        libmagic-dev \
+        default-libmysqlclient-dev \
+        mysql-client \
+    && rm -rf /var/lib/apt/lists/*
+
+# ----------------------------------------------------------------------------
+# add node.js 6.x, copied from:
+#     https://github.com/nodejs/docker-node/blob/master/6/stretch/Dockerfile
+# but with package updates and version definitions moved above
+# ----------------------------------------------------------------------------
+
+RUN set -ex \
+  && for key in \
+    94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+    FD3A5288F042B6850C66B31F09FE44734EB7990E \
+    71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+    DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+    C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+    B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+    56730D5401028683275BD23C23EFEFE93C4CFFFE \
+    77984A986EBC2AA786BC0F66B01FBB92821C587A \
+  ; do \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+  done
+
+RUN ARCH=  && dpkgArch="$(dpkg --print-architecture)" \
+    && case "${dpkgArch##*-}" in \
+      amd64) ARCH='x64';; \
+      ppc64el) ARCH='ppc64le';; \
+      s390x) ARCH='s390x';; \
+      arm64) ARCH='arm64';; \
+      armhf) ARCH='armv7l';; \
+      i386) ARCH='x86';; \
+      *) echo "unsupported architecture"; exit 1 ;; \
+    esac \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-$ARCH.tar.xz" \
+    && curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+    && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc \
+    && grep " node-v$NODE_VERSION-linux-$ARCH.tar.xz\$" SHASUMS256.txt | sha256sum -c - \
+    && tar -xJf "node-v$NODE_VERSION-linux-$ARCH.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
+    && rm "node-v$NODE_VERSION-linux-$ARCH.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt \
+    && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+# ----------------------------------------------------------------------------
+
+# add non-priviledged user
+RUN adduser --uid 1000 --disabled-password --gecos '' --no-create-home kuma
+
+WORKDIR /app
+EXPOSE 8000
+
+RUN npm install -g \
+        fibers@1.0.15 \
+        csslint@0.10.0 \
+        jshint@2.7.0 \
+        node-sass@4.3.0 \
+        uglify-js@2.4.13 \
+        clean-css@3.4.23 \
+        stylelint@7.10.1
+
+COPY ./requirements /app/requirements
+RUN pip install --no-cache-dir -r requirements/dev.txt
+
+USER kuma
+
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "--timeout=120", "--worker-class=meinheld.gmeinheld.MeinheldWorker", "kuma.wsgi:application"]


### PR DESCRIPTION
Remove the kuma_base variants from the Django update process, and add a new one for the Python 3 update effort.  To use it:

1. Run ``make build-base-py3``
2. Create ``docker-compose.override.yml`` that recreates the ``worker`` container, but with the py3 variant image, and running pytest:

    ```yaml
    version: '2.1'
    services:
      py3:
        image: quay.io/mozmar/kuma_base:py3
        command: pytest --reuse-db kuma
        user: ${UID:-33}
        volumes:
          - ./:/app:z
        depends_on:
          - memcached
          - mysql
          - elasticsearch
          - redis
          - kumascript
        environment:
          # Django settings overrides:
          - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
          - ALLOWED_HOSTS=*
          - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
          - BROKER_URL=redis://redis:6379/0
          - CELERY_ALWAYS_EAGER=False
          - CELERY_RESULT_BACKEND=redis://redis:6379/1
          - CSRF_COOKIE_SECURE=False
          - DATABASE_URL=mysql://${DATABASE_USER:-root}:${DATABASE_PASSWORD:-kuma}@mysql:3306/developer_mozilla_org
          - DEBUG=${DEBUG:-True}
          - DOMAIN=localhost
          - ENABLE_RESTRICTIONS_BY_HOST=${ENABLE_RESTRICTIONS_BY_HOST:-False}
          - ES_URLS=elasticsearch:9200
          - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
          - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
          - MEMCACHE_SERVERS=memcached:11211
          - PROTOCOL=http://
          - SESSION_COOKIE_SECURE=False
          - SITE_URL=http://localhost:8000
          - STATIC_URL=${STATIC_URL:-/static/}
          # Other environment overrides
          - PYTHONDONTWRITEBYTECODE=1
          - PYTHONUNBUFFERED=True
          - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
          - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
          # AND
          - PYTHONWARNINGS=all
    ```
3. Run ``make up && docker-compose logs -f py3`` to view the failures.