### PR TITLE
Bug 1487656 ‑ Comment out the indicator `:matches(…)` block for now

### DIFF
--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -99,10 +99,12 @@ pre + p:empty + pre {
 /* If there are 2 indicators in close proximity, snug them up.
    Too many combinations to do them all but this
    should take care of most common combinations */
+/* Commented out because of https://bugzil.la/1487656
 :matches(.warning, .overheadIndicator, .note, .notice, pre) + :matches(.warning, .overheadIndicator, .note, .notice, pre),
 :matches(.warning, .overheadIndicator, .note, .notice, pre) + p:empty + :matches(.warning, .overheadIndicator, .note, .notice, pre) {
     margin-top: ($grid-spacing * -1) + 5px;
 }
+*/
 
 /* code block looks funny without it's padding,
    only appears in kumascript error boxes AFIK */


### PR DESCRIPTION
Fixes [bug 1487656](https://bugzil.la/1487656):
> Inspecting the minified stylesheet, it turns out that the minifier actually merged the :matches(…) and non‑:matches(…) blocks together, which breaks on browsers which don’t support :matches(…).
> 
> A temporary solution would be to comment out the :matches(…) block, but a long term one will require a way to tell the CSS minifier to not merge the :matches(…) and non‑:matches(…) blocks together.
> 
> ```css
> .note+.note, .note+.notice, .note+.overheadIndicator, .note+.warning,
> .note+p:empty+.note, .note+p:empty+.notice,
> .note+p:empty+.overheadIndicator, .note+p:empty+.warning, .note+p:empty+pre,
> .note+pre, .notice+.note, .notice+.notice, .notice+.overheadIndicator,
> .notice+.warning, .notice+p:empty+.note, .notice+p:empty+.notice,
> .notice+p:empty+.overheadIndicator, .notice+p:empty+.warning,
> .notice+p:empty+pre, .notice+pre, .overheadIndicator+.note,
> .overheadIndicator+.notice, .overheadIndicator+.overheadIndicator,
> .overheadIndicator+.warning, .overheadIndicator+p:empty+.note,
> .overheadIndicator+p:empty+.notice,
> .overheadIndicator+p:empty+.overheadIndicator,
> .overheadIndicator+p:empty+.warning, .overheadIndicator+p:empty+pre,
> .overheadIndicator+pre, .warning+.note, .warning+.notice,
> .warning+.overheadIndicator, .warning+.warning, .warning+p:empty+.note,
> .warning+p:empty+.notice, .warning+p:empty+.overheadIndicator,
> .warning+p:empty+.warning, .warning+p:empty+pre, .warning+pre,
> :matches(.warning, .overheadIndicator, .note, .notice,
> pre)+:matches(.warning, .overheadIndicator, .note, .notice, pre),
> :matches(.warning, .overheadIndicator, .note, .notice,
> pre)+p:empty+:matches(.warning, .overheadIndicator, .note, .notice, pre),
> pre+.note, pre+.notice, pre+.overheadIndicator, pre+.warning,
> pre+p:empty+.note, pre+p:empty+.notice, pre+p:empty+.overheadIndicator,
> pre+p:empty+.warning, pre+p:empty+pre, pre+pre {margin-top:-15px}
> ```

Follow‑up to #4958, necessary for #4884

---

review?(@jwhitlock)

See also w3c/csswg-drafts#3082, which is the reason why we are in this situation to begin with.