### PR TITLE
Bug 1467518: First chunk of unittest fixes for Python 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ export DJANGO_SETTINGS_MODULE ?= kuma.settings.testing
 test:
 	py.test $(target)
 
+# Short test should stop after the first failure, it allows to fix test one by one for heavy test breaking
+# process such as the Python 2 to Python 3 migration
+shorttest:
+	py.test --maxfail=2 ${target}
+
 coveragetest: clean
 	py.test --cov=$(target) $(target)
 

--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,6 @@ export DJANGO_SETTINGS_MODULE ?= kuma.settings.testing
 test:
 	py.test $(target)
 
-# Short test should stop after the first failure, it allows to fix test one by one for heavy test breaking
-# process such as the Python 2 to Python 3 migration
-shorttest:
-	py.test --maxfail=2 ${target}
-
 coveragetest: clean
 	py.test --cov=$(target) $(target)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   worker: &worker
-    image: "quay.io/mozmar/kuma_base:py3"
+    image: quay.io/mozmar/kuma_base
     command: ./manage.py celery worker --loglevel=INFO --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
     user: ${UID:-1000}
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   worker: &worker
-    image: quay.io/mozmar/kuma_base
+    image: "quay.io/mozmar/kuma_base:py3"
     command: ./manage.py celery worker --loglevel=INFO --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,celery
     user: ${UID:-1000}
     volumes:

--- a/jinja2/includes/lang_switcher.html
+++ b/jinja2/includes/lang_switcher.html
@@ -2,7 +2,7 @@
 {% set default_language = settings.LOCALES[default_locale].native %}
 <form class="languages go" method="get" action="#">
   <label for="language">{{ _('Other languages:') }}</label>
-  {% for name, value in request.GET.iteritems() %}
+  {% for name, value in request.GET.items() %}
     {% if name != 'lang' %}
     <input type="hidden" name="{{ name }}" value="{{ value }}">
     {% endif %}

--- a/kuma/attachments/forms.py
+++ b/kuma/attachments/forms.py
@@ -55,7 +55,7 @@ class AttachmentRevisionForm(forms.ModelForm):
 
     def mime_type_from_file(self, file):
         m_mime = magic.Magic(mime=True)
-        mime_type = m_mime.from_buffer(file.read(1024)).split(';')[0]
+        mime_type = m_mime.from_buffer(file.read(1024)).decode('utf-8').split(';')[0]
         file.seek(0)
         return mime_type
 

--- a/kuma/attachments/tests/__init__.py
+++ b/kuma/attachments/tests/__init__.py
@@ -10,6 +10,6 @@ def make_test_file(content=None, suffix='.txt'):
     # Shamelessly stolen from Django's own file-upload tests.
     tdir = tempfile.gettempdir()
     file_for_upload = tempfile.NamedTemporaryFile(suffix=suffix, dir=tdir)
-    file_for_upload.write(content)
+    file_for_upload.write(content.encode('utf-8'))
     file_for_upload.seek(0)
     return file_for_upload

--- a/kuma/attachments/utils.py
+++ b/kuma/attachments/utils.py
@@ -77,6 +77,6 @@ def attachment_upload_to(instance, filename):
     return "attachments/%(date)s/%(id)s/%(md5)s/%(filename)s" % {
         'date': now.strftime('%Y/%m/%d'),
         'id': instance.attachment.id,
-        'md5': hashlib.md5(str(now)).hexdigest(),
+        'md5': hashlib.md5(str(now).encode('utf-8')).hexdigest(),
         'filename': filename
     }

--- a/kuma/authkeys/decorators.py
+++ b/kuma/authkeys/decorators.py
@@ -23,7 +23,7 @@ def accepts_auth_key(func):
                 try:
                     basic, b64_auth = http_auth.split(' ', 1)
                     if 'Basic' == basic:
-                        auth = base64.decodestring(b64_auth)
+                        auth = base64.decodestring(b64_auth.encode('utf-8')).decode('utf-8')
                         key_id, secret = auth.split(':', 1)
                         key = Key.objects.get(key=key_id)
                         if key.check_secret(secret):

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import base64
 import hashlib
 import random

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -9,7 +9,7 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.crypto import constant_time_compare
-from django.utils.six import binary_type, int2byte
+from django.utils.six import int2byte
 from django.utils.translation import ugettext_lazy as _
 
 

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -9,21 +9,22 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.crypto import constant_time_compare
+from django.utils.six import binary_type, int2byte
 from django.utils.translation import ugettext_lazy as _
 
 
 def generate_key():
-    """
-    Generate a random API key
-    see: http://jetfar.com/simple-api-key-generation-in-python/
-    """
-    random_hash = hashlib.sha256(str(random.getrandbits(256))).digest()
-    random_chars = random.choice(['rA', 'aZ', 'gQ', 'hH', 'hG', 'aR', 'DD'])
-    return (base64.b64encode(random_hash, random_chars).rstrip('=='))
+    """Generate a random API key."""
+    # 32 * 8 = 256 random bits
+    random_bytes = b''.join(int2byte(random.randint(0, 255)) for _ in range(32))
+    random_hash = hashlib.sha256(random_bytes).digest()
+    replacements = [b'rA', b'aZ', b'gQ', b'hH', b'hG', b'aR', b'DD']
+    random_repl = random.choice(replacements)
+    return base64.b64encode(random_hash, random_repl).rstrip(b'=')
 
 
 def hash_secret(secret):
-    return hashlib.sha512(settings.SECRET_KEY + secret).hexdigest()
+    return hashlib.sha512((settings.SECRET_KEY + secret).encode('utf-8')).hexdigest()
 
 
 class Key(models.Model):
@@ -43,8 +44,8 @@ class Key(models.Model):
         return '<Key %s %s>' % (self.user, self.key)
 
     def generate_secret(self):
-        self.key = generate_key()
-        secret = generate_key()
+        self.key = generate_key().decode('utf-8')
+        secret = generate_key().decode('utf-8')
         self.hashed_secret = hash_secret(secret)
         return secret
 

--- a/kuma/authkeys/models.py
+++ b/kuma/authkeys/models.py
@@ -20,7 +20,7 @@ def generate_key():
     random_hash = hashlib.sha256(random_bytes).digest()
     replacements = [b'rA', b'aZ', b'gQ', b'hH', b'hG', b'aR', b'DD']
     random_repl = random.choice(replacements)
-    return base64.b64encode(random_hash, random_repl).rstrip(b'=')
+    return base64.b64encode(random_hash, random_repl).rstrip(b'=').decode('utf-8')
 
 
 def hash_secret(secret):
@@ -44,8 +44,8 @@ class Key(models.Model):
         return '<Key %s %s>' % (self.user, self.key)
 
     def generate_secret(self):
-        self.key = generate_key().decode('utf-8')
-        secret = generate_key().decode('utf-8')
+        self.key = generate_key()
+        secret = generate_key()
         self.hashed_secret = hash_secret(secret)
         return secret
 

--- a/kuma/authkeys/tests/conftest.py
+++ b/kuma/authkeys/tests/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
-from kuma.users.tests import user
-
 from django.utils.six import iteritems
+
+from kuma.users.tests import user
 
 from ..models import Key
 

--- a/kuma/authkeys/tests/conftest.py
+++ b/kuma/authkeys/tests/conftest.py
@@ -2,12 +2,14 @@ import pytest
 
 from kuma.users.tests import user
 
+from django.utils.six import iteritems
+
 from ..models import Key
 
 
 class Object(object):
     def __init__(self, **kwargs):
-        for k, v in kwargs.iteritems():
+        for k, v in iteritems(kwargs):
             setattr(self, k, v)
 
 

--- a/kuma/authkeys/tests/conftest.py
+++ b/kuma/authkeys/tests/conftest.py
@@ -1,7 +1,5 @@
 import pytest
 
-from django.utils.six import iteritems
-
 from kuma.users.tests import user
 
 from ..models import Key
@@ -9,7 +7,7 @@ from ..models import Key
 
 class Object(object):
     def __init__(self, **kwargs):
-        for k, v in iteritems(kwargs):
+        for k, v in kwargs.items():
             setattr(self, k, v)
 
 

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -5,6 +5,7 @@ import base64
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
+from django.utils.six import binary_type
 
 from kuma.authkeys.decorators import accepts_auth_key
 
@@ -31,7 +32,7 @@ def test_auth_key_decorator(user_auth_key, settings, use_valid_key,
         user_auth_key.secret if use_valid_secret else 'FAKE'
     )
 
