### PR TITLE
Fix alignment of icons and titles in search results

### DIFF
--- a/kuma/static/styles/search.scss
+++ b/kuma/static/styles/search.scss
@@ -172,8 +172,15 @@ input.filter-button {
             display: none;
         }
 
+        .column-1 > svg {
+            vertical-align: middle;
+        }
+
         .result-list-item {
             @include column-11();
+            h4 {
+                margin-top: 0;
+            }
         }
     }
 }


### PR DESCRIPTION
MDN's search result pages have had for years a problem
where the icon in the left column is substantially
above the title of the page to its right. This PR
fixes that problem.