### PR TITLE
bug 1464093: Upgrade to ElasticSearch 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma
         - DJANGO_SETTINGS_MODULE=kuma.settings.travis
         - DOCKER_COMPOSE_VERSION=1.9.0
-        - ES_VERSION=2.4.5
-        - ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/2.4.5/elasticsearch-2.4.5.tar.gz
+        - ES_VERSION=5.6.10
+        - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz
         - PIPELINE_CLEANCSS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/cleancss
         - PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor
         - PIPELINE_JS_COMPRESSOR=pipeline.compressors.uglifyjs.UglifyJSCompressor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,6 +82,7 @@ services:
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
     volumes:
       - esdata:/usr/share/elasticsearch/data
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,12 @@ services:
       - mysqlvolume:/var/lib/mysql
 
   elasticsearch:
-    image: elasticsearch:2.4
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.10
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+    volumes:
+      - esdata:/usr/share/elasticsearch/data
 
   redis:
     image: redis
@@ -109,3 +114,5 @@ services:
       - ./kumascript:/app
 volumes:
     mysqlvolume:
+    esdata:
+      driver: local

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -124,11 +124,11 @@ class SearchQueryBackend(BaseFilterBackend):
         return queryset
 
 
-class AdvancedSearchQueryBackend(BaseFilterBackend):
+class KeywordQueryBackend(BaseFilterBackend):
     """
     A django-rest-framework filter backend that filters the given queryset
-    based on additional query parameters that correspond to advanced search
-    indexes.
+    based on additional query parameters that correspond to case-insensitive
+    keywords.
     """
     fields = (
         'kumascript_macros',
@@ -161,10 +161,10 @@ class AdvancedSearchQueryBackend(BaseFilterBackend):
         return queryset
 
 
-class DatabaseFilterBackend(BaseFilterBackend):
+class TagGroupFilterBackend(BaseFilterBackend):
     """
     A django-rest-framework filter backend that filters the given
-    queryset based on the filters stored in the database.
+    queryset based on named tag groups.
 
     If there are more than one tag attached to the filter it will
     use the filter's operator to determine which logical operation to

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -96,10 +96,10 @@ class SearchQueryBackend(BaseFilterBackend):
     """
     search_operations = [
         # (<query type>, <field>, <boost factor>)
-        ('match', 'title', 6.0),
+        ('match', 'title', 7.2),
         ('match', 'summary', 2.0),
         ('match', 'content', 1.0),
-        ('match_phrase', 'title', 10.0),
+        ('match_phrase', 'title', 12.0),
         ('match_phrase', 'content', 8.0),
     ]
 

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -145,10 +145,10 @@ class AdvancedSearchQueryBackend(BaseFilterBackend):
                 continue
 
             queries.append(
-                Q('match', **{field: {'query': search_param,
+                Q('match', **{field: {'query': search_param.lower(),
                                       'boost': 10.0}}))
             queries.append(
-                Q('prefix', **{field: {'value': search_param,
+                Q('prefix', **{field: {'value': search_param.lower(),
                                        'boost': 5.0}}))
 
         if queries:

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -219,13 +219,13 @@ def test_search_query_backend(rf, mock_search):
                     'bool': {
                         'should': [
                             {'match': {'title': {
-                                'boost': 6.0, 'query': 'article'}}},
+                                'boost': 7.2, 'query': 'article'}}},
                             {'match': {'summary': {
                                 'boost': 2.0, 'query': 'article'}}},
                             {'match': {'content': {
                                 'boost': 1.0, 'query': 'article'}}},
                             {'match_phrase': {'title': {
-                                'boost': 10.0, 'query': 'article'}}},
+                                'boost': 12.0, 'query': 'article'}}},
                             {'match_phrase': {'content': {
                                 'boost': 8.0, 'query': 'article'}}},
                         ]

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -10,9 +10,9 @@ from kuma.wiki.search import WikiDocumentType
 from kuma.wiki.signals import render_done
 
 from . import ElasticTestCase
-from ..filters import (AdvancedSearchQueryBackend, DatabaseFilterBackend,
-                       get_filters, HighlightFilterBackend,
-                       LanguageFilterBackend, SearchQueryBackend)
+from ..filters import (get_filters, HighlightFilterBackend,
+                       KeywordQueryBackend, LanguageFilterBackend,
+                       SearchQueryBackend, TagGroupFilterBackend)
 from ..models import FilterGroup
 from ..views import SearchView
 
@@ -119,7 +119,7 @@ def fake_view(request, selected_filters=None):
     view = mock.Mock()
     view.query_params = request.GET
     if selected_filters is not None:
-        # DatabaseFilterBackend tests require these
+        # TagGroupFilterBackend tests require these
         view.serialized_filters = SERIALIZED_FILTERS
         view.selected_filters = selected_filters
     return view
@@ -260,9 +260,9 @@ def test_search_query_backend_as_admin(rf, mock_search, admin_user):
                          ('kumascript_macros',
                           'css_classnames',
                           'html_attributes',))
-def test_advanced_search_query(rf, mock_search, param):
-    '''The AdvancedSearchQueryBackend searches keywords.'''
-    backend = AdvancedSearchQueryBackend()
+def test_keyword_query(rf, mock_search, param):
+    '''The KeywordQueryBackend searches keywords.'''
+    backend = KeywordQueryBackend()
     request = rf.get('/en-US/search?%s=test' % param)
     search = backend.filter_queryset(request, mock_search, fake_view(request))
     expected = {
@@ -279,9 +279,9 @@ def test_advanced_search_query(rf, mock_search, param):
                          ('kumascript_macros',
                           'css_classnames',
                           'html_attributes',))
-def test_advanced_search_query_wildcard(rf, mock_search, param):
-    '''The AdvancedSearchQueryBackend can add wildcard searches.'''
-    backend = AdvancedSearchQueryBackend()
+def test_keyword_query_wildcard(rf, mock_search, param):
+    '''The KeywordQueryBackend can add wildcard searches.'''
+    backend = KeywordQueryBackend()
     request = rf.get('/en-US/search?%s=test*' % param)
     search = backend.filter_queryset(request, mock_search, fake_view(request))
     expected = {
@@ -296,17 +296,17 @@ def test_advanced_search_query_wildcard(rf, mock_search, param):
     assert search.to_dict() == expected
 
 
-def test_advanced_search_query_ignores_unknown_index(rf, mock_search):
-    '''The AdvancedSearchQueryBackend ignores an unknown parameter.'''
-    backend = AdvancedSearchQueryBackend()
+def test_keyword_query_ignores_unknown_index(rf, mock_search):
+    '''The KeywordQueryBackend ignores an unknown parameter.'''
+    backend = KeywordQueryBackend()
     request = rf.get('/en-US/search?topic=test')
     search = backend.filter_queryset(request, mock_search, fake_view(request))
     assert search.to_dict() == {'query': {'match_all': {}}}
 
 
-def test_database_filter_backend(rf, mock_search):
-    '''The DatabaseFilterBackend matches requests to database filter groups.'''
-    backend = DatabaseFilterBackend()
+def test_tag_group_filter_backend(rf, mock_search):
+    '''The TagGroupFilterBackend filters and aggregates by groups of tags.'''
+    backend = TagGroupFilterBackend()
     request = rf.get('/en-US/search?group=tagged')
     view = fake_view(request, selected_filters=['tagged'])
     search = backend.filter_queryset(request, mock_search, view)
@@ -322,9 +322,9 @@ def test_database_filter_backend(rf, mock_search):
     assert search.to_dict() == expected
 
 
-def test_database_filter_backend_multiple_tags_or_operator(rf, mock_search):
-    '''The DatabaseFilterBackend searches for any tag in the group.'''
-    backend = DatabaseFilterBackend()
+def test_tag_group_filter_backend_multiple_tags_or_operator(rf, mock_search):
+    '''The TagGroupFilterBackend searches for any tag in an OR group.'''
+    backend = TagGroupFilterBackend()
     request = rf.get('/en-US/search?topic=addons')
     view = fake_view(request, selected_filters=['addons'])
     search = backend.filter_queryset(request, mock_search, view)
@@ -342,9 +342,9 @@ def test_database_filter_backend_multiple_tags_or_operator(rf, mock_search):
     assert search.to_dict() == expected
 
 
-def test_database_filter_backend_multiple_tags_and_operator(rf, mock_search):
-    '''The DatabaseFilterBackend searches for all tags in the group.'''
-    backend = DatabaseFilterBackend()
+def test_tag_group_filter_backend_multiple_tags_and_operator(rf, mock_search):
+    '''The TagGroupFilterBackend searches for all tags in an AND group.'''
+    backend = TagGroupFilterBackend()
     request = rf.get('/en-US/search?dogs=brown-dogs')
     view = fake_view(request, selected_filters=['brown-dogs'])
     search = backend.filter_queryset(request, mock_search, view)
@@ -362,9 +362,9 @@ def test_database_filter_backend_multiple_tags_and_operator(rf, mock_search):
     assert search.to_dict() == expected
 
 
-def test_database_filter_backend_multiple_groups(rf, mock_search):
-    '''The DatabaseFilterBackend searches for multiple groups.'''
-    backend = DatabaseFilterBackend()
+def test_tag_group_filter_backend_multiple_groups(rf, mock_search):
+    '''The TagGroupFilterBackend searches for multiple groups.'''
+    backend = TagGroupFilterBackend()
     request = rf.get('/en-US/search?topic=addons,css')
     view = fake_view(request, selected_filters=['addons', 'css'])
     search = backend.filter_queryset(request, mock_search, view)
@@ -384,9 +384,9 @@ def test_database_filter_backend_multiple_groups(rf, mock_search):
     assert search.to_dict() == expected
 
 
-def test_database_filter_backend_no_groups(rf, mock_search):
-    '''The DatabaseFilterBackend still counts if no groups are selected.'''
-    backend = DatabaseFilterBackend()
+def test_tag_group_filter_backend_no_groups(rf, mock_search):
+    '''The TagGroupFilterBackend still counts if no groups are selected.'''
+    backend = TagGroupFilterBackend()
     request = rf.get('/en-US/search')
     view = fake_view(request, selected_filters=[])
     search = backend.filter_queryset(request, mock_search, view)
@@ -439,8 +439,8 @@ class FilterTexts(ElasticTestCase):
         assert 'CSS/article-title-3' == response.data['documents'][0]['slug']
         assert 'en-US' == response.data['documents'][0]['locale']
 
-    def test_advanced_search_query(self):
-        """Test advanced search query filter."""
+    def test_keyword_query(self):
+        """Test keyword query filter."""
         # Update a document so that it has a `css_classname` and trigger a
         # reindex via `render_done`.
         doc = Document.objects.get(pk=1)
@@ -450,7 +450,7 @@ class FilterTexts(ElasticTestCase):
         self.refresh()
 
         class View(SearchView):
-            filter_backends = (AdvancedSearchQueryBackend,)
+            filter_backends = (KeywordQueryBackend,)
 
         view = View.as_view()
         request = self.get_request('/en-US/search?css_classnames=eval')
@@ -513,11 +513,11 @@ class FilterTexts(ElasticTestCase):
         response = view(request)
         assert len(response.data['documents']) == response.data['count'] == 0
 
-    def test_database_filter(self):
-        class DatabaseFilterView(SearchView):
-            filter_backends = (DatabaseFilterBackend,)
+    def test_tag_group_filter(self):
+        class TagGroupFilterView(SearchView):
+            filter_backends = (TagGroupFilterBackend,)
 
-        view = DatabaseFilterView.as_view()
+        view = TagGroupFilterView.as_view()
         request = self.get_request('/en-US/search?group=tagged')
         response = view(request)
         assert len(response.data['documents']) == response.data['count'] == 2

--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -11,9 +11,9 @@ from rest_framework.renderers import JSONRenderer
 from kuma.core.decorators import shared_cache_control
 from kuma.wiki.search import WikiDocumentType
 
-from .filters import (AdvancedSearchQueryBackend, DatabaseFilterBackend,
-                      get_filters, HighlightFilterBackend,
-                      LanguageFilterBackend, SearchQueryBackend)
+from .filters import (get_filters, HighlightFilterBackend, KeywordQueryBackend,
+                      LanguageFilterBackend, SearchQueryBackend,
+                      TagGroupFilterBackend)
 from .jobs import AvailableFiltersJob
 from .pagination import SearchPagination
 from .queries import Filter, FilterGroup
@@ -34,8 +34,8 @@ class SearchView(ListAPIView):
     #: the specific search feature
     filter_backends = (
         SearchQueryBackend,
-        AdvancedSearchQueryBackend,
-        DatabaseFilterBackend,
+        KeywordQueryBackend,
+        TagGroupFilterBackend,
         LanguageFilterBackend,
         HighlightFilterBackend,
     )

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -38,7 +38,7 @@ class WikiDocumentType(document.DocType):
     kumascript_macros = field.Keyword()
     locale = field.Keyword()
     modified = field.Date()
-    parent = field.Nested(properties={
+    parent = field.Object(properties={
         'id': field.Long(),
         'title': field.Text(analyzer='kuma_title'),
         'slug': field.Keyword(),

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -49,7 +49,7 @@ class WikiDocumentType(document.DocType):
     summary = field.Text(analyzer='kuma_content',
                          term_vector='with_positions_offsets')
     tags = field.Keyword()
-    title = field.Text(analyzer='kuma_title', boost=1.2)
+    title = field.Text(analyzer='kuma_title')
 
     class Meta(object):
         mapping = Mapping('wiki_document')

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -190,10 +190,10 @@ futures==3.0.5 \
 # Code: https://github.com/elastic/elasticsearch-py
 # Changes: https://elasticsearch-py.readthedocs.io/en/master/Changelog.html
 # Docs: https://elasticsearch-py.readthedocs.io/en/master/
-elasticsearch==2.4.1 \
-    --hash=sha256:bb8f9a365ba6650d599428538c8aed42033264661d8f7d353da59d5892305f72 \
-    --hash=sha256:fead47ebfcaabd1c53dbfc21403eb99ac207eef76de8002fe11a1c8ec9589ce2
 # Extensions to datetime module
+elasticsearch==5.5.0 \
+    --hash=sha256:a9d1dabc18c2b593b1be5c85b697af2bbfb094a7d9cca21c48ac323257e3e7a0 \
+    --hash=sha256:d03379ef519dde70b3b842deb0df576520a7a4735abe1d5ec3f32f8e66899be2
 # Code: https://github.com/dateutil/dateutil/
 # Changes: https://dateutil.readthedocs.io/en/stable/changelog.html
 # Docs: https://dateutil.readthedocs.io/en/stable/

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -209,9 +209,9 @@ dj-email-url==0.0.4 \
 # Code: https://github.com/elastic/elasticsearch-dsl-py
 # Changes: https://elasticsearch-dsl.readthedocs.io/en/latest/Changelog.html
 # Docs: https://elasticsearch-dsl.readthedocs.io/en/latest/
-elasticsearch-dsl==2.2.0 \
-    --hash=sha256:99bbb4dcbcfb5db4f57499237f24acf1397543e895e99994a09af2a6fbef93bc \
-    --hash=sha256:c8132c6e1bdfc5c345999d3949dd53a53b59ea73e2ee005f695de78be0552ceb
+elasticsearch-dsl==5.4.0 \
+    --hash=sha256:197246ddd556b4b7d2738dfa9e4831068c9b5cb21706f6aca035136d42849109 \
+    --hash=sha256:cbef6467085d7debc870bc450d996c7ba5b8822eb86a6033bba09134ffb01ba8
 
 # Parse external RSS / Atom feeds
 feedparser==5.2.1 \


### PR DESCRIPTION
* Update the development environment to ElasticSearch 5.6.10, using [elastic.co's docker image](https://www.docker.elastic.co). They are deprecating [the images on dockerhub](https://hub.docker.com/_/elasticsearch/).
* Update the client libraries to the latest compatible with ES 5.6.10. Unlike the 0.x to 2.x transition, the client libraries have to be in sync with the server version, and there are several breaking changes that require simultaneous code changes. This makes me less impressed with the ElasticSearch libraries.
* ES 5 splits ``String`` into ``Text`` (tokenization and full text search) and ``Keyword`` (optimized for exact matches). I took the opportunity to move case-insensitive keyword queries into Python.
* Fix [bug 1180144](https://bugzilla.mozilla.org/show_bug.cgi?id=1180144), where searching for ``csssyntax`` returned ``{{csssyntax}}`` and ``{{csssyntax2}}``. Matches for keywords are now exact, unless a wildcard ``*`` or ``?`` is added.

**Update**: PR #4905 and PR #4906 are merged, so this is ready for review.