### PR TITLE
Bug 1490727 Use correct static URL in thank you email.

### DIFF
--- a/kuma/contributions/jinja2/contributions/email/thank_you/email.html
+++ b/kuma/contributions/jinja2/contributions/email/thank_you/email.html
@@ -25,7 +25,7 @@
                               <tbody>
                                 <tr>
                                   <td align="left" style="padding:16px 0px">
-                                    <img src="{{ site }}{{ static('img/mdn-web-docs-email-logo.png') }}" width="219" height="45" alt="Mozilla" style="display:block;border:0">
+                                    <img src="{{ static('img/mdn-web-docs-email-logo.png') }}" width="219" height="45" alt="Mozilla" style="display:block;border:0">
                                   </td>
                                 </tr>
                               </tbody>
@@ -153,7 +153,7 @@
                         <tr>
                           <td align="center" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:18px;color:#738597;padding:0 20px 40px">
                             <a href="{{ site }}" target="_blank">
-                              <img src="{{ site }}{{ static('img/favicon144.png') }}" height="50" width="50" alt="Mozilla" style="display:block;border:0">
+                              <img src="{{ static('img/favicon144.png') }}" height="50" width="50" alt="Mozilla" style="display:block;border:0">
                             </a>
                             <br>
                             <span>


### PR DESCRIPTION
We missed that staging and prod have proper STATIC_URL
We currently have
`{{ site }}{{ static('img/image.png') }}`
seems like all we need is `{{ static('img/image.png') }`

This PR should solve this!