### PR TITLE
bug 1467532: Update MySQL libraries

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -240,10 +240,11 @@ meinheld==0.6.1 \
     --hash=sha256:293eff4983b7fcbd9134b47706b22189883fe354993bd10163c65869d141e565
 
 # MySQL driver with Python 3 support
-mysqlclient==1.3.7 \
-    --hash=sha256:c54e3045e883fa7cfd20be61f112835d4f9fae07f8db057f6c0fa6816fe52a93 \
-    --hash=sha256:835faf2f26a2329c392ac20b14fc41ab0105b47b8b7126ed7058e8c56bfe05f4 \
-    --hash=sha256:c74a83b4cb2933d0e43370117eeebdfa03077ae72686d2df43d31879267f1f1b
+# Code: https://github.com/PyMySQL/mysqlclient-python
+# Changes: https://github.com/PyMySQL/mysqlclient-python/blob/master/HISTORY.rst
+# Docs: https://mysqlclient.readthedocs.io/
+mysqlclient==1.3.13 \
+    --hash=sha256:ff8ee1be84215e6c30a746b728c41eb0701a46ca76e343af445b35ce6250644f
 
 # Report performance metrics and exceptions to New Relic
 # Docs: https://docs.newrelic.com/docs/agents/python-agent/

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -112,9 +112,12 @@ django-memcached-hashring==0.1.2 \
     --hash=sha256:14c2dc29bc693feaf114dea8c871f4d25daca72bba8f37b159d552fed4ab6337
 
 # Allow Django to use MySQL-specific features
-django-mysql==1.0.4 \
-    --hash=sha256:a90eaaff1b9cfca374e565a873ba98b20209753e774ee136c526d1c4dd641561 \
-    --hash=sha256:0ced44721f0b36b618c7eb4c3813f57a5a7df71b959dc97ddf94e2281813a971
+# Code: https://github.com/adamchainz/django-mysql
+# Docs: https://django-mysql.readthedocs.io/en/latest/index.html
+# Changes: https://github.com/adamchainz/django-mysql/blob/master/HISTORY.rst
+django-mysql==2.3.1 \
+    --hash=sha256:53bf05dfa8e98db371adbd5b6c669a904e9f556f4ce7e3552cd42796c5f44841 \
+    --hash=sha256:7c13e453535f20e12b01c2b8f452d67e9973721f30ffd296ae6f0e5af0b475fb
 
 # Serialize objects with Python's pickle
 # Required by django-constance with database backend

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -31,9 +31,9 @@ flake8-import-order==0.17.1 \
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin
-hashin==0.13.0 \
-    --hash=sha256:6e3d9abfcb7c622a3432c800fbcdf2b73fe6003243aa58c17ab7852bb7a58120 \
-    --hash=sha256:b8ad3900fd6ad292ff892a7252021143705b8861b0900f5f2f5ab0c3b127f690
+hashin==0.13.2 \
+    --hash=sha256:40c51ea166442889c1cedf0f909956e6ca1c4b39c28d121a9b22dc90b4b44b1d \
+    --hash=sha256:4aaa2890d63e0eff9e1038e8a602eccbfe2eb90aa8177ff2b2db018815e2be95
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
I've install MySQL 8 locally, and now ``mysqlclient`` won't install. This fixes it, but more importantly our MySQL libraries are very stale.

* ``hashin`` 0.13.0 → 0.13.2: Allow pre-release only packages, more Python version matching. Not needed, but I update this whenever I use it for version updates.
* ``django-mysql`` 1.0.4 → 2.3.1: Fix JSONField serialization, add Django 1.11+ and mysqlclient compatibility, MariaDB 10.3 support.
* ``mysqlclient`` 1.3.7 → 1.3.13: Support MariaDB 10.2, MySQL 8, other fixes.

Here's our MySQL versions:
* Development: MySQL 5.6, in [docker-compose.yml](https://github.com/mozilla/kuma/blob/705339d6b92d1b788896b1727f7394567a4cd0be/docker-compose.yml#L66)
* TravisCI: MySQL 5.6, the [default](https://docs.travis-ci.com/user/database-setup/#MySQL)
* Production: MariaDB 10.1, [compatible with MySQL 5.6](https://mariadb.com/kb/en/library/mariadb-vs-mysql-compatibility/), maintained by Amazon.

MySQL 8.0 is the successor to 5.7, and I'm not suggesting we update yet. When we do update, it would be to MySQL 5.7 and MariaDB 10.2/3. For now, I just want to get the libraries up to date.