### PR TITLE
bug 1474435: "Publish & keep editing" button taller than the others

### DIFF
--- a/kuma/static/styles/base/elements/forms.scss
+++ b/kuma/static/styles/base/elements/forms.scss
@@ -88,6 +88,7 @@ input[type='button'] {
     }
 
     &.positive {
+        min-height: 32px;
         border-color: $green;
         color: $green-dark;
     }


### PR DESCRIPTION
The publish and keep editing button in the editing section looks taller than Publish button hence adding a min height to Publish button fixes this issue.