-    b64_auth = base64.encodestring(auth)
+    b64_auth = base64.encodestring(binary_type(auth)).decode('utf-8')
     request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % b64_auth
 
     settings.MAINTENANCE_MODE = maintenance_mode

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -5,7 +5,6 @@ import base64
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
-from django.utils.six import binary_type
 
 from kuma.authkeys.decorators import accepts_auth_key
 
@@ -32,7 +31,7 @@ def test_auth_key_decorator(user_auth_key, settings, use_valid_key,
         user_auth_key.secret if use_valid_secret else 'FAKE'
     )
 
-    b64_auth = base64.encodestring(binary_type(auth)).decode('utf-8')
+    b64_auth = base64.encodestring(auth.encode('utf-8')).decode('utf-8')
     request.META['HTTP_AUTHORIZATION'] = 'Basic %s' % b64_auth
 
     settings.MAINTENANCE_MODE = maintenance_mode

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import base64
 
 import pytest

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -8,7 +8,6 @@ from django.http import (HttpResponseForbidden,
                          HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
 from django.utils.encoding import iri_to_uri, smart_str
-from django.utils.six import iteritems
 from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
 from whitenoise.middleware import WhiteNoiseMiddleware
 
@@ -59,7 +58,7 @@ class LangSelectorMiddleware(MiddlewareBase):
 
         # Redirect to same path with requested language and without ?lang
         new_query = dict((smart_str(k), v) for
-                         k, v in iteritems(request.GET) if k != 'lang')
+                         k, v in request.GET.items() if k != 'lang')
         if new_query:
             new_path = urlparams(new_path, **new_query)
         response = HttpResponseRedirect(new_path)

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -8,6 +8,7 @@ from django.http import (HttpResponseForbidden,
                          HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
 from django.utils.encoding import iri_to_uri, smart_str
+from django.utils.six import iteritems
 from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
 from whitenoise.middleware import WhiteNoiseMiddleware
 
@@ -58,7 +59,7 @@ class LangSelectorMiddleware(MiddlewareBase):
 
         # Redirect to same path with requested language and without ?lang
         new_query = dict((smart_str(k), v) for
-                         k, v in request.GET.iteritems() if k != 'lang')
+                         k, v in iteritems(request.GET) if k != 'lang')
         if new_query:
             new_path = urlparams(new_path, **new_query)
         response = HttpResponseRedirect(new_path)

--- a/kuma/core/tests/test_commands.py
+++ b/kuma/core/tests/test_commands.py
@@ -1,6 +1,6 @@
 import pytest
 from django.core.management import call_command, CommandError
-from django.utils.six import StringIO, PY2
+from django.utils.six import PY2, StringIO
 
 
 def test_help():

--- a/kuma/core/tests/test_commands.py
+++ b/kuma/core/tests/test_commands.py
@@ -6,7 +6,7 @@ from django.utils.six import StringIO
 def test_help():
     with pytest.raises(CommandError) as excinfo:
         call_command('ihavepower', stdout=StringIO())
-    assert str(excinfo.value) == 'Error: too few arguments'
+    assert 'Error: the following arguments are required: username' == str(excinfo.value)
 
 
 def test_user_doesnt_exist(db):

--- a/kuma/core/tests/test_commands.py
+++ b/kuma/core/tests/test_commands.py
@@ -1,17 +1,22 @@
 import pytest
 from django.core.management import call_command, CommandError
-from django.utils.six import StringIO
+from django.utils.six import StringIO, PY2
 
 
 def test_help():
     with pytest.raises(CommandError) as excinfo:
         call_command('ihavepower', stdout=StringIO())
-    assert 'Error: the following arguments are required: username' == str(excinfo.value)
+
+    if PY2:
+        assert str(excinfo.value) == 'Error: too few arguments'
+    else:
+        assert str(excinfo.value) == 'Error: the following arguments are required: username'
 
 
 def test_user_doesnt_exist(db):
     with pytest.raises(CommandError) as excinfo:
         call_command('ihavepower', 'fordprefect', stdout=StringIO())
+
     assert str(excinfo.value) == 'User fordprefect does not exist.'
 
 

--- a/kuma/core/tests/test_taggit_extras.py
+++ b/kuma/core/tests/test_taggit_extras.py
@@ -10,7 +10,7 @@ class NamespacedTaggableManagerTest(TestCase):
     food_model = Food
 
     def assert_tags_equal(self, qs, tags, attr="name"):
-        got = map(lambda tag: getattr(tag, attr), qs)
+        got = list(map(lambda tag: getattr(tag, attr), qs))
         got.sort()
         tags.sort()
         self.assertEqual(got, tags)
@@ -32,9 +32,9 @@ class NamespacedTaggableManagerTest(TestCase):
 
         ns_tags = apple.tags.all_ns()
 
-        expected_ns = expected_tags.keys()
+        expected_ns = list(expected_tags)
         expected_ns.sort()
-        result_ns = ns_tags.keys()
+        result_ns = list(ns_tags)
         result_ns.sort()
         self.assertEqual(expected_ns, result_ns)
 

--- a/kuma/core/tests/test_taggit_extras.py
+++ b/kuma/core/tests/test_taggit_extras.py
@@ -10,10 +10,8 @@ class NamespacedTaggableManagerTest(TestCase):
     food_model = Food
 
     def assert_tags_equal(self, qs, tags, attr="name"):
-        got = list(map(lambda tag: getattr(tag, attr), qs))
-        got.sort()
-        tags.sort()
-        self.assertEqual(got, tags)
+        got = sorted(map(lambda tag: getattr(tag, attr), qs))
+        self.assertEqual(got, sorted(tags))
 
     def test_all_ns(self):
         """Tags can be collated or fetched by namespace"""
@@ -32,10 +30,8 @@ class NamespacedTaggableManagerTest(TestCase):
 
         ns_tags = apple.tags.all_ns()
 
-        expected_ns = list(expected_tags)
-        expected_ns.sort()
-        result_ns = list(ns_tags)
-        result_ns.sort()
+        expected_ns = sorted(expected_tags)
+        result_ns = sorted(ns_tags)
         self.assertEqual(expected_ns, result_ns)
 
         for ns in expected_ns:

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -177,7 +177,9 @@ def test_sitemap(client, settings, sitemaps, db, method):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'application/xml'
     if method == 'get':
