### PR TITLE
bug 1467518: Enable pytest to collect all test on the Python 3 image.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,14 +56,14 @@ matrix:
             INSTALL_NPM_TOOLS=1
         - python: "3.6"
           env:
-            TOXENV=pytest
+            TOXENV=pytest3
             CREATE_DB=kuma
             INSTALL_ELASTICSEARCH=1
             INSTALL_NPM_TOOLS=1
     allow_failures:
         - python: "3.6"
           env:
-            TOXENV=pytest
+            TOXENV=pytest3
             CREATE_DB=kuma
             INSTALL_ELASTICSEARCH=1
             INSTALL_NPM_TOOLS=1

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -1,5 +1,4 @@
 import datetime
-import HTMLParser
 import json
 
 import jinja2
@@ -10,6 +9,7 @@ from django.template import defaultfilters
 from django.template.loader import get_template
 from django.utils.encoding import force_text
 from django.utils.html import strip_tags
+from django.utils.six.moves import html_parser
 from django.utils.translation import ugettext_lazy as _
 from django_jinja import library
 from pytz import timezone, utc
@@ -20,7 +20,7 @@ from urlobject import URLObject
 from ..urlresolvers import reverse, split_path
 from ..utils import format_date_time, order_params, urlparams
 
-htmlparser = HTMLParser.HTMLParser()
+htmlparser = html_parser.HTMLParser()
 
 
 # Yanking filters from Django.

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -1,8 +1,4 @@
 import datetime
-try:
-    import urlparse
-except ImportError:
-    import urllib.parse as urlparse
 import functools
 import hashlib
 import logging
@@ -19,12 +15,12 @@ from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.http import QueryDict
 from django.shortcuts import _get_queryset
 from django.utils.cache import patch_cache_control
-from django.utils.encoding import force_unicode, smart_str
+from django.utils.encoding import force_text, smart_bytes
 from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 from polib import pofile
 from pytz import timezone
-from six.moves.urllib.parse import parse_qsl, urlsplit, urlunsplit
+from six.moves.urllib.parse import parse_qsl, urlparse, urlsplit, urlunsplit
 from taggit.utils import split_strip
 
 from .exceptions import DateTimeFormatError
@@ -220,7 +216,7 @@ def parse_tags(tagstring, sorted=True):
     if not tagstring:
         return []
 
-    tagstring = force_unicode(tagstring)
+    tagstring = force_text(tagstring)
 
     # Special case - if there are no commas or double quotes in the
     # input, we don't *do* a recall... I mean, we know we only need to
@@ -361,7 +357,7 @@ def urlparams(url_, fragment=None, query_dict=None, **query):
     fragment = fragment if fragment is not None else url_.fragment
 
     q = url_.query
