### PR TITLE
bug 1467513: Add request attributes in error view

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -154,7 +154,7 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    <script src="{{ statici18n(request.LANGUAGE_CODE or 'en-US') }}"></script>
+    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'main' %}
     <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -9,6 +9,7 @@ from django.utils.log import AdminEmailHandler
 from pyquery import PyQuery as pq
 from ratelimit.exceptions import Ratelimited
 from soapbox.models import Message
+from waffle.models import Flag
 
 from . import (assert_no_cache_header, assert_shared_cache_header,
                KumaTestCase)
@@ -231,12 +232,20 @@ def test_ratelimit_429(client, db):
     assert_no_cache_header(response)
 
 
-def test_error_handler_minimal_request(rf, db):
+def test_error_handler_minimal_request(rf, db, constance_config):
     '''Error page renders if middleware hasn't added request members.'''
+    # Setup conditions for adding analytics with a flag check
+    constance_config.GOOGLE_ANALYTICS_ACCOUNT = 'UA-00000000-0'
+    Flag.objects.create(name='section_edit', authenticated=True)
+
+    # Create minimal request
     request = rf.get('/en-US/docs/tags/Open Protocol')
     assert not hasattr(request, 'LANGUAGE_CODE')
     assert not hasattr(request, 'user')
+
+    # Generate the 500 page
     exception = Exception('Something went wrong.')
     response = handler500(request, exception)
     assert response.status_code == 500
     assert 'Internal Server Error' in response.content
+    open('test.html', 'w').write(response.content)

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -248,4 +248,3 @@ def test_error_handler_minimal_request(rf, db, constance_config):
     response = handler500(request, exception)
     assert response.status_code == 500
     assert 'Internal Server Error' in response.content
-    open('test.html', 'w').write(response.content)

--- a/kuma/core/views.py
+++ b/kuma/core/views.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.auth.models import AnonymousUser
 from django.http import HttpResponse
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
@@ -10,7 +11,16 @@ from .i18n import get_kuma_languages
 
 @never_cache
 def _error_page(request, status):
-    """Render error pages with jinja2."""
+    """
+    Render error pages with jinja2.
+
+    Sometimes, an error is raised by a middleware, and the request is not
+    fully populated with a user or language code. Add in good defaults.
+    """
+    if not hasattr(request, 'user'):
+        request.user = AnonymousUser()
+    if not hasattr(request, 'LANGUAGE_CODE'):
+        request.LANGUAGE_CODE = 'en-US'
     return render(request, '%d.html' % status, status=status)
 
 


### PR DESCRIPTION
Update the test to trigger the production bug, where ``request.user`` was being read to determine if a flag ``section_edit`` was applicable.

In the error view, detect if the request object is missing attributes ``.user`` or ``.LANGUAGE_CODE``, and add good defaults, before rendering.