### PR TITLE
bug 1467532: Update to bleach 2.1.4

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -8,9 +8,9 @@
 # Code: https://github.com/mozilla/bleach
 # Changes: https://bleach.readthedocs.io/en/latest/changes.html
 # Docs: https://bleach.readthedocs.io/en/latest/
-bleach==2.1.3 \
-    --hash=sha256:eb7386f632349d10d9ce9d4a838b134d4731571851149f9cc2c05a9a837a9a44 \
-    --hash=sha256:b8fa79e91f96c2c2cd9fd1f9eda906efb1b88b483048978ba62fef680e962b34
+bleach==2.1.4 \
+    --hash=sha256:0ee95f6167129859c5dce9b1ca291ebdb5d8cd7e382ca0e237dfd0dad63f63d8 \
+    --hash=sha256:24754b9a7d530bf30ce7cbc805bc6cce785660b4a10ff3a43633728438c105ab
 
 # Process tasks in the background
 # Code: https://github.com/celery/celery


### PR DESCRIPTION
* bleach 2.1.3 → 2.1.4: Handle ambiguous ampersands, like &xx;