### PR TITLE
Fix Bug 1479817, anchor link headings are obscured by toc

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -990,6 +990,7 @@ PIPELINE_JS = {
             'js/wiki-samples.js',
             'js/wiki-toc.js',
             'js/components/local-anchor.js',
+            'js/components/page-load-actions.js',
         ),
         'output_filename': 'build/js/wiki.js',
         'extra_context': {

--- a/kuma/static/js/components/local-anchor.js
+++ b/kuma/static/js/components/local-anchor.js
@@ -7,17 +7,25 @@
     'use strict';
 
     function prependLocalAnchors() {
-        // collect all headings in wiki articles with an `id` attribute
-        var headings = Array.from(document.querySelectorAll('#wikiArticle h2[id]')).concat(
-            Array.from(document.querySelectorAll('#wikiArticle h3[id]'))
+        var mainDocument = document.getElementById('document-main');
+        // collect all headings with an `id` attribute
+        var headings = Array.from(document.querySelectorAll('h2[id]')).concat(
+            Array.from(document.querySelectorAll('h3[id]'))
         );
-        var pageUrl = document.location.href;
+        var pageUrl = new URL(document.location.href);
+
+        // if the pageUrl containes a hash, clear it
+        if (pageUrl.hash) {
+            pageUrl.hash = '';
+        }
 
         for (var i = 0, l = headings.length; i < l; i++) {
             var currentHeading = headings[i];
             var localAnchorTag = document.createElement('a');
             var span = document.createElement('span');
-            var link = window.mdnIcons ? window.mdnIcons.getIcon('link') : gettext('Link');
+            var link = window.mdnIcons
+                ? window.mdnIcons.getIcon('link')
+                : gettext('Link');
 
             localAnchorTag.classList.add('local-anchor');
             span.textContent = gettext('Section');
@@ -26,10 +34,33 @@
 
             // only append to headings that are not offscreen
             if (!currentHeading.classList.contains('offscreen')) {
-                localAnchorTag.href = pageUrl + '#' + currentHeading.id;
-                currentHeading.insertAdjacentElement('beforeend', localAnchorTag);
+                pageUrl.hash = currentHeading.id;
+                localAnchorTag.href = pageUrl;
+                localAnchorTag.dataset.headingId = currentHeading.id;
+                currentHeading.insertAdjacentElement(
+                    'beforeend',
+                    localAnchorTag
+                );
             }
         }
+
+        mainDocument.addEventListener('click', function(event) {
+            var target = event.target;
+            /* getting the attribute value as apposed to the target property
+               to ensure we get the actual text value of the attribute */
+            var hrefAttrValue = target.getAttribute('href');
+            var isInDocumentLink = hrefAttrValue.startsWith('#');
+
+            var headingId = isInDocumentLink
+                ? hrefAttrValue.substr(1)
+                : target.dataset.headingId;
+            /* only handle clicks on in document links or, that originated from
+               a `local-anchor` */
+            if (target.classList.contains('local-anchor') || isInDocumentLink) {
+                event.preventDefault();
+                mdn.utils.scrollToHeading(headingId);
+            }
+        });
     }
 
     // `Array.from` is not supported in IE, progressively enhance

--- a/kuma/static/js/components/local-anchor.js
+++ b/kuma/static/js/components/local-anchor.js
@@ -46,19 +46,26 @@
 
         mainDocument.addEventListener('click', function(event) {
             var target = event.target;
-            /* getting the attribute value as apposed to the target property
-               to ensure we get the actual text value of the attribute */
-            var hrefAttrValue = target.getAttribute('href');
-            var isInDocumentLink = hrefAttrValue.startsWith('#');
 
-            var headingId = isInDocumentLink
-                ? hrefAttrValue.substr(1)
-                : target.dataset.headingId;
-            /* only handle clicks on in document links or, that originated from
-               a `local-anchor` */
-            if (target.classList.contains('local-anchor') || isInDocumentLink) {
-                event.preventDefault();
-                mdn.utils.scrollToHeading(headingId);
+            // only handle clicks on anchor elements
+            if (target.tagName === 'A') {
+                /* getting the attribute value as apposed to the target property
+                   to ensure we get the actual text value of the attribute */
+                var hrefAttrValue = target.getAttribute('href');
+                var isInDocumentLink = hrefAttrValue.startsWith('#');
+
+                var headingId = isInDocumentLink
+                    ? hrefAttrValue.substr(1)
+                    : target.dataset.headingId;
+                /* only handle clicks on in document links or, that originated from
+                   a `local-anchor` */
+                if (
+                    target.classList.contains('local-anchor') ||
+                    isInDocumentLink
+                ) {
+                    event.preventDefault();
+                    mdn.utils.scrollToHeading(headingId);
+                }
             }
         });
     }

--- a/kuma/static/js/components/page-load-actions.js
+++ b/kuma/static/js/components/page-load-actions.js
@@ -11,7 +11,12 @@ window.addEventListener('load', function() {
         var id = hash.substr(1);
         var elem = document.getElementById(id);
         if (elem) {
-            mdn.utils.scrollToHeading(id);
+            /* Firefox ignores whatever value is passed to
+               `scroll` if called immediately on `load`, so,
+               wait for 60ms before calling the function */
+            setTimeout(function() {
+                mdn.utils.scrollToHeading(id);
+            }, 60);
         }
     }
 });

--- a/kuma/static/js/components/page-load-actions.js
+++ b/kuma/static/js/components/page-load-actions.js
@@ -1,0 +1,17 @@
+/**
+ * Actions that should happen during various stages
+ * during page load
+ */
+window.addEventListener('load', function() {
+    var hash = window.location.hash;
+    /* if the doument url contains a hash,
+       find the element with an `id` matching
+       the hash, and scroll to it */
+    if (hash) {
+        var id = hash.substr(1);
+        var elem = document.getElementById(id);
+        if (elem) {
+            mdn.utils.scrollToHeading(id);
+        }
+    }
+});

--- a/kuma/static/js/utils/utils.js
+++ b/kuma/static/js/utils/utils.js
@@ -1,4 +1,6 @@
 window.mdn.utils = {
+    isTocSticky: false,
+    tocHeight: 0,
     /**
      * From the jQuery source:
      * Get document-relative position by adding viewport scroll
@@ -12,7 +14,9 @@ window.mdn.utils = {
         /* Get the window object associated with the
            top-level document object for this node */
         var elemDocumentWindow = elem.ownerDocument.defaultView;
-        return boundingClientRect.top + elemDocumentWindow.pageYOffset;
+        var top = boundingClientRect.top;
+        var yOffset = parseInt(elemDocumentWindow.pageYOffset, 10);
+        return top + yOffset;
     },
     /**
      * Generate and returns a random string thanks to:
@@ -43,15 +47,30 @@ window.mdn.utils = {
      */
     scrollToHeading: function(id) {
         'use strict';
+        var toc = document.getElementById('toc');
+
+        // if page has a TOC,
+        if (toc !== undefined) {
+            // get and store the `offsetHeight`
+            this.tocHeight = toc.offsetHeight;
+            // and its sticky status
+            this.isTocSticky = getComputedStyle(toc).position === 'sticky';
+        }
+
         var heading = document.getElementById(id);
         var headingTop = mdn.utils.getOffsetTop(heading);
-        var toc = document.getElementById('toc');
-        var tocHeight = toc.offsetHeight;
-        var scrollY = headingTop - tocHeight;
+        var scrollY = 0;
+
+        // if the toc is sticky
+        if (toc && this.isTocSticky) {
+            scrollY = headingTop - this.tocHeight;
+        } else {
+            scrollY = headingTop;
+        }
 
         // update hash
         window.location.hash = id;
         // scroll to heading
-        window.scroll(0, scrollY);
+        window.scroll(0, parseInt(scrollY, 10));
     }
 };

