### PR TITLE
bug 948151: Add permissive CSP

### DIFF
--- a/kuma/health/urls.py
+++ b/kuma/health/urls.py
@@ -13,4 +13,7 @@ urlpatterns = [
     url(r'^_kuma_status.json$',
         views.status,
         name='health.status'),
+    url(r'^csp-violation-capture$',
+        views.csp_violation_capture,
+        name='health.csp_violation_capture'),
 ]

--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -1,10 +1,15 @@
+import json
+import logging
+
 from django.conf import settings
 from django.db import DatabaseError
-from django.http import HttpResponse, JsonResponse
+from django.http import HttpResponse, HttpResponseBadRequest, JsonResponse
 from django.views.decorators.cache import never_cache
-from django.views.decorators.http import require_safe
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST, require_safe
 from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
                                       NotFoundError)
+from raven.contrib.django.models import client
 from requests.exceptions import ConnectionError as Requests_ConnectionError
 
 from kuma.users.models import User
@@ -156,3 +161,39 @@ def status(request):
     data['services']['test_accounts'] = test_account_data
 
     return JsonResponse(data)
+
+
+@csrf_exempt
+@require_POST
+def csp_violation_capture(request):
+    """
+    Capture CSP violation reports, forward to Sentry.
+
+    HT @glogiotatidis https://github.com/mozmeao/lumbergh/pull/180
+    HT @pmac, @jgmize https://github.com/mozilla/bedrock/pull/4335
+    """
+    if not settings.CSP_REPORT_ENABLE:
+        # mitigation option for a flood of violation reports
+        return HttpResponse()
+
+    data = client.get_data_from_request(request)
+    data.update({
+        'level': logging.INFO,
+        'logger': 'CSP',
+    })
+    try:
+        csp_data = json.loads(request.body)
+    except ValueError:
+        # Cannot decode CSP violation data, ignore
+        return HttpResponseBadRequest('Invalid CSP Report')
+
+    try:
+        blocked_uri = csp_data['csp-report']['blocked-uri']
+    except KeyError:
+        # Incomplete CSP report
+        return HttpResponseBadRequest('Incomplete CSP Report')
+
+    client.captureMessage(message='CSP Violation: {}'.format(blocked_uri),
+                          data=data)
+
+    return HttpResponse('Captured CSP violation, thanks for reporting.')

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import newrelic.agent
+from csp.decorators import csp_update
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
@@ -80,6 +81,7 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 @login_required  # TODO: Stop repeating this knowledge here and in Document.allows_editing_by.
 @ratelimit(key='user', rate='60/m', block=True)
 @block_banned_ips
+@csp_update(SCRIPT_SRC="'unsafe-eval'")  # Required until CKEditor 4.7
 @process_document_path
 @check_readonly
 @prevent_indexing

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from csp.decorators import csp_update
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.http import JsonResponse
@@ -39,6 +40,7 @@ def select_locale(request, document_slug, document_locale):
 @never_cache
 @block_user_agents
 @login_required
+@csp_update(SCRIPT_SRC="'unsafe-eval'")  # Required until CKEditor 4.7
 @process_document_path
 @check_readonly
 @prevent_indexing


### PR DESCRIPTION
Builds on PR #5001, which can be merged first to get the libraries into the base image.

Add a CSP configuration, based on testing several pages on development. Enabling CSP and other options are configured from the environment, and off by default. The policy is configured in the Django settings, and not configured by the environment. The policy allows inline CSS and JavaScript, so that the site works without modification, but doesn't add as much security as it could.

CKEditor 4.5.10 still requires ``unsafe-eval``, but [4.7](https://ckeditor.com/blog/CKEditor-4.7-released/) claims to remove this requirement. A decorator adds ``unsafe-eval`` only on the editing pages that use CKEditor.

The reporting view is copied from [mozilla/bedrock](https://github.com/mozilla/bedrock/blob/333d3df02ad697f1694a88553119f98931519557/bedrock/base/views.py#L153-L181), and it used to forward violation reports to Sentry. There were no tests to copy.