### PR TITLE
bug 1482159: Allow allow attribute for iframes

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -37,7 +37,8 @@ ALLOWED_ATTRIBUTES = bleach.ALLOWED_ATTRIBUTES
 ALLOWED_ATTRIBUTES['*'] = ['lang']
 # Note: <iframe> is allowed, but src="" is pre-filtered before bleach
 ALLOWED_ATTRIBUTES['iframe'] = ['id', 'src', 'sandbox', 'seamless',
-                                'frameborder', 'width', 'height', 'class']
+                                'frameborder', 'width', 'height', 'class',
+                                'allow']
 ALLOWED_ATTRIBUTES['p'] = ['style', 'class', 'id', 'align', 'lang', 'dir']
 ALLOWED_ATTRIBUTES['span'] = ['style', 'class', 'id', 'title', 'lang', 'dir']
 ALLOWED_ATTRIBUTES['abbr'] = ['style', 'class', 'id', 'title', 'lang', 'dir']


### PR DESCRIPTION
The ``allow`` value is a semicolon-separated list of restricted features to allow an ``iframe`` to use. In Chrome and Safari, this is required for some demos (such as those using the video camera) to run. These browsers still ask for the user's permission to use the feature. Firefox is currently unaffected. See [bug 1482159](https://bugzilla.mozilla.org/show_bug.cgi?id=1482159) for more details.

The ``allow`` value will be able to be set with https://github.com/mdn/kumascript/pull/786, which is the required PR for production.  Staging will also require the changes in https://github.com/mdn/infra/pull/46.

Local testing requires many additional changes. The features are only available for iframes loaded from ``https``, so PR #4950 is required. The demo domain needs to be different, requiring PR #4951. It can be tricky to get the domains right, and if they aren't in the allowed lists, then you get a blank ``src`` after bleaching. The ``ALLOW_ALL_IFRAMES`` setting from PR #4953 is useful for debugging.

Because local testing is hard, I suggest testing in staging.