### PR TITLE
bug 948151: Library, other updates for CSP effort

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -8,7 +8,7 @@
         (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-        })(window,document,'script','//www.google-analytics.com/{{ GA_FILE }}.js','ga');
+        })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
 
         ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -289,9 +289,12 @@ pytidylib==0.2.4 \
     --hash=sha256:0af07bd8ebd256af70ca925ada9337faf16d85b3072624f975136a5134150ab6
 
 # Send tracebacks to Sentry instead of emailing admins
-raven==6.2.1 \
-    --hash=sha256:f58ead6842c02d427617e827f4c0a97cfd3f8b648a52e53ef12182002a8663cb \
-    --hash=sha256:c0a30bcc3e3206059f79656d80362ce080b1c991c95d867edce559a7294570fe
+# Code: https://github.com/getsentry/raven-python
+# Changes: https://github.com/getsentry/raven-python/blob/master/CHANGELOG.md
+# Docs: https://docs.sentry.io/hosted/clients/python/
+raven==6.9.0 \
+    --hash=sha256:3fd787d19ebb49919268f06f19310e8112d619ef364f7989246fc8753d469888 \
+    --hash=sha256:95f44f3ea2c1b176d5450df4becdb96c15bf2632888f9ab193e9dd22300ce46a
 
 # Modern caching server, to replace memcached in AWS
 redis==2.10.5 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -73,6 +73,14 @@ django-constance==2.2.0 \
     --hash=sha256:fe601fe384d1629f6f0460175e4ce3d66e8177654525bddd4bdb68025c816adc \
     --hash=sha256:1d74fa615ee6c69512faa214ec7b4962aa039dfe802e967972c3fbdad7852977
 
+# Provide a Content Security Policy header and related services
+# Code: https://github.com/mozilla/django-csp
+# Changes: https://github.com/mozilla/django-csp/blob/master/CHANGES
+# Docs: http://django-csp.readthedocs.org/
+django_csp==3.4 \
+    --hash=sha256:04c0ccd4e1339e8f6af48c55c3347dc996fde2d22d79e8bf2f6b7a920412e408 \
+    --hash=sha256:096b634430d8ea81c3d9f216f87be890f3a975c17bb9a4631f6a1619ac09c91e
+
 # Include Django URL patterns with decorators.
 # Code: https://github.com/twidi/django-decorator-include
 # Changes: https://github.com/twidi/django-decorator-include/blob/develop/CHANGELOG.rst#changelog

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,9 +10,12 @@ django-babel==0.6.2 \
     --hash=sha256:1e621b198e1f98ae4f93e43463cf78cbedbace475eb6e0853ba1e2567f3b8119
 
 # Analyze Django performance during request
-django-debug-toolbar==1.8 \
-    --hash=sha256:e9f08b94f9423ac76cfc287151182bbaddbe7521ae32bef9f9863e2ac58018d3 \
-    --hash=sha256:0b4d2b1ac49a8bc5604518e8e20f56c1c08c0c4873336107e7c773c42537876b
+# Code: https://github.com/jazzband/django-debug-toolbar
+# Changes: https://django-debug-toolbar.readthedocs.io/en/latest/changes.html
+# Docs: https://django-debug-toolbar.readthedocs.io/en/latest/
+django-debug-toolbar==1.10.1 \
+    --hash=sha256:08e0e43f6c1fd9820af4cbdcd54b5fb80bf83a2e08b2cc952547a671174999b8 \
+    --hash=sha256:1dcae28d430522debafde2602b3450eb784410b78e16c29a00448032df2a4c90
 
 # Code quality checker
 # Code: https://github.com/PyCQA/flake8


### PR DESCRIPTION
Update and add libraries:

* django-debug-toolbar 1.8 → 1.10.1: Update Django support matrix, remove jQuery dependency. The jQuery dependency was loaded with a protocol-relative URL, which made for a more complex policy.
* raven 6.2.1 → 6.9.0: Better remote user support, Django support matrix update, sanitization support, other updates. This is the Python Sentry client, and I'm borrowing the pattern from other Mozilla projects, which forward CSP violation reports to Sentry.
* [django_csp](https://github.com/mozilla/django-csp) 3.4: Mozilla's Django project for adding the  Content Security Policy header. Unused in this PR, but it would be good to get it in the base image for future reviews.

This also updates the Google Analytics snippet to force SSL, used in the [current snippet](https://developers.google.com/analytics/devguides/collection/analyticsjs/). The protocol-relative URL made the policy more complicated.



