### PR TITLE
bug 1464093: Prepare for ElasticSearch 2 client libraries

### DIFF
--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -20,3 +20,13 @@
 # See https://github.com/mdn/interactive-examples/
 # Constance KUMA_WIKI_IFRAME_ALLOWED_HOSTS will need to allow this iframe src
 #INTERACTIVE_EXAMPLES_BASE=http://localhost:8080
+
+# Set the level of the ElasticSearch logger in Kuma
+#ES_LOG_LEVEL=ERROR    # Default, never logs
+#ES_LOG_LEVEL=WARNING  # Logs HTTP method and path of ElasticSearch requests
+#ES_LOG_LEVEL=DEBUG    # Logs the body (usually JSON) of the ES requests and responses
+
+# Set the level of the ElasticSearch trace logging in Kuma
+# ES_TRACE_LOG_LEVEL=ERROR   # Default, never logs
+# ES_TRACE_LOG_LEVEL=INFO    # Logs pretty-printed curl variant of the request
+# ES_TRACE_LOG_LEVEL=DEBUG   # Logs pretty-printed JSON response

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -175,6 +175,9 @@ class DatabaseFilterBackend(BaseFilterBackend):
 
         for serialized_filter in view.serialized_filters:
             filter_tags = serialized_filter['tags']
+            if not filter_tags:
+                # Incomplete filter has no tags, skip it
+                continue
             filter_operator = Filter.OPERATORS[serialized_filter['operator']]
             if serialized_filter['slug'] in view.selected_filters:
                 if len(filter_tags) > 1:
@@ -188,10 +191,8 @@ class DatabaseFilterBackend(BaseFilterBackend):
             if len(filter_tags) > 1:
                 facet_params = F('terms', tags=list(filter_tags))
             else:
-                if filter_tags:
-                    facet_params = F('term', tags=filter_tags[0])
-            if len(filter_tags):
-                active_facets.append((serialized_filter['slug'], facet_params))
+                facet_params = F('term', tags=filter_tags[0])
+            active_facets.append((serialized_filter['slug'], facet_params))
 
         if active_filters:
             if len(active_filters) == 1:

--- a/kuma/search/filters.py
+++ b/kuma/search/filters.py
@@ -178,31 +178,39 @@ class DatabaseFilterBackend(BaseFilterBackend):
             if not filter_tags:
                 # Incomplete filter has no tags, skip it
                 continue
-            filter_operator = Filter.OPERATORS[serialized_filter['operator']]
-            if serialized_filter['slug'] in view.selected_filters:
-                if len(filter_tags) > 1:
-                    tag_filters = []
-                    for filter_tag in filter_tags:
-                        tag_filters.append(F('term', tags=filter_tag))
-                    active_filters.append(F(filter_operator, tag_filters))
-                else:
-                    active_filters.append(F('term', tags=filter_tags[0]))
 
+            if serialized_filter['slug'] in view.selected_filters:
+                # User selected this filter - filter on the associated tags
+                tag_filters = []
+                for filter_tag in filter_tags:
+                    tag_filters.append(F('term', tags=filter_tag))
+
+                filter_operator = Filter.OPERATORS[serialized_filter['operator']]
+                if len(tag_filters) > 1 and filter_operator == 'and':
+                    # Add an AND filter as a subclause
+                    active_filters.append(F('and', tag_filters))
+                else:
+                    # Extend list of tags for the OR clause
+                    active_filters.extend(tag_filters)
+
+            # Aggregate counts for active filters for sidebar
             if len(filter_tags) > 1:
                 facet_params = F('terms', tags=list(filter_tags))
             else:
                 facet_params = F('term', tags=filter_tags[0])
             active_facets.append((serialized_filter['slug'], facet_params))
 
+        # Count documents across all tags
+        for facet_slug, facet_params in active_facets:
+            queryset.aggs.bucket(facet_slug, 'filter',
+                                 **facet_params.to_dict())
+
+        # Filter by tag only after counting documents across all tags
         if active_filters:
             if len(active_filters) == 1:
                 queryset = queryset.post_filter(active_filters[0])
             else:
                 queryset = queryset.post_filter(F('or', active_filters))
