### PR TITLE
bug 1483072: pass jenkins user id to docker runs

### DIFF
--- a/Jenkinsfiles/integration-tests.groovy
+++ b/Jenkinsfiles/integration-tests.groovy
@@ -46,7 +46,7 @@ def functional_test(browser, hub_name, base_dir) {
                           ["docker_args": "--link ${hub_name}:hub" +
                                           " --name ${test_name}" +
                                           " --volume ${base_dir}/test_results:/test_results" +
-                                          " --user 1000",
+                                          " --user ${UID}",
                            "cmd": cmd])
             }
         } finally {
@@ -67,7 +67,7 @@ def headless_test(base_dir) {
       dockerRun("kuma-integration-tests:${GIT_COMMIT_SHORT}",
                   ["docker_args": "--volume ${base_dir}/test_results:/test_results" +
                                   " --name ${test_name}" +
-                                  " --user 1000",
+                                  " --user ${UID}",
                   "cmd": "py.test tests/headless" +
                           " --base-url='${config.job.base_url}'" +
                           " --junit-xml=/test_results/headless.xml" +


### PR DESCRIPTION
This PR fixes the `stage-integration-tests` branch within the multi-branch `kuma` pipeline on the new IT-managed Jenkins service. On the new IT-managed Jenkins service, the `jenkins` user does not have a user ID of `1000`, so the Docker-based test runs don't have permission to write to the test results directory, so pass the actual `jenkins` user ID instead.

This change has been tested on both the new IT-managed as well as the current MozMEAO-managed Jenkins service.