### PR TITLE
bug 1423719: Remove suffix '| MDN' from page title

### DIFF
--- a/jinja2/403.html
+++ b/jinja2/403.html
@@ -2,7 +2,7 @@
 
 {% block bodyclass %}error{% endblock %}
 
-{% block title %}{{ page_title(_('Permission Denied')) }}{% endblock %}
+{% block title %}{{ _('Permission Denied') }}{% endblock %}
 
 {% block site_css %}
     {{ super() }}
@@ -16,7 +16,7 @@
 
   <section id="content-main" class="full" role="main">
 
-    <h1 class="page-title">{% block page_title %}{{ _('Permission Denied') }}{% endblock %}</h1>
+    <h1 class="page-title">{{ _('Permission Denied') }}</h1>
     {% block reason -%}
 
     {% if reason == 'kumaediting' %}

--- a/jinja2/404.html
+++ b/jinja2/404.html
@@ -3,7 +3,7 @@
 {% set styles = ('error-404',) %}
 
 {% block bodyclass %}error{% endblock %}
-{% block title %}{{ page_title(_('Not Found')) }}{% endblock %}
+{% block title %}{{ _('Not Found') }}{% endblock %}
 
 {% block content %}
 

--- a/jinja2/429.html
+++ b/jinja2/429.html
@@ -2,7 +2,7 @@
 
 {% block bodyclass %}error{% endblock %}
 
-{% block title %}{{ page_title(_('Too Many Requests')) }}{% endblock %}
+{% block title %}{{ _('Too Many Requests') }}{% endblock %}
 
 {% block site_css %}
     {{ super() }}

--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -2,7 +2,7 @@
 
 {% block bodyclass %}error{% endblock %}
 
-{% block title %}{{ page_title(_('Internal Server Error')) }}{% endblock %}
+{% block title %}{{ _('Internal Server Error') }}{% endblock %}
 
 {% set styles = ('error',) %}
 

--- a/jinja2/handlers/400.html
+++ b/jinja2/handlers/400.html
@@ -2,7 +2,7 @@
 
 {% block bodyclass %}error{% endblock %}
 
-{% block title %}{{ page_title(_('Permission Denied')) }}{% endblock %}
+{% block title %}{{ _('Permission Denied') }}{% endblock %}
 
 {% set styles = ('error',) %}
 

