### PR TITLE
bug 1490727: fix typo in answer to FAQ #1

### DIFF
--- a/kuma/contributions/jinja2/contributions/contribute.html
+++ b/kuma/contributions/jinja2/contributions/contribute.html
@@ -55,7 +55,7 @@
                         MDN is experimenting with seeking direct support from
                         our users in order to accelerate growing and
                         maintaining our content and platform, with assistance
-                        for those who use it.
+                        from those who use it.
                     {% endtrans %}
                 </p>
                 <p>


### PR DESCRIPTION
This fixes a typo (per @alispivak) in the copy for FAQ 1 within the contribution workflow.