### PR TITLE
bug 1431259: reset cdn cache ttl to 5min

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1687,4 +1687,4 @@ RATELIMIT_VIEW = 'kuma.core.views.rate_limited'
 
 # Caching constants for the Cache-Control header.
 CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE = config(
-    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 60 * 48, cast=int)
+    'CACHE_CONTROL_DEFAULT_SHARED_MAX_AGE', default=60 * 5, cast=int)


### PR DESCRIPTION
This reverts the experiment started with the deployment of #4876.