### PR TITLE
bug 1308630: Refactor clean_content

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -3,6 +3,7 @@ import re
 from collections import defaultdict
 from xml.sax.saxutils import quoteattr
 
+import bleach
 import html5lib
 import newrelic.agent
 from django.conf import settings
@@ -16,6 +17,8 @@ from pyquery import PyQuery as pq
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import order_params, to_html
 
+from .constants import (ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
+                        ALLOWED_STYLES, ALLOWED_TAGS)
 from .exceptions import DocumentRenderedContentNotAvailable
 from .utils import locale_and_slug_from_path
 
@@ -165,6 +168,20 @@ class Extractor(object):
                 data[part] = src
 
         return data
+
+
+def clean_content(content):
+    """Clean content with standard bleaching and filtering."""
+    bleached = bleach.clean(content,
+                            attributes=ALLOWED_ATTRIBUTES,
+                            tags=ALLOWED_TAGS,
+                            styles=ALLOWED_STYLES,
+                            protocols=ALLOWED_PROTOCOLS)
+    parsed = parse(bleached)
+    allowed_iframe_patterns = settings.ALLOWED_IFRAME_PATTERNS
+    filtered = parsed.filterIframeHosts(allowed_iframe_patterns)
+    content_out = filtered.serialize()
+    return content_out
 
 
 @newrelic.agent.function_trace()

--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -15,6 +15,7 @@ from django.utils.six.moves.urllib.parse import urljoin
 from elasticsearch import TransportError
 
 from .constants import KUMASCRIPT_BASE_URL, KUMASCRIPT_TIMEOUT_ERROR
+from .content import clean_content
 from .search import WikiDocumentType
 
 
@@ -213,8 +214,7 @@ def process_body(response):
     # We defer bleach sanitation of kumascript content all the way
     # through editing, source display, and raw output. But, we still
     # want sanitation, so it finally gets picked up here.
-    from kuma.wiki.models import Document
-    return Document.objects.clean_content(response.text)
+    return clean_content(response.text)
 
 
 def process_errors(response):

--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -1,34 +1,13 @@
 from datetime import date, datetime, timedelta
 
-import bleach
-from django.conf import settings
 from django.db import models
 from django_mysql.models import QuerySet
-
-from .constants import (ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
-                        ALLOWED_STYLES, ALLOWED_TAGS)
-from .content import parse as parse_content
 
 
 class BaseDocumentManager(models.Manager):
     """Manager for Documents, assists for queries"""
     def get_queryset(self):
         return QuerySet(self.model)
-
-    def clean_content(self, content_in):
-        tags = ALLOWED_TAGS
-        attributes = ALLOWED_ATTRIBUTES
-        styles = ALLOWED_STYLES
-        protocols = ALLOWED_PROTOCOLS
-        allowed_iframe_patterns = settings.ALLOWED_IFRAME_PATTERNS
-
-        bleached_content = bleach.clean(content_in, attributes=attributes,
-                                        tags=tags, styles=styles,
-                                        protocols=protocols)
-        filtered_content = (parse_content(bleached_content)
-                            .filterIframeHosts(allowed_iframe_patterns)
-                            .serialize())
-        return filtered_content
 
     def get_by_natural_key(self, locale, slug):
         return self.get(locale=locale, slug=slug)

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -30,8 +30,9 @@ from kuma.spam.models import AkismetSubmission, SpamAttempt
 from . import kumascript
 from .constants import (DEKI_FILE_URL, EXPERIMENT_TITLE_PREFIX, KUMA_FILE_URL,
                         REDIRECT_CONTENT, REDIRECT_HTML)
