### PR TITLE
bug 1401246: Update Django Debug Toolbar injection for MIDDLEWARE

### DIFF
--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -33,10 +33,10 @@ if DEBUG:
     WHITENOISE_MAX_AGE = 0
     if DEBUG_TOOLBAR:
         INSTALLED_APPS = INSTALLED_APPS + ('debug_toolbar',)
-        MIDDLEWARE_CLASSES = list(MIDDLEWARE_CLASSES)
-        common_index = MIDDLEWARE_CLASSES.index(
+        MIDDLEWARE = list(MIDDLEWARE)
+        common_index = MIDDLEWARE.index(
             'django.middleware.common.CommonMiddleware')
-        MIDDLEWARE_CLASSES.insert(
+        MIDDLEWARE.insert(
             common_index + 1,
             'debug_toolbar.middleware.DebugToolbarMiddleware')
         DEBUG_TOOLBAR_INSTALLED = 1


### PR DESCRIPTION
Update the code that enables Django Debug Toolbar (DDT) for the change from ``MIDDLEWARE_CLASSES`` to ``MIDDLEWARE`` in Django 1.10. This should have been done in PR #4830 (oops).

I want to get rid of the alternate settings files entirely ([bug 1308630](https://bugzilla.mozilla.org/show_bug.cgi?id=1308630)), but I also want my debug toolbar working again, so I'm going with the minimal change.