-    new_query_dict = (QueryDict(smart_str(q), mutable=True) if
+    new_query_dict = (QueryDict(smart_bytes(q), mutable=True) if
                       q else QueryDict('', mutable=True))
     if query_dict:
         for k, l in query_dict.lists():

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -20,7 +20,7 @@ from django.utils.http import urlencode
 from django.utils.translation import ugettext_lazy as _
 from polib import pofile
 from pytz import timezone
-from six.moves.urllib.parse import parse_qsl, urlparse, urlsplit, urlunsplit
+from six.moves.urllib.parse import parse_qsl, ParseResult, urlparse, urlsplit, urlunsplit
 from taggit.utils import split_strip
 
 from .exceptions import DateTimeFormatError
@@ -353,7 +353,7 @@ def urlparams(url_, fragment=None, query_dict=None, **query):
     New query params will be appended to exising parameters, except duplicate
     names, which will be replaced.
     """
-    url_ = urlparse.urlparse(url_)
+    url_ = urlparse(url_)
     fragment = fragment if fragment is not None else url_.fragment
 
     q = url_.query
@@ -374,8 +374,7 @@ def urlparams(url_, fragment=None, query_dict=None, **query):
 
     query_string = urlencode([(k, v) for k, l in new_query_dict.lists() for
                               v in l if v is not None])
-    new = urlparse.ParseResult(url_.scheme, url_.netloc, url_.path,
-                               url_.params, query_string, fragment)
+    new = ParseResult(url_.scheme, url_.netloc, url_.path, url_.params, query_string, fragment)
     return new.geturl()
 
 

--- a/kuma/feeder/tests/test_utils.py
+++ b/kuma/feeder/tests/test_utils.py
@@ -2,11 +2,11 @@
 import socket
 from datetime import datetime
 from time import mktime, struct_time
-from urllib2 import URLError
 
 import jsonpickle
 import mock
 import pytest
+from django.utils.six.moves.urllib.error import URLError
 from feedparser import FeedParserDict
 
 from ..models import Entry, Feed

--- a/kuma/feeder/utils.py
+++ b/kuma/feeder/utils.py
@@ -3,12 +3,12 @@ import socket
 from datetime import datetime
 from hashlib import md5
 from time import mktime
-from urllib2 import URLError
 
 import feedparser
 import jsonpickle
 from django.conf import settings
 from django.utils.encoding import smart_str
+from django.utils.six.moves.urllib.error import URLError
 
 from .models import Entry, Feed
 

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -168,7 +168,7 @@ STATUS_SETTINGS_CASES = {
 
 @pytest.mark.parametrize('name,new_value',
                          STATUS_SETTINGS_CASES.items(),
-                         ids=STATUS_SETTINGS_CASES.keys())
+                         ids=list(STATUS_SETTINGS_CASES))
 def test_status_settings_change(name, new_value, client, settings,
                                 mock_status_externals):
     """The status JSON reflects the current Django settings."""

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -126,7 +126,7 @@ rate_limit_tests = {
 @mock.patch('kuma.scrape.scraper.time.sleep')
 @pytest.mark.parametrize('retry_after,sleep_time',
                          rate_limit_tests.values(),
-                         ids=rate_limit_tests.keys())
+                         ids=list(rate_limit_tests))
 def test_request_429_is_retried(mock_sleep, retry_after, sleep_time):
     """Requests are retried after a 429 Too Many Requests status."""
     requester = Requester('example.com', True)

--- a/kuma/search/tests/test_serializers.py
+++ b/kuma/search/tests/test_serializers.py
@@ -24,7 +24,7 @@ class SerializerTests(ElasticTestCase):
         filter_.tags.add('tag')
         filter_serializer = FilterWithGroupSerializer(filter_)
         data = filter_serializer.data
-        assert ({'order': 1L, 'name': u'Group', 'slug': u'group'} ==
+        assert ({'order': 1, 'name': u'Group', 'slug': u'group'} ==
                 data['group'])
         assert u'Serializer' == data['name']
         assert 'OR' == data['operator']

--- a/kuma/search/tests/test_views.py
+++ b/kuma/search/tests/test_views.py
@@ -38,7 +38,7 @@ class ViewTests(ElasticTestCase):
                 assert list(serialized_filter['tags']) == [u'tagged']
                 assert serialized_filter['operator'] == 'OR'
                 assert serialized_filter['group'] == {
-                    'order': 1L,
+                    'order': 1,
                     'name': 'Group',
                     'slug': 'group',
                 }
@@ -63,7 +63,7 @@ class ViewTests(ElasticTestCase):
                 assert list(filter_1['tags']) == [u'tagged']
                 assert filter_1['operator'] == 'OR'
                 assert filter_1['group'] == {
-                    'order': 1L,
+                    'order': 1,
                     'name': 'Group',
                     'slug': 'group',
                 }
@@ -73,7 +73,7 @@ class ViewTests(ElasticTestCase):
                 assert list(filter_2['tags']) == []
                 assert filter_2['operator'] == 'OR'
                 assert filter_2['group'] == {
-                    'order': 1L,
+                    'order': 1,
                     'name': 'Group',
                     'slug': 'group',
                 }

--- a/kuma/spam/akismet.py
+++ b/kuma/spam/akismet.py
@@ -1,9 +1,9 @@
 import sys
-import urlparse
 
 import newrelic.agent
 from constance import config
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urljoin
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.exceptions import RequestException
@@ -84,7 +84,7 @@ class Akismet(object):
         if 'blog' not in payload:
             scheme = 'https' if self.ssl else 'http'
             payload['blog'] = u'%s://%s/' % (scheme, self.domain)
-        url = urlparse.urljoin(self.url, method)
+        url = urljoin(self.url, method)
         return self.session.post(url, data=payload)
 
     def handle_exception(self, payload):

--- a/kuma/version/tests/test_views.py
+++ b/kuma/version/tests/test_views.py
@@ -1,6 +1,6 @@
-from urlparse import urljoin
-
 import pytest
+
+from django.utils.six.moves.urllib.parse import urljoin
 
 from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -1,8 +1,8 @@
 import re
-from urlparse import urlparse, urlunparse
 
 import bleach
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlparse, urlunparse
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -1,14 +1,12 @@
 # -*- coding: utf-8 -*-
 import re
-import urllib
 from collections import defaultdict
-from urllib import urlencode
-from urlparse import urlparse
 from xml.sax.saxutils import quoteattr
 
 import html5lib
 import newrelic.agent
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlencode, urlparse
 from django.utils.translation import ugettext
 from html5lib.filters.base import Filter as html5lib_Filter
 from lxml import etree

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -6,7 +6,7 @@ from xml.sax.saxutils import quoteattr
 import html5lib
 import newrelic.agent
 from django.conf import settings
-from django.utils.six.moves.urllib.parse import urlencode, urlparse
+from django.utils.six.moves.urllib.parse import unquote, urlencode, urlparse
 from django.utils.translation import ugettext
 from html5lib.filters.base import Filter as html5lib_Filter
 from lxml import etree
@@ -440,7 +440,7 @@ class LinkAnnotationFilter(html5lib_Filter):
 
                 # Handle any URL-encoded UTF-8 characters in the path
                 href_path = href_path.encode('utf-8', 'ignore')
-                href_path = urllib.unquote(href_path)
+                href_path = unquote(href_path)
                 href_path = href_path.decode('utf-8', 'ignore')
 
                 # Try to sort out the locale and slug through some of our

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -5,13 +5,13 @@ import time
 import unicodedata
 from collections import defaultdict
 from functools import partial
-from urlparse import urljoin
 
 import requests
 from constance import config
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.cache import cache
+from django.utils.six.moves.urllib.parse import urljoin
 from elasticsearch import TransportError
 
 from .constants import KUMASCRIPT_BASE_URL, KUMASCRIPT_TIMEOUT_ERROR

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -2,7 +2,6 @@
 import difflib
 import json
 import re
-import urlparse
 
 import jinja2
 from constance import config
@@ -12,6 +11,7 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.template import loader
 from django.utils import lru_cache
 from django.utils.html import conditional_escape
+from django.utils.six.moves.urllib.parse import urlsplit, urlunparse
 from django.utils.translation import ugettext
 from django_jinja import library
 from pyquery import PyQuery as pq
@@ -216,7 +216,7 @@ def absolutify(url, site=None):
     if not site:
         site = Site.objects.get_current()
 
-    parts = urlparse.urlsplit(url)
+    parts = urlsplit(url)
 
     scheme = 'https'
     netloc = site.domain
@@ -227,7 +227,7 @@ def absolutify(url, site=None):
     if path == '':
         path = '/'
 
-    return urlparse.urlunparse([scheme, netloc, path, None, query, fragment])
+    return urlunparse([scheme, netloc, path, None, query, fragment])
 
 
 @library.global_function

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from datetime import datetime
 
 from django.contrib.auth import get_user_model
@@ -33,11 +35,11 @@ class WikiTestCase(KumaTestCase):
 def document(save=False, **kwargs):
     """Return an empty document with enough stuff filled out that it can be
     saved."""
-    defaults = {'title': unicode(datetime.now()),
+    defaults = {'title': datetime.now(),
                 'is_redirect': 0}
     defaults.update(kwargs)
     if 'slug' not in kwargs:
-        defaults['slug'] = slugify(unicode(defaults['title']))
+        defaults['slug'] = slugify(defaults['title'])
     d = Document(**defaults)
     if save:
         d.save()
@@ -121,7 +123,7 @@ def normalize_html(html):
     equivalence in tests
     """
     return (kuma.wiki.content
-            .parse(unicode(html))
+            .parse(html)
             .filter(WhitespaceRemovalFilter)
             .serialize(alphabetical_attributes=True))
 

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -748,8 +748,8 @@ FILTERIFRAME_REJECTED = {
 }
 
 
-@pytest.mark.parametrize('url', FILTERIFRAME_ACCEPTED.values(),
-                         ids=FILTERIFRAME_ACCEPTED.keys())
+@pytest.mark.parametrize('url', list(FILTERIFRAME_ACCEPTED.values()),
+                         ids=list(FILTERIFRAME_ACCEPTED))
 def test_filteriframe_default_accepted(url):
     doc_src = '<iframe id="test" src="%s"></iframe>' % url
     pattern = settings.CONSTANCE_CONFIG['KUMA_WIKI_IFRAME_ALLOWED_HOSTS'][0]
@@ -758,8 +758,8 @@ def test_filteriframe_default_accepted(url):
     assert page('#test').attr('src') == url
 
 
-@pytest.mark.parametrize('url', FILTERIFRAME_REJECTED.values(),
-                         ids=FILTERIFRAME_REJECTED.keys())
+@pytest.mark.parametrize('url', list(FILTERIFRAME_REJECTED.values()),
+                         ids=list(FILTERIFRAME_REJECTED))
 def test_filteriframe_default_rejected(url):
     doc_src = '<iframe id="test" src="%s"></iframe>' % url
     pattern = settings.CONSTANCE_CONFIG['KUMA_WIKI_IFRAME_ALLOWED_HOSTS'][0]
@@ -770,10 +770,9 @@ def test_filteriframe_default_rejected(url):
 
 BLEACH_INVALID_HREFS = {
     'b64_script1': ('data:text/html;base64,' +
-                    b64encode('<script>alert("document.cookie:" +'
-                              ' document.cookie);')),
+                    b64encode(b'<script>alert("document.cookie:" + document.cookie);').decode('utf-8')),
     'b64_script2': ('data:text/html;base64,' +
-                    b64encode('<script>alert(document.domain)</script>')),
+                    b64encode(b'<script>alert(document.domain)</script>').decode('utf-8')),
     'javascript': 'javascript:alert(1)',
     'js_htmlref1': 'javas&#x09;cript:alert(1)',
     'js_htmlref2': '&#14;javascript:alert(1)',
