### PR TITLE
bug 1380388: Improve document purging

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -78,6 +78,7 @@ def wiki_user_3(db, django_user_model):
 
 @pytest.fixture
 def user_client(client, wiki_user):
+    """A test client with wiki_user logged in."""
     wiki_user.set_password('password')
     wiki_user.save()
     client.login(username=wiki_user.username, password='password')
@@ -86,6 +87,7 @@ def user_client(client, wiki_user):
 
 @pytest.fixture
 def editor_client(user_client):
+    """A test client with wiki_user logged in for editing."""
     with override_flag('kumaediting', True):
         yield user_client
 

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -32,6 +32,17 @@ library.filter(urlparams)
 library.global_function(statici18n)
 
 
+@library.global_function(name='assert')
+def assert_function(statement, message=None):
+    """Add runtime assertions to Jinja2 templates."""
+    if not statement:
+        if message:
+            raise RuntimeError('Failed assertion: {}'.format(message))
+        else:
+            raise RuntimeError('Failed assertion')
+    return ''
+
+
 @library.filter
 def paginator(pager):
     """Render list of pages."""

--- a/kuma/core/tests/test_helpers.py
+++ b/kuma/core/tests/test_helpers.py
@@ -14,9 +14,26 @@ from kuma.core.urlresolvers import reverse
 from kuma.users.tests import UserTestCase
 
 from ..exceptions import DateTimeFormatError
-from ..templatetags.jinja_helpers import (datetimeformat, get_soapbox_messages,
-                                          in_utc, jsonencode, page_title,
+from ..templatetags.jinja_helpers import (assert_function, datetimeformat,
+                                          get_soapbox_messages, in_utc,
+                                          jsonencode, page_title,
                                           soapbox_messages, yesno)
+
+
+def test_assert_function():
+    with pytest.raises(RuntimeError) as exc:
+        assert_function(False, 'Message')
+    assert str(exc.value) == 'Failed assertion: Message'
+
+
+def test_assert_function_no_message():
+    with pytest.raises(RuntimeError) as exc:
+        assert_function(False)
+    assert str(exc.value) == 'Failed assertion'
+
+
+def test_assert_function_passes():
+    assert assert_function(True, 'Message') == ''
 
 
 class TestYesNo(KumaTestCase):

--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -40,13 +40,66 @@ block indicators aka banners
     @extend %indicator-block-heading;
 }
 
+/* Expand out the following for browsers which don’t support `:matches(…)`
+   TODO: Use postcss-matches-selectro once https://bugzil.la/1366868 is resolved. */
+.warning + .warning,
+.overheadIndicator + .warning,
+.note + .warning,
+.notice + .warning,
+pre + .warning,
+.warning + .overheadIndicator,
+.overheadIndicator + .overheadIndicator,
+.note + .overheadIndicator,
+.notice + .overheadIndicator,
+pre + .overheadIndicator,
+.warning + .note,
+.overheadIndicator + .note,
+.note + .note,
+.notice + .note,
+pre + .note,
+.warning + .notice,
+.overheadIndicator + .notice,
+.note + .notice,
+.notice + .notice,
+pre + .notice,
+.warning + pre,
+.overheadIndicator + pre,
+.note + pre,
+.notice + pre,
+pre + pre,
+.warning + p:empty + .warning,
+.overheadIndicator + p:empty + .warning,
+.note + p:empty + .warning,
+.notice + p:empty + .warning,
+pre + p:empty + .warning,
+.warning + p:empty + .overheadIndicator,
+.overheadIndicator + p:empty + .overheadIndicator,
+.note + p:empty + .overheadIndicator,
+.notice + p:empty + .overheadIndicator,
+pre + p:empty + .overheadIndicator,
+.warning + p:empty + .note,
+.overheadIndicator + p:empty + .note,
+.note + p:empty + .note,
+.notice + p:empty + .note,
+pre + p:empty + .note,
+.warning + p:empty + .notice,
+.overheadIndicator + p:empty + .notice,
+.note + p:empty + .notice,
+.notice + p:empty + .notice,
+pre + p:empty + .notice,
+.warning + p:empty + pre,
+.overheadIndicator + p:empty + pre,
+.note + p:empty + pre,
+.notice + p:empty + pre,
+pre + p:empty + pre {
+    margin-top: ($grid-spacing * -1) + 5px;
+}
+
 /* If there are 2 indicators in close proximity, snug them up.
    Too many combinations to do them all but this
    should take care of most common combinations */
