### PR TITLE
bug 1488884: Allow attribute <details open>

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -54,7 +54,6 @@ ALLOWED_ATTRIBUTES['th'] = ['style', 'id', 'class', 'colspan', 'rowspan',
 ALLOWED_ATTRIBUTES['video'] = ['style', 'id', 'class', 'lang', 'src',
                                'controls', 'dir']
 ALLOWED_ATTRIBUTES['font'] = ['color', 'face', 'size', 'dir']
-ALLOWED_ATTRIBUTES['details'] = ['open']
 ALLOWED_ATTRIBUTES['select'] = ['name', 'dir']
 ALLOWED_ATTRIBUTES['option'] = ['value', 'selected', 'dir']
 ALLOWED_ATTRIBUTES['ol'] = ['style', 'class', 'id', 'lang', 'start', 'dir']
@@ -79,6 +78,7 @@ ALLOWED_ATTRIBUTES['ins'] = ['datetime']
 ALLOWED_ATTRIBUTES['del'] = ['datetime']
 ALLOWED_ATTRIBUTES['meter'] += ['max', 'min', 'value', 'low', 'high', 'optimum',
                                 'form']
+ALLOWED_ATTRIBUTES['details'] += ['open']
 # MathML
 ALLOWED_ATTRIBUTES.update(dict((x, ['encoding', 'src']) for x in (
     'annotation', 'annotation-xml')))


### PR DESCRIPTION
Due to an issue with initialization order, ``<details>`` allowed the standard attributes ``style``, ``class``, ``id``, ``lang``, ``dir``, and ``title``, but not ``open``.  

Required for the changes in PR #4957 and https://github.com/mdn/kumascript/pull/789. 