### PR TITLE
bug 1490727: Fix contrib_beta waffle check

### DIFF
--- a/kuma/contributions/utils.py
+++ b/kuma/contributions/utils.py
@@ -7,4 +7,5 @@ from .constants import CONTRIBUTION_BETA_FLAG
 def enabled(request):
     """Return True if contributions are enabled."""
     return (settings.MDN_CONTRIBUTION and
+            hasattr(request, 'user') and
             flag_is_active(request, CONTRIBUTION_BETA_FLAG))

--- a/kuma/contributions/views.py
+++ b/kuma/contributions/views.py
@@ -16,9 +16,9 @@ from .utils import enabled
 def skip_if_disabled(func):
     """If contributions are not enabled, then 404."""
     @wraps(func)
-    def wrapped(*args, **kwargs):
-        if enabled():
-            return func(*args, **kwargs)
+    def wrapped(request, *args, **kwargs):
+        if enabled(request):
+            return func(request, *args, **kwargs)
         raise Http404
 
     return wrapped

--- a/kuma/core/email_utils.py
+++ b/kuma/core/email_utils.py
@@ -55,7 +55,7 @@ def render_email(template, context):
         Because of safe_translation decorator, if this fails,
         the function will be run again in English.
         """
-        req = RequestFactory()
+        req = RequestFactory().get('/')
         req.META = {}
         req.LANGUAGE_CODE = locale
 


### PR DESCRIPTION
* Pass request to ``enabled()``, fixing the contribute views.
* Handle ``request`` objects without a ``user`` attribute
* Make the ``request`` object in the backend email renderer a fake ``Request`` object, not a ``RequestFactory``.