### PR TITLE
bug 1458197: Merge DNT and GA inline scripts

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -42,9 +42,6 @@
   {% stylesheet 'locale-%s' % LANG %}
 
   {% block site_analytics %}
-    <script>
-      {% include "js/libs/mozilla.dnthelper.min.js" %}
-    </script>
     {% include "includes/google_analytics.html" %}
   {% endblock %}
 

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -1,6 +1,8 @@
-{% if config.GOOGLE_ANALYTICS_ACCOUNT != '0' %}
-{% set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
 <script>
+    // Mozilla DNT Helper
+    {% include "js/libs/mozilla.dnthelper.min.js" %}
+    {%- if config.GOOGLE_ANALYTICS_ACCOUNT != '0' %}
+    {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
@@ -63,5 +65,5 @@
             ga('send', 'pageview', {'hitCallback': removeUtms});
         })();
     }
+    {%- endif %}
 </script>
-{% endif %}


### PR DESCRIPTION
Merge the minimized Mozilla DNT Helper and the Google Analytics setup into a single inline ``<head>`` script.