@@ -786,8 +785,8 @@ BLEACH_VALID_HREFS = {
 }
 
 
-@pytest.mark.parametrize('href', BLEACH_INVALID_HREFS.values(),
-                         ids=BLEACH_INVALID_HREFS.keys())
+@pytest.mark.parametrize('href', list(BLEACH_INVALID_HREFS.values()),
+                         ids=list(BLEACH_INVALID_HREFS))
 def test_bleach_clean_removes_invalid_hrefs(href):
     """Bleach removes invalid hrefs."""
     html = '<p><a id="test" href="%s">click me</a></p>' % href
@@ -799,8 +798,8 @@ def test_bleach_clean_removes_invalid_hrefs(href):
     assert link.attr('href') is None
 
 
-@pytest.mark.parametrize('href', BLEACH_VALID_HREFS.values(),
-                         ids=BLEACH_VALID_HREFS.keys())
+@pytest.mark.parametrize('href', list(BLEACH_VALID_HREFS.values()),
+                         ids=list(BLEACH_VALID_HREFS))
 def test_bleach_clean_hrefs(href):
     """Bleach retains valid hrefs."""
     html = '<p><a id="test" href="%s">click me</a></p>' % href
@@ -1300,21 +1299,21 @@ def test_extractor_section(root_doc, annotate_links):
     assert normalize_html(result) == normalize_html(expected)
 
 