-        assert ''.join([chunk.decode('utf-8') for chunk in response.streaming_content]) == sitemaps['index']
+        assert ''.join(
+            [chunk.decode('utf-8') for chunk in response.streaming_content]
+        ) == sitemaps['index']
 
 
 @pytest.mark.parametrize(

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 import mock
@@ -247,4 +249,4 @@ def test_error_handler_minimal_request(rf, db, constance_config):
     exception = Exception('Something went wrong.')
     response = handler500(request, exception)
     assert response.status_code == 500
-    assert 'Internal Server Error' in response.content
+    assert b'Internal Server Error' in response.content

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -177,7 +177,7 @@ def test_sitemap(client, settings, sitemaps, db, method):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'application/xml'
     if method == 'get':
-        assert ''.join(response.streaming_content) == sitemaps['index']
+        assert ''.join([chunk.decode('utf-8') for chunk in response.streaming_content]) == sitemaps['index']
 
 
 @pytest.mark.parametrize(
@@ -203,7 +203,7 @@ def test_sitemaps(client, settings, sitemaps, db, method):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'application/xml'
     if method == 'get':
-        assert (''.join(response.streaming_content) ==
+        assert (''.join([chunk.decode('utf-8') for chunk in response.streaming_content]) ==
                 sitemaps['locales']['en-US'])
 
 

--- a/kuma/core/validators.py
+++ b/kuma/core/validators.py
@@ -7,8 +7,6 @@
 import re
 from unicodedata import category
 
-from django.utils.six import string_types
-
 # ------------------------------------------------------------------------------
 # javascript identifier unicode categories and "exceptional" chars
 # ------------------------------------------------------------------------------
@@ -62,9 +60,9 @@ def valid_javascript_identifier(identifier, escape=r'\u', ucd_cat=category):
     if not identifier:
         return False
 
-    if not isinstance(identifier, string_types):
+    if not isinstance(identifier, unicode):
         try:
-            identifier = str(identifier, 'utf-8')
+            identifier = unicode(identifier, 'utf-8')
         except UnicodeDecodeError:
             return False
 

--- a/kuma/core/validators.py
+++ b/kuma/core/validators.py
@@ -7,6 +7,8 @@
 import re
 from unicodedata import category
 
+from django.utils.six import string_types
+
 # ------------------------------------------------------------------------------
 # javascript identifier unicode categories and "exceptional" chars
 # ------------------------------------------------------------------------------
@@ -60,9 +62,9 @@ def valid_javascript_identifier(identifier, escape=r'\u', ucd_cat=category):
     if not identifier:
         return False
 
-    if not isinstance(identifier, unicode):
+    if not isinstance(identifier, string_types):
         try:
-            identifier = unicode(identifier, 'utf-8')
+            identifier = str(identifier, 'utf-8')
         except UnicodeDecodeError:
             return False
 

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -303,7 +303,6 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
-        print(response)
         assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))

--- a/kuma/dashboards/tests/test_views.py
+++ b/kuma/dashboards/tests/test_views.py
@@ -303,6 +303,7 @@ class SpamDashTest(SampleRevisionsMixin, UserTestCase):
         self.client.login(username='admin', password='testpass')
         # The first response will say that the report is being processed
         response = self.client.get(reverse('dashboards.spam'))
+        print(response)
         assert 200 == response.status_code
 
         response2 = self.client.get(reverse('dashboards.spam'))

--- a/kuma/feeder/models.py
+++ b/kuma/feeder/models.py
@@ -11,6 +11,7 @@ class BundleManager(models.Manager):
         """Most recent entries."""
         return Entry.objects.filter(feed__bundles__shortname=bundle)
 
+
 @python_2_unicode_compatible
 class Bundle(models.Model):
     """A bundle of several feeds. A feed can be in several (or no) bundles."""
@@ -24,6 +25,7 @@ class Bundle(models.Model):
 
     def __str__(self):
         return self.shortname
+
 
 @python_2_unicode_compatible
 class Feed(models.Model):
@@ -66,6 +68,7 @@ class Feed(models.Model):
             # to keep exactly `n` entries around, as LIMIT is invalid in a
             # DELETE statement.
             item.delete()
+
 
 @python_2_unicode_compatible
 class Entry(models.Model):

--- a/kuma/feeder/models.py
+++ b/kuma/feeder/models.py
@@ -1,5 +1,6 @@
 import jsonpickle
 from django.db import models
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 
 
@@ -10,7 +11,7 @@ class BundleManager(models.Manager):
         """Most recent entries."""
         return Entry.objects.filter(feed__bundles__shortname=bundle)
 
-
+@python_2_unicode_compatible
 class Bundle(models.Model):
     """A bundle of several feeds. A feed can be in several (or no) bundles."""
 
@@ -21,10 +22,10 @@ class Bundle(models.Model):
 
     objects = BundleManager()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.shortname
 
-
+@python_2_unicode_compatible
 class Feed(models.Model):
     """A feed holds the metadata of an RSS feed."""
 
@@ -51,7 +52,7 @@ class Feed(models.Model):
     updated = models.DateTimeField(
         auto_now=True, verbose_name='Last Modified')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.shortname
 
     def delete_old_entries(self):
@@ -66,7 +67,7 @@ class Feed(models.Model):
             # DELETE statement.
             item.delete()
 
-
+@python_2_unicode_compatible
 class Entry(models.Model):
     """An entry is an item representing feed content."""
 
@@ -90,7 +91,7 @@ class Entry(models.Model):
         unique_together = ('feed', 'guid')
         verbose_name_plural = 'Entries'
 
-    def __unicode__(self):
+    def __str__(self):
         return '%s: %s' % (self.feed.shortname, self.guid)
 
     @cached_property

--- a/kuma/feeder/tests/test_utils.py
+++ b/kuma/feeder/tests/test_utils.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import socket
 from datetime import datetime
 from time import mktime, struct_time

--- a/kuma/feeder/utils.py
+++ b/kuma/feeder/utils.py
@@ -9,7 +9,7 @@ from time import mktime
 import feedparser
 import jsonpickle
 from django.conf import settings
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
 from django.utils.six.moves.urllib.error import URLError
 
 from .models import Entry, Feed
@@ -178,7 +178,7 @@ def save_entry(feed, entry):
     if len(entry.guid) <= max_guid_length:
         entry_guid = entry.guid
     else:
-        entry_guid = md5(smart_str(entry.guid).encode('utf-8')).hexdigest()
+        entry_guid = md5(smart_bytes(entry.guid)).hexdigest()
 
     last_published = datetime.fromtimestamp(mktime(entry.published_parsed))
 

--- a/kuma/feeder/utils.py
+++ b/kuma/feeder/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 import socket
 from datetime import datetime
@@ -176,7 +178,7 @@ def save_entry(feed, entry):
     if len(entry.guid) <= max_guid_length:
         entry_guid = entry.guid
     else:
-        entry_guid = md5(smart_str(entry.guid)).hexdigest()
+        entry_guid = md5(smart_str(entry.guid).encode('utf-8')).hexdigest()
 
     last_published = datetime.fromtimestamp(mktime(entry.published_parsed))
 

--- a/kuma/humans/models.py
+++ b/kuma/humans/models.py
@@ -29,8 +29,7 @@ class HumansTXT(object):
     def write_to_file(self, humans, target, message, role):
         target.write("%s \n" % message)
         for h in humans:
-            target.write("%s: %s \n" %
-                         (role, h.name))
+            target.write("%s: %s \n" % (role, h.name))
             if h.website is not None:
                 target.write("Website: %s \n" % h.website)
                 target.write('\n')

--- a/kuma/humans/models.py
+++ b/kuma/humans/models.py
@@ -1,5 +1,5 @@
-from __future__ import with_statement
 from __future__ import unicode_literals
+from __future__ import with_statement
 
 import json
 import os

--- a/kuma/humans/models.py
+++ b/kuma/humans/models.py
@@ -1,11 +1,11 @@
 from __future__ import with_statement
+from __future__ import unicode_literals
 
 import json
 import os
-import urllib
 
 from django.conf import settings
-
+from django.utils.six.moves.urllib.request import urlopen
 
 GITHUB_REPOS = "https://api.github.com/repos/mozilla/kuma/contributors"
 
@@ -19,7 +19,7 @@ class Human(object):
 class HumansTXT(object):
 
     def generate_file(self):
-        githubbers = self.get_github(json.load(urllib.urlopen(GITHUB_REPOS)))
+        githubbers = self.get_github(json.load(urlopen(GITHUB_REPOS)))
         path = os.path.join(settings.HUMANSTXT_ROOT, "humans.txt")
 
         with open(path, 'w') as target:
@@ -30,7 +30,7 @@ class HumansTXT(object):
         target.write("%s \n" % message)
         for h in humans:
             target.write("%s: %s \n" %
-                         (role, h.name.encode('ascii', 'ignore')))
+                         (role, h.name))
             if h.website is not None:
                 target.write("Website: %s \n" % h.website)
                 target.write('\n')
@@ -38,7 +38,7 @@ class HumansTXT(object):
 
     def get_github(self, data=None):
         if not data:
-            raw_data = json.load(urllib.urlopen(GITHUB_REPOS))
+            raw_data = json.load(urlopen(GITHUB_REPOS))
         else:
             raw_data = data
 

--- a/kuma/humans/tests.py
+++ b/kuma/humans/tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 from os.path import dirname
 
@@ -66,4 +68,8 @@ class HumansTest(TestCase):
             "",
             ""
         ))
+
+        print(output)
+        print('---------')
+        print(expected)
         assert output == expected

--- a/kuma/humans/tests.py
+++ b/kuma/humans/tests.py
@@ -69,7 +69,4 @@ class HumansTest(TestCase):
             ""
         ))
 
-        print(output)
-        print('---------')
-        print(expected)
         assert output == expected

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -15,12 +15,12 @@ class HomeTests(KumaTestCase):
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
             response = self.client.get(url, follow=True)
             assert 200 == response.status_code
-            assert b'ga(\'create' not in response.content
+            assert b"ga('create" not in response.content
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
             response = self.client.get(url, follow=True)
             assert 200 == response.status_code
-            assert b'ga(\'create' in response.content
+            assert b"ga('create" in response.content
 
     def test_default_search_filters(self):
         url = reverse('home')

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from constance.test import override_config
 from pyquery import PyQuery as pq
 
