### PR TITLE
bug 1490727: Update copy

### DIFF
--- a/kuma/contributions/jinja2/contributions/includes/contribution-form.html
+++ b/kuma/contributions/jinja2/contributions/includes/contribution-form.html
@@ -15,10 +15,10 @@
                 <h4 tabindex="-1">{{_('Support MDN, and it comes back to you.')}}</h4>
                 <p class="body">
                     {% trans %}
-                        You’ve turned to MDN for information and assurance. Now
-                        we turn to you, for support. Help MDN and get back more
-                        of the information and tools you rely on for when your
-                        work has to work.
+                        You come to MDN for information and assistance. Be a
+                        part of making MDN even better. You’ll get back more of
+                        the knowledge and tools you rely on for when your work
+                        has to work.
                     {% endtrans %}
                 </p>
                 {% if is_popover %}
@@ -74,7 +74,7 @@
                 </ul>
                 <div class="form-footer">
                     <button type="button" id="stripe_submit">
-                        <span class="hide-expand">{{_('Contribute')}} {% include 'includes/icons/arrows/chevron-up.svg' %}</span>
+                        <span class="hide-expand">{{_('Support MDN')}} {% include 'includes/icons/arrows/chevron-up.svg' %}</span>
                         <span class="hide-collapse">
                             {{_('Pay <span id="%(span_id)s">%(amount)s</span>', span_id="amount", amount="$64") }}
                         </span>

--- a/kuma/contributions/jinja2/contributions/thank_you.html
+++ b/kuma/contributions/jinja2/contributions/thank_you.html
@@ -36,8 +36,10 @@
                         <span class="highlight-span">{{_('Ooops, something went wrong')}}</span>
                     </h2>
                     <p>
-                        {% trans %}
-                        Please contact <a href="mailto:support@mozilla.com">support@mozilla.com</a>  for more information on this problem.
+                        {% trans mailto='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL,
+                                 email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
+                            Please contact <a href="{{ mailto }}">{{ email }}</a>
+                            for more information on this problem.
                         {% endtrans %}
                     </p>
                     <p>

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1711,3 +1711,5 @@ STRIPE_SECRET_KEY = config('STRIPE_SECRET_KEY', default='')
 MDN_CONTRIBUTION = config('MDN_CONTRIBUTION', False, cast=bool)
 MDN_CONTRIBUTION_CONFIRMATION_EMAIL = config('MDN_CONTRIBUTION_CONFIRMATION_EMAIL', False, cast=bool)
 CONTRIBUTION_FORM_CHOICES = [32, 64, 128]
+CONTRIBUTION_SUPPORT_EMAIL = config('CONTRIBUTION_SUPPORT_EMAIL',
+                                    default='mdn-support@mozilla.com')


### PR DESCRIPTION
More copy tweaks from @atopal:
* Banner button changes from "Contribute" to "Support MDN"
* Banner copy update
* Update the support email to mdn-support@mozilla.com (use credit card ``4100000000000019`` to see support message)