### PR TITLE
bug 1483072: enable deployments to MozIT standby

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -67,7 +67,7 @@ def get_region() {
         return is_mozmeao_pipeline() ? 'portland' : 'oregon'
     }
     if (env.BRANCH_NAME == STANDBY_BRANCH_NAME) {
-        return 'frankfurt'
+        return is_mozmeao_pipeline() ? 'frankfurt' : 'germany'
     }
     throw new Exception(
         'Unable to determine the region from the branch name.'


### PR DESCRIPTION
This should enable the MozIT Jenkins service to start pushing both Kuma and Kumascript images to the MozIT standby cluster on updates to `standby-push` branch within the Kuma and Kumascript repos. @limed has already configured the MozIT Jenkins service with the required K8s credentials (`${HOME}/.kube/germany.config`).