### PR TITLE
bug 1431497: Swap spam for health in noext tests

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -6,7 +6,7 @@ services:
     user: ${UID:-0}
     volumes:
       - ./:/app
-    command: py.test --nomigrations --junit-xml=/app/test_results/smoke.xml kuma/humans kuma/spam
+    command: py.test --nomigrations --junit-xml=/app/test_results/smoke.xml kuma/humans kuma/health
     environment:
       - DATABASE_URL=sqlite:///
       - PYTHONDONTWRITEBYTECODE=1


### PR DESCRIPTION
The spam tests use waffle flags and switches, which are now stored inthe Redis cache, and fail in the noext tests. Instead, check kuma/health.

Test process:
```
VERSION=latest make build-base  # Get a base image with the new libraries
docker-compose -f docker-compose.yml -f docker-compose.test.yml run noext
```