-@pytest.mark.parametrize('wrapper', SUMMARY_PLUS_SEO_WRAPPERS.values(),
-                         ids=SUMMARY_PLUS_SEO_WRAPPERS.keys())
-@pytest.mark.parametrize('markup, text', SUMMARY_CONTENT.values(),
-                         ids=SUMMARY_CONTENT.keys())
+@pytest.mark.parametrize('wrapper', list(SUMMARY_PLUS_SEO_WRAPPERS.values()),
+                         ids=list(SUMMARY_PLUS_SEO_WRAPPERS))
+@pytest.mark.parametrize('markup, text', list(SUMMARY_CONTENT.values()),
+                         ids=list(SUMMARY_CONTENT))
 def test_summary_section(markup, text, wrapper):
     content = wrapper.format(markup)
     assert get_seo_description(content, 'en-US') == text
     assert normalize_html(get_seo_description(content, 'en-US', False)) == normalize_html(markup)
 
 
-@pytest.mark.parametrize('wrapper', SUMMARY_WRAPPERS.values(),
-                         ids=SUMMARY_WRAPPERS.keys())
+@pytest.mark.parametrize('wrapper', list(SUMMARY_WRAPPERS.values()),
+                         ids=list(SUMMARY_WRAPPERS))
 @pytest.mark.parametrize('markup, expected_markup, text',
-                         SUMMARIES_SEO_CONTENT.values(),
-                         ids=SUMMARIES_SEO_CONTENT.keys())
+                         list(SUMMARIES_SEO_CONTENT.values()),
+                         ids=list(SUMMARIES_SEO_CONTENT))
 def test_multiple_seo_summaries(markup, expected_markup, text, wrapper):
     content = wrapper.format(markup)
     assert get_seo_description(content, 'en-US') == text

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from base64 import b64encode
-from urlparse import urljoin
 
 import bleach
 import pytest
 from django.conf import settings
 from django.test import TestCase