@@ -13,12 +15,12 @@ class HomeTests(KumaTestCase):
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
             response = self.client.get(url, follow=True)
             assert 200 == response.status_code
-            assert 'ga(\'create' not in response.content
+            assert b'ga(\'create' not in response.content
 
         with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
             response = self.client.get(url, follow=True)
             assert 200 == response.status_code
-            assert 'ga(\'create' in response.content
+            assert b'ga(\'create' in response.content
 
     def test_default_search_filters(self):
         url = reverse('home')

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import mock
 import pytest
 from django.core.cache import cache
@@ -68,9 +70,9 @@ def test_robots_not_allowed(client):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'text/plain'
     content = response.content
-    assert 'Sitemap: ' not in content
-    assert 'Disallow: /\n' in content
-    assert 'Disallow: /admin/\n' not in content
+    assert b'Sitemap: ' not in content
+    assert b'Disallow: /\n' in content
+    assert b'Disallow: /admin/\n' not in content
 
 
 def test_robots_allowed_main_website(client, settings):
@@ -83,9 +85,9 @@ def test_robots_allowed_main_website(client, settings):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'text/plain'
     content = response.content
-    assert 'Sitemap: ' in content
-    assert 'Disallow: /\n' not in content
-    assert 'Disallow: /admin/\n' in content
+    assert b'Sitemap: ' in content
+    assert b'Disallow: /\n' not in content
+    assert b'Disallow: /admin/\n' in content
 
 
 def test_robots_allowed_main_attachment_host(client, settings):
@@ -98,7 +100,7 @@ def test_robots_allowed_main_attachment_host(client, settings):
     assert_shared_cache_header(response)
     assert response['Content-Type'] == 'text/plain'
     content = response.content
