### PR TITLE
bug 1490727: More contributions updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
       - SITE_URL=http://localhost:8000
-      - STATIC_URL=${STATIC_URL:-/static/}
+      - STATIC_URL=${STATIC_URL:-http://localhost:8000/static/}
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=True

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -37,7 +37,8 @@
 
         win.mdn.notifications = [];
         win.mdn.contributions = {
-            enabled: {% if contribution_enabled %}true{% else %}false{% endif %}
+            enabled: {% if contribution_enabled %}true{% else %}false{% endif %},
+            popup: {% if contribution_popup %}true{% else %}false{% endif %}
         };
 
         {% if messages %}

--- a/kuma/contributions/context_processors.py
+++ b/kuma/contributions/context_processors.py
@@ -1,5 +1,5 @@
 from .forms import ContributionForm
-from .utils import enabled
+from .utils import enabled, popup_enabled
 
 
 def global_contribution_form(request):
@@ -7,6 +7,7 @@ def global_contribution_form(request):
     if enabled(request):
         return {
             'contribution_enabled': True,
+            'contribution_popup': popup_enabled(request),
             'contribution_form': ContributionForm(),
             'hide_cta': True,
         }

--- a/kuma/contributions/forms.py
+++ b/kuma/contributions/forms.py
@@ -123,7 +123,7 @@ class ContributionForm(forms.Form):
                     amount=amount,
                     currency='usd',
                     source=token,
-                    description='Contribute to MDN Web Docs',
+                    description='Support MDN Web Docs',
                     receipt_email=self.cleaned_data['email'],
                     metadata={'name': self.cleaned_data['name']}
                 )

--- a/kuma/contributions/tests/test_forms.py
+++ b/kuma/contributions/tests/test_forms.py
@@ -43,7 +43,7 @@ def test_valid_data(data, amount):
     mock_create.assert_called_once_with(
         amount=amount,
         currency='usd',
-        description=u'Contribute to MDN Web Docs',
+        description='Support MDN Web Docs',
         metadata={'name': form_data['name']},
         receipt_email=form_data['email'],
         source=form_data['stripe_token'])

--- a/kuma/contributions/utils.py
+++ b/kuma/contributions/utils.py
@@ -6,6 +6,11 @@ from .constants import CONTRIBUTION_BETA_FLAG
 
 def enabled(request):
     """Return True if contributions are enabled."""
-    return (settings.MDN_CONTRIBUTION and
+    return bool(settings.MDN_CONTRIBUTION)
+
+
+def popup_enabled(request):
+    """Returns True if the popup is enabled for the user."""
+    return (enabled(request) and
             hasattr(request, 'user') and
             flag_is_active(request, CONTRIBUTION_BETA_FLAG))

--- a/kuma/landing/jinja2/landing/homepage.html
+++ b/kuma/landing/jinja2/landing/homepage.html
@@ -140,7 +140,7 @@
 {% endblock %}
 
 {% block contrib_popup %}
-    {%- if contribution_enabled %}
+    {%- if contribution_popup %}
         {%- with form=contribution_form, is_popover=True %}
             {%- include "contributions/includes/contribution-form.html" %}
         {%- endwith %}
@@ -152,7 +152,7 @@
   {% if settings.NEWSLETTER %}
     {% javascript 'newsletter' %}
   {% endif %}
-  {%- if contribution_enabled %}
+  {%- if contribution_popup %}
     {% javascript 'contribute' %}
   {%- endif %}
 {% endblock %}

--- a/kuma/landing/tests/test_utils.py
+++ b/kuma/landing/tests/test_utils.py
@@ -14,5 +14,6 @@ from ..utils import favicon_url
 def test_favicon_url(settings, domain, expected):
     settings.DOMAIN = domain
     settings.ALLOWED_HOSTS.append(domain)
+    settings.STATIC_URL = '/static/'
     url = favicon_url()
     assert url == expected

--- a/kuma/landing/tests/test_views.py
+++ b/kuma/landing/tests/test_views.py
@@ -103,7 +103,8 @@ def test_robots_allowed_main_attachment_host(client, settings):
     assert content == b''
 
 
-def test_favicon_ico(client):
+def test_favicon_ico(client, settings):
+    settings.STATIC_URL = '/static/'
     response = client.get('/favicon.ico')
     assert response.status_code == 302
     assert_shared_cache_header(response)

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -289,7 +289,7 @@
 {% endblock %}
 
 {% block contrib_popup %}
-    {%- if contribution_enabled %}
+    {%- if contribution_popup %}
         {%- with form=contribution_form, is_popover=True %}
             {%- include "contributions/includes/contribution-form.html" %}
         {%- endwith %}
@@ -340,7 +340,7 @@
     {% javascript 'newsletter' %}
   {% endif %}
 
-  {%- if contribution_enabled %}
+  {%- if contribution_popup %}
     {% javascript 'contribute' %}
   {%- endif %}
 


### PR DESCRIPTION
More nits and blockers for beta launch:

* Update ``STATIC_URL`` in development environment, to reduce confusion between development, staging, and production.
* Change the charge description from 'Contribute to MDN Web Docs' to 'Support MDN Web Docs'
* Enable the Contribution standalone pages always, because of social sharing, but the popup for waffle-selected users.