### PR TITLE
bug 1308630: Replace KUMA_WIKI_IFRAME_ALLOWED_HOSTS with ALLOWED_IFRAME_PATTERNS

### DIFF
--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -18,8 +18,7 @@
 
 # Local development of Interactive Examples
 # See https://github.com/mdn/interactive-examples/
-# Constance KUMA_WIKI_IFRAME_ALLOWED_HOSTS will need to allow this iframe src
-#INTERACTIVE_EXAMPLES_BASE=http://localhost:8080
+#INTERACTIVE_EXAMPLES_BASE=http://localhost:9090
 
 # Set the level of the ElasticSearch logger in Kuma
 #ES_LOG_LEVEL=ERROR    # Default, never logs

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -47,9 +47,9 @@ PRODUCTION_DOMAIN = 'developer.mozilla.org'
 STAGING_DOMAIN = 'developer.allizom.org'
 STAGING_URL = PROTOCOL + STAGING_DOMAIN
 
+_PROD_INTERACTIVE_EXAMPLES = 'https://interactive-examples.mdn.mozilla.net'
 INTERACTIVE_EXAMPLES_BASE = config(
-    'INTERACTIVE_EXAMPLES_BASE',
-    default='https://interactive-examples.mdn.mozilla.net')
+    'INTERACTIVE_EXAMPLES_BASE', default=_PROD_INTERACTIVE_EXAMPLES)
 
 MAINTENANCE_MODE = config('MAINTENANCE_MODE', default=False, cast=bool)
 REVISION_HASH = config('REVISION_HASH', default='undefined')
@@ -1125,8 +1125,10 @@ LEGACY_HOSTS = config('LEGACY_HOSTS', default='', cast=Csv())
 MAX_FILENAME_LENGTH = 200
 MAX_FILEPATH_LENGTH = 250
 