--- a/kuma/static/js/utils/utils.js
+++ b/kuma/static/js/utils/utils.js
@@ -1,11 +1,27 @@
 window.mdn.utils = {
     /**
+     * From the jQuery source:
+     * Get document-relative position by adding viewport scroll
+     * to viewport-relative gBCR.
+     * @param {Object} elem - The element for which to get the top offset
+     * @returns {Number} The top offset of the element
+     */
+    getOffsetTop: function(elem) {
+        'use strict';
+        var boundingClientRect = elem.getBoundingClientRect();
+        /* Get the window object associated with the
+           top-level document object for this node */
+        var elemDocumentWindow = elem.ownerDocument.defaultView;
+        return boundingClientRect.top + elemDocumentWindow.pageYOffset;
+    },
+    /**
      * Generate and returns a random string thanks to:
      * https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript
      * @param {Number} [strLength] - The length of the string to return
      * @return {String} a randomly generated string with a chracter count of `strLength`
      */
     randomString: function(strLength) {
+        'use strict';
         var length = strLength || 5;
         var possible =
             'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
@@ -18,5 +34,24 @@ window.mdn.utils = {
         }
 
         return text;
+    },
+    /**
+     * Scroll the page to the location of the element with
+     * the given `id`. Takes into account the space taken
+     * up by the `#toc` to avoid overlap.
+     * @param {String} id = The elements `id`
+     */
+    scrollToHeading: function(id) {
+        'use strict';
+        var heading = document.getElementById(id);
+        var headingTop = mdn.utils.getOffsetTop(heading);
+        var toc = document.getElementById('toc');
+        var tocHeight = toc.offsetHeight;
+        var scrollY = headingTop - tocHeight;
+
+        // update hash
+        window.location.hash = id;
+        // scroll to heading
+        window.scroll(0, scrollY);
     }
 };

