### PR TITLE
bug 1481078: Fix zone redirects with format chars

### DIFF
--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -8,12 +8,6 @@ shared_cache_control_for_zones = shared_cache_control(
     s_maxage=60 * 60 * 24 * 7)
 
 
-def get_sub_path_handler(root_path):
-    def get_path(request, sub_path):
-        return root_path + (sub_path or '')
-    return get_path
-
-
 def redirect(pattern, to, **kwargs):
     """
     Return a url matcher suited for urlpatterns
@@ -808,7 +802,7 @@ zone_redirects = (
 )
 
 zone_pattern_fmt = r'^{prefix}{zone_root_pattern}(?:/?|(?P<sub_path>[/$].+))$'
-sub_path_fmt = u'/{prefix}docs/{wiki_slug}'
+sub_path_fmt = u'/{prefix}docs/{wiki_slug}{{sub_path}}'
 
 zone_redirectpatterns = []
 for zone_root, wiki_slug, locales in zone_redirects:
@@ -826,7 +820,7 @@ for zone_root, wiki_slug, locales in zone_redirects:
         sub_path = sub_path_fmt.format(prefix=prefix, wiki_slug=wiki_slug)
         zone_redirectpatterns.append(redirect(
             pattern,
-            get_sub_path_handler(sub_path),
+            sub_path,
             permanent=False,
             decorators=shared_cache_control_for_zones))
 

--- a/tests/headless/map_301.py
+++ b/tests/headless/map_301.py
@@ -429,6 +429,10 @@ for zone_root, wiki_slug, child_path, locales in zone_redirects:
             ZONE_REDIRECT_URLS.append(
                 url_test(path + u'$edit', redirect_path + u'$edit',
                          **zone_url_test_kwargs))
+            # A zone path with curly braces {}
+            ZONE_REDIRECT_URLS.append(
+                url_test(path + u'/{test}', redirect_path + '/{test}',
+                         **zone_url_test_kwargs))
 
 # Redirects added after 2017 AWS move
 REDIRECT_URLS = list(flatten((


### PR DESCRIPTION
Previously, the sub-path was added to the destination URL by appending it in a callable. If the ``sub_path`` included a Python format string, like ``/foo/bar/{var}``, then django-redirect-urls would run ``.format`` on it, and raise a ``KeyError`` for ``{var}``.

Instead of a callable, use a format string like ``/en-US/docs/Learn/{sub_path}``. This way, django-redirect-urls will format the string with the ``sub_path`` captured in the regex.