--- a/kuma/attachments/jinja2/attachments/edit_attachment.html
+++ b/kuma/attachments/jinja2/attachments/edit_attachment.html
@@ -1,7 +1,7 @@
 {% extends "wiki/base.html" %}
 {# L10n: 'title' is the title of the document. #}
 {% set title = _('Attachments | %(title)s', title=document.title) %}
-{% block title %}{{ page_title(document.title) }}{% endblock %}
+{% block title %}{{ document.title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 {% from 'includes/common_macros.html' import li_field %}

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -92,11 +92,6 @@ def entity_decode(str):
     return htmlparser.unescape(str)
 
 
-@library.global_function
-def page_title(title):
-    return jinja2.Markup(u'%s | MDN' % jinja2.escape(title))
-
-
 @library.filter
 def level_tag(message):
     return jinja2.Markup(force_text(LEVEL_TAGS.get(message.level, ''),

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -6,7 +6,7 @@ import pytest
 import pytz
 from babel.dates import format_date, format_datetime, format_time
 from django.conf import settings
-from django.test import override_settings, RequestFactory, TestCase
+from django.test import override_settings, RequestFactory
 from soapbox.models import Message
 
 from kuma.core.tests import KumaTestCase
@@ -15,8 +15,7 @@ from kuma.users.tests import UserTestCase
 
 from ..exceptions import DateTimeFormatError
 from ..templatetags.jinja_helpers import (datetimeformat, get_soapbox_messages,
-                                          in_utc, jsonencode, page_title,
-                                          soapbox_messages, yesno)
+                                          in_utc, jsonencode, soapbox_messages, yesno)
 
 
 class TestYesNo(KumaTestCase):
@@ -204,12 +203,3 @@ class TestInUtc(KumaTestCase):
         dt = datetime(2016, 3, 10, hour, 8)
         out = in_utc(dt)
         assert out == datetime(2016, 3, 10, hour + 8, 8, tzinfo=pytz.utc)
-
-
-class TestPageTitle(TestCase):
-    def test_ascii(self):
-        assert page_title('title') == 'title | MDN'
-
-    def test_xss(self):
-        pt = page_title('</title><Img src=x onerror=alert(1)>')
-        assert pt == '&lt;/title&gt;&lt;Img src=x onerror=alert(1)&gt; | MDN'

--- a/kuma/dashboards/jinja2/dashboards/macros.html
+++ b/kuma/dashboards/jinja2/dashboards/macros.html
@@ -3,7 +3,7 @@
 {% set title = _("Active macros") %}
 {% set github_macro_list = "https://github.com/mdn/kumascript/tree/master/macros/" %}
 {% set github_macro_view_prefix = "https://github.com/mdn/kumascript/blob/master/macros/" %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}

--- a/kuma/dashboards/jinja2/dashboards/revisions.html
+++ b/kuma/dashboards/jinja2/dashboards/revisions.html
@@ -3,7 +3,7 @@
 {% set styles = ('dashboards', 'jquery-ui') %}
 {% set classes = 'compare' %}
 
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block document_head %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -2,7 +2,7 @@
 {% set styles = ('dashboards',) %}
 {% set title = 'Spam Dashboard' %}
 
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set stat_ids=(('spam_viewers_change', '% Change', 'rate'),

--- a/kuma/landing/jinja2/landing/maintenance-mode.html
+++ b/kuma/landing/jinja2/landing/maintenance-mode.html
@@ -2,7 +2,7 @@
 
 {% set styles = ('maintenance-mode',) %}
 
-{% block title %}{{ page_title(_('Maintenance Mode')) }}{% endblock %}
+{% block title %}{{ _('Maintenance Mode') }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block content %}

--- a/kuma/landing/jinja2/landing/promote_buttons.html
+++ b/kuma/landing/jinja2/landing/promote_buttons.html
@@ -2,7 +2,7 @@
 
 {% block body_attributes %}id="promote-buttons"{% endblock %}
 
-{% block title %}{{ page_title(_('Promote MDN')) }}{% endblock %}
+{% block title %}{{ _('Promote MDN') }}{% endblock %}
 
 {% set styles = ('promote',) %}
 

--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -11,9 +11,9 @@
 
 {% block title %}
   {% if query %}
-    {{ page_title(_('Search Results for "%(query)s"', query=query)) }}
+    {{ _('Search Results for "%(query)s"', query=query) }}
   {% else %}
-    {{ page_title(_('Search')) }}
+    {{ _('Search') }}
   {% endif %}
 {% endblock %}
 

--- a/kuma/users/jinja2/account/account_inactive.html
+++ b/kuma/users/jinja2/account/account_inactive.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Profile Inactive")) }}{% endblock %}
+{% block title %}{{ _("Profile Inactive") }}{% endblock %}
 {% block content %}
 <div class="text-content readable-line-length">
 

--- a/kuma/users/jinja2/account/email.html
+++ b/kuma/users/jinja2/account/email.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Email addresses")) }}{% endblock %}
+{% block title %}{{ _("Email addresses") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/email_confirm.html
+++ b/kuma/users/jinja2/account/email_confirm.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Confirm Email Address")) }}{% endblock %}
+{% block title %}{{ _("Confirm Email Address") }}{% endblock %}
 
 
 {% block content %}

--- a/kuma/users/jinja2/account/email_confirmed.html
+++ b/kuma/users/jinja2/account/email_confirmed.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Confirm Email Address")) }}{% endblock %}
+{% block title %}{{ _("Confirm Email Address") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/logout.html
+++ b/kuma/users/jinja2/account/logout.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Sign Out")) }}{% endblock %}
+{% block title %}{{ _("Sign Out") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_change.html
+++ b/kuma/users/jinja2/account/password_change.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Change Password")) }}{% endblock %}
+{% block title %}{{ _("Change Password") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_reset.html
+++ b/kuma/users/jinja2/account/password_reset.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Password Reset")) }}{% endblock %}
+{% block title %}{{ _("Password Reset") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_reset_done.html
+++ b/kuma/users/jinja2/account/password_reset_done.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Password Reset")) }}{% endblock %}
+{% block title %}{{ _("Password Reset") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_reset_from_key.html
+++ b/kuma/users/jinja2/account/password_reset_from_key.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Change Password")) }}{% endblock %}
+{% block title %}{{ _("Change Password") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_reset_from_key_done.html
+++ b/kuma/users/jinja2/account/password_reset_from_key_done.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Change Password")) }}{% endblock %}
+{% block title %}{{ _("Change Password") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/password_set.html
+++ b/kuma/users/jinja2/account/password_set.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Set Password")) }}{% endblock %}
+{% block title %}{{ _("Set Password") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/signup.html
+++ b/kuma/users/jinja2/account/signup.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Signup")) }}{% endblock %}
+{% block title %}{{ _("Signup") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/signup_closed.html
+++ b/kuma/users/jinja2/account/signup_closed.html
@@ -3,7 +3,7 @@
 {% set subtitle = _('Profile Creation Disabled') %}
 {% set message = _('We are sorry, but profile creation is currently disabled.') %}
 
-{% block title %}{{ page_title(subtitle) }}{% endblock %}
+{% block title %}{{ subtitle }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/verification_sent.html
+++ b/kuma/users/jinja2/account/verification_sent.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Confirm Your Email Address")) }}{% endblock %}
+{% block title %}{{ _("Confirm Your Email Address") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/account/verified_email_required.html
+++ b/kuma/users/jinja2/account/verified_email_required.html
@@ -1,6 +1,6 @@
 {% extends "account/base.html" %}
 
-{% block title %}{{ page_title(_("Confirm Your Email Address")) }}{% endblock %}
+{% block title %}{{ _("Confirm Your Email Address") }}{% endblock %}
 
 {% block content %}
 <div class="text-content readable-line-length">

--- a/kuma/users/jinja2/openid/login.html
+++ b/kuma/users/jinja2/openid/login.html
@@ -1,6 +1,6 @@
 {% extends "openid/base.html" %}
 
-{% block title %}{{ page_title(_("OpenID Sign In")) }}{% endblock %}
+{% block title %}{{ _("OpenID Sign In") }}{% endblock %}
 
 {% block content %}
 <h1>{{ _("OpenID Sign In") }}</h1>

--- a/kuma/users/jinja2/socialaccount/authentication_error.html
+++ b/kuma/users/jinja2/socialaccount/authentication_error.html
@@ -1,6 +1,6 @@
 {% extends "socialaccount/base.html" %}
 
-{% block title %}{{ page_title(_("Account Sign In Failure")) }}{% endblock %}
+{% block title %}{{ _("Account Sign In Failure") }}{% endblock %}
 
 {% block content %}
 <h1>{{ _("Account Sign In Failure") }}</h1>

--- a/kuma/users/jinja2/socialaccount/login_cancelled.html
+++ b/kuma/users/jinja2/socialaccount/login_cancelled.html
@@ -1,6 +1,6 @@
 {% extends "socialaccount/base.html" %}
 
-{% block title %}{{ page_title(_("Login Cancelled")) }}{% endblock %}
+{% block title %}{{ _("Login Cancelled") }}{% endblock %}
 
 {% block content %}
 

--- a/kuma/users/jinja2/users/recover_done.html
+++ b/kuma/users/jinja2/users/recover_done.html
@@ -2,7 +2,7 @@
 
 {% set title=_("Connect Account") %}
 
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block content %}
 <h1>{{ title }}</h1>

--- a/kuma/users/jinja2/users/user_banned.html
+++ b/kuma/users/jinja2/users/user_banned.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
 {% endblock %}
 
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block site_css %}
     {{ super() }}

--- a/kuma/users/jinja2/users/user_delete.html
+++ b/kuma/users/jinja2/users/user_delete.html
@@ -9,7 +9,7 @@
 {% block bodyclass %}user user-delete{% endblock %}
 
 {% set title=_("Delete your profile") %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block site_css %}
   {{ super() }}

--- a/kuma/users/jinja2/users/user_detail.html
+++ b/kuma/users/jinja2/users/user_detail.html
@@ -7,7 +7,7 @@
 
 {% block bodyclass %}user user-display{% endblock %}
 
-{% block title %}{{ page_title(detail_user) }}{% endblock %}
+{% block title %}{{ detail_user }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}

--- a/kuma/users/jinja2/users/user_edit.html
+++ b/kuma/users/jinja2/users/user_edit.html
@@ -8,7 +8,7 @@
 
 {% block bodyclass %}user user-edit{% endblock %}
 
-{% block title %}{{ page_title(_('Edit Your Profile')) }}{% endblock %}
+{% block title %}{{ _('Edit Your Profile') }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}

--- a/kuma/wiki/jinja2/403-create-page.html
+++ b/kuma/wiki/jinja2/403-create-page.html
@@ -1,6 +1,6 @@
 {% extends "403.html" %}
 
-{% block page_title %}{{ _("You're trying to create a new page.") }}{% endblock %}
+{{ _("You're trying to create a new page.") }}
 
 {% block reason %}
 <p class="notice">

--- a/kuma/wiki/jinja2/wiki/compare_revisions.html
+++ b/kuma/wiki/jinja2/wiki/compare_revisions.html
@@ -2,7 +2,7 @@
 {% from "wiki/includes/document_macros.html" import revision_diff with context %}
 
 {% set title = _('Compare Revisions | %(document)s', document=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'compare' %}
 

--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% from "wiki/includes/document_macros.html" import build_document_crumbs with context %}
-{% block title %}{{ page_title(_('Delete Document | %(document)s', document=document.title)) }}{% endblock %}
+{% block title %}{{ _('Delete Document | %(document)s', document=document.title) }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% block content %}
 

--- a/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revert Revision | %(document)s', document=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}revert-document{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/create.html
+++ b/kuma/wiki/jinja2/wiki/create.html
@@ -3,7 +3,7 @@
 {% from 'wiki/includes/page_buttons.html' import page_buttons with context %}
 {% from "includes/common_macros.html" import content_editor %}
 {% set title = _('Create a New Article') %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'new' %}
 {% block bodyclass %}new{% endblock %}

--- a/kuma/wiki/jinja2/wiki/deletion_log.html
+++ b/kuma/wiki/jinja2/wiki/deletion_log.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% block title %}{{ page_title(_('Document Deleted')) }}{% endblock %}
+{% block title %}{{ _('Document Deleted') }}{% endblock %}
 {% block content %}
 
   <article>

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
+{% block title %}{{ document.title + seo_parent_title }}{% endblock %}
 
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
 {% from "wiki/includes/buttons.html" import get_document_buttons with context %}

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -2,7 +2,7 @@
 {% from "includes/error_list.html" import errorlist %}
 {% from 'wiki/includes/page_buttons.html' import page_buttons %}
 
-{% block title %}{{ page_title(_('%(title)s | Edit Article', title=document.title)) }}{% endblock %}
+{% block title %}{{ _('%(title)s | Edit Article', title=document.title) }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% set classes = 'edit' %}

--- a/kuma/wiki/jinja2/wiki/list/documents.html
+++ b/kuma/wiki/jinja2/wiki/list/documents.html
@@ -11,7 +11,7 @@
 {% else %}
   {% set title = _('All documents') %}
 {% endif %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% set crumbs = [(None, title)] %}
 

--- a/kuma/wiki/jinja2/wiki/list/needs_review.html
+++ b/kuma/wiki/jinja2/wiki/list/needs_review.html
@@ -13,7 +13,7 @@
 {% else %}
   {% set title = _('All articles in need of review') %}
 {% endif %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision History | %(document)s', document=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block site_css %}

--- a/kuma/wiki/jinja2/wiki/list/tags.html
+++ b/kuma/wiki/jinja2/wiki/list/tags.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('All Tags') %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block content %}
     <div id="document-list">

--- a/kuma/wiki/jinja2/wiki/list/with_localization_tags.html
+++ b/kuma/wiki/jinja2/wiki/list/with_localization_tags.html
@@ -4,7 +4,7 @@
 {% else %}
   {% set title = _('Articles tagged with any localization tags') %}
 {% endif %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% set crumbs = [(None, title)] %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/move.html
+++ b/kuma/wiki/jinja2/wiki/move.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Move Article | %(document)s', document=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass %}move-page{% endblock %}
 

--- a/kuma/wiki/jinja2/wiki/move_requested.html
+++ b/kuma/wiki/jinja2/wiki/move_requested.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Page move requested') %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block bodyclass %}move-page{% endblock %}
 
 {% block content %}

--- a/kuma/wiki/jinja2/wiki/revision.html
+++ b/kuma/wiki/jinja2/wiki/revision.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Revision %(id)s | %(title)s', id=revision.id, title=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% set classes = 'document' %}
 

--- a/kuma/wiki/jinja2/wiki/select_locale.html
+++ b/kuma/wiki/jinja2/wiki/select_locale.html
@@ -1,6 +1,6 @@
 {% extends "wiki/base.html" %}
 {% set title = _('Select language | %(document)s', document=document.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 
 {% block content %}
 

--- a/kuma/wiki/jinja2/wiki/translate.html
+++ b/kuma/wiki/jinja2/wiki/translate.html
@@ -5,7 +5,7 @@
 {% from "wiki/includes/document_macros.html" import revision_diff with context %}
 
 {% set title = _('Translate Article | %(document)s', document=parent.title) %}
-{% block title %}{{ page_title(title) }}{% endblock %}
+{% block title %}{{ title }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}
 {% block bodyclass%}translate{% endblock %}
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -617,22 +617,22 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
             assert page.find('head > title').text() in aught_titles
 
         # Test nested document titles
-        _make_doc('One', ['One | MDN'], 'one')
-        _make_doc('Two', ['Two - One | MDN'], 'one/two')
-        _make_doc('Three', ['Three - One | MDN'], 'one/two/three')
+        _make_doc('One', ['One'], 'one')
+        _make_doc('Two', ['Two - One'], 'one/two')
+        _make_doc('Three', ['Three - One'], 'one/two/three')
         _make_doc(u'Special Φ Char',
-                  [u'Special \u03a6 Char - One | MDN',
-                   u'Special \xce\xa6 Char - One | MDN'],
+                  [u'Special \u03a6 Char - One',
+                   u'Special \xce\xa6 Char - One'],
                   'one/two/special_char')
 
         # Additional tests for /Web/*  changes
-        _make_doc('Firefox OS', ['Firefox OS | MDN'], 'firefox_os')
-        _make_doc('Email App', ['Email App - Firefox OS | MDN'],
+        _make_doc('Firefox OS', ['Firefox OS'], 'firefox_os')
+        _make_doc('Email App', ['Email App - Firefox OS'],
                   'firefox_os/email_app')
-        _make_doc('Web', ['Web | MDN'], 'Web')
-        _make_doc('HTML', ['HTML | MDN'], 'Web/html')
-        _make_doc('Fieldset', ['Fieldset - HTML | MDN'], 'Web/html/fieldset')
-        _make_doc('Legend', ['Legend - HTML | MDN'],
+        _make_doc('Web', ['Web'], 'Web')
+        _make_doc('HTML', ['HTML'], 'Web/html')
+        _make_doc('Fieldset', ['Fieldset - HTML'], 'Web/html/fieldset')
+        _make_doc('Legend', ['Legend - HTML'],
                   'Web/html/fieldset/legend')
 
     def test_seo_script(self):

--- a/tests/functional/test_article.py
+++ b/tests/functional/test_article.py
@@ -7,16 +7,13 @@ from utils.decorators import (
 )
 
 ARTICLE_NAME = 'User:anonymous:uitest'
-ARTICLE_TITLE_SUFIX = " | MDN"
 
 
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_title(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
-    assert (ARTICLE_NAME + ARTICLE_TITLE_SUFIX) == selenium.title
-    assert page.article_title_text == ARTICLE_NAME
-    assert page.article_title_text in selenium.title
+    assert page.article_title_text == selenium.title == ARTICLE_NAME
 
 
 # layout

--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -13,7 +13,7 @@ ARTICLE_NAME = 'Send feedback (about|on) MDN'
 def test_location(base_url, selenium):
     article_page = ArticlePage(selenium, base_url).open()
     page = article_page.header.open_feedback()
-    assert re.match(ARTICLE_NAME + ' - The MDN project \| MDN', selenium.title)
+    assert re.match(ARTICLE_NAME + ' - The MDN project', selenium.title)
     assert re.match(ARTICLE_NAME, page.article_title_text)
     assert page.article_title_text in selenium.title
 

--- a/tests/functional/test_notfound.py
+++ b/tests/functional/test_notfound.py
@@ -6,7 +6,6 @@ from utils.decorators import skip_if_not_maintenance_mode
 from utils.urls import assert_valid_url
 
 ARTICLE_NAME = 'Not Found'
-ARTICLE_TITLE_SUFIX = " | MDN"
 
 
 # page headers
@@ -37,7 +36,5 @@ def test_is_expected_content(base_url, selenium, is_debug):
     if is_debug:
         assert selenium.title == 'Page not found at /en-US/%s' % page.SLUG
     else:
-        assert selenium.title == (ARTICLE_NAME + ARTICLE_TITLE_SUFIX)
-        assert page.page_title_text == ARTICLE_NAME
-        assert page.page_title_text in selenium.title
+        assert selenium.title == page.page_title_text == ARTICLE_NAME
         assert page.is_report_link_displayed

--- a/tests/functional/test_report.py
+++ b/tests/functional/test_report.py
@@ -4,7 +4,6 @@ from pages.article import ArticlePage
 from utils.urls import assert_valid_url
 
 ARTICLE_NAME = 'User:anonymous:uitest'
-ARTICLE_TITLE_SUFIX = " | MDN"
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
We believe that adding '| MDN' at the end of each page title could be
harming our SEO.

To prove this theory we are removing it from Kuma as an experiment,
this commit should be reverted if this experience is unsuccesful.