### PR TITLE
bug 1483072: handle the new Jenkins pipelines

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -5,8 +5,22 @@
 PROD_BRANCH_NAME = 'prod-push'
 STAGE_BRANCH_NAME = 'stage-push'
 STANDBY_BRANCH_NAME = 'standby-push'
-KUMA_PIPELINE = 'mdn_multibranch_pipeline'
-KUMASCRIPT_PIPELINE= 'kumascript_multibranch_pipeline'
+KUMA_PIPELINE = 'kuma'
+KUMASCRIPT_PIPELINE= 'kumascript'
+// TODO: After cutover to IT-owned services, remove these.
+MOZMEAO_KUMA_PIPELINE = 'mdn_multibranch_pipeline'
+MOZMEAO_KUMASCRIPT_PIPELINE= 'kumascript_multibranch_pipeline'
+
+def is_mozmeao_pipeline() {
+    /*
+     * Temporary function that returns true if this is running on the
+     * MozMEAO-owned Jenkins service targeting the MozMEAO-owned Kubernetes
+     * cluster.
+     * TODO: After cutover to IT-owned services, remove this function.
+     */
+    return (env.JOB_NAME.startsWith(MOZMEAO_KUMA_PIPELINE + '/') ||
+            env.JOB_NAME.startsWith(MOZMEAO_KUMASCRIPT_PIPELINE + '/'))
+}
 
 def get_commit_tag() {
     return env.GIT_COMMIT.take(7)
@@ -44,10 +58,12 @@ def get_target_script() {
 
 def get_region() {
     if (env.BRANCH_NAME == PROD_BRANCH_NAME) {
-        return 'portland'
+        // TODO: After cutover to IT-owned services, just use 'oregon'.
+        return is_mozmeao_pipeline() ? 'portland' : 'oregon'
     }
     if (env.BRANCH_NAME == STAGE_BRANCH_NAME) {
-        return 'portland'
+        // TODO: After cutover to IT-owned services, just use 'oregon'.
+        return is_mozmeao_pipeline() ? 'portland' : 'oregon'
     }
     if (env.BRANCH_NAME == STANDBY_BRANCH_NAME) {
         return 'frankfurt'
@@ -58,10 +74,12 @@ def get_region() {
 }
 
 def get_repo_name() {
-    if (env.JOB_NAME.startsWith(KUMA_PIPELINE)) {
+    if (env.JOB_NAME.startsWith(KUMA_PIPELINE + '/') ||
+        env.JOB_NAME.startsWith(MOZMEAO_KUMA_PIPELINE + '/')) {
         return 'kuma'
     }
-    if (env.JOB_NAME.startsWith(KUMASCRIPT_PIPELINE)) {
+    if (env.JOB_NAME.startsWith(KUMASCRIPT_PIPELINE + '/') ||
+        env.JOB_NAME.startsWith(MOZMEAO_KUMASCRIPT_PIPELINE + '/')) {
         return 'kumascript'
     }
     throw new Exception(


### PR DESCRIPTION
This PR allows us to handle both the current and new Jenkins pipelines during this period of transition.

On the new Jenkins service owned by IT, it will use the new configuration scripts [within the `oregon` region](https://github.com/mdn/infra/tree/master/apps/mdn/mdn-aws/k8s/regions/oregon) rather than the current ones [within the `portland` region](https://github.com/mdn/infra/tree/master/apps/mdn/mdn-aws/k8s/regions/portland).