### PR TITLE
bug 1464093: Update ElasticSearch docs for 5.6.10

### DIFF
--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -7,15 +7,24 @@ Kuma uses Elasticsearch_ to power its on-site search.
 
 Installed version
 =================
-Elasticsearch `releases new versions often`_, and Kuma is slow to upgrade. The
-Docker environment uses 2.4, and production uses 1.7, with a planned update to 2.4.
+Elasticsearch `releases new versions often`_. They release a new minor version
+(for example, 6.2.0, 6.3.0) every 30 to 90 days, and support the most recent
+minor version. They release a major version (5.0.0, 6.0.0) every 12 to 18
+months, and support the last minor version of the previous major release
+(for example, 2.4.x supported until 6.x is released, 5.6.x supported until 7.x
+is released).
+
+Kuma's goal is to update to the last minor version of the previous major
+release, so we expect to update every 12 to 18 months. Kuma is running on
+ElasticSearch 5.6.10 in development and production, which is planned to be
+supported until March 2019.
 
 The Kuma search tests use the configured Elasticsearch, and can be run inside
 the ``web`` Docker container to confirm the engine works::
 
     py.test kuma/search/
 
-.. _releases new versions often: https://en.wikipedia.org/wiki/Elasticsearch#History
+.. _releases new versions often: https://www.elastic.co/support/eol
 
 .. _indexing-documents:
 


### PR DESCRIPTION
Kuma is using 5.6.10 in development and production. The previous production version was 2.4, but the docs were not updated.

Add some more details about the ElasticSearch support policy, and which version Kuma is targeting. The version history was removed from Wikipedia, and there doesn't seem to be a good release history on the ES website, so link to the end-of-life support page.