### PR TITLE
bug 1483072: Get jenkins user ID via shell

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,8 @@ node {
     sh 'git submodule update --init --recursive'
     setGitEnvironmentVariables()
     // Set UID to jenkins
-    env['UID'] = 1000
+    jenkins_uid = sh returnStdout: true, script: 'id -u jenkins'
+    env['UID'] = jenkins_uid.trim()
     // Prepare for junit test results
     sh "mkdir -p test_results"
     sh "rm -f test_results/*.xml"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,7 @@ node {
     sh 'git submodule update --init --recursive'
     setGitEnvironmentVariables()
     // Set UID to jenkins
-    jenkins_uid = sh returnStdout: true, script: 'id -u jenkins'
-    env['UID'] = jenkins_uid.trim()
+    env['UID'] = sh(returnStdout: true, script: 'id -u jenkins').trim()
     // Prepare for junit test results
     sh "mkdir -p test_results"
     sh "rm -f test_results/*.xml"


### PR DESCRIPTION
The ``jenkins`` user's ID is different in the MozMEAO and IT Jenkins server, so don't hard-code it.