### PR TITLE
bug 957802: Fix link to MDN GitHub org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ can ask:
 
 [get-involved]: https://wiki.mozilla.org/Webdev/GetInvolved/developer.mozilla.org#Mentored_Bugs
 [irc-howto]: https://wiki.mozilla.org/Irc
-[MDN projects]: https://github.com/mdn
+[mdn-projects]: https://github.com/mdn
 
 How to submit code
 ==================


### PR DESCRIPTION
Fix typo in Markdown reference to the MDN GitHub organization.