### PR TITLE
Fix Bug 1470644, items inside compat data dialog should respond to touch events on mobile

### DIFF
--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -13,6 +13,7 @@
         // Site configuration
         win.mdn.ckeditor = {};
         win.mdn.features = {};
+        win.mdn.siteUrl = '{{ SITE_URL }}';
         win.mdn.staticPath = '{{ STATIC_URL }}';
         win.mdn.wiki = {
             {%- if not untrusted %}

--- a/kuma/static/js/components.js
+++ b/kuma/static/js/components.js
@@ -119,7 +119,7 @@
                     });
 
                     // Close button should close the submenu
-                    $closeButton.on('click', function(){
+                    $closeButton.on('click touchend', function(){
                         closeSubmenu($submenu || $(this).parent());
                     });
                 }

--- a/kuma/static/js/wiki-compat-tables.js
+++ b/kuma/static/js/wiki-compat-tables.js
@@ -99,15 +99,24 @@
                 var $betaMenuTrigger = $('<a />', { text: gettext('New compatibility tables are in beta '), href: '/docs/New_Compatibility_Tables_Beta' }).append($('<i />', { class: 'icon-caret-down', 'aria-hidden': 'true' }));
                 var $betaSubmenu = $('<ul />', { 'class': 'submenu js-submenu' });
                 var betaSubmenuItems = [];
+                var betaInfoUrl = '/docs/New_Compatibility_Tables_Beta';
+                var surveyUrl = 'https://www.surveygizmo.com/s3/2342437/0b5ff6b6b8f6';
+                var siteUrl = window.mdn.siteUrl;
 
-                var $betaLink = $('<a />', { text: gettext('More about the beta.'), href: '/docs/New_Compatibility_Tables_Beta' });
+                var $betaLink = $('<a />', { text: gettext('More about the beta.'), href: betaInfoUrl });
+                $betaLink.on('touchend', function() {
+                    document.location = siteUrl + betaInfoUrl;
+                });
                 betaSubmenuItems.push($betaLink);
 
-                var $betaSurvey = $('<a />', { text: gettext('Take the survey'), href: 'https://www.surveygizmo.com/s3/2342437/0b5ff6b6b8f6', 'class': 'external external-icon' });
+                var $betaSurvey = $('<a />', { text: gettext('Take the survey'), href: surveyUrl, 'class': 'external external-icon' });
+                $betaSurvey.on('touchend', function() {
+                    window.open(surveyUrl);
+                });
                 betaSubmenuItems.push($betaSurvey);
 
                 var $betaError = $('<button />', { text: gettext('Report an error.'), 'class': 'button bc-error' });
-                $betaError.on('click', function() {
+                $betaError.on('click touchend', function() {
                     mdn.analytics.trackEvent({
                         category: 'Compat Tables Error',
                         action: location.pathname
@@ -117,7 +126,7 @@
                 betaSubmenuItems.push($betaError);
 
                 var $betaShowOld = $('<button />', { text: gettext('Show old table.'), 'class': 'button bc-old' });
-                $betaShowOld.on('click', function() {
+                $betaShowOld.on('click touchend', function() {
                     $('.bc-old').toggle();
                     mdn.analytics.trackEvent({
                         category: 'Compat Tables Show Old',


### PR DESCRIPTION
@jwhitlock This fixes the problem of items inside the dialog not responding to touch events. I did some digging as I initially thought it may be a `z-index` issue but, after much debugging that was leading nowhere.

I noticed that the close icon and the two buttons had listeners for `click` events but not touch so, I simply added `touchend` as well. The one that is really odd is that even the plain old links does not respond to the touch events. Adding `touchend` listeners to them, resolved the problem though.

r?