### PR TITLE
bug 773921: remove mm tests of invalid endpoints

### DIFF
--- a/tests/functional/test_maintenance_mode_redirects.py
+++ b/tests/functional/test_maintenance_mode_redirects.py
@@ -20,8 +20,6 @@ from utils.decorators import skip_if_not_maintenance_mode
     ('post', 'admin/password_change'),
     ('get', '{locale}/docs/User:anonymous:uitest$edit'),
     ('post', '{locale}/docs/User:anonymous:uitest$edit'),
-    ('get', '{locale}/docs/User:anonymous:uitest$edit/1'),
-    ('post', '{locale}/docs/User:anonymous:uitest$edit/1'),
     ('get', '{locale}/docs/User:anonymous:uitest$files'),
     ('post', '{locale}/docs/User:anonymous:uitest$files'),
     ('put', '{locale}/docs/User:anonymous:uitest$files'),


### PR DESCRIPTION
While testing the new prod PoC instance in maintenance mode, I discovered that I failed to remove two maintenance-mode tests when I submitted https://github.com/mozilla/kuma/pull/4769 about 4 months ago. This PR does that.