### PR TITLE
bug 1490727: update thank-you html email copy

### DIFF
--- a/kuma/contributions/jinja2/contributions/email/thank_you/email.html
+++ b/kuma/contributions/jinja2/contributions/email/thank_you/email.html
@@ -81,23 +81,8 @@
                                                           <tr>
                                                             <td align="left" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:22px;color:#555555;padding-top:16px">
                                                               {% trans %}
-                                                              We are committed to providing the best source of information about web standards. Your support enables MDN to build more of the content and tools you use every day, and helps us make sure MDN can be available to everyone, everywhere.
+                                                              We are committed to providing the best source of information about web standards. Your support enables MDN to move even faster as we build more of the content and tools you use every day, and helps us make sure MDN can be available to everyone, everywhere.
                                                               {% endtrans %}
-                                                            </td>
-                                                          </tr>
-                                                        </tbody>
-                                                      </table>
-                                                    </td>
-                                                  </tr>
-                                                  <tr>
-                                                    <td width="640" align="left" style="background:#fff">
-                                                      <table cellspacing="0" cellpadding="0">
-                                                        <tbody>
-                                                          <tr>
-                                                            <td align="left" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:22px;color:#555555;padding-top:16px">
-                                                                {% trans url = site + url('contribute') + "#contribute-faqs" %}
-                                                                If you didn’t get a chance to, <a href="{{ url }}">read more</a> about why MDN are asking for contributions.
-                                                                {% endtrans %}
                                                             </td>
                                                           </tr>
                                                         </tbody>
@@ -158,7 +143,7 @@
                             <br>
                             <span>
                               <font color="#888888">{{_('Mozilla')}}<br>
-                                <a href="https://www.google.com/maps/place/331+E+Evelyn+Ave,+Mountain+View,+CA+94041,+USA/@37.3873074,-122.0623627,17z/data=!3m1!4b1!4m5!3m4!1s0x808fb71f6f496cbd:0x112f2322399b2fcc!8m2!3d37.3873074!4d-122.060174">{{_('331 E. Evelyn Avenue Mountain View CA 94041')}}</a> 
+                                <a href="https://www.google.com/maps/place/331+E+Evelyn+Ave,+Mountain+View,+CA+94041,+USA/@37.3873074,-122.0623627,17z/data=!3m1!4b1!4m5!3m4!1s0x808fb71f6f496cbd:0x112f2322399b2fcc!8m2!3d37.3873074!4d-122.060174">{{_('331 E. Evelyn Avenue Mountain View CA 94041')}}</a>
                                 <br>
                                 <a href="https://www.mozilla.org/en-US/about/legal/terms/mozilla/">{{_('Legal')}}</a> • <a href="https://www.mozilla.org/en-US/privacy/websites/">{{_('Privacy')}}</a>
                               </font>


### PR DESCRIPTION
I didn't realize that the "thank-you" copy in the HTML for emails had its own copy rather than using the plain text copy within it.