-
-        for facet_slug, facet_params in active_facets:
-            queryset.aggs.bucket(facet_slug, 'filter',
-                                 **facet_params.to_dict())
 
         return queryset
 

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -1,6 +1,12 @@
+import mock
+import pytest
+from django.contrib.auth.models import AnonymousUser
 from django.http import QueryDict
+from elasticsearch import Elasticsearch
+from elasticsearch_dsl.serializer import serializer as es_dsl_serializer
 
 from kuma.wiki.models import Document
+from kuma.wiki.search import WikiDocumentType
 from kuma.wiki.signals import render_done
 
 from . import ElasticTestCase
@@ -11,7 +17,396 @@ from ..models import FilterGroup
 from ..views import SearchView
 
 
-class FilterTests(ElasticTestCase):
+class MockTransport(object):
+    '''
+    A fake ElasticSearch transport object, avoiding network calls.
+
+    Based on DummyTransport from elasticsearch:
+    https://github.com/elastic/elasticsearch-py/blob/master/test_elasticsearch/test_cases.py
+    '''
+
+    def __init__(self, hosts, responses=None, *args, **kwargs):
+        self.args, self.kwargs = args, kwargs
+        self.responses = responses or []
+        self.call_count = 0
+        self.calls = []
+
+    def perform_request(self, method, url, params=None, body=None):
+        resp = 200, {}
+        if self.responses:
+            resp = self.responses[self.call_count]
+        self.call_count += 1
+        self.calls.append((method, url, params, body))
+        return resp
+
+
+@pytest.fixture
+def mock_elasticsearch():
+    '''Create an Elasticsearch object that won't make network requests.'''
+    return Elasticsearch(transport_class=MockTransport,
+                         serializer=es_dsl_serializer)
+
+
+@pytest.fixture
+def mock_search(mock_elasticsearch):
+    '''Mock WikiDocumentType.search() for a fake Elasticsearch and index.'''
+    patcher_get_conn = mock.patch(
+        'kuma.wiki.search.connections.get_connection',
+        return_value=mock_elasticsearch)
+    patcher_get_index = mock.patch(
+        'kuma.wiki.search.WikiDocumentType.get_index',
+        return_value='mdn-test')
+    patcher_get_conn.start()
+    patcher_get_index.start()
+    yield WikiDocumentType.search()
+    patcher_get_index.stop()
+    patcher_get_conn.stop()
+
+
+# Testing version of named groups of tags for filtering
+# This is serialized from the database in .views.SearchView.initial
+FILTER_GROUP_GROUP = {'name': 'Group', 'slug': 'group', 'order': 1}
+FILTER_GROUP_TOPIC = {'name': 'Topics', 'slug': 'topic', 'order': 1}
+FILTER_GROUP_DOGS = {'name': 'Dogs', 'slug': 'dogs', 'order': 1}
+SERIALIZED_FILTERS = [
+    {
+        # Test data from fixtures/search/filters.json
+        'group': FILTER_GROUP_GROUP,
+        'name': 'Tagged',
+        'operator': 'OR',
+        'shortcut': None,
+        'slug': 'tagged',
+        'tags': ['tagged']
+    }, {
+        # Topic CSS
+        'group': FILTER_GROUP_TOPIC,
+        'name': 'CSS',
+        'operator': 'OR',
+        'shortcut': None,
+        'slug': 'css',
+        'tags': ['CSS']
+    }, {
+        # Topic Add-ons & Extensions
+        'group': FILTER_GROUP_TOPIC,
+        'name': 'Add-ons & Extensions',
+        'operator': 'OR',
+        'shortcut': None,
+        'slug': 'addons',
+        'tags': ['Add-ons', 'Extensions']
+    }, {
+        # A FilterGroup with no tags (yet? to be deleted?)
+        'group': FILTER_GROUP_DOGS,
+        'name': 'Bad Dogs',
+        'operator': 'OR',
+        'shortcut': None,
+        'slug': 'baddogs',
+        'tags': []
+    }, {
+        # A FilterGroup with an 'AND' combination of two terms
+        # TODO: This isn't used in production, disallow AND
+        'group': FILTER_GROUP_DOGS,
+        'name': 'Brown Dogs',
+        'operator': 'AND',
+        'shortcut': None,
+        'slug': 'brown-dogs',
+        'tags': ['Brown', 'Dog']
+    }
+]
+
+
+def fake_view(request, selected_filters=None):
+    '''A fake django-rest-framework view with query_params.'''
+    view = mock.Mock()
+    view.query_params = request.GET
+    if selected_filters is not None:
+        # DatabaseFilterBackend tests require these
+        view.serialized_filters = SERIALIZED_FILTERS
+        view.selected_filters = selected_filters
+    return view
+
+
+def test_base_search(db):
+    '''WikiDocumentType.search() searches all documents by default.'''
+    search = WikiDocumentType.search()
+    expected = {
+        'query': {
+            'match_all': {}
+        }
+    }
+    assert search.to_dict() == expected
+
+
+def test_base_search_mocked_es(mock_search):
+    '''Mocked WikiDocumentType.search() returns same search query.'''
+    expected = {
+        'query': {
+            'match_all': {}
+        }
+    }
+    assert mock_search.to_dict() == expected
+
+
+def test_language_filter_backend_fr(rf, mock_search):
+    '''The LanguageFilterBackend gets en-US and fr docs, prefers fr.'''
+    backend = LanguageFilterBackend()
+    request = rf.get('/fr/search?q=article')
+    request.LANGUAGE_CODE = 'fr'
+    search = backend.filter_queryset(request, mock_search, None)
+    expected = {
+        'query': {
+            'boosting': {
+                'negative': {
+                    'bool': {'must_not': [{'term': {'locale': 'fr'}}]}
+                },
+                'negative_boost': 0.5,
+                'positive': {
+                    'filtered': {
+                        'filter': {'terms': {'locale': ['fr', 'en-US']}},
+                        'query': {'match_all': {}}
+                    }
+                }
+            }
+        }
+    }
+    assert search.to_dict() == expected
+
+
+def test_language_filter_backend_en_US(rf, mock_search):
+    '''The LanguageFilterBackend can search for en-US-only docs.'''
+    backend = LanguageFilterBackend()
+    request = rf.get('/en-US/search?q=article')
+    request.LANGUAGE_CODE = 'en-US'
+    search = backend.filter_queryset(request, mock_search, None)
+    expected = {
+        'query': {
+            'boosting': {
+                'negative': {
+                    'bool': {'must_not': [{'term': {'locale': 'en-US'}}]}
+                },
+                'negative_boost': 0.5,
+                'positive': {
+                    'filtered': {
+                        'filter': {'terms': {'locale': ['en-US']}},
+                        'query': {'match_all': {}}
+                    }
+                }
+            }
+        }
+    }
+    assert search.to_dict() == expected
+
+
+def test_language_filter_backend_all(rf, mock_search):
+    '''The LanguageFilterBackend treats '*' as all locales.'''
+    backend = LanguageFilterBackend()
+    request = rf.get('/en-US/search?q=article&locale=*')
+    request.LANGUAGE_CODE = 'en-US'
+    search = backend.filter_queryset(request, mock_search, None)
+    assert search.to_dict() == {'query': {'match_all': {}}}
+
+
+def test_search_query_backend(rf, mock_search):
+    '''The SearchQueryBackend matches several fields against the query.'''
+    backend = SearchQueryBackend()
+    request = rf.get('/en-US/search?q=article')
+    request.user = AnonymousUser()
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    expected = {
+        'query': {
+            'function_score': {
+                'functions': [{'field_value_factor': {'field': 'boost'}}],
+                'query': {
+                    'bool': {
+                        'should': [
+                            {'match': {'title': {
+                                'boost': 6.0, 'query': 'article'}}},
+                            {'match': {'summary': {
+                                'boost': 2.0, 'query': 'article'}}},
+                            {'match': {'content': {
+                                'boost': 1.0, 'query': 'article'}}},
+                            {'match_phrase': {'title': {
+                                'boost': 10.0, 'query': 'article'}}},
+                            {'match_phrase': {'content': {
+                                'boost': 8.0, 'query': 'article'}}},
+                        ]
+                    }
+                }
+            }
+        }
+    }
+    assert search.to_dict() == expected
+
+
+def test_search_query_backend_empty(rf, mock_search):
+    '''The SearchQueryBackend doesn't filter an empty query.'''
+    backend = SearchQueryBackend()
+    request = rf.get('/en-US/search?q=')
+    request.user = AnonymousUser()
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    assert search.to_dict() == {'query': {'match_all': {}}}
+
+
+def test_search_query_backend_as_admin(rf, mock_search, admin_user):
+    '''The SearchQueryBackend adds explain=True for superusers.'''
+    backend = SearchQueryBackend()
+    request = rf.get('/en-US/search?q=')
+    request.user = admin_user
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    assert search.to_dict() == {'explain': True,
+                                'query': {'match_all': {}}}
+
+
+@pytest.mark.parametrize('param',
+                         ('kumascript_macros',
+                          'css_classnames',
+                          'html_attributes',))
+def test_advanced_search_query(rf, mock_search, param):
+    '''The AdvancedSearchQueryBackend searches additional indexes.'''
+    backend = AdvancedSearchQueryBackend()
+    request = rf.get('/en-US/search?%s=test' % param)
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    expected = {
+        'query': {
+            'bool': {
+                'should': [
+                    {'match': {
+                        param: {'boost': 10.0, 'query': 'test'}}},
+                    {'prefix': {
+                        param: {'boost': 5.0, 'value': 'test'}}}]}}}
+    assert search.to_dict() == expected
+
+
+def test_advanced_search_query_ignores_unknown_index(rf, mock_search):
+    '''The AdvancedSearchQueryBackend ignores an unknown parameter.'''
+    backend = AdvancedSearchQueryBackend()
+    request = rf.get('/en-US/search?topic=test')
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    assert search.to_dict() == {'query': {'match_all': {}}}
+
+
+def test_database_filter_backend(rf, mock_search):
+    '''The DatabaseFilterBackend matches requests to database filter groups.'''
+    backend = DatabaseFilterBackend()
+    request = rf.get('/en-US/search?group=tagged')
+    view = fake_view(request, selected_filters=['tagged'])
+    search = backend.filter_queryset(request, mock_search, view)
+    expected = {
+        'query': {'match_all': {}},
+        'post_filter': {'term': {'tags': 'tagged'}},
+        'aggs': {
+            'addons': {'filter': {'terms': {'tags': ['Add-ons',
+                                                     'Extensions']}}},
+            'css': {'filter': {'term': {'tags': 'CSS'}}},
+            'brown-dogs': {'filter': {'terms': {'tags': ['Brown', 'Dog']}}},
+            'tagged': {'filter': {'term': {'tags': 'tagged'}}}}}
+    assert search.to_dict() == expected
+
+
+def test_database_filter_backend_multiple_tags_or_operator(rf, mock_search):
+    '''The DatabaseFilterBackend searches for any tag in the group.'''
+    backend = DatabaseFilterBackend()
+    request = rf.get('/en-US/search?topic=addons')
+    view = fake_view(request, selected_filters=['addons'])
+    search = backend.filter_queryset(request, mock_search, view)
+    expected = {
+        'query': {'match_all': {}},
+        'post_filter': {'or': {'filters': [
+            {'term': {'tags': 'Add-ons'}},
+            {'term': {'tags': 'Extensions'}}]}},
+        'aggs': {
+            'addons': {'filter': {'terms': {'tags': ['Add-ons',
+                                                     'Extensions']}}},
+            'css': {'filter': {'term': {'tags': 'CSS'}}},
+            'brown-dogs': {'filter': {'terms': {'tags': ['Brown', 'Dog']}}},
+            'tagged': {'filter': {'term': {'tags': 'tagged'}}}}}
+    assert search.to_dict() == expected
+
+
+def test_database_filter_backend_multiple_tags_and_operator(rf, mock_search):
+    '''The DatabaseFilterBackend searches for all tags in the group.'''
+    backend = DatabaseFilterBackend()
+    request = rf.get('/en-US/search?dogs=brown-dogs')
+    view = fake_view(request, selected_filters=['brown-dogs'])
+    search = backend.filter_queryset(request, mock_search, view)
+    expected = {
+        'query': {'match_all': {}},
+        'post_filter': {'and': {'filters': [
+            {'term': {'tags': 'Brown'}},
+            {'term': {'tags': 'Dog'}}]}},
+        'aggs': {
+            'addons': {'filter': {'terms': {'tags': ['Add-ons',
+                                                     'Extensions']}}},
+            'css': {'filter': {'term': {'tags': 'CSS'}}},
+            'brown-dogs': {'filter': {'terms': {'tags': ['Brown', 'Dog']}}},
+            'tagged': {'filter': {'term': {'tags': 'tagged'}}}}}
+    assert search.to_dict() == expected
+
+
+def test_database_filter_backend_multiple_groups(rf, mock_search):
+    '''The DatabaseFilterBackend searches for multiple groups.'''
+    backend = DatabaseFilterBackend()
+    request = rf.get('/en-US/search?topic=addons,css')
+    view = fake_view(request, selected_filters=['addons', 'css'])
+    search = backend.filter_queryset(request, mock_search, view)
+    expected = {
+        'query': {'match_all': {}},
+        'post_filter': {'or': {'filters': [
+            {'term': {'tags': 'CSS'}},
+            {'or': {'filters': [
+                {'term': {'tags': 'Add-ons'}},
+                {'term': {'tags': 'Extensions'}}
+            ]}}
+        ]}},
+        'aggs': {
+            'addons': {'filter': {'terms': {'tags': ['Add-ons',
+                                                     'Extensions']}}},
+            'css': {'filter': {'term': {'tags': 'CSS'}}},
+            'brown-dogs': {'filter': {'terms': {'tags': ['Brown', 'Dog']}}},
+            'tagged': {'filter': {'term': {'tags': 'tagged'}}}}}
+    assert search.to_dict() == expected
+
+
+def test_database_filter_backend_no_groups(rf, mock_search):
+    '''The DatabaseFilterBackend still counts if no groups are selected.'''
+    backend = DatabaseFilterBackend()
+    request = rf.get('/en-US/search')
+    view = fake_view(request, selected_filters=[])
+    search = backend.filter_queryset(request, mock_search, view)
+    expected = {
+        'query': {'match_all': {}},
+        'aggs': {
+            'addons': {'filter': {'terms': {'tags': ['Add-ons',
+                                                     'Extensions']}}},
+            'css': {'filter': {'term': {'tags': 'CSS'}}},
+            'brown-dogs': {'filter': {'terms': {'tags': ['Brown', 'Dog']}}},
+            'tagged': {'filter': {'term': {'tags': 'tagged'}}}}}
+    assert search.to_dict() == expected
+
+
+def test_highlight_filter_backend(rf, mock_search):
+    '''The HighlightFilterBackend highlights with marks.'''
+    backend = HighlightFilterBackend()
+    request = rf.get('/en-US/search?highlight=1')
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    expected = {
+        'query': {'match_all': {}},
+        'highlight': {'fields': {'content': {}, 'summary': {}},
+                      'order': 'score',
+                      'post_tags': ['</mark>'],
+                      'pre_tags': ['<mark>']}}
+    assert search.to_dict() == expected
+
+
+def test_highlight_filter_backend_no_highlight(rf, mock_search):
+    '''The HighlightFilterBackend checks that highlight is selected.'''
+    backend = HighlightFilterBackend()
+    request = rf.get('/en-US/search')
+    search = backend.filter_queryset(request, mock_search, fake_view(request))
+    assert search.to_dict() == {'query': {'match_all': {}}}
+
+
+class FilterTexts(ElasticTestCase):
+    '''Filter tests that require a database and ES server.'''
     fixtures = ElasticTestCase.fixtures + ['wiki/documents.json',
                                            'search/filters.json']
 

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -352,10 +352,8 @@ def test_database_filter_backend_multiple_groups(rf, mock_search):
         'query': {'match_all': {}},
         'post_filter': {'or': {'filters': [
             {'term': {'tags': 'CSS'}},
-            {'or': {'filters': [
-                {'term': {'tags': 'Add-ons'}},
-                {'term': {'tags': 'Extensions'}}
-            ]}}
+            {'term': {'tags': 'Add-ons'}},
+            {'term': {'tags': 'Extensions'}}
         ]}},
         'aggs': {
             'addons': {'filter': {'terms': {'tags': ['Add-ons',

--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -1,4 +1,3 @@
-import logging
 from .common import *  # noqa
 
 # Settings for Docker Development
@@ -18,7 +17,6 @@ PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = config('PIPELINE_COLLECTOR_ENABLED',
                                                 not DEBUG, cast=bool)
 TEMPLATES[1]['OPTIONS']['debug'] = DEBUG
 
-LOG_LEVEL = logging.ERROR
 PROTOCOL = config('PROTOCOL', default='https://')
 DOMAIN = config('DOMAIN', default='developer-local.allizom.org')
 SITE_URL = config('SITE_URL', default=PROTOCOL + DOMAIN)

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -12,11 +12,11 @@ from constance import config
 from django.conf import settings
 from django.contrib.sites.models import Site
 from elasticsearch import TransportError
-from elasticsearch_dsl import Search
 
 from kuma.core.cache import memcache
 
 from .constants import KUMASCRIPT_BASE_URL, KUMASCRIPT_TIMEOUT_ERROR
+from .search import WikiDocumentType
 
 
 def should_use_rendered(doc, params, html=None):
@@ -304,7 +304,7 @@ def macro_page_count(locale='*'):
     Keyword Arguments:
     locale - Filter by this locale (default no locale filter)
     """
-    search = Search().from_dict({'size': 0})  # Return no documents
+    search = WikiDocumentType.search().extra(size=0)  # Return no documents
     search.aggs.bucket('usage', 'terms', field='kumascript_macros',
                        size=0)  # Return unpaginated count of macro usage
     if locale != '*':

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -101,7 +101,7 @@ def test_macro_sources_error(mock_requests):
     assert macros == {}
 
 
-def test_macro_page_count(mock_es_client):
+def test_macro_page_count(db, mock_es_client):
     """macro_page_count returns macro usage across all locales by default."""
     mock_es_client.search.return_value = {
         '_shards': {u'failed': 0, u'successful': 2, u'total': 2},
@@ -124,12 +124,14 @@ def test_macro_page_count(mock_es_client):
             'size': 0}
         }}
     }
-    mock_es_client.search.assert_called_once_with(body=es_json, doc_type=[],
-                                                  index=None)
+    mock_es_client.search.assert_called_once_with(
+        body=es_json,
+        doc_type=['wiki_document'],
+        index=['mdn-main_index'])
     assert macros == {'a11yrolequicklinks': 200, 'othermacro': 50}
 
 
-def test_macro_page_count_en(mock_es_client):
+def test_macro_page_count_en(db, mock_es_client):
     """macro_page_count('en-US') returns macro usage in the en-US locale."""
     mock_es_client.search.return_value = {
         '_shards': {u'failed': 0, u'successful': 2, u'total': 2},
@@ -155,8 +157,10 @@ def test_macro_page_count_en(mock_es_client):
             'size': 0}
         }},
     }
-    mock_es_client.search.assert_called_once_with(body=es_json, doc_type=[],
-                                                  index=None)
+    mock_es_client.search.assert_called_once_with(
+        body=es_json,
+        doc_type=['wiki_document'],
+        index=['mdn-main_index'])
     assert macros == {'a11yrolequicklinks': 100, 'othermacro': 30}
 
 


### PR DESCRIPTION
Prepare for working on ElasticSearch updates:

* Refactor logging, which was becoming hard to follow and didn't look like [the Django docs](https://docs.djangoproject.com/en/1.11/topics/logging/). This seemed like a good idea during the 1.8 → 1.11 transition.
* Add ``ES_LOG_LEVEL`` and ``ES_TRACE_LOG_LEVEL`` environment overrides. Adding ``ES_LOG_LEVEL=DEBUG`` to my ``.env`` file allowed me to peek at requests and responses, which made it easier to cross-reference query JSON with the ElasticSearch documentation.
* Add tests that just check the query JSON generated by the filters, without talking to the database or ElasticSearch. Again, this helped with cross-referencing with the ElasticSearch documentation.
* Make some changes to the ``DatabaseFilterBackend``, to make the query JSON more sane, and prepare for the ``or`` and ``and`` queries to be removed in ES 2 and 5.  This is the filter that populates the Topic search sidebar, based on tag relations setup in the database. This should be moved from the database to code, but I decided it could be done later, once we've beaten the ES 5 deadline.
* Fix [bug 1373848](https://bugzilla.mozilla.org/show_bug.cgi?id=1373848), where the document count in the macro dashboard doesn't match the document count in search.


