### PR TITLE
bug 1486527: Improve indicator snugging

### DIFF
--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -41,7 +41,8 @@ block indicators aka banners
 }
 
 /* Expand out the following for browsers which don’t support `:matches(…)`
-   TODO: Use postcss-matches-selectro once https://bugzil.la/1366868 is resolved. */
+   TODO: Use postcss-selector-matches once https://bugzil.la/1366868 is resolved.
+   See https://github.com/mozilla/kuma/pull/4884 */
 .warning + .warning,
 .overheadIndicator + .warning,
 .note + .warning,


### PR DESCRIPTION
Multiple indicator sections are separated by whitespace unless hacks and CSS classes are applied. Use the ``:matches`` selector to add some more automatic "snugging", with auto-expanded rules for browsers (like Firefox) that don't support :matches, since PostCSS will require additional work to integrate into the asset pipeline ([bug 1366868](https://bugzilla.mozilla.org/show_bug.cgi?id=1366868)).

This was cherry-picked from PR #4884, without the changes that add PostCSS and ``postcss-selector-matches``