### PR TITLE
fix(styles.wiki): Hide sidebar contents in preview mode

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -100,3 +100,8 @@
         }
     }
 }
+
+#wikiArticle .Quick_links,
+#wikiArticle #Quick_Links {
+    display: none;
+}


### PR DESCRIPTION
This PR makes it so that the result of `{{...Sidebar}}` macros doesn’t appear in preview mode, which is implemented in some sidebar macros, but not others.

## TODO:

- [ ] Either find or open a bug for this PR.