-.warning + .warning,
-.warning + .overheadIndicator,
-.overheadIndicator + .overheadIndicator,
-.note + .note {
+:matches(.warning, .overheadIndicator, .note, .notice, pre) + :matches(.warning, .overheadIndicator, .note, .notice, pre),
+:matches(.warning, .overheadIndicator, .note, .notice, pre) + p:empty + :matches(.warning, .overheadIndicator, .note, .notice, pre) {
     margin-top: ($grid-spacing * -1) + 5px;
 }
 

--- a/kuma/wiki/jinja2/wiki/confirm_purge.html
+++ b/kuma/wiki/jinja2/wiki/confirm_purge.html
@@ -1,0 +1,31 @@
+{% extends "wiki/base.html" %}
+{% block title %}{{ page_title(_('Purge Document | %(document)s', document=document.title)) }}{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
+{% block content %}
+
+  <article>
+    <h1>{{ _('Purge') }} <a href="{{ document.get_absolute_url() }}">{{ document.title }}</a></h1>
+
+    {% if deletion_log -%}
+      <p>
+        {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
+          This document was deleted by <a href="{{ url }}">{{ username }}</a> on {{ when }}.
+        {% endtrans -%}
+      </p>
+      <h2>{{ _('Reason for Deletion') }}</h2>
+      <p>{{ deletion_log.reason }}</p>
+
+    {% else -%}
+      <p>{{ _('This document was deleted, for unknown reasons.') }}</p>
+    {% endif -%}
+
+    <p>{{ _('Purge this document?') }}</p>
+    <form action="" method="post">
+      {% csrf_token %}
+      <input type="hidden" name="confirm" value="true" />
+      <input type="submit" value="{{ _('Purge') }}" />
+      <a href="{{ document.get_absolute_url() }}">{{ _('Cancel') }}</a>
+    </form>
+  </article>
+
+{% endblock %}

--- a/kuma/wiki/jinja2/wiki/deletion_log.html
+++ b/kuma/wiki/jinja2/wiki/deletion_log.html
@@ -24,6 +24,13 @@
     <p><a href="{{ url('wiki.restore_document', deletion_log.slug) }}" class="button">{{ _('Restore this document') }}</a></p>
     {% endif -%}
 
+    {% if user.has_perm('wiki.purge_document') -%}
+      <form action="{{ url('wiki.purge_document', deletion_log.slug) }}" method="post">
+        {% csrf_token %}
+        <input type="hidden" name="confirm" value="true" />
+        <button class="button" type="submit">{{ _('Purge this document') }}</button>
+      </form>
+    {% endif -%}
   </article>
 
 {% endblock %}

--- a/kuma/wiki/jinja2/wiki/deletion_log.html
+++ b/kuma/wiki/jinja2/wiki/deletion_log.html
@@ -6,17 +6,23 @@
 
     <h1>{{ _('Document Deleted') }}</h1>
     <p>
-    {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  %}
-      This document was deleted on {{ when }}.
-    {% endtrans %}
+      {% if user.has_perm('wiki.restore_document') -%}
+        {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
+          This document was deleted by <a href="{{ url }}">{{ username }}</a> on {{ when }}.
+        {% endtrans -%}
+      {% else -%}
+        {% trans when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
+          This document was deleted on {{ when }}.
+        {% endtrans -%}
+      {% endif -%}
     </p>
 
     <h2>{{ _('Reason for Deletion') }}</h2>
     <p>{{ deletion_log.reason }}</p>
 
-    {% if user.has_perm('wiki.restore_document') %}
+    {% if user.has_perm('wiki.restore_document') -%}
     <p><a href="{{ url('wiki.restore_document', deletion_log.slug) }}" class="button">{{ _('Restore this document') }}</a></p>
-    {% endif %}
+    {% endif -%}
 
   </article>
 

--- a/kuma/wiki/jinja2/wiki/deletion_log.html
+++ b/kuma/wiki/jinja2/wiki/deletion_log.html
@@ -6,23 +6,17 @@
 
     <h1>{{ _('Document Deleted') }}</h1>
     <p>
-      {% if user.has_perm('wiki.restore_document') -%}
-        {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
-          This document was deleted by <a href="{{ url }}">{{ username }}</a> on {{ when }}.
-        {% endtrans -%}
-      {% else -%}
-        {% trans when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
-          This document was deleted on {{ when }}.
-        {% endtrans -%}
-      {% endif -%}
+      {{- assert(user.has_perm('wiki.restore_document'),
+                 'Deletion log details are only for moderators.') }}
+      {% trans url=deletion_log.user.get_absolute_url(), username=deletion_log.user, when=datetimeformat(deletion_log.timestamp, format='longdatetime')  -%}
+        This document was deleted by <a href="{{ url }}">{{ username }}</a> on {{ when }}.
+      {% endtrans -%}
     </p>
 
     <h2>{{ _('Reason for Deletion') }}</h2>
     <p>{{ deletion_log.reason }}</p>
 
-    {% if user.has_perm('wiki.restore_document') -%}
     <p><a href="{{ url('wiki.restore_document', deletion_log.slug) }}" class="button">{{ _('Restore this document') }}</a></p>
-    {% endif -%}
 
     {% if user.has_perm('wiki.purge_document') -%}
       <form action="{{ url('wiki.purge_document', deletion_log.slug) }}" method="post">

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from datetime import datetime
 
-from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 from django.utils.text import slugify
 from html5lib.filters.base import Filter as html5lib_Filter
@@ -137,19 +136,6 @@ def create_document_editor_group():
     group.permissions = perms
     group.save()
     return group
-
-
-def create_document_editor_user():
-    """Get or create a user empowered with document editing."""
-    User = get_user_model()
-    user = User.objects.create(username='conantheeditor',
-                               email='conantheeditor@example.com',
-                               is_active=True, is_staff=False,
-                               is_superuser=False)
-    user.set_password('testpass')
-    user.groups = [create_document_editor_group()]
-    user.save()
-    return user
 
 
 def create_topical_parents_docs():

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -6,11 +6,13 @@ from collections import namedtuple
 from datetime import datetime
 
 import pytest
+from django.contrib.auth.models import Permission
+from waffle.testutils import override_flag
 
 from kuma.core.urlresolvers import reverse
 
 from ..constants import REDIRECT_CONTENT
-from ..models import Document, Revision
+from ..models import Document, DocumentDeletionLog, Revision
 
 
 BannedUser = namedtuple('BannedUser', 'user ban')
@@ -43,6 +45,27 @@ def banned_wiki_user(db, django_user_model, wiki_user):
     )
     ban = user.bans.create(by=wiki_user, reason='because')
     return BannedUser(user=user, ban=ban)
+
+
+@pytest.fixture
+def wiki_moderator(wiki_user):
+    """Upgrade wiki_user to a moderator."""
+    wiki_user.user_permissions.add(
+        Permission.objects.get(codename='purge_document'),
+        Permission.objects.get(codename='delete_document'),
+        Permission.objects.get(codename='restore_document')
+    )
+    return wiki_user
+
+
+@pytest.fixture
+def moderator_client(client, wiki_moderator):
+    """A test client with wiki_moderator logged in."""
+    wiki_moderator.set_password('password')
+    wiki_moderator.save()
+    client.login(username=wiki_moderator.username, password='password')
+    with override_flag('kumaediting', True):
+        yield client
 
 
 @pytest.fixture
@@ -116,6 +139,28 @@ def redirect_doc(wiki_user, root_doc):
         title='Redirect Document',
         created=datetime(2017, 4, 17, 12, 15))
     return redirect_doc
+
+
+@pytest.fixture
+def deleted_doc(wiki_moderator):
+    """A recently deleted but unpurged document."""
+    deleted_doc = Document.objects.create(
+        locale='en-US', slug='Doomed', title='Doomed Document')
+    Revision.objects.create(
+        document=deleted_doc,
+        creator=wiki_moderator,
+        content='<p>This document is doomed...</p>',
+        title='Doomed Document',
+        created=datetime(2018, 8, 21, 17, 3))
+    deleted_doc.delete()
+    DocumentDeletionLog.objects.create(
+        user=wiki_moderator,
+        reason="Deleted doomed document",
+        locale='en-US',
+        slug='Doomed')
+    DocumentDeletionLog.objects.filter(user=wiki_moderator).update(
+        timestamp=datetime(2018, 8, 21, 17, 22))
+    return deleted_doc
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/conftest.py
+++ b/kuma/wiki/tests/conftest.py
@@ -48,14 +48,18 @@ def banned_wiki_user(db, django_user_model, wiki_user):
 
 
 @pytest.fixture
-def wiki_moderator(wiki_user):
-    """Upgrade wiki_user to a moderator."""
-    wiki_user.user_permissions.add(
+def wiki_moderator(db, django_user_model):
+    """A user with moderator permissions."""
+    moderator = django_user_model.objects.create(
+        username='moderator',
+        email='moderator@example.com',
+        date_joined=datetime(2018, 8, 21, 18, 19))
+    moderator.user_permissions.add(
         Permission.objects.get(codename='purge_document'),
         Permission.objects.get(codename='delete_document'),
         Permission.objects.get(codename='restore_document')
     )
-    return wiki_user
+    return moderator
 
 
 @pytest.fixture

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -7,9 +7,10 @@ import pytest
 from constance import config
 from constance.test import override_config
 from django.conf import settings
-from django.contrib.auth.models import Group
+from django.contrib.auth.models import AnonymousUser, Group
 from django.contrib.sites.models import Site
 from django.core import mail
+from django.shortcuts import render
 from django.test.utils import override_settings
 from django.utils import translation
 from django.utils.http import urlquote
@@ -41,6 +42,17 @@ link, or paste it into your browser's location bar:
 
 https://testserver/en-US/docs/%s$history
 """
+
+
+def test_deletion_log_assert(db, rf):
+    """deletion_log.html doesn't render for non-moderators."""
+    user = AnonymousUser()
+    request = rf.get('/en-US/docs/DeletedDoc')
+    request.user = user
+    with pytest.raises(RuntimeError) as exc:
+        render(request, 'wiki/deletion_log.html')
+    assert str(exc.value) == ('Failed assertion: Deletion log details are only'
+                              ' for moderators.')
 
 
 class DocumentTests(UserTestCase, WikiTestCase):

--- a/kuma/wiki/tests/test_views_delete.py
+++ b/kuma/wiki/tests/test_views_delete.py
@@ -64,14 +64,21 @@ def test_delete_get(root_doc, delete_client):
     assert_no_cache_header(response)
 
 
-@pytest.mark.xfail(reason='The "wiki/confirm_purge.html" template is missing'
-                          ' (see bugzilla 1197390).')
-def test_purge_get(root_doc, delete_client):
-    root_doc.delete()
-    url = reverse('wiki.purge_document', args=[root_doc.slug])
+def test_purge_get(deleted_doc, delete_client):
+    url = reverse('wiki.purge_document', args=[deleted_doc.slug])
     response = delete_client.get(url)
     assert response.status_code == 200
     assert_no_cache_header(response)
+    assert 'This document was deleted by' in response.content
+
+
+def test_purge_get_no_log(deleted_doc, delete_client):
+    url = reverse('wiki.purge_document', args=[deleted_doc.slug])
+    DocumentDeletionLog.objects.all().delete()
+    response = delete_client.get(url)
+    assert response.status_code == 200
+    assert_no_cache_header(response)
+    assert 'deleted, for unknown reasons' in response.content
 
 
 def test_restore_get(root_doc, delete_client):

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 import mock
 import pytest
 import requests_mock
+from django.contrib.auth.models import Permission
 from django.test.client import BOUNDARY, encode_multipart, MULTIPART_CONTENT
 from django.utils.http import quote_etag
 from django.utils.six.moves.urllib.parse import quote, urlparse
@@ -711,3 +712,43 @@ def test_watch_unwatch(user_client, wiki_user, root_doc, endpoint, event):
         reverse('wiki.document', args=[root_doc.slug]))
     assert not event.is_notifying(wiki_user, root_doc), \
         'Watch was not destroyed'
+
+
+def test_deleted_doc_anon(deleted_doc, client):
+    """Requesting a deleted doc returns 404"""
+    response = client.get(deleted_doc.get_absolute_url())
+    assert response.status_code == 404
+    assert "This document was deleted" not in response.content
+    assert 'Reason for Deletion' not in response.content
+
+
+def test_deleted_doc_moderator(deleted_doc, wiki_moderator, user_client):
+    """Requesting deleted doc as moderator returns 404 with action buttons."""
+    response = user_client.get(deleted_doc.get_absolute_url())
+    assert response.status_code == 404
+    assert 'Reason for Deletion' in response.content
+    full_description = (
+        'This document was deleted by'
+        ' <a href="/en-US/profiles/wiki_user">wiki_user</a>'
+        ' on <time datetime="2018-08-21T17:22:00-07:00">'
+        'August 21, 2018 at 5:22:00 PM PDT</time>.')
+    assert full_description in response.content
+    assert 'Restore this document' in response.content
+    assert 'Purge this document' in response.content
+
+
+def test_deleted_doc_deleted(deleted_doc, wiki_moderator, user_client):
+    """Requesting deleted doc without purge perm removes purge button."""
+    wiki_moderator.user_permissions.remove(
+        Permission.objects.get(codename='purge_document'))
+    response = user_client.get(deleted_doc.get_absolute_url())
+    assert response.status_code == 404
+    assert 'Reason for Deletion' in response.content
+    full_description = (
+        'This document was deleted by'
+        ' <a href="/en-US/profiles/wiki_user">wiki_user</a>'
+        ' on <time datetime="2018-08-21T17:22:00-07:00">'
+        'August 21, 2018 at 5:22:00 PM PDT</time>.')
+    assert full_description in response.content
+    assert 'Restore this document' in response.content
+    assert 'Purge this document' not in response.content

--- a/kuma/wiki/views/delete.py
+++ b/kuma/wiki/views/delete.py
@@ -132,6 +132,15 @@ def purge_document(request, document_slug, document_locale):
     document = get_object_or_404(Document.deleted_objects.all(),
                                  slug=document_slug,
                                  locale=document_locale)
+    deletion_log_entries = DocumentDeletionLog.objects.filter(
+        locale=document_locale,
+        slug=document_slug
+    )
+    if deletion_log_entries.exists():
+        deletion_log = deletion_log_entries.order_by('-pk')[0]
+    else:
+        deletion_log = {}
+
     if request.method == 'POST' and 'confirm' in request.POST:
         document.purge()
         return redirect(reverse('wiki.document',
@@ -140,4 +149,6 @@ def purge_document(request, document_slug, document_locale):
     else:
         return render(request,
                       'wiki/confirm_purge.html',
-                      {'document': document})
+                      {'document': document,
+                       'deletion_log': deletion_log,
+                       })

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -614,7 +614,7 @@ def document(request, document_slug, document_locale):
             slug=document_slug
         )
         if deletion_log_entries.exists():
-            # Show deletion log and restore option for soft-deleted docs
+            # Show deletion log and restore / purge for soft-deleted docs
             deleted_doc = Document.deleted_objects.filter(
                 locale=document_locale, slug=document_slug)
             if deleted_doc.exists():

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -614,7 +614,11 @@ def document(request, document_slug, document_locale):
             slug=document_slug
         )
         if deletion_log_entries.exists():
-            return _document_deleted(request, deletion_log_entries)
+            # Show deletion log and restore option for soft-deleted docs
+            deleted_doc = Document.deleted_objects.filter(
+                locale=document_locale, slug=document_slug)
+            if deleted_doc.exists():
+                return _document_deleted(request, deletion_log_entries)
 
         # We can throw a 404 immediately if the request type is HEAD.
         # TODO: take a shortcut if the document was found?


### PR DESCRIPTION
This fixes a few bugs and issues with document purging:

* On the deleted document page, show who deleted a document if the viewer has revert permissions.
* On the deleted document page, add a "Purge document" button if the viewer is allowed to purge the document.
* Add a purge confirmation page, so GET will work for ``$purge`` pages (fixes [bug 1197390](https://bugzilla.mozilla.org/show_bug.cgi?id=1197390)).
* If a document has been purged, treat it as a missing document (fixes [bug 1380388](https://bugzilla.mozilla.org/show_bug.cgi?id=1380388)).
* Add an async task to remove deletion logs for purged documents.