### PR TITLE
bug 1462475: Drop zone table in anon script

### DIFF
--- a/scripts/anonymize.sql
+++ b/scripts/anonymize.sql
@@ -59,7 +59,6 @@ SET FOREIGN_KEY_CHECKS=0;
 -- wiki_document
 -- wiki_documentdeletionlog
 -- wiki_documenttag
--- wiki_documentzone
 -- wiki_editortoolbar
 -- wiki_localizationtag
 -- wiki_localizationtaggedrevision
@@ -90,6 +89,9 @@ TRUNCATE socialaccount_socialapp_sites;
 TRUNCATE socialaccount_socialtoken;
 TRUNCATE tidings_watch;
 TRUNCATE tidings_watchfilter;
+
+-- Old tables
+DROP TABLE IF EXISTS wiki_documentzone;
 
 UPDATE account_emailaddress SET
     email = CONCAT(MD5(CONCAT(email, @common_hash_secret)), '@example.com');

--- a/scripts/clone_db.py
+++ b/scripts/clone_db.py
@@ -9,13 +9,13 @@ This script performs all the steps needed to produce an anonymized DB dump:
     * Drop the temporary DB
     * Delete the dump of the original DB
 """
-from datetime import datetime
 import os
 import os.path
 import subprocess
 import sys
-from textwrap import dedent
+from datetime import datetime
 from optparse import OptionParser
+from textwrap import dedent
 
 opts = None
 args = None
@@ -98,7 +98,6 @@ TABLES_TO_DUMP = [x.strip() for x in """
     wiki_documentdeletionlog
     wiki_documentspamattempt
     wiki_documenttag
-    wiki_documentzone
     wiki_editortoolbar
     wiki_localizationtag
     wiki_localizationtaggedrevision


### PR DESCRIPTION
Don't clone the table when anonymizing, and drop it if present.

A test run is fast with the sample database in the development environment:

```
(host) $ make bash
 (web) $ scripts/clone_db.py developer_mozilla_org -H mysql -p kuma
```
