### PR TITLE
bug 1462475: Improve ./manage.py scrape_links

### DIFF
--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -223,7 +223,10 @@ class DocumentBaseSource(Source):
         super(DocumentBaseSource, self).__init__(path, **options)
         if path != unquote(path):
             raise ValueError('URL-encoded path "%s"' % path)
-        self.locale, self.slug = self.locale_and_slug(path)
+        try:
+            self.locale, self.slug = self.locale_and_slug(path)
+        except ValueError:
+            self.locale, self.slug = None, None
 
     def locale_and_slug(self, path):
         """Extract a document locale and slug from a path."""

--- a/kuma/scrape/sources/document.py
+++ b/kuma/scrape/sources/document.py
@@ -17,11 +17,10 @@ class DocumentSource(DocumentBaseSource):
 
     def load_and_validate_existing(self, storage):
         """Load the document from storage in simple cases."""
-
         just_this_doc = (not self.translations and
                          self.depth == 0 and
                          self.revisions == 1)
-        if not self.force and just_this_doc:
+        if not self.force and just_this_doc and self.locale and self.slug:
             document = storage.get_document(self.locale, self.slug)
             if document:
                 return True, []
@@ -30,6 +29,9 @@ class DocumentSource(DocumentBaseSource):
     def load_prereqs(self, requester, storage):
         """Load the data needed for a document."""
         data = {'needs': []}
+
+        if self.locale is None and self.slug is None:
+            raise self.SourceError('Not a document path "%s"', self.path)
 
         # Load data, gathering further source needs
         self.load_prereq_parent_topic(storage, data)

--- a/kuma/scrape/sources/links.py
+++ b/kuma/scrape/sources/links.py
@@ -34,6 +34,7 @@ class LinksSource(Source):
         'profiles',
         'search',
         'users/signin',
+        'docs/tag/',
     ))
 
     def __init__(self, path=None, **options):

--- a/kuma/scrape/tests/test_source_document.py
+++ b/kuma/scrape/tests/test_source_document.py
@@ -126,6 +126,17 @@ def test_gather_standard_doc_empty_history_is_error():
     assert source.state == source.STATE_ERROR
 
 
+def test_gather_document_zone_url_is_error():
+    """Old vanity zone URLs are not loaded."""
+    doc_path = "/en-US/Firefox/Releases/22"
+    source = DocumentSource(doc_path)
+    storage = mock_storage(spec=[])  # Storage is skipped
+    resources = source.gather(None, storage)
+    assert resources == []
+    assert source.state == source.STATE_ERROR
+    assert source.freshness == source.FRESH_UNKNOWN
+
+
 def test_gather_standard_doc_all_prereqs():
     path = '/en-US/docs/Test'
     source = DocumentSource(path, force=True)


### PR DESCRIPTION
To review https://github.com/mdn/kumascript/pull/789 (in progress), I needed a bunch of documents from the sidebar. Two issues made this hard:

``{{CompatGeckoDesktop(version)}}`` still [outputs URLs for the Firefox zone](https://github.com/mdn/kumascript/blob/b566c863c733b7ee3757f65bb5c6e32967ad80e1/macros/CompatGeckoDesktop.ejs#L137), and the scraper now halts on an exception when it tries to process it. The zone URL handler was removed in PR #4920 for [bug 1462475](https://bugzilla.mozilla.org/show_bug.cgi?id=1462475), which wasn't so long ago, so I'm adding another commit to the bug.  This doesn't resurrect the whole ``normalized_path`` code (5b527e703ef90dfe35f3a20991203b90fb706145), just handles paths that don't look like documents.  I hope to fix ``{{CompatGeckoDesktop}}``, but the scraper should expect the occasional in-content zone link.

The other issue is that the tag list has links that look like document links (https:/developer.mozilla.org/en-US/docs/tag/API) but aren't documents. The ``LinksSource`` now includes these as a slug prefix to ignore.  Since that code is a year old, I filed [new bug 1488892](https://bugzilla.mozilla.org/show_bug.cgi?id=1488892). I didn't add [all the possible URLs](https://github.com/mozilla/kuma/blob/b8ce8cdb12585a58ad260ec2091ed18ac1d437d3/kuma/wiki/urls.py#L90-L172) with ``/docs/`` in the name, because I expect them to be rare, and I hope to move them soon.

To see the issues on master:

```
# Has Firefox Zone URL
./manage.py scrape_links https://developer.mozilla.org/en-US/docs/Web/Events/addstream
# Has tags
./manage.py scrape_links https://developer.mozilla.org/en-US/docs/Web/API/Animation/id
# Do it twice to just see the errors
./manage.py scrape_links https://developer.mozilla.org/en-US/docs/Web/API/Animation/id
```