+from django.utils.six.moves.urllib.parse import urljoin
 from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
 

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 import base64
 import json
-from urlparse import urljoin
 
 import mock
 import pytest
+from django.utils.six.moves.urllib.parse import urljoin
 from elasticsearch import TransportError
 from elasticsearch_dsl.connections import connections
 

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -52,7 +52,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(r.document.get_absolute_url())
         assert 200 == response.status_code
         doc = pq(response.content)
-        assert doc('main#content div.document-head h1').text() == r.document.title
+        assert doc('main#content div.document-head h1').text() == str(r.document.title)
         assert doc('article#wikiArticle').text() == r.document.html
 
     @pytest.mark.breadcrumbs
@@ -99,7 +99,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(r.document.get_absolute_url())
         assert 200 == response.status_code
         doc = pq(response.content)
-        assert doc('main#content div.document-head h1').text() == r.document.title
+        assert doc('main#content div.document-head h1').text() == str(r.document.title)
         assert ("This article doesn't have approved content yet." ==
                 doc('article#wikiArticle').text())
 
@@ -112,7 +112,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(d2.get_absolute_url())
         assert 200 == response.status_code
         doc = pq(response.content)
-        assert doc('main#content div.document-head h1').text() == d2.title
+        assert doc('main#content div.document-head h1').text() == str(d2.title)
         # HACK: fr doc has different message if locale/ is updated
         assert (("This article doesn't have approved content yet." in
                  doc('article#wikiArticle').text()) or
@@ -130,7 +130,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         assert response.status_code == 200
         assert_shared_cache_header(response)
         doc = pq(response.content)
-        assert doc('main#content div.document-head h1').text() == d2.title
+        assert doc('main#content div.document-head h1').text() == str(d2.title)
 
         # Fallback message is shown.
         assert len(doc('#doc-pending-fallback')) == 1
@@ -151,7 +151,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         assert_shared_cache_header(response)
         doc = pq(response.content)
         assert (doc('main#content div.document-head h1').text() ==
-                r.document.title)
+                str(r.document.title))
 
         # Fallback message is shown.
         assert len(doc('#doc-pending-fallback')) == 1
@@ -290,7 +290,7 @@ class DocumentTests(UserTestCase, WikiTestCase):
         assert response.status_code == 200
         doc = pq(response.content)
         doc_title = doc('main#content div.document-head h1').text()
-        assert doc_title == r.document.title
+        assert doc_title == str(r.document.title)
         assert doc('article#wikiArticle').text() == r.document.html
         metas = doc("meta[name='robots']")
         assert len(metas) == 1

--- a/kuma/wiki/tests/test_utils.py
+++ b/kuma/wiki/tests/test_utils.py
@@ -174,10 +174,8 @@ class AnalyticsUpageviewsTests(KumaTestCase):
         ])
         mock_creds.authorize.return_value = sequence
 
-        results = analytics_upageviews([1068728L, 1074760L], self.start_date)
+        results = analytics_upageviews([1068728, 1074760], self.start_date)
 
-        # Check that the last request's parameters contain a
-        # representation of the ids as ints, not longs (i.e. without the L)
         args, kwargs = sequence.request_calls[-1]
         self.assertIn('["1068728", "1074760"]', kwargs['body'])
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import datetime
-import HTMLParser
 import json
 
 import mock
@@ -11,6 +10,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.template.loader import render_to_string
+from django.utils.six.moves import html_parser
 from django.utils.six.moves.urllib.parse import parse_qs, urlencode, urlparse
 from pyquery import PyQuery as pq
 from waffle.testutils import override_flag, override_switch
@@ -1634,7 +1634,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
             # Add an some extra characters to the end, since the unescaped length
             # is a little less than the escaped length
             end_of_error = start_of_error + len(midair_collission_error) + 20
