### PR TITLE
Fix bug 1493506: Move document-actions below document-title

### DIFF
--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -19,11 +19,12 @@
 }
 
 .document-actions {
-    position: relative;
-    z-index: $document-actions-z;
-    @include bidi(((float, right, left),));
-    width: 100%;
-    margin-bottom: ($grid-spacing / 2);
+    @include bidi(((text-align, right, left),));
+    padding-bottom: 0;
+
+    .page-buttons {
+        @include bidi(((float, none, none),));
+    }
 }
 
 @media #{$mq-mobile-and-up} {
@@ -32,11 +33,24 @@
             @include set-font-size($h1-font-size);
         }
     }
+}
 
-    .document-actions {
-        width: auto;
-        @include bidi(((margin-left, $grid-spacing, margin-right, 0),));
-        margin-bottom: 0;
+@media #{$mq-mobile-and-up} {
+    @supports (display: flex) {
+        .document-head .center {
+            display: flex;
+            justify-content: space-between;
+            flex-wrap: wrap;
+
+            .document-title {
+                flex-grow: 1;
+            }
+
+            .document-actions {
+                flex-grow: 9999;
+                @include bidi(((text-align, right, left),));
+            }
+        }
     }
 }
 

--- a/kuma/static/styles/components/structure/page-header/submenu.scss
+++ b/kuma/static/styles/components/structure/page-header/submenu.scss
@@ -1,4 +1,5 @@
 .submenu {
+    box-sizing: border-box;
     display: none;
     position: absolute;
     z-index: $submenu-z;

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -102,13 +102,13 @@
   <!-- heading -->
   <div id="wiki-document-head" class="document-head">
     <div class="center">
+      <div class="document-title">
+        <h1>{{ document.title }}</h1>
+      </div>
+
       <!-- action buttons -->
       <div class="document-actions">
         {{ buttons }}
-      </div>
-
-      <div class="document-title">
-        <h1>{{ document.title }}</h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- move document-actions below document title
- use flex box to preserve the existing side by side display
- buttons wrap underneath long titles now