### PR TITLE
bug 1495765: Add index of dashboards

### DIFF
--- a/kuma/dashboards/jinja2/dashboards/index.html
+++ b/kuma/dashboards/jinja2/dashboards/index.html
@@ -1,0 +1,48 @@
+{% extends "base.html" %}
+{% set title = _('Dashboards') %}
+
+{% block title %}{{ page_title(title) }}{% endblock %}
+
+{# Use the same titles as dashboards to avoid new i18n strings #}
+{% set dashboards = [
+    (_("Active macros"), url('dashboards.macros')),
+    (_("All articles in need of review"), url('wiki.list_review')),
+    (_("Articles in need of review: %(tag)s", tag='technical'),
+        url('wiki.list_review_tag', tag='technical')),
+    (_("Articles in need of review: %(tag)s", tag='editorial'),
+        url('wiki.list_review_tag', tag='editorial')),
+    (_("All documents"), url('wiki.all_documents')),
+    (_("All Tags"), url('wiki.list_tags')),
+    (_("Doc status by topic"),
+        url('wiki.document', document_path='MDN/Doc_status')),
+    (_("Documents with errors"), url('wiki.errors')),
+    (_("Documents with no parent"), url('wiki.without_parent')),
+    (_("Revision Dashboard"), url('dashboards.revisions')),
+    (_("Top level documents"), url('wiki.top_level')),
+    (_("Server charts"),
+        url('wiki.document', document_path='MDN/Kuma/Server_charts')),
+    (_("Spam Dashboard"), url('dashboards.spam'),
+        (request.user.has_perm('wiki.add_revisionakismetsubmission') and
+         request.user.has_perm('wiki.add_documentspamattempt') and
+         request.user.has_perm('users.add_userban'))),
+    (_("Localized articles tagged with: %(tag)s", tag='inprogress'),
+        url('wiki.list_with_localization_tag', tag='inprogress'),
+        request.LANGUAGE_CODE and
+        request.LANGUAGE_CODE != settings.LANGUAGE_CODE),
+]
+%}
+
+{% block content %}
+<h1>{{ title }}</h1>
+
+<ul>
+    {%- for item in dashboards | sort(attribute='0') %}
+        {%- set name = item[0] %}
+        {%- set url = item[1] %}
+        {%- set enabled = item[2] | default(True) %}
+        {%- if enabled %}
+            <li><a href="{{ url }}">{{ name }}</a></li>
+        {%- endif %}
+    {%- endfor %}
+</ul>
+{% endblock %}

--- a/kuma/dashboards/jinja2/dashboards/spam.html
+++ b/kuma/dashboards/jinja2/dashboards/spam.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% set styles = ('dashboards',) %}
-{% set title = 'Spam Dashboard' %}
+{% set title = _('Spam Dashboard') %}
 
 {% block title %}{{ page_title(title) }}{% endblock %}
 {% block robots_value %}noindex, nofollow{% endblock %}

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -25,6 +25,13 @@ from .jobs import SpamDashboardHistoricalStats
 
 
 @shared_cache_control
+def index(request):
+    """Index of dashboards."""
+
+    return render(request, 'dashboards/index.html')
+
+
+@shared_cache_control
 @vary_on_headers('X-Requested-With')
 @require_GET
 def revisions(request):

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -16,6 +16,7 @@ from kuma.core import views as core_views
 from kuma.core.decorators import shared_cache_control
 from kuma.core.urlresolvers import i18n_patterns
 from kuma.dashboards.urls import lang_urlpatterns as dashboards_lang_urlpatterns
+from kuma.dashboards.views import index as dashboards_index
 from kuma.landing.urls import lang_urlpatterns as landing_lang_urlpatterns
 from kuma.search.urls import (
     lang_base_urlpatterns as search_lang_base_urlpatterns,
@@ -87,6 +88,9 @@ urlpatterns += i18n_patterns(url(r'^docs.json$', document_as_json,
                                  name='wiki.json'))
 urlpatterns += i18n_patterns(url(r'^docs/', include(wiki_lang_urlpatterns)))
 urlpatterns += [url('', include('kuma.attachments.urls'))]
+urlpatterns += i18n_patterns(
+    url(r'dashboards/?$', dashboards_index, name='dashboards.index'),
+)
 urlpatterns += i18n_patterns(url(r'^dashboards/',
                                  include(dashboards_lang_urlpatterns)))
 urlpatterns += [url('users/', include('kuma.users.urls'))]


### PR DESCRIPTION
Add index of dashboards, lists of documents, and special wiki pages for moderators.

It sorts by translated titles, so that is makes some sense in French as well.  "Spam Dashboard" wasn't translated before, so this marks it for translation.  There are some wiki documents included that add new strings as well.

I omit the link to the "inprogress" translations tag in English, since it is always empty. I also omit the Spam Dashboard link if the user doesn't have permission to see it.