-            location_of_error = HTMLParser.HTMLParser().unescape(
+            location_of_error = html_parser.HTMLParser().unescape(
                 resp.content[start_of_error: end_of_error]
             )
         assert midair_collission_error in location_of_error

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -2120,7 +2120,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         self.assertEquals(1, len(mail.outbox))
         message = mail.outbox[0]
         assert testuser2.email in message.to
-        assert rev.document.title in message.body
+        assert str(rev.document.title) in message.body
         assert 'sub-articles' not in message.body
         # Test that the compare URL points to the right revisions
         rev = Document.objects.get(pk=rev.document_id).current_revision

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -130,8 +130,8 @@ def test_create_valid(add_doc_client):
 @pytest.mark.review_tags
 @pytest.mark.parametrize(
     'slug',
-    SLUG_SIMPLE_CASES.values() + SLUG_RESERVED_CASES.values(),
-    ids=SLUG_SIMPLE_CASES.keys() + SLUG_RESERVED_CASES.keys())
+    list(SLUG_SIMPLE_CASES.values()) + list(SLUG_RESERVED_CASES.values()),
+    ids=list(SLUG_SIMPLE_CASES) + list(SLUG_RESERVED_CASES))
 def test_create_invalid(add_doc_client, slug):
     """Test creating a new document with valid and invalid slugs."""
     data = dict(
@@ -198,8 +198,8 @@ def test_create_child_valid(root_doc, add_doc_client, slug):
 @pytest.mark.review_tags
 @pytest.mark.parametrize(
     'slug',
-    SLUG_SIMPLE_CASES.values(),
-    ids=SLUG_SIMPLE_CASES.keys())
+    list(SLUG_SIMPLE_CASES.values()),
+    ids=list(SLUG_SIMPLE_CASES))
 def test_create_child_invalid(root_doc, add_doc_client, slug):
     """Test creating a new child document with valid and invalid slugs."""
     data = dict(

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -6,14 +6,13 @@ Legacy tests are in test_views.py.
 import base64
 import json
 from collections import namedtuple
-from urllib import quote
 
 import mock
 import pytest
 import requests_mock
 from django.test.client import BOUNDARY, encode_multipart, MULTIPART_CONTENT
 from django.utils.http import quote_etag
-from django.utils.six.moves.urllib.parse import urlparse
+from django.utils.six.moves.urllib.parse import quote, urlparse
 from pyquery import PyQuery as pq
 from waffle.testutils import override_switch
 

--- a/kuma/wiki/tests/test_views_misc.py
+++ b/kuma/wiki/tests/test_views_misc.py
@@ -1,7 +1,7 @@
 import json
-from urllib import urlencode
 
 import pytest
+from django.utils.six.moves.urllib.parse import urlencode
 from waffle.testutils import override_switch
 
 from kuma.core.tests import assert_shared_cache_header

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -1,8 +1,4 @@
 # -*- coding: utf-8 -*-
-try:
-    from cStringIO import cStringIO as StringIO
-except ImportError:
-    from StringIO import StringIO
 import json
 
 import newrelic.agent
@@ -16,6 +12,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.cache import add_never_cache_headers, patch_vary_headers
 from django.utils.http import parse_etags, quote_etag
 from django.utils.safestring import mark_safe
+from django.utils.six import StringIO
 from django.utils.translation import ugettext
 from django.views.decorators.cache import never_cache
 from django.views.decorators.csrf import csrf_exempt

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from urllib import urlencode
 
 import newrelic.agent
 from django.conf import settings
@@ -7,6 +6,7 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
+from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.translation import ugettext
 from django.views.decorators.cache import never_cache
 from django.views.decorators.clickjacking import xframe_options_sameorigin

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -1,11 +1,10 @@
 # -*- coding: utf-8 -*-
-from urllib import urlencode
-
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
+from django.utils.six.moves.urllib.parse import urlencode
 from django.utils.translation import ugettext_lazy as _
 from django.views.decorators.cache import never_cache
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,19 @@ passenv =
     DJANGO_SETTINGS_MODULE
     PIPELINE_*
 
+[testenv:pytest3]
+basepython = python3.6
+whitelist_externals = make
+deps =
+    -rrequirements/dev.txt
+commands =
+    make compilejsi18n collectstatic clean
+    pytest --cov=kuma --maxfail=10 kuma
+passenv =
+    DATABASE_URL
+    DJANGO_SETTINGS_MODULE
+    PIPELINE_*
+
 [testenv:flake8]
 basepython = python2.7
 deps = flake8


### PR DESCRIPTION
Move a step closer to run the tests on Python 3.

This PR rewrite the minimal necessary code to allow `pytest` to properly collect all the tests before running them.

## Yet to be done:
<strike>- There is one error left that I don't manage to fix at this stage.</strike>

## Actions that needs to be taken before merging:
- Merge PR #4870 or cherry-pick those changes to a branch based on master.

## Notes:
- This PR is based on #4870 (which removes a blocker for the migration to Python 3).
- `make lint` returns errors due to code no longer compatible with Python 3.
- `django.utils.six` is used for the compatibility layer as suggested by @jwhitlock on IRC.