### PR TITLE
bug 1490727: Exclude CSRF checking from Stripe contribute webhook

### DIFF
--- a/kuma/contributions/jinja2/contributions/includes/contribution-form.html
+++ b/kuma/contributions/jinja2/contributions/includes/contribution-form.html
@@ -35,7 +35,6 @@
         </div>
         <div class="column-half">
             <form id="contribute-form" class="contribution-form" method="post" action="{{ url('contribute') }}" novalidate>
-                {% csrf_token %}
                 <div class="form-group">
                     <label class="offscreen" for="id_{{form.name.name}}">{{form.name.label}}</label>
                     {{form.name}}

--- a/kuma/contributions/views.py
+++ b/kuma/contributions/views.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.http import Http404
 from django.shortcuts import redirect, render
 from django.views.decorators.cache import never_cache
+from django.views.decorators.csrf import csrf_exempt
 
 from .forms import ContributionForm
 from .tasks import contribute_thank_you_email
@@ -26,6 +27,7 @@ def skip_if_disabled(func):
 
 @skip_if_disabled
 @never_cache
+@csrf_exempt
 def contribute(request):
     initial_data = {}
     if request.user.is_authenticated and request.user.email:

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,37 +1,44 @@
 from __future__ import unicode_literals
 
-from constance.test import override_config
 from pyquery import PyQuery as pq
 
-from kuma.core.tests import KumaTestCase
 from kuma.core.urlresolvers import reverse
 from kuma.search.models import Filter, FilterGroup
 
 
-class HomeTests(KumaTestCase):
-    def test_google_analytics(self):
-        url = reverse('home')
+def test_google_analytics_disabled(constance_config, client):
+    constance_config.GOOGLE_ANALYTICS_ACCOUNT = '0'
+    response = client.get(reverse('home'), follow=True)
+    assert 200 == response.status_code
+    assert b"ga('create" not in response.content
 
-        with override_config(GOOGLE_ANALYTICS_ACCOUNT='0'):
-            response = self.client.get(url, follow=True)
-            assert 200 == response.status_code
-            assert b"ga('create" not in response.content
 
-        with override_config(GOOGLE_ANALYTICS_ACCOUNT='UA-99999999-9'):
-            response = self.client.get(url, follow=True)
-            assert 200 == response.status_code
-            assert b"ga('create" in response.content
+def test_google_analytics_enabled(constance_config, client):
+    constance_config.GOOGLE_ANALYTICS_ACCOUNT = 'UA-99999999-9'
+    response = client.get(reverse('home'), follow=True)
+    assert 200 == response.status_code
+    assert b"ga('create" in response.content
 
-    def test_default_search_filters(self):
-        url = reverse('home')
-        group = FilterGroup.objects.create(name='Topic', slug='topic')
-        for name in ['CSS', 'HTML', 'JavaScript']:
-            Filter.objects.create(group=group, name=name, slug=name.lower(),
-                                  default=True)
 
-        response = self.client.get(url, follow=True)
-        page = pq(response.content)
-        filters = page.find('#home-search-form input[type=hidden]')
+def test_default_search_filters(db, client):
+    group = FilterGroup.objects.create(name='Topic', slug='topic')
+    for name in ['CSS', 'HTML', 'JavaScript']:
+        Filter.objects.create(group=group, name=name, slug=name.lower(),
+                              default=True)
 
-        assert 'topic' == filters.eq(0).attr('name')
-        assert set(p.val() for p in filters.items()) == {'css', 'html', 'javascript'}
+    response = client.get(reverse('home'), follow=True)
+    page = pq(response.content)
+    filters = page.find('#home-search-form input[type=hidden]')
+
+    assert 'topic' == filters.eq(0).attr('name')
+    assert set(p.val() for p in filters.items()) == {'css', 'html', 'javascript'}
+
+
+def test_does_not_include_csrf(user_client):
+    """
+    The document should not include CSRF tokens, since it causes
+    problems when used with a CDN like CloudFront (see bugzilla #1456165).
+    """
+    resp = user_client.get(reverse('home'))
+    doc = pq(resp.content)
+    assert not doc('input[name="csrfmiddlewaretoken"]')

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+import mock
+
 from pyquery import PyQuery as pq
 
 from kuma.core.urlresolvers import reverse
@@ -34,11 +36,13 @@ def test_default_search_filters(db, client):
     assert set(p.val() for p in filters.items()) == {'css', 'html', 'javascript'}
 
 
-def test_does_not_include_csrf(user_client):
+@mock.patch('kuma.contributions.context_processors.enabled')
+def test_does_not_include_csrf(mock_enabled, db, user_client):
     """
     The document should not include CSRF tokens, since it causes
     problems when used with a CDN like CloudFront (see bugzilla #1456165).
     """
+    mock_enabled.return_value = True
     resp = user_client.get(reverse('home'))
     doc = pq(resp.content)
     assert not doc('input[name="csrfmiddlewaretoken"]')

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -201,11 +201,13 @@ class DocumentTests(UserTestCase, WikiTestCase):
         response = self.client.get(urlparams(d.get_absolute_url()))
         self.assertNotContains(response, 'Redirected from ')
 
-    def test_does_not_include_csrf(self):
+    @mock.patch('kuma.contributions.context_processors.enabled')
+    def test_does_not_include_csrf(self, mock_enabled):
         """
         The document should not include CSRF tokens, since it causes
         problems when used with a CDN like CloudFront (see bugzilla #1456165).
         """
+        mock_enabled.return_value = True
         self.client.login(username='testuser', password='testpass')
         d = document(save=True)
         resp = self.client.get(d.get_absolute_url())


### PR DESCRIPTION
Similar to PR #4757, remove the CSRF protection from the stripe callback, since it adds a ``csrf_token`` cookie to requests on the homepage and wiki document pages, and interacts poorly with the CDN. 

Stripe's Checkout example code (like [rails](https://stripe.com/docs/checkout/rails)), does not include CSRF checking, and they show how to [exclude CSRF checks on Django](https://stripe.com/docs/webhooks#receiving-webhooks-with-csrf-protection). I believe our code is safe, because the Stripe-generated token, ``POST``ed to the callback, is used to identify a legitimate transaction. Opening this up will allow someone to make a contribution form for MDN that posts to us, but not to substitute their own Stripe account.