### PR TITLE
bug 1465085: Return 404 for the child of a 301 to a non-document URL

### DIFF
--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -573,6 +573,9 @@ def _document_redirect_to_create(document_slug, document_locale, slug_dict):
                                        slug=slug_dict['parent'])
         if parent_doc.is_redirect:
             parent_doc = parent_doc.get_redirect_document(id_only=True)
+            if parent_doc is None:
+                # Redirect is not to a Document, can't create subpage
+                raise Http404()
 
         url = urlparams(url, parent=parent_doc.id,
                         slug=slug_dict['specific'])


### PR DESCRIPTION
If [/en-US/docs/Main_Page](https://developer.mozilla.org/en-US/docs/Main_page) is a redirect to a non-Document MDN URL, then return a 404 to [/en-US/docs/MainPage/SubPage](https://developer.mozilla.org/en-US/docs/Main_page/SubPage) when logged in, rather than raise an Internal Server Error (500 ISE).

I didn't refactor the tests, which can be refactored after PR #4853 simplifies the logic.