### PR TITLE
bug 1490727: tweak thank-you copy for contributions

### DIFF
--- a/kuma/contributions/jinja2/contributions/email/thank_you/plain.ltxt
+++ b/kuma/contributions/jinja2/contributions/email/thank_you/plain.ltxt
@@ -4,11 +4,7 @@ Thank you {{ username }} [{{ user_email }}] for supporting MDN.
 {%- endtrans %}
 
 {% trans -%}
-We are committed to providing the best source of information about web standards. Your support enables MDN to build more of the content and tools you use every day, and helps us make sure MDN can be available to everyone, everywhere.
-{%- endtrans %}
-
-{% trans url = site + url('contribute') + "#contribute-faqs" -%}
-If you didn’t get a chance to, <a href="{{ url }}">read more</a> about why MDN are asking for contributions.
+We are committed to providing the best source of information about web standards. Your support enables MDN to move even faster as we build more of the content and tools you use every day, and helps us make sure MDN can be available to everyone, everywhere.
 {%- endtrans %}
 
 {{_('Thank you again,')}}

--- a/kuma/contributions/jinja2/contributions/thank_you.html
+++ b/kuma/contributions/jinja2/contributions/thank_you.html
@@ -18,10 +18,10 @@
                     <p class="subtext">
                         {% trans %}
                             We are committed to providing the best source of
-                            information about web standards. Your support enables
-                            MDN to build more of the content and tools you use every
-                            day, and helps us make sure MDN can be available to
-                            everyone, everywhere.
+                            information about web standards. Your support enables MDN
+                            to move even faster as we build more of the content and
+                            tools you use every day, and helps us make sure MDN can
+                            be available to everyone, everywhere.
                         {% endtrans %}
                     </p>
                     <p class="subtext">{{_('Thank you again,')}}</p>


### PR DESCRIPTION
Changes to the "thank-you" copy both on the page as well as the email.