-from .content import (Extractor, get_content_sections, get_seo_description,
-                      H2TOCFilter, H3TOCFilter, SectionTOCFilter)
+from .content import (clean_content, Extractor, get_content_sections,
+                      get_seo_description, H2TOCFilter, H3TOCFilter,
+                      SectionTOCFilter)
 from .content import parse as parse_content
 from .exceptions import (DocumentRenderedContentNotAvailable,
                          DocumentRenderingInProgress, NotDocumentView,
@@ -1701,7 +1702,7 @@ class Revision(models.Model):
 
     @property
     def content_cleaned(self):
-        return Document.objects.clean_content(self.content)
+        return clean_content(self.content)
 
     @cached_property
     def previous(self):

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -20,6 +20,7 @@ from kuma.core.urlresolvers import reverse
 from kuma.core.utils import order_params, urlparams
 
 from ..constants import DIFF_WRAP_COLUMN
+from ..content import clean_content
 from ..utils import tidy_content
 
 
@@ -142,8 +143,7 @@ def colorize_diff(diff):
 
 @library.filter
 def wiki_bleach(val):
-    from kuma.wiki.models import Document
-    return jinja2.Markup(Document.objects.clean_content(val))
+    return jinja2.Markup(clean_content(val))
 
 
 @library.filter

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -14,7 +14,7 @@ import kuma.wiki.content
 from . import document, normalize_html
 from ..constants import (ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
                          ALLOWED_STYLES, ALLOWED_TAGS)
-from ..content import (CodeSyntaxFilter, get_content_sections,
+from ..content import (clean_content, CodeSyntaxFilter, get_content_sections,
                        get_seo_description, H2TOCFilter, H3TOCFilter, parse,
                        SECTION_TAGS, SectionIDFilter, SectionTOCFilter)
 from ..models import Document, Revision
@@ -1079,7 +1079,7 @@ def test_clean_content_stripped_ie_comment():
         <p>Hi there.</p>
         <p>Goodbye</p>
     """
-    result = Document.objects.clean_content(content)
+    result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 
 
@@ -1089,7 +1089,7 @@ def test_clean_content_iframe_in_script():
                '</iframe></script>')
     expected = ('&lt;script&gt;&lt;iframe src="data:text/plain,foo"&gt;'
                 '&lt;/iframe&gt;&lt;/script&gt;')
-    result = Document.objects.clean_content(content)
+    result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 
 
@@ -1099,7 +1099,7 @@ def test_clean_content_iframe_in_style():
                '</iframe></style>')
     expected = ('&lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;'
                 '&lt;/iframe&gt;&lt;/style&gt;')
-    result = Document.objects.clean_content(content)
+    result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 
 
@@ -1113,7 +1113,7 @@ def test_clean_content_iframe_in_textarea():
     expected = """
         <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
     """
-    result = Document.objects.clean_content(content)
+    result = clean_content(content)
     assert normalize_html(expected) == normalize_html(result)
 
 

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -10,10 +10,10 @@ from jinja2 import escape, Markup
 from pyquery import PyQuery as pq
 
 import kuma.wiki.content
-from kuma.core.tests import KumaTestCase
 
 from . import document, normalize_html
-from ..constants import ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS, ALLOWED_TAGS
+from ..constants import (ALLOWED_ATTRIBUTES, ALLOWED_PROTOCOLS,
+                         ALLOWED_STYLES, ALLOWED_TAGS)
 from ..content import (CodeSyntaxFilter, get_content_sections,
                        get_seo_description, H2TOCFilter, H3TOCFilter, parse,
                        SECTION_TAGS, SectionIDFilter, SectionTOCFilter)
@@ -988,109 +988,133 @@ class FilterEditorSafetyTests(TestCase):
         assert normalize_html(expected_src) == normalize_html(result_src)
 
 
-class AllowedHTMLTests(KumaTestCase):
-    simple_tags = (
-        'div', 'span', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'pre',
-        'code', 'dl', 'dt', 'dd', 'table',
-        'section', 'header', 'footer',
-        'nav', 'article', 'aside', 'figure', 'dialog', 'hgroup',
-        'mark', 'time', 'meter', 'output', 'progress',
-        'audio', 'details', 'datagrid', 'datalist', 'table',
-        'address'
-    )
+# Sample of tags from ALLOWED_TAGS
+SIMPLE_TAGS = (
+    'address',
+    'article',
+    'code',
+    'datagrid',
+    'details',
+    'dt',
+    'figure',
+    'h5',
+    'mark',
+    'output',
+    'pre',
+    'progress',
+)
 
-    unclose_tags = ('img', 'input', 'br', 'command')
 
-    special_tags = (
-        "<table><thead><tr><th>foo</th></tr></thead><tbody><tr><td>foo</td></tr></tbody></table>",
-    )
+SELF_CLOSED_TAGS = (
+    'br',
+    'command',
+    'img',
+    'input',
+)
 
-    special_attributes = (
-        '<command id="foo">',
-        '<img align="left" alt="picture of foo" class="foo" dir="rtl" id="foo" src="foo" title="foo">',
-        '<a class="foo" href="foo" id="foo" title="foo">foo</a>',
-        '<div class="foo">foo</div>',
-        '<video class="movie" controls id="some-movie" lang="en-US" src="some-movie.mpg">Fallback</video>'
-        # TODO: Styles have to be cleaned on a case-by-case basis. We
-        # need to enumerate the styles we're going to allow, then feed
-        # them to bleach.
-        # '<span style="font-size: 24px"></span>',
-    )
 
-    def test_allowed_tags(self):
-        for tag in self.simple_tags:
-            html_str = '<%(tag)s></%(tag)s>' % {'tag': tag}
-            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                            tags=ALLOWED_TAGS)
+@pytest.mark.parametrize('tag', SIMPLE_TAGS)
+def test_bleach_allowed_simple_tag(tag):
+    """bleach.clean allows simple tags."""
+    html = '<%(tag)s></%(tag)s>' % {'tag': tag}
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS)
+    assert out == html
 
-        for tag in self.unclose_tags:
-            html_str = '<%s>' % tag
-            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                            tags=ALLOWED_TAGS)
 
-        for html_str in self.special_tags:
-            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                            tags=ALLOWED_TAGS)
+@pytest.mark.parametrize('tag', SELF_CLOSED_TAGS)
+def test_bleach_allowed_self_closed_tags(tag):
+    """bleach.clean allows self-closed tags."""
+    html = '<%s>' % tag
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS)
+    assert out == html
 
-    def test_allowed_attributes(self):
-        for tag in ('div', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'pre', 'code',
-                    'dl', 'dt', 'dd', 'section', 'header', 'footer', 'nav',
-                    'article', 'aside', 'figure', 'dialog', 'hgroup', 'mark',
-                    'time', 'meter', 'output', 'progress', 'audio', 'details',
-                    'datagrid', 'datalist', 'address'):
-            html_str = '<%(tag)s id="foo"></%(tag)s>' % {'tag': tag}
-            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                            tags=ALLOWED_TAGS)
 
-        for html_str in self.special_attributes:
-            assert html_str == bleach.clean(html_str, attributes=ALLOWED_ATTRIBUTES,
-                                            tags=ALLOWED_TAGS)
+def test_bleach_allows_table():
+    """bleach.clean allows an HTML table."""
+    html = ('<table><thead><tr><th>foo</th></tr></thead>'
+            '<tbody><tr><td>foo</td></tr></tbody></table>')
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS)
+    assert out == html
 
-    def test_stripped_ie_comment(self):
-        """bug 801046: strip IE conditional comments"""
-        content = """
-            <p>Hi there.</p>
-            <!--[if]><script>alert(1)</script -->
-            <!--[if<img src=x onerror=alert(2)//]> -->
-            <p>Goodbye</p>
-        """
-        expected = """
-            <p>Hi there.</p>
-            <p>Goodbye</p>
-        """
-        result = Document.objects.clean_content(content)
-        assert normalize_html(expected) == normalize_html(result)
 
-    def test_iframe_in_script(self):
-        """iframe in script should be filtered"""
-        content = ('<script><iframe src="data:text/plain,foo">'
-                   '</iframe></script>')
-        expected = ('&lt;script&gt;&lt;iframe src="data:text/plain,foo"&gt;'
-                    '&lt;/iframe&gt;&lt;/script&gt;')
-        result = Document.objects.clean_content(content)
-        assert normalize_html(expected) == normalize_html(result)
+@pytest.mark.parametrize('tag', SIMPLE_TAGS)
+def test_bleach_allows_id_attr(tag):
+    """bleach.clean allows the attribute id."""
+    html = '<%(tag)s id="foo"></%(tag)s>' % {'tag': tag}
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS)
+    assert out == html
 
-    def test_iframe_in_style(self):
-        """iframe in style should be filtered"""
-        content = ('<style><iframe src="data:text/plain,foo">'
-                   '</iframe></style>')
-        expected = ('&lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;'
-                    '&lt;/iframe&gt;&lt;/style&gt;')
-        result = Document.objects.clean_content(content)
-        assert normalize_html(expected) == normalize_html(result)
 
-    def test_iframe_in_textarea(self):
-        """
-        iframe in textarea should not be filtered since it's not parsed as tag
-        """
-        content = """
-            <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
-        """
-        expected = """
-            <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
-        """
-        result = Document.objects.clean_content(content)
-        assert normalize_html(expected) == normalize_html(result)
+@pytest.mark.parametrize(
+    'html',
+    ('<command id="foo">',
+     '<img align="left" alt="picture of foo" class="foo" dir="rtl" id="foo" src="foo" title="foo">',
+     '<a class="foo" href="foo" id="foo" title="foo">foo</a>',
+     '<div class="foo">foo</div>',
+     '<video class="movie" controls id="some-movie" lang="en-US" src="some-movie.mpg">Fallback</video>',
+     ))
+def test_bleach_allows_some_attributes(html):
+    """bleach.clean allows some attributes."""
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS)
+    assert out == html
+
+
+def test_bleach_allows_some_styles():
+    """bleach.clean allow some style values."""
+    html = '<span style="font-size: 24px; rotate: 90deg"></span>'
+    out = bleach.clean(html, attributes=ALLOWED_ATTRIBUTES, tags=ALLOWED_TAGS,
+                       styles=ALLOWED_STYLES)
+    assert out == '<span style="font-size: 24px;"></span>'
+
+
+def test_clean_content_stripped_ie_comment():
+    """bug 801046: strip IE conditional comments"""
+    content = """
+        <p>Hi there.</p>
+        <!--[if]><script>alert(1)</script -->
+        <!--[if<img src=x onerror=alert(2)//]> -->
+        <p>Goodbye</p>
+    """
+    expected = """
+        <p>Hi there.</p>
+        <p>Goodbye</p>
+    """
+    result = Document.objects.clean_content(content)
+    assert normalize_html(expected) == normalize_html(result)
+
+
+def test_clean_content_iframe_in_script():
+    """iframe in script should be filtered"""
+    content = ('<script><iframe src="data:text/plain,foo">'
+               '</iframe></script>')
+    expected = ('&lt;script&gt;&lt;iframe src="data:text/plain,foo"&gt;'
+                '&lt;/iframe&gt;&lt;/script&gt;')
+    result = Document.objects.clean_content(content)
+    assert normalize_html(expected) == normalize_html(result)
+
+
+def test_clean_content_iframe_in_style():
+    """iframe in style should be filtered"""
+    content = ('<style><iframe src="data:text/plain,foo">'
+               '</iframe></style>')
+    expected = ('&lt;style&gt;&lt;iframe src="data:text/plain,foo"&gt;'
+                '&lt;/iframe&gt;&lt;/style&gt;')
+    result = Document.objects.clean_content(content)
+    assert normalize_html(expected) == normalize_html(result)
+
+
+def test_clean_content_iframe_in_textarea():
+    """
+    iframe in textarea should not be filtered since it's not parsed as tag
+    """
+    content = """
+        <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
+    """
+    expected = """
+        <textarea><iframe src="data:text/plain,foo"></iframe></textarea>
+    """
+    result = Document.objects.clean_content(content)
+    assert normalize_html(expected) == normalize_html(result)
 
 
 def test_extractor_css_classnames(root_doc, wiki_user):


### PR DESCRIPTION
The method ``Document.objects.clean_content`` provides the default bleaching and ``iframe`` ``src`` filtering for rendered wiki content. However, it doesn't act like a manager method, and this makes it awkward to call as a Jinja2 filter or on KumaScript preview content. It also made it awkward to optionally turn off ``iframe`` ``src`` filtering via a setting.

This moves ``clean_content`` to ``kuma.wiki.content`` as a plain function, and refactors to ``AllowedHTMLTests`` tests to be standard ``pytest`` tests, and to use ``clean_content`` rather than a ``bleach.clean`` call that is almost the same.  It also reduces the test cases, since many of the existing tests were little more than ``bleach.clean`` configuration tests.


