### PR TITLE
bug 1308630, bug 1468271: Fixes for custom Interactive Examples URLs

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -48,7 +48,7 @@ STAGING_DOMAIN = 'developer.allizom.org'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
 INTERACTIVE_EXAMPLES_BASE = config(
-    'https://interactive-examples.mdn.mozilla.net',
+    'INTERACTIVE_EXAMPLES_BASE',
     default='https://interactive-examples.mdn.mozilla.net')
 
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', default=False, cast=bool)

--- a/kuma/static/js/interactive.js
+++ b/kuma/static/js/interactive.js
@@ -17,9 +17,7 @@
             if (
                 currentEntry.initiatorType &&
                 currentEntry.initiatorType === 'iframe' &&
-                currentEntry.name.indexOf(
-                    'interactive-examples.mdn.mozilla.net'
-                ) > -1
+                currentEntry.name.indexOf(targetOrigin) > -1
             ) {
                 return perfEntries[i];
             }


### PR DESCRIPTION
This addresses some issues when reviewing PR #4935 and getting my Kuma dev environment to talk to a local checkout of https://github.com/mdn/interactive-examples/

* I gave @schalkneethling the wrong command in https://github.com/mozilla/kuma/pull/4404#discussion_r137103509 to override ``INTERACTIVE_EXAMPLES_BASE`` from the environment, this corrects it.
* The code that looks for the interactive example iframe events was always looking for the production domain, this changes it to look for ``INTERACTIVE_EXAMPLES_BASE`` via ``mdn.interactiveEditor.editorUrl``.