--- a/kuma/static/js/wiki-toc.js
+++ b/kuma/static/js/wiki-toc.js
@@ -7,18 +7,6 @@
     var tocItemHeight = 0;
     var headingMargin = 0;
 
-    function scrollToHeading(id) {
-        /* must use plain JS to get element, IDs contain characters jQuery can't handle */
-        var $heading = $(doc.getElementById(id));
-        var headingTop = $heading.offset().top;
-        var scrollY = headingTop - tocHeight - headingMargin;
-
-        // update hash
-        win.location.hash = '#' + id;
-        // scroll to heading
-        win.scroll(0, scrollY);
-    }
-
     /* Mobile
     ************************************************************************ */
 
@@ -67,7 +55,7 @@
                 var $button = $heading.find('button');
                 $button.click();
             }
-            scrollToHeading(headingId);
+            mdn.utils.scrollToHeading(headingId);
         }
     }
 
@@ -179,7 +167,7 @@
 
             // track click
             mdn.analytics.trackLink(event, linkHref, linkData);
-            scrollToHeading(headingId);
+            mdn.utils.scrollToHeading(headingId);
         }
 
         // if 3 lines tall or more make it not sticky
@@ -204,7 +192,7 @@
         if(window.location.hash) {
             var thisHash = window.location.hash;
             var headingId = thisHash.replace(/^#/, '');
-            scrollToHeading(headingId);
+            mdn.utils.scrollToHeading(headingId);
         }
     }
 

--- a/kuma/static/js/wiki-toc.js
+++ b/kuma/static/js/wiki-toc.js
@@ -188,12 +188,6 @@
             // underline current section
             countDownToUnderline();
         });
-
-        if(window.location.hash) {
-            var thisHash = window.location.hash;
-            var headingId = thisHash.replace(/^#/, '');
-            mdn.utils.scrollToHeading(headingId);
-        }
     }
 
     if(win.matchMedia(breakpoint).matches === true) {

--- a/kuma/static/styles/base/elements/document.scss
+++ b/kuma/static/styles/base/elements/document.scss
@@ -5,6 +5,7 @@ Styles for overall document.  Minimally styles the canvas.
 html {
     background: #fff;
     color: $text-color;
+    scroll-behavior: smooth;
 }
 
 body {

--- a/kuma/static/styles/components/wiki/elements.scss
+++ b/kuma/static/styles/components/wiki/elements.scss
@@ -29,6 +29,8 @@ article {
             color: $link-color;
             width: 16px;
             height: 16px;
+            /* ensure svg will never be target of mouse event */
+            pointer-events: none;
             @include bidi(((margin-left, ($grid-spacing / 2 ), margin-right, 0),));
         }
 


### PR DESCRIPTION
This resolves the problem described in bug 1479817 on Bugzilla:
https://bugzilla.mozilla.org/show_bug.cgi?id=1479817

I also extracted the `scrollToHeading` function into utils and removed the jQuery dependency it had. Also, added `scroll-behaviour: smooth;` to the `html` element so, now in supported browsers, the scroll behaviour will be silky smooth. (Try Fx)

@jwhitlock @hobinjk r?