### PR TITLE
bug 1483072: temporarily use prod.mm.test for oregon

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -43,7 +43,8 @@ def get_target_name() {
 
 def get_target_script() {
     if (env.BRANCH_NAME == PROD_BRANCH_NAME) {
-        return 'prod'
+        // TODO: After cutover to IT-owned services, just use 'prod'.
+        return is_mozmeao_pipeline() ? 'prod' : 'prod.mm.test'
     }
     if (env.BRANCH_NAME == STAGE_BRANCH_NAME) {
         return 'stage'


### PR DESCRIPTION
Temporarily use the [`prod.mm.test.sh` configuration file](https://github.com/mdn/infra/blob/master/apps/mdn/mdn-aws/k8s/regions/oregon/prod.mm.test.sh) for production deployments to the `oregon` Kubernetes cluster (new MozIT cluster). This temporarily prevents full-scale deployments until we are ready to move to the new cluster.