### PR TITLE
Move close button to start of menu

### DIFF
--- a/kuma/static/js/components.js
+++ b/kuma/static/js/components.js
@@ -81,7 +81,7 @@
                     var $closeButton = $('<button type="button" class="submenu-close transparent">' +
                         '<span class="offscreen">' + gettext('Close submenu') + '</span></button>')
                         .append(closeIcon)
-                        .appendTo($submenu);
+                        .prependTo($submenu);
 
                     // Hide the submenu when the main menu is blurred for hideDelay
                     $self.on('mouseleave focusout', function() {


### PR DESCRIPTION
To enable tabbing through the menu without being forced to tab through each item.

See also [bug #1056933](https://bugzilla.mozilla.org/show_bug.cgi?id=1056933). Marco said this was a useful hack, though, as we already know there are better long term improvements that could be made.