### PR TITLE
bug 1482159: Set live samples URL for Kumascript

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,7 @@ services:
       - memcached
     environment:
       - interactive_examples__base_url=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
+      - live_samples__base_url=http://${ATTACHMENT_HOST:-localhost:8000}
       - log__console=true
       - log__file=
       - server__template_root_dir=macros


### PR DESCRIPTION
Use the ``ATTACHMENT_HOST`` environment variable to customize the domain for the live samples base URL for KumaScript. This KumaScript setting is added in https://github.com/mdn/kumascript/pull/777.