### PR TITLE
bug 1445641, bug 1464892: enable deployment recording

### DIFF
--- a/Jenkinsfiles/push.groovy
+++ b/Jenkinsfiles/push.groovy
@@ -15,11 +15,16 @@ stage("Prepare Infra") {
 
 stage('Push') {
     dir('infra/apps/mdn/mdn-aws/k8s') {
-        // Run the database migrations.
-        utils.migrate_db()
-        // Start a rolling update of the Kuma-based deployments.
-        utils.rollout()
-        // Monitor the rollout until it has completed.
-        utils.monitor_rollout()
+        def current_revision_hash = utils.get_revision_hash()
+        withEnv(["FROM_REVISION_HASH=${current_revision_hash}"]) {
+            // Run the database migrations.
+            utils.migrate_db()
+            // Start a rolling update of the Kuma-based deployments.
+            utils.rollout()
+            // Monitor the rollout until it has completed.
+            utils.monitor_rollout()
+            // Record the rollout in external services like New-Relic.
+            utils.record_rollout()
+        }
     }
 }

--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -110,6 +110,19 @@ def sh_with_notify(cmd, display, notify_on_success=false) {
     }
 }
 
+def get_revision_hash() {
+    def region = get_region()
+    def target = get_target_script()
+    def repo_name = get_repo_name()
+    return sh(
+        returnStdout: true,
+        script: """
+            . regions/${region}/${target}.sh >/dev/null
+            make k8s-get-${repo_name}-revision-hash
+        """
+    ).trim()
+}
+
 def ensure_pull() {
     /*
      * This can be used to avoid deploying images to Kubernetes that don't
@@ -175,6 +188,14 @@ def monitor_rollout() {
      */
     def repo = get_repo_name()
     make("k8s-${repo}-rollout-status", 'Check Rollout Status')
+}
+
+def record_rollout() {
+    /*
+     * Record the rollout in external services like New Relic and SpeedCurve.
+     */
+    def repo = get_repo_name()
+    make("k8s-${repo}-record-deployment-job", 'Record Rollout')
 }
 
 def announce_push() {


### PR DESCRIPTION
This PR depends on the infrastructure pieces added by mdn/infra#16, using them to create two new `utils` functions (`get_revision_hash` and `record_rollout`) for use by the `Kuma` and `Kumascript` push pipelines, and also updates the `push.groovy` file to use those `utils` functions to record deployments for the `Kuma` push pipeline.