-    assert content == ''
+    assert content == b''
 
 
 def test_favicon_ico(client):

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -3,8 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 
-from django.utils.six import (binary_type, PY3,
-                              python_2_unicode_compatible,
+from django.utils.six import (binary_type, PY3, python_2_unicode_compatible,
                               text_type)
 from django.utils.six.moves.urllib.parse import unquote
 

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -148,7 +148,7 @@ class Source(object):
             bhref = href
         else:
             bhref = href.encode('utf-8')
-        decoded = unquote(bhref, 'utf-8')
+        decoded = unquote(bhref)
         assert isinstance(decoded, binary_type)
         decoded = decoded.decode('utf8')
         return decoded

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, unicode_literals
 
 import re
 
-from django.utils.six import (binary_type,
+from django.utils.six import (binary_type, PY3,
                               python_2_unicode_compatible,
                               text_type)
 from django.utils.six.moves.urllib.parse import unquote
@@ -144,13 +144,25 @@ class Source(object):
 
     def decode_href(self, href):
         """Convert URL-escaped href attributes to unicode."""
-        if isinstance(href, binary_type):
-            bhref = href
+        if PY3:  # pragma: no cover
+            # TODO: Remove the PY3 condition once we don't run Python 2 anymore
+            # In Python 3, unquote returns unicode
+            # decoded = unquote(href.decode('ascii'))
+            if isinstance(href, binary_type):
+                uhref = href.decode('ascii')
+            else:
+                uhref = href
+            decoded = unquote(uhref)
+            assert isinstance(decoded, text_type)
         else:
-            bhref = href.encode('utf-8')
-        decoded = unquote(bhref)
-        assert isinstance(decoded, binary_type)
-        decoded = decoded.decode('utf8')
+            # In Python 2, unquote takes and returns binary
+            if isinstance(href, binary_type):
+                bhref = href
+            else:
+                bhref = href.encode('utf-8')
+            decoded = unquote(bhref)
+            assert isinstance(decoded, binary_type)
+            decoded = decoded.decode('utf8')
         return decoded
 
     def gather(self, requester, storage):

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -148,7 +148,7 @@ class Source(object):
             bhref = href
         else:
             bhref = href.encode('utf-8')
-        decoded = unquote(bhref)
+        decoded = unquote(bhref, 'utf-8')
         assert isinstance(decoded, binary_type)
         decoded = decoded.decode('utf8')
         return decoded

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -146,7 +146,6 @@ class Source(object):
         if PY3:  # pragma: no cover
             # TODO: Remove the PY3 condition once we don't run Python 2 anymore
             # In Python 3, unquote returns unicode
-            # decoded = unquote(href.decode('ascii'))
             if isinstance(href, binary_type):
                 uhref = href.decode('ascii')
             else:

--- a/kuma/scrape/tests/test_scraper.py
+++ b/kuma/scrape/tests/test_scraper.py
@@ -247,7 +247,7 @@ def test_scrape(scraper):
     """The scraper will loop through sources until complete."""
     scraper.add_source('fake', 'loop', length=2, depth=2)
     sources = scraper.scrape()
-    assert sources.keys() == ['fake:loop', 'fake:loop2', 'fake:loop21']
+    assert set(sources.keys()) == {'fake:loop', 'fake:loop2', 'fake:loop21'}
 
 
 def test_scrape_error(scraper):

--- a/kuma/search/store.py
+++ b/kuma/search/store.py
@@ -63,6 +63,6 @@ def ref_from_url(url):
     locale = translation.get_language()
 
     for value in [query, page, locale] + filters:
-        md5.update(smart_str(value))
+        md5.update(smart_str(value).encode('utf-8'))
 
     return md5.hexdigest()[:16]

--- a/kuma/search/store.py
+++ b/kuma/search/store.py
@@ -2,7 +2,7 @@ import hashlib
 
 from django.contrib.sites.models import Site
 from django.utils import translation
-from django.utils.encoding import smart_str
+from django.utils.encoding import smart_bytes
 from urlobject import URLObject as URL
 
 from kuma.core.urlresolvers import reverse
@@ -63,6 +63,6 @@ def ref_from_url(url):
     locale = translation.get_language()
 
     for value in [query, page, locale] + filters:
-        md5.update(smart_str(value).encode('utf-8'))
+        md5.update(smart_bytes(value))
 
     return md5.hexdigest()[:16]

--- a/kuma/spam/tests/test_akismet.py
+++ b/kuma/spam/tests/test_akismet.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import mock
 import pytest
 import requests
@@ -16,7 +18,7 @@ def test_verify_empty_key(spam_check_everyone, constance_config):
 def test_verify_valid_key(spam_check_everyone, constance_config,
                           mock_requests):
     constance_config.AKISMET_KEY = 'api-key'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
     assert not mock_requests.called
     assert client.ready
@@ -27,7 +29,7 @@ def test_verify_valid_key(spam_check_everyone, constance_config,
 def test_verify_invalid_key(spam_check_everyone, constance_config,
                             mock_requests):
     constance_config.AKISMET_KEY = 'api-key'
-    mock_requests.post(VERIFY_URL, content='invalid')
+    mock_requests.post(VERIFY_URL, content=b'invalid')
     client = Akismet()
     assert not mock_requests.called
     assert not client.ready
@@ -38,7 +40,7 @@ def test_verify_invalid_key(spam_check_everyone, constance_config,
 def test_verify_invalid_key_wrong_response(spam_check_everyone,
                                            constance_config, mock_requests):
     constance_config.AKISMET_KEY = 'api-key'
-    mock_requests.post(VERIFY_URL, content='fail')
+    mock_requests.post(VERIFY_URL, content=b'fail')
     client = Akismet()
     assert not client.ready
     assert client.key == 'api-key'
@@ -64,7 +66,7 @@ def test_exception_attributes(spam_check_everyone, constance_config,
     constance_config.AKISMET_KEY = 'comment'
     mock_requests.post(
         VERIFY_URL,
-        content='uh uh',
+        content=b'uh uh',
         headers={'X-Akismet-Debug-Help': 'err0r!'},
     )
 
@@ -75,11 +77,11 @@ def test_exception_attributes(spam_check_everyone, constance_config,
 def test_check_comment_ham(spam_check_everyone, constance_config,
                            mock_requests):
     constance_config.AKISMET_KEY = 'comment'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
     assert client.ready
 
-    mock_requests.post(CHECK_URL, content='true')
+    mock_requests.post(CHECK_URL, content=b'true')
     valid = client.check_comment('0.0.0.0', 'Mozilla',
                                  comment_content='yada yada')
     assert valid
@@ -92,8 +94,8 @@ def test_check_comment_ham(spam_check_everyone, constance_config,
 def test_check_comment_spam(spam_check_everyone, constance_config,
                             mock_requests):
     constance_config.AKISMET_KEY = 'comment'
-    mock_requests.post(VERIFY_URL, content='valid')
-    mock_requests.post(CHECK_URL, content='false')
+    mock_requests.post(VERIFY_URL, content=b'valid')
+    mock_requests.post(CHECK_URL, content=b'false')
     client = Akismet()
     valid = client.check_comment('0.0.0.0', 'Mozilla',
                                  comment_content='yada yada')
@@ -103,9 +105,9 @@ def test_check_comment_spam(spam_check_everyone, constance_config,
 def test_check_comment_wrong_response(spam_check_everyone, constance_config,
                                       mock_requests):
     constance_config.AKISMET_KEY = 'comment'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
-    mock_requests.post(CHECK_URL, content='wat', status_code=202)
+    mock_requests.post(CHECK_URL, content=b'wat', status_code=202)
     with pytest.raises(AkismetError) as excinfo:
         client.check_comment('0.0.0.0', 'Mozilla',
                              comment_content='yada yada')
@@ -118,7 +120,7 @@ def test_check_comment_wrong_response(spam_check_everyone, constance_config,
 def test_submit_spam_success(spam_check_everyone, constance_config,
                              mock_requests):
     constance_config.AKISMET_KEY = 'spam'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
     mock_requests.post(SPAM_URL, content=client.submission_success)
     result = client.submit_spam('0.0.0.0', 'Mozilla',
@@ -129,9 +131,9 @@ def test_submit_spam_success(spam_check_everyone, constance_config,
 def test_submit_spam_failure(spam_check_everyone, constance_config,
                              mock_requests):
     constance_config.AKISMET_KEY = 'spam'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
-    mock_requests.post(SPAM_URL, content='something completely different')
+    mock_requests.post(SPAM_URL, content=b'something completely different')
     with pytest.raises(AkismetError) as excinfo:
         client.submit_spam('0.0.0.0', 'Mozilla',
                            comment_content='spam. eggs.')
@@ -144,7 +146,7 @@ def test_submit_spam_failure(spam_check_everyone, constance_config,
 def test_submit_ham_success(spam_check_everyone, constance_config,
                             mock_requests):
     constance_config.AKISMET_KEY = 'spam'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
     mock_requests.post(HAM_URL, content=client.submission_success)
     result = client.submit_ham('0.0.0.0', 'Mozilla',
@@ -155,9 +157,9 @@ def test_submit_ham_success(spam_check_everyone, constance_config,
 def test_submit_ham_failure(spam_check_everyone, constance_config,
                             mock_requests):
     constance_config.AKISMET_KEY = 'spam'
-    mock_requests.post(VERIFY_URL, content='valid')
+    mock_requests.post(VERIFY_URL, content=b'valid')
     client = Akismet()
-    mock_requests.post(HAM_URL, content='something completely different')
+    mock_requests.post(HAM_URL, content=b'something completely different')
     with pytest.raises(AkismetError) as excinfo:
         client.submit_ham('0.0.0.0', 'Mozilla',
                           comment_content='eggs with ham. ham with eggs.')

--- a/kuma/users/jobs.py
+++ b/kuma/users/jobs.py
@@ -1,7 +1,7 @@
 import hashlib
-import urllib
 
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlencode
 
 from kuma.core.jobs import KumaJob
 
@@ -17,7 +17,7 @@ class UserGravatarURLJob(KumaJob):
         base_url = (secure and 'https://secure.gravatar.com' or
                     'http://www.gravatar.com')
         email_hash = hashlib.md5(email.lower().encode('utf8'))
-        params = urllib.urlencode({'s': size, 'd': default, 'r': rating})
+        params = urlencode({'s': size, 'd': default, 'r': rating})
         return '%(base_url)s/avatar/%(hash)s?%(params)s' % {
             'base_url': base_url,
             'hash': email_hash.hexdigest(),

--- a/kuma/users/migrations/0001_squashed_0008_update_locales_tz_help.py
+++ b/kuma/users/migrations/0001_squashed_0008_update_locales_tz_help.py
@@ -49,9 +49,9 @@ class Migration(migrations.Migration):
                 ('linkedin_url', models.TextField(blank=True, verbose_name='LinkedIn', validators=[django.core.validators.RegexValidator(b'^https?://((www|\\w\\w)\\.)?linkedin.com/((in/[^/]+/?)|(pub/[^/]+/((\\w|\\d)+/?){3}))$', 'Enter a valid LinkedIn URL.', b'invalid')])),
                 ('facebook_url', models.TextField(blank=True, verbose_name='Facebook', validators=[django.core.validators.RegexValidator(b'^https?://www\\.facebook\\.com/', 'Enter a valid Facebook URL.', b'invalid')])),
                 ('stackoverflow_url', models.TextField(blank=True, verbose_name='Stack Overflow', validators=[django.core.validators.RegexValidator(b'^https?://stackoverflow\\.com/users/', 'Enter a valid Stack Overflow URL.', b'invalid')])),
-                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to=b'auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of his/her group.', verbose_name='groups')),
+                ('groups', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of his/her group.', verbose_name='groups')),
                 ('tags', kuma.core.managers.NamespacedTaggableManager(to='taggit.Tag', through='taggit.TaggedItem', blank=True, help_text='A comma-separated list of tags.', verbose_name='Tags')),
-                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to=b'auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
+                ('user_permissions', models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Permission', blank=True, help_text='Specific permissions for this user.', verbose_name='user permissions')),
             ],
             options={
                 'db_table': 'auth_user',
@@ -82,7 +82,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='user',
             name='groups',
-            field=models.ManyToManyField(related_query_name='user', related_name='user_set', to=b'auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups'),
+            field=models.ManyToManyField(related_query_name='user', related_name='user_set', to='auth.Group', blank=True, help_text='The groups this user belongs to. A user will get all permissions granted to each of their groups.', verbose_name='groups'),
         ),
         migrations.AlterField(
             model_name='user',

--- a/kuma/users/tests/test_adapters.py
+++ b/kuma/users/tests/test_adapters.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pytest
 from allauth.exceptions import ImmediateHttpResponse
 from allauth.socialaccount.models import SocialAccount, SocialLogin
@@ -162,7 +164,7 @@ class KumaSocialAccountAdapterTestCase(UserTestCase):
         with pytest.raises(ImmediateHttpResponse) as e_info:
             self.adapter.pre_social_login(request, github_login)
         resp = e_info.value.response
-        assert 'Banned by unit test.' in resp.content
+        assert b'Banned by unit test.' in resp.content
         assert not resp.has_header('Vary')
 
         never_cache = ['no-cache', 'no-store', 'must-revalidate', 'max-age=0']

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -1,7 +1,7 @@
-import urllib
 from hashlib import md5
 
 from django.conf import settings
+from django.utils.six.moves.urllib.parse import urlencode
 
 from . import UserTestCase
 from ..templatetags.jinja_helpers import gravatar_url, public_email
@@ -14,7 +14,7 @@ class HelperTestCase(UserTestCase):
         self.u = self.user_model.objects.get(username=u'testuser')
 
     def test_default_gravatar(self):
-        d_param = urllib.urlencode({'d': settings.DEFAULT_AVATAR})
+        d_param = urlencode({'d': settings.DEFAULT_AVATAR})
         assert d_param in gravatar_url(self.u.email), \
             "Bad default avatar: %s" % gravatar_url(self.u.email)
 

--- a/kuma/users/tests/test_helpers.py
+++ b/kuma/users/tests/test_helpers.py
@@ -20,7 +20,7 @@ class HelperTestCase(UserTestCase):
 
     def test_gravatar_url(self):
         self.u.email = 'test@test.com'
-        assert md5(self.u.email).hexdigest() in gravatar_url(self.u.email)
+        assert md5(self.u.email.encode('utf-8')).hexdigest() in gravatar_url(self.u.email)
 
     def test_public_email(self):
         assert ('<span class="email">'

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -74,10 +74,11 @@ def test_account_email_page_single_email(user_client):
     response = user_client.get(reverse('account_email'))
     assert response.status_code == 200
     assert_no_cache_header(response)
-    assert b'is your <em>primary</em> email address' in response.content
-    assert b'Make Primary' not in response.content
-    assert b'Re-send Confirmation' not in response.content
-    assert b'Remove' not in response.content
+    content = response.content.decode(response.charset)
+    assert 'is your <em>primary</em> email address' in content
+    assert 'Make Primary' not in content
+    assert 'Re-send Confirmation' not in content
+    assert 'Remove' not in content
 
 
 def test_account_email_page_multiple_emails(wiki_user, user_client):
@@ -86,11 +87,12 @@ def test_account_email_page_multiple_emails(wiki_user, user_client):
     response = user_client.get(reverse('account_email'))
     assert response.status_code == 200
     assert_no_cache_header(response)
-    assert b'Make Primary' in response.content
-    assert b'Re-send Confirmation' in response.content
-    assert b'Remove' in response.content
-    assert b'Add Email' in response.content
-    assert b'Edit profile' in response.content
+    content = response.content.decode(response.charset)
+    assert 'Make Primary' in content
+    assert 'Re-send Confirmation' in content
+    assert 'Remove' in content
+    assert 'Add Email' in content
+    assert 'Edit profile' in content
 
 
 class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -67,17 +67,17 @@ def test_account_email_page_requires_signin(db, client):
     assert_no_cache_header(response)
     response = client.get(response['Location'], follow=True)
     assert response.status_code == 200
-    assert 'Please sign in' in response.content
+    assert b'Please sign in' in response.content
 
 
 def test_account_email_page_single_email(user_client):
     response = user_client.get(reverse('account_email'))
     assert response.status_code == 200
     assert_no_cache_header(response)
-    assert 'is your <em>primary</em> email address' in response.content
-    assert 'Make Primary' not in response.content
-    assert 'Re-send Confirmation' not in response.content
-    assert 'Remove' not in response.content
+    assert b'is your <em>primary</em> email address' in response.content
+    assert b'Make Primary' not in response.content
+    assert b'Re-send Confirmation' not in response.content
+    assert b'Remove' not in response.content
 
 
 def test_account_email_page_multiple_emails(wiki_user, user_client):
@@ -86,11 +86,11 @@ def test_account_email_page_multiple_emails(wiki_user, user_client):
     response = user_client.get(reverse('account_email'))
     assert response.status_code == 200
     assert_no_cache_header(response)
-    assert 'Make Primary' in response.content
-    assert 'Re-send Confirmation' in response.content
-    assert 'Remove' in response.content
-    assert 'Add Email' in response.content
-    assert 'Edit profile' in response.content
+    assert b'Make Primary' in response.content
+    assert b'Re-send Confirmation' in response.content
+    assert b'Remove' in response.content
+    assert b'Add Email' in response.content
+    assert b'Edit profile' in response.content
 
 
 class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
@@ -106,19 +106,19 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
         response = self.github_login(token_data=token_data)
         assert response.status_code == 200
         content = response.content
-        assert 'Account Sign In Failure' in content
+        assert b'Account Sign In Failure' in content
         error = ('An error occurred while attempting to sign in with your'
                  ' account.')
-        assert error in content
-        assert 'Thanks for signing in to MDN' not in content
+        assert bytes(error) in content
+        assert b'Thanks for signing in to MDN' not in content
 
     def test_auth_success_username_available(self):
         """Successful auth shows profile creation with GitHub details."""
         response = self.github_login()
         assert response.status_code == 200
         content = response.content
-        assert 'Thanks for signing in to MDN with GitHub.' in content
-        assert 'Account Sign In Failure' not in content
+        assert b'Thanks for signing in to MDN with GitHub.' in content
+        assert b'Account Sign In Failure' not in content
 
         parsed = pq(response.content)
         username = parsed('#id_username')[0]

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -107,9 +107,9 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
         assert response.status_code == 200
         content = response.content
         assert b'Account Sign In Failure' in content
-        error = ('An error occurred while attempting to sign in with your'
-                 ' account.')
-        assert bytes(error) in content
+        error = (b'An error occurred while attempting to sign in with your'
+                 b' account.')
+        assert error in content
         assert b'Thanks for signing in to MDN' not in content
 
     def test_auth_success_username_available(self):

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1378,7 +1378,7 @@ def test_invalid_token_fails(wiki_user, client):
     bad_last_char = '2' if recover_url[-1] == '3' else '3'
     bad_recover_url = recover_url[:-1] + bad_last_char
     response = client.get(bad_recover_url)
-    assert 'This link is no longer valid.' in response.content
+    assert b'This link is no longer valid.' in response.content
 
 
 def test_invalid_uid_fails(wiki_user, client):
@@ -1388,4 +1388,4 @@ def test_invalid_uid_fails(wiki_user, client):
     response = client.get(bad_recover_url)
     assert response.status_code == 200
     assert_no_cache_header(response)
-    assert 'This link is no longer valid.' in response.content
+    assert b'This link is no longer valid.' in response.content

--- a/kuma/version/tests/test_views.py
+++ b/kuma/version/tests/test_views.py
@@ -15,7 +15,7 @@ def test_revision_hash(client, db, method, settings):
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
     assert_no_cache_header(response)
     if method == 'get':
-        assert response.content == 'the_revision_hash'
+        assert response.content.decode('utf-8') == 'the_revision_hash'
 
 
 @pytest.mark.parametrize(
@@ -42,7 +42,7 @@ def test_kumascript_revision_hash(client, db, method, mock_requests):
     assert response['Content-Type'] == 'text/plain; charset=utf-8'
     assert_no_cache_header(response)
     if method == 'get':
-        assert response.content == hash
+        assert response.content.decode('utf-8') == hash
 
 
 @pytest.mark.parametrize(

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -460,9 +460,9 @@ class LinkAnnotationFilter(html5lib_Filter):
                     href_path, _, _ = href_path.partition('#')
 
                 # Handle any URL-encoded UTF-8 characters in the path
-                # href_path = href_path.encode('utf-8', 'ignore')
+                href_path = href_path.encode('utf-8', 'ignore')
                 href_path = unquote(href_path)
-                # href_path = href_path.decode('utf-8', 'ignore')
+                href_path = href_path.decode('utf-8', 'ignore')
 
                 # Try to sort out the locale and slug through some of our
                 # redirection logic.

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -460,9 +460,9 @@ class LinkAnnotationFilter(html5lib_Filter):
                     href_path, _, _ = href_path.partition('#')
 
                 # Handle any URL-encoded UTF-8 characters in the path
-                href_path = href_path.encode('utf-8', 'ignore')
+                # href_path = href_path.encode('utf-8', 'ignore')
                 href_path = unquote(href_path)
-                href_path = href_path.decode('utf-8', 'ignore')
+                # href_path = href_path.decode('utf-8', 'ignore')
 
                 # Try to sort out the locale and slug through some of our
                 # redirection logic.
@@ -514,7 +514,7 @@ class LinkAnnotationFilter(html5lib_Filter):
             if token['type'] == 'StartTag' and token['name'] == 'a':
                 attrs = dict(token['data'])
                 names = [name for (namespace, name) in attrs.keys()]
-                for (namespace, name), value in attrs.items():
+                for (namespace, name), value in attrs.copy().items():
                     if name == 'href':
                         href = value
                         href_parsed = urlparse(value)
@@ -1060,7 +1060,7 @@ class CodeSyntaxFilter(html5lib_Filter):
         for token in html5lib_Filter.__iter__(self):
             if token['type'] == 'StartTag' and token['name'] == 'pre':
                 attrs = dict(token['data'])
-                for (namespace, name), value in attrs.items():
+                for (namespace, name), value in attrs.copy().items():
                     if name == 'function' and value:
                         m = MT_SYNTAX_RE.match(value)
                         if m:

--- a/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
+++ b/kuma/wiki/migrations/0001_squashed_0036_update_locales.py
@@ -229,7 +229,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='document',
             name='files',
-            field=models.ManyToManyField(to=b'attachments.Attachment', through='wiki.DocumentAttachment'),
+            field=models.ManyToManyField(to='attachments.Attachment', through='wiki.DocumentAttachment'),
         ),
         migrations.AddField(
             model_name='document',

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -13,6 +13,7 @@ from django.core.exceptions import ValidationError
 from django.db import models, transaction
 from django.db.models import signals
 from django.utils.decorators import available_attrs
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext, ugettext_lazy as _
 from pyquery import PyQuery
@@ -177,6 +178,7 @@ class DocumentAttachment(models.Model):
             )
 
 
+@python_2_unicode_compatible
 class Document(NotificationsMixin, models.Model):
     """A localized knowledgebase document, not revision-specific."""
     TOC_FILTERS = {
@@ -316,8 +318,8 @@ class Document(NotificationsMixin, models.Model):
     deleted_objects = DeletedDocumentManager()
     admin_objects = DocumentAdminManager()
 
-    def __unicode__(self):
-        return u'%s (%s)' % (self.get_absolute_url(), self.title)
+    def __str__(self):
+        return '%s (%s)' % (self.get_absolute_url(), self.title)
 
     @cache_with_field('body_html')
     def get_body_html(self, *args, **kwargs):

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -361,7 +361,7 @@ def ks_toolbox():
     }
 
     d_json = json.dumps(errors)
-    d_b64 = base64.encodestring(d_json)
+    d_b64 = base64.encodestring(d_json.encode('utf-8'))
     d_lines = [x for x in d_b64.split("\n") if x]
 
     # Headers are case-insensitive, so let's drive that point home.

--- a/kuma/wiki/tests/test_admin.py
+++ b/kuma/wiki/tests/test_admin.py
@@ -327,7 +327,7 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
         self.client.login(username='admin', password='testpass')
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(SUBMISSION_NOT_AVAILABLE, response.content)
+        self.assertIn(SUBMISSION_NOT_AVAILABLE, response.content.decode('utf-8'))
 
     @override_flag(SPAM_SUBMISSIONS_FLAG, True)
     def test_view_change_existing(self):
@@ -341,7 +341,7 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
                       args=(submission.id,))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn(SUBMISSION_NOT_AVAILABLE, response.content)
+        self.assertIn(SUBMISSION_NOT_AVAILABLE, response.content.decode('utf-8'))
 
     @override_flag(SPAM_SUBMISSIONS_FLAG, True)
     def test_view_change_with_data(self):
@@ -357,7 +357,7 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
                       args=(submission.id,))
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
-        self.assertIn('<dt>content</dt><dd>spam</dd>',
+        self.assertIn(b'<dt>content</dt><dd>spam</dd>',
                       response.content)
 
     @override_flag(SPAM_SUBMISSIONS_FLAG, True)
@@ -375,5 +375,5 @@ class RevisionAkismetSubmissionAdminTestCase(UserTestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         revision_url = revision.get_absolute_url()
-        self.assertIn(revision_url, response.content)
+        self.assertIn(revision_url.encode('utf-8'), response.content)
         self.assertIn('None', response.content)

--- a/kuma/wiki/tests/test_feeds.py
+++ b/kuma/wiki/tests/test_feeds.py
@@ -460,7 +460,7 @@ def test_feeds_update_after_doc_tag_change(client, wiki_user, root_doc):
         response = client.get(reverse('wiki.feeds.recent_documents',
                                       args=['atom', tag]), follow=True)
         assert response.status_code == 200
-        assert root_doc.title in response.content
+        assert root_doc.title.encode('utf-8') in response.content
 
     # Check document is not in the previous tags feed
     for tag in tags1:

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -240,13 +240,13 @@ class DocumentTests(UserTestCase, WikiTestCase):
         r = revision(save=True, content=doc_content, is_approved=True)
         response = self.client.get(r.document.get_absolute_url())
         assert 200 == response.status_code
-        assert '<div id="toc"' in response.content
+        assert b'<div id="toc"' in response.content
         new_r = revision(document=r.document, content=r.content,
                          toc_depth=0, is_approved=True)
         new_r.save()
         response = self.client.get(r.document.get_absolute_url())
         assert 200 == response.status_code
-        assert '<div class="page-toc">' not in response.content
+        assert b'<div class="page-toc">' not in response.content
 
     def test_lang_switcher_footer(self):
         """Test the language switcher footer"""
@@ -349,9 +349,9 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
                        slug='Original')
         response = self.client.get(rev.document.get_absolute_url())
         assert response.status_code == 200
-        assert 'Original Content.' in response.content
-        assert 'dimension15' not in response.content
-        assert self.script_src in response.content
+        assert b'Original Content.' in response.content
+        assert b'dimension15' not in response.content
+        assert self.script_src.encode('utf-8') in response.content
 
     def test_user_no_variant_selected(self):
         """Users get original page without the experiment script."""
@@ -360,7 +360,7 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
         self.client.login(username='testuser', password='testpass')
         response = self.client.get(rev.document.get_absolute_url())
         assert response.status_code == 200
-        assert self.script_src not in response.content
+        assert self.script_src.encode('utf-8') not in response.content
 
     def test_anon_valid_variant_selected(self):
         """Anon users are in the Google Analytics cohort on the variant."""
@@ -371,11 +371,11 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
         response = self.client.get(rev.document.get_absolute_url(),
                                    {'v': 'test'})
         assert response.status_code == 200
-        assert 'Original Content.' not in response.content
-        assert 'Variant Content.' in response.content
-        assert self.expected_15 in response.content
-        assert self.expected_16 in response.content
-        assert self.script_src not in response.content
+        assert b'Original Content.' not in response.content
+        assert b'Variant Content.' in response.content
+        assert self.expected_15.encode('utf-8') in response.content
+        assert self.expected_16.encode('utf-8') in response.content
+        assert self.script_src.encode('utf-8') not in response.content
         doc = pq(response.content)
         assert not doc('#edit-button')
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -260,7 +260,7 @@ class ViewTests(UserTestCase, WikiTestCase):
                                rev.document.get_absolute_url())
         assert resp.status_code == 200
         assert_shared_cache_header(resp)
-        assert resp.content == 'Foo bar <a href="http://example.com">baz</a>'
+        assert resp.content == b'Foo bar <a href="http://example.com">baz</a>'
 
     @mock.patch('waffle.flag_is_active', return_value=True)
     @mock.patch('kuma.wiki.jobs.DocumentContributorsJob.get', return_value=[
@@ -302,8 +302,8 @@ class ViewTests(UserTestCase, WikiTestCase):
         resp = self.client.get(r.get_absolute_url())
         page = pq(resp.content)
 
-        assert 'Revision Source' in resp.content
-        assert 'Revision Content' in resp.content
+        assert b'Revision Source' in resp.content
+        assert b'Revision Content' in resp.content
         assert 'open' == page.find('#wikiArticle').parent().attr('open')
         assert page.find('#doc-source').parent().attr('open') is None
 
@@ -337,7 +337,7 @@ class ReadOnlyTests(UserTestCase, WikiTestCase):
         self.client.login(username='testuser', password='testpass')
         resp = self.client.get(self.edit_url)
         assert resp.status_code == 403
-        assert 'The wiki is in read-only mode.' in resp.content
+        assert b'The wiki is in read-only mode.' in resp.content
         assert_no_cache_header(resp)
         self.client.logout()
 
@@ -614,8 +614,7 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
             response = self.client.get(reverse('wiki.document', args=[slug]))
             page = pq(response.content)
             meta_content = page.find('meta[name=description]').attr('content')
-            assert (str(meta_content).decode('utf-8') ==
-                    str(aught_preview).decode('utf-8'))
+            assert str(meta_content) == str(aught_preview)
 
         # Test pages - very basic
         good = 'This is the content which should be chosen, man.'
@@ -1358,13 +1357,13 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         # HACK: Too lazy to parse the XML. Lazy lazy.
         response = self.client.get(reverse('wiki.feeds.list_review',
                                            args=('atom',)))
-        assert doc_entry in response.content
+        assert doc_entry.encode('utf-8') in response.content
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'technical', )))
-        assert doc_entry in response.content
+        assert doc_entry.encode('utf-8') in response.content
         response = self.client.get(reverse('wiki.feeds.list_review_tag',
                                            args=('atom', 'editorial', )))
-        assert doc_entry in response.content
+        assert doc_entry.encode('utf-8') in response.content
 
         # Post an edit that removes the technical review tag.
         data.update({
@@ -1938,7 +1937,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
 
         assert resp.status_code == 200
         assert_no_cache_header(resp)
-        assert "cannot revert a document that has been moved" in resp.content
+        assert b'cannot revert a document that has been moved' in resp.content
 
     def test_store_revision_ip(self):
         self.client.login(username='testuser', password='testpass')
@@ -2234,8 +2233,8 @@ class SectionEditingResourceTests(UserTestCase, WikiTestCase):
         assert response.status_code == 200
         # Since the client is logged-in, the response should not be cached.
         assert_no_cache_header(response)
-        assert '<p onload=' not in response.content
-        assert '<circle onload=' not in response.content
+        assert b'<p onload=' not in response.content
+        assert b'<circle onload=' not in response.content
 
     def test_raw_with_editing_links_source(self):
         """The raw source for a document can be requested, with section editing

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -46,7 +46,7 @@ def test_code_sample(code_sample_doc, client, settings, domain):
     assert 'ETag' in response
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']
-    assert response.content.startswith('<!DOCTYPE html>')
+    assert response.content.startswith(b'<!DOCTYPE html>')
 
     normalized = normalize_html(response.content)
     expected = (
@@ -144,7 +144,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     settings.ATTACHMENT_HOST = 'testserver'
     response = admin_client.get(sample_url)
     assert response.status_code == 200
-    assert url_css in response.content
+    assert url_css.encode('utf-8') in response.content
     assert 'public' in response['Cache-Control']
     assert 'max-age=86400' in response['Cache-Control']
 

--- a/kuma/wiki/tests/test_views_create.py
+++ b/kuma/wiki/tests/test_views_create.py
@@ -150,7 +150,7 @@ def test_create_invalid(add_doc_client, slug):
     assert resp.status_code == 200
     assert resp['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(resp)
-    assert 'The slug provided is not valid.' in resp.content
+    assert b'The slug provided is not valid.' in resp.content
     with pytest.raises(Document.DoesNotExist):
         Document.objects.get(slug=slug, locale='en-US')
     assert pq(resp.content).find('input[name=slug]')[0].value == slug
@@ -220,7 +220,7 @@ def test_create_child_invalid(root_doc, add_doc_client, slug):
     assert resp.status_code == 200
     assert resp['X-Robots-Tag'] == 'noindex'
     assert_no_cache_header(resp)
-    assert 'The slug provided is not valid.' in resp.content
+    assert b'The slug provided is not valid.' in resp.content
     with pytest.raises(Document.DoesNotExist):
         Document.objects.get(slug=full_slug, locale='en-US')
     page = pq(resp.content)

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -102,7 +102,7 @@ def authkey(wiki_user):
     key.save()
     auth = '%s:%s' % (key.key, secret)
     # TODO: Once Python 2/3 is gone, replace encodestring by encodebytes
-    header = 'Basic %s' % base64.encodestring(auth.encode('utf-8')).decode('utf-8')
+    header = 'Basic %s' % base64.b64encode(auth.encode('utf-8')).decode('utf-8')
     return AuthKey(key=key, header=header)
 
 

--- a/kuma/wiki/tests/test_views_edit.py
+++ b/kuma/wiki/tests/test_views_edit.py
@@ -24,4 +24,4 @@ def test_edit_banned_ip_not_allowed(method, editor_client, root_doc,
     response = caller(url, REMOTE_ADDR=ip)
     assert response.status_code == 403
     assert_no_cache_header(response)
-    assert 'Your IP address has been banned.' in response.content
+    assert b'Your IP address has been banned.' in response.content

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import pytest
 from pyquery import PyQuery as pq
-from django.utils.six import binary_type
 
 from kuma.core.tests import assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
@@ -151,7 +150,7 @@ def test_list_no_redirects(redirect_doc, doc_hierarchy, client):
     # doc_hierarchy, plus the root_doc (which is pulled-in by
     # the redirect_doc), but the redirect_doc should not be one of them.
     assert len(pq(resp.content).find('.document-list li')) == 5
-    assert binary_type(redirect_doc.slug, 'utf-8') not in resp.content
+    assert redirect_doc.slug not in resp.content
 
 
 def test_tags(root_doc, client):
@@ -197,8 +196,8 @@ def test_tag_list(root_doc, trans_doc, client, locale_case, tag_case, tag):
     assert resp.status_code == 200
     dom = pq(resp.content)
     assert len(dom('#document-list ul.document-list li')) == 0
-    assert binary_type(root_doc.slug, 'utf-8') not in resp.content
-    assert binary_type(trans_doc.slug, 'utf-8') not in resp.content
+    assert root_doc.slug not in resp.content
+    assert trans_doc.slug not in resp.content
 
 
 @pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -150,7 +150,7 @@ def test_list_no_redirects(redirect_doc, doc_hierarchy, client):
     # doc_hierarchy, plus the root_doc (which is pulled-in by
     # the redirect_doc), but the redirect_doc should not be one of them.
     assert len(pq(resp.content).find('.document-list li')) == 5
-    assert redirect_doc.slug not in resp.content
+    assert redirect_doc.slug.encode('utf-8') not in resp.content
 
 
 def test_tags(root_doc, client):
@@ -196,8 +196,8 @@ def test_tag_list(root_doc, trans_doc, client, locale_case, tag_case, tag):
     assert resp.status_code == 200
     dom = pq(resp.content)
     assert len(dom('#document-list ul.document-list li')) == 0
-    assert root_doc.slug not in resp.content
-    assert trans_doc.slug not in resp.content
+    assert root_doc.slug not in resp.content.decode('utf-8')
+    assert trans_doc.slug not in resp.content.decode('utf-8')
 
 
 @pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])

--- a/kuma/wiki/tests/test_views_list.py
+++ b/kuma/wiki/tests/test_views_list.py
@@ -1,5 +1,8 @@
+from __future__ import unicode_literals
+
 import pytest
 from pyquery import PyQuery as pq
+from django.utils.six import binary_type
 
 from kuma.core.tests import assert_shared_cache_header
 from kuma.core.urlresolvers import reverse
@@ -148,7 +151,7 @@ def test_list_no_redirects(redirect_doc, doc_hierarchy, client):
     # doc_hierarchy, plus the root_doc (which is pulled-in by
     # the redirect_doc), but the redirect_doc should not be one of them.
     assert len(pq(resp.content).find('.document-list li')) == 5
-    assert redirect_doc.slug not in resp.content
+    assert binary_type(redirect_doc.slug, 'utf-8') not in resp.content
 
 
 def test_tags(root_doc, client):
@@ -157,8 +160,8 @@ def test_tags(root_doc, client):
     url = reverse('wiki.list_tags')
     resp = client.get(url)
     assert resp.status_code == 200
-    assert 'foobar' in resp.content
-    assert 'blast' in resp.content
+    assert b'foobar' in resp.content
+    assert b'blast' in resp.content
     assert 'wiki/list/tags.html' in [t.name for t in resp.templates]
     assert_shared_cache_header(resp)
 
@@ -194,8 +197,8 @@ def test_tag_list(root_doc, trans_doc, client, locale_case, tag_case, tag):
     assert resp.status_code == 200
     dom = pq(resp.content)
     assert len(dom('#document-list ul.document-list li')) == 0
-    assert root_doc.slug not in resp.content
-    assert trans_doc.slug not in resp.content
+    assert binary_type(root_doc.slug, 'utf-8') not in resp.content
+    assert binary_type(trans_doc.slug, 'utf-8') not in resp.content
 
 
 @pytest.mark.parametrize('locale', ['en-US', 'de', 'fr'])

--- a/kuma/wiki/tests/test_views_revision.py
+++ b/kuma/wiki/tests/test_views_revision.py
@@ -63,7 +63,7 @@ def test_compare_revisions_without_tidied_content(edit_revision, client, raw):
 
     response = client.get(url)
     assert response.status_code == 200
-    assert 'Please refresh this page in a few minutes.' in response.content
+    assert b'Please refresh this page in a few minutes.' in response.content
 
 
 @pytest.mark.parametrize("id1,id2",

--- a/kuma/wiki/views/utils.py
+++ b/kuma/wiki/views/utils.py
@@ -50,4 +50,4 @@ def document_form_initial(document):
 
 
 def calculate_etag(content):
-    return hashlib.md5(content).hexdigest()
+    return hashlib.md5(content.encode('utf-8')).hexdigest()


### PR DESCRIPTION
This PR fixes a first chunk of the unittest on the Python 3 version.

## Yet to be done:
- [x] Fix more tests
- [x] Ensure no python 2 tests are broken
- [ ] Clean the commits, some are dirty

## Actions that needs to be taken before merging:
- [x] Merge PR #4899 or cherry-pick those changes to a branch based on master.
- [x] Merge PR #4870 or cherry-pick those changes to a branch based on master.
    - Since this has been merged with squash, this branch needs to be rebased on #4899 once #4899 has been rebased on master

## Notes:
- This PR is based on #4870 (which removes a blocker for the migration to Python 3) & #4870 (which removes a blocker to run the unittests).
- `make lint` returns errors due to code no longer compatible with Python 3.
- This PR is open early in the process, so it is visible to anyone interested
