### PR TITLE
bug 1486852: Don't abbrev. compatibility

### DIFF
--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -132,7 +132,7 @@
         <li><a href="{{ wiki_url('MDN/Contribute/Localize/Translating_pages') }}">{{ _('Translating') }}</a></li>
         <li><a href="{{ wiki_url('MDN/Promote') }}">{{ _('Promoting MDN') }}</a></li>
         <li><a href="https://github.com/mozilla/kuma#readme">{{ _('Contributing to the MDN codebase') }}</a></li>
-        <li><a href="https://github.com/mdn/browser-compat-data">{{ _('Updating browser compat data') }}</a></li>
+        <li><a href="https://github.com/mdn/browser-compat-data">{{ _('Updating browser compatibility data') }}</a></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
"compat" is a useful abbreviation for compatibility in English, but could be challenging to translate.  Fix before sending to translators.