### PR TITLE
bug 1467532: Update to django-soapbox 1.5

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -152,9 +152,10 @@ djangorestframework==3.6.4 \
     --hash=sha256:0f9bfbac702f3376dfb2db4971ad8af4e066bfa35393b1b85e085f7e8b91189a \
     --hash=sha256:de8ac68b3cf6dd41b98e01dcc92dc0022a5958f096eafc181a17fa975d18ca42
 
-# Add site-wide announcements in the database
-django-soapbox==1.3 \
-    --hash=sha256:69ccf5eb9200f294f400864c9f11990a8bdcd75ed8965cd984b7d6d3d243cf49
+# Publish site-wide announcements without deployments
+django-soapbox==1.5 \
+    --hash=sha256:9f330db2b4098d24d7a2c4c9de63b0cc4d5579c69c2a904621914371f8039200 \
+    --hash=sha256:a65810a406416e3a945feb6c834a58fac341f506e7d1ea1b8abc488df5562f7e
 
 # Generate localization catalogs for JavaScript
 # Code: https://github.com/zyegfryed/django-statici18n


### PR DESCRIPTION
* django-soapbox 1.3 → 1.5: Django 1.11, Python 3.6 support, and working database migrations.

This was discovered because the sample database no longer has soapbox tables in Django 1.11. This is fixed in 1.5. I tested by building the base image (``VERSION=latest make build-base``), removing almost all the sources from ``/etc/sample_db.json``, building the sample DB (``scripts/create_sample_db.sh``), and looking for the soapbox table in the SQL (``grep soapbox mdn_sample_db.sql ``).


It appears Django migrations were never applied for the existing tables.  We'll need a one-time different migrate command in production, such as:

```
./manage.py migrate --fake-initial
```

or
```
./manage.py migrate soapbox 0001 --fake
./manage.py migrate
```

This is run during deployments, as https://github.com/mdn/infra/blob/master/apps/mdn/mdn-aws/k8s/mdn-db-migration-job.yaml.j2.  We'll need a strategy for running the one-time migration (short-lived alternate for ``mdn-db-migration-job``, create an alternate version and update ``push.yml``, run the command manually, etc.)

