### PR TITLE
bug 1490356: Fix scraper bugs for Unicode URLs and 504 responses

### DIFF
--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -72,7 +72,7 @@ class Requester(object):
                 time.sleep(pause)
             elif response.status_code == 504:
                 retry = True
-                logger.warn("Gateway timeout (504) returned for $s.", url)
+                logger.warn("Gateway timeout (504) returned for %s.", url)
                 time.sleep(timeout)
                 timeout *= 2
 

--- a/kuma/scrape/sources/base.py
+++ b/kuma/scrape/sources/base.py
@@ -144,7 +144,11 @@ class Source(object):
 
     def decode_href(self, href):
         """Convert URL-escaped href attributes to unicode."""
-        decoded = unquote(binary_type(href))
+        if isinstance(href, binary_type):
+            bhref = href
+        else:
+            bhref = href.encode('utf-8')
+        decoded = unquote(bhref)
         assert isinstance(decoded, binary_type)
         decoded = decoded.decode('utf8')
         return decoded

--- a/kuma/scrape/tests/test_source.py
+++ b/kuma/scrape/tests/test_source.py
@@ -171,6 +171,7 @@ def test_invalid_values(option_type, option, bad_value):
     "href,decoded", [
         (b'binary', u'binary'),
         (b'%E7%A7%BB%E8%A1%8C%E4%BA%88%E5%AE%9A', u'移行予定'),
+        (u'Slug#Anchor_\u2014_With_Dash', u'Slug#Anchor_\u2014_With_Dash'),
     ])
 def test_decode_href(href, decoded):
     """Source.decode_href() turns URL-encoded hrefs into unicode strings."""


### PR DESCRIPTION
Fix a couple of issues with the scraper:

When running ``./manage.py scrape_links https://developer.mozilla.org/en-US/docs/Web/HTML/Element/audio``, there was a link to https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable#Guideline_1.2_\u2014_Providing_text_alternatives_for_time-based_media, which has a unicode character in the anchor tag. Make the ``decode_href`` function a little more flexible, so it handles unicode strings that aren't ``ascii``.

When running ``./manage.py scrape_links https://developer.mozilla.org/en-US/docs/MDN/Doc_status/Guide``, I got some ``504 Gateway Timeout`` responses. The scraper handles these, but the log format message was malformed. The format string is fixed.