### PR TITLE
Bug 924583: Use $blue-dark for link color against grey background

### DIFF
--- a/kuma/static/styles/base/elements/typography.scss
+++ b/kuma/static/styles/base/elements/typography.scss
@@ -132,6 +132,10 @@ mono space elements (pre, code, kbd)
         background-color: transparent;
         padding: 0;
     }
+
+    a {
+        color: $blue-dark;
+    }
 }
 
 @media #{$mq-mobile-and-down} {

--- a/kuma/static/styles/components/tags.scss
+++ b/kuma/static/styles/components/tags.scss
@@ -34,6 +34,10 @@ ul.tags li {
     label {
         margin-bottom: 0; /* for tag lists of expertise on user edit page */
     }
+
+    a {
+        color: $blue-dark;
+    }
 }
 
 /*


### PR DESCRIPTION
When against a grey background, the blue color used for links is below the minimum 4.5 ratio needed to meet the WCAG AA guidelines, even after #4983.