-ATTACHMENT_HOST = config('ATTACHMENT_HOST', default='mdn.mozillademos.org')
-ATTACHMENT_ORIGIN = config('ATTACHMENT_ORIGIN', default=ATTACHMENT_HOST)
+_PROD_ATTACHMENT_HOST = 'mdn.mozillademos.org'
+ATTACHMENT_HOST = config('ATTACHMENT_HOST', default=_PROD_ATTACHMENT_HOST)
+_PROD_ATTACHMENT_ORIGIN = 'mdn-demos-origin.moz.works'
+ATTACHMENT_ORIGIN = config('ATTACHMENT_ORIGIN', default=_PROD_ATTACHMENT_ORIGIN)
 
 # This should never be false for the production and stage deployments.
 ENABLE_RESTRICTIONS_BY_HOST = config(
@@ -1146,7 +1148,7 @@ ALLOW_ROBOTS_WEB_DOMAINS = set(
 # If the domain is a CDN, the CDN origin should be included.
 ALLOW_ROBOTS_DOMAINS = set(
     config('ALLOW_ROBOTS_DOMAINS',
-           default='mdn.mozillademos.org,mdn-demos-origin.moz.works',
+           default=','.join((_PROD_ATTACHMENT_HOST, _PROD_ATTACHMENT_ORIGIN)),
            cast=Csv()))
 
 # Video settings, hard coded here for now.

--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -3,9 +3,6 @@ from .common import *  # noqa
 # Settings for Docker Development
 # TODO: Use environment to override, not settings picker
 
-ATTACHMENT_HOST = config('ATTACHMENT_HOST',
-                         default='mdn-local.mozillademos.org')
-
 INTERNAL_IPS = ('127.0.0.1', '192.168.10.1', '172.18.0.1')
 
 # Default DEBUG to True, and recompute derived settings

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -1105,10 +1105,12 @@ class IframeHostFilter(html5lib_Filter):
         for scheme, netloc, path in self.allowed_src_patterns:
             if parts.netloc != netloc or parts.scheme != scheme:
                 continue
-            if isinstance(path, re._pattern_type):
+            if hasattr(path, 'match'):
+                # path must match a compiled regex
                 if not path.match(parts.path):
                     continue
             elif path:
+                # path must start with this prefix
                 if not parts.path.startswith(path):
                     continue
             return True

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -1,7 +1,7 @@
 from datetime import date, datetime, timedelta
 
 import bleach
-from constance import config
+from django.conf import settings
 from django.db import models
 from django_mysql.models import QuerySet
 
@@ -20,13 +20,13 @@ class BaseDocumentManager(models.Manager):
         attributes = ALLOWED_ATTRIBUTES
         styles = ALLOWED_STYLES
         protocols = ALLOWED_PROTOCOLS
-        allowed_hosts = config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS
+        allowed_iframe_patterns = settings.ALLOWED_IFRAME_PATTERNS
 
         bleached_content = bleach.clean(content_in, attributes=attributes,
                                         tags=tags, styles=styles,
                                         protocols=protocols)
         filtered_content = (parse_content(bleached_content)
-                            .filterIframeHosts(allowed_hosts)
+                            .filterIframeHosts(allowed_iframe_patterns)
                             .serialize())
         return filtered_content
 

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -3,6 +3,7 @@ from base64 import b64encode
 
 import bleach
 import pytest
+from django.conf import settings
 from django.test import TestCase
 from django.utils.six.moves.urllib.parse import urljoin
 from jinja2 import escape, Markup
@@ -716,7 +717,6 @@ def test_filteriframe_empty_contents():
 
 
 FILTERIFRAME_ACCEPTED = {
-    'docker': 'http://localhost:8000/de/docs/Test$samples/test?revision=678',
     'youtube_ssl': ('https://www.youtube.com/embed/'
                     'iaNoBlae5Qw/?feature=player_detailpage'),
     'prod': ('https://mdn.mozillademos.org/'
@@ -727,6 +727,10 @@ FILTERIFRAME_ACCEPTED = {
                   'tutorial/sample6/index.html'),
     'ie_moz_net': ('https://interactive-examples.mdn.mozilla.net/'
                    'pages/js/array-push.html'),
+    'code_sample': (settings.PROTOCOL + settings.ATTACHMENT_HOST +
+                    '/de/docs/Test$samples/test?revision=678'),
+    'interactive': (settings.INTERACTIVE_EXAMPLES_BASE +
+                    '/pages/http/headers.html')
 }
 
 FILTERIFRAME_REJECTED = {

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -28,11 +28,12 @@ def code_sample_doc(root_doc, wiki_user):
     return root_doc
 
 
-def test_code_sample(code_sample_doc, constance_config, client, settings):
+@pytest.mark.parametrize('domain', ('HOST', 'ORIGIN'))
+def test_code_sample(code_sample_doc, client, settings, domain):
     """The raw source for a document can be requested."""
     url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*testserver'
+    setattr(settings, 'ATTACHMENT_' + domain, 'testserver')
     with override_switch('application_ACAO', True):
         response = client.get(
             url,
@@ -60,23 +61,23 @@ def test_code_sample(code_sample_doc, constance_config, client, settings):
     assert normalized == expected
 
 
-def test_code_sample_host_not_allowed(code_sample_doc, constance_config,
-                                      client):
+def test_code_sample_host_not_allowed(code_sample_doc, settings, client):
     """Users are not allowed to view samples on a restricted domain."""
     url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*sampleserver'
-    response = client.get(url, HTTP_HOST='testserver')
+    host = 'testserver'
+    assert settings.ATTACHMENT_HOST != host
+    assert settings.ATTACHMENT_ORIGIN != host
+    response = client.get(url, HTTP_HOST=host)
     assert response.status_code == 403
 
 
-def test_code_sample_host_allowed(code_sample_doc, constance_config, settings,
-                                  client):
+def test_code_sample_host_allowed(code_sample_doc, settings, client):
     """Users are allowed to view samples on an allowed domain."""
     host = 'sampleserver'
     url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*' + host
+    settings.ATTACHMENT_HOST = host
     settings.ALLOWED_HOSTS.append(host)
     response = client.get(url, HTTP_HOST=host)
     assert response.status_code == 200
@@ -86,8 +87,7 @@ def test_code_sample_host_allowed(code_sample_doc, constance_config, settings,
 
 # The pytest-django urls marker also resets urlconf caches after the test
 @pytest.mark.urls(settings.ROOT_URLCONF)
-def test_code_sample_host_restricted_host(code_sample_doc, constance_config,
-                                          settings, client):
+def test_code_sample_host_restricted_host(code_sample_doc, settings, client):
     """Users are allowed to view samples on the attachment domain."""
     # Render the document, which will be a sync operation, before applying
     # host restrictions.
@@ -96,7 +96,6 @@ def test_code_sample_host_restricted_host(code_sample_doc, constance_config,
     url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
     host = 'sampleserver'
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*' + host
     settings.ALLOWED_HOSTS.append(host)
     settings.ATTACHMENT_HOST = host
     settings.ENABLE_RESTRICTIONS_BY_HOST = True
@@ -107,7 +106,7 @@ def test_code_sample_host_restricted_host(code_sample_doc, constance_config,
 
 
 def test_raw_code_sample_file(code_sample_doc, constance_config,
-                              wiki_user, admin_client):
+                              wiki_user, admin_client, settings):
 
     # Upload an attachment
     upload_url = reverse('attachments.edit_attachment',
@@ -119,7 +118,6 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
         'comment': 'Yadda yadda yadda',
         'file': file_for_upload,
     }
-    constance_config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS = '^.*testserver'
     constance_config.WIKI_ATTACHMENT_ALLOWED_TYPES = 'text/plain'
     response = admin_client.post(upload_url, data=post_data)
     assert response.status_code == 302
@@ -143,6 +141,7 @@ def test_raw_code_sample_file(code_sample_doc, constance_config,
     sample_url = reverse('wiki.code_sample',
                          args=[code_sample_doc.slug, 'sample1'])
 
+    settings.ATTACHMENT_HOST = 'testserver'
     response = admin_client.get(sample_url)
     assert response.status_code == 200
     assert url_css in response.content

--- a/kuma/wiki/views/code.py
+++ b/kuma/wiki/views/code.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-import re
-
-from constance import config
+from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.cache import cache_control
@@ -26,8 +24,8 @@ def code_sample(request, document_slug, document_locale, sample_name):
     HTML document
     """
     # Restrict rendering of live code samples to specified hosts
-    if not re.search(config.KUMA_WIKI_IFRAME_ALLOWED_HOSTS,
-                     request.build_absolute_uri()):
+    if request.get_host() not in (settings.ATTACHMENT_HOST,
+                                  settings.ATTACHMENT_ORIGIN):
         raise PermissionDenied
 
     document = get_object_or_404(Document, slug=document_slug,


### PR DESCRIPTION
The constance setting ``KUMA_WIKI_IFRAME_ALLOWED_HOSTS`` was a regex used to validate code sample request hosts and what ``src`` URLs were allowed for ``<iframe src="">``. It was also easy to get wrong, and needed to change in predictable ways for each deployment environment.

Code sample domain checking is updated to use ``ATTACHMENT_HOST`` and ``ATTACHMENT_ORIGIN`` for domain validation. This may require setting these correctly in stage and production.

A new setting ``ALLOWED_IFRAME_PATTERNS`` allows for more precise protocol and domain matching, optional path matching (by prefix or regex match), and can be automatically adjusted for ``ATTACHMENT_HOST`` and ``INTERACTIVE_EXAMPLE_BASE`` settings.

There are patterns that are no longer allowed by default:

* https://stage-files.mdn.moz.works/ - Stage's ``ATTACHMENT_HOST``. On Stage, this will be added automatically.
* http://localhost:8000/ - Dev's ``ATTACHMENT_HOST``. In the dev environment, this will be added automatically.
* http://localhost:8080/ - Dev's (old) ``INTERACTIVE_EXAMPLES_BASE``. The new port for [npm run start-server](https://github.com/mdn/interactive-examples/blob/bd8a91b5dd6c85c51adce007218838d3daf1d465/package.json#L44-L45) is ``9090``.
* http://testserver/ - The Django test client hostname. Tests now add this as needed.
* https://youtube.com/ - [EmbedYouTube](https://github.com/mdn/kumascript/blob/0006405761fc7ff977c7c6bdc467e90014b8a63b/macros/EmbedYouTube.ejs#L28) always uses www.youtube.com
* http:// variants - Production iframes use https://, and SSL should be the default in 2018.

``KUMA_WIKI_IFRAME_ALLOWED_HOSTS`` is retained for now, for debugging issues as this deploys. 