### PR TITLE
bug 1477016: Resync locale logic with Django 1.11, use en-US when no translation is active

### DIFF
--- a/kuma/core/i18n.py
+++ b/kuma/core/i18n.py
@@ -196,7 +196,19 @@ def get_language_mapping():
 
 
 def activate_language_from_request(request):
-    """Activate the language, based on the request."""
+    """
+    Activate the language, based on the request.
+
+    Based on Django 1.8.19's LocaleMiddleware.process_request from
+    django/middleware/locale, with these changes:
+
+    * Assume language prefix patterns are used.
+    * Use Kuma's language selection via our get_language_from_request.
+    * Set request.LANGUAGE_CODE to Kuma language code.
+
+    This is in its own function so it can be called from the
+    kuma.search tests to set the request language.
+    """
     language = get_language_from_request(request)
     translation.activate(language)
     request.LANGUAGE_CODE = language

--- a/kuma/core/i18n.py
+++ b/kuma/core/i18n.py
@@ -76,7 +76,7 @@ def get_supported_language_variant(raw_lang_code):
     as the provided language codes are taken from the HTTP request. See also
     <https://www.djangoproject.com/weblog/2007/oct/26/security-fix/>.
 
-    Based on Django 1.8.19's get_supported_language_variant from
+    Based on Django 1.11.16's get_supported_language_variant from
     django/utils/translation/trans_real.py, with changes:
 
     * Language code can also be a Kuma language code
@@ -84,9 +84,10 @@ def get_supported_language_variant(raw_lang_code):
     * Force strict=False to always allow fuzzy matching (zh-CHS gets zh-CN)
     """
     if raw_lang_code:
+        # Kuma: Convert Kuma to Django language code
         lang_code = kuma_language_code_to_django(raw_lang_code)
 
-        # Check for known override
+        # Kuma: Check for known override
         if lang_code in settings.LOCALE_ALIASES:
             return settings.LOCALE_ALIASES[lang_code]
 
@@ -103,10 +104,12 @@ def get_supported_language_variant(raw_lang_code):
         # Look for exact match
         for code in possible_lang_codes:
             if code in supported_lang_codes and check_for_language(code):
+                # Kuma: Convert to Kuma language code
                 return django_language_code_to_kuma(code)
         # If fr-fr is not supported, try fr-ca.
         for supported_code in supported_lang_codes:
             if supported_code.startswith(generic_lang_code + '-'):
+                # Kuma: Convert to Kuma language code
                 return django_language_code_to_kuma(supported_code)
     raise LookupError(raw_lang_code)
 
@@ -116,13 +119,11 @@ def get_language_from_path(path):
     Returns the language-code if there is a valid language-code
     found in the `path`.
 
-    If `strict` is False (the default), the function will look for an alternative
-    country-specific variant when the currently checked is not found.
-
-    Based on Django 1.8.19's get_language_from_path from
+    Based on Django 1.11.16's get_language_from_path from
     django/utils/translation/trans_real.py, with changes:
 
     * Don't accept or pass strict parameter (assume strict=False).
+    * Use our customized get_supported_language_variant().
     """
     regex_match = language_code_prefix_re.match(path)
     if not regex_match:
@@ -146,18 +147,22 @@ def get_language_from_request(request):
     header) are skipped. In Django, the URL path prefix can be skipped with the
     check_path=False parameter, removed in this code.
 
-    Based on Django 1.8.19's get_language_from_request from
+    Based on Django 1.11.16's get_language_from_request from
     django/utils/translation/trans_real.py, with changes:
 
-    * Always check the path
-    * Don't check session language
+    * Always check the path.
+    * Don't check session language.
     * Use LANGUAGE_CODE as the fallback language code, instead of passing it
-      through get_supported_language_variant first
+      through get_supported_language_variant first.
     """
+    # Kuma: Always use the URL's langauge (force check_path=True)
     lang_code = get_language_from_path(request.path_info)
     if lang_code is not None:
         return lang_code
 
+    # Kuma: Skip checking the session-stored language via LANGUAGE_SESSION_KEY
+
+    # Use the (valid) language cookie override
     lang_code = request.COOKIES.get(settings.LANGUAGE_COOKIE_NAME)
 
     try:
@@ -165,11 +170,13 @@ def get_language_from_request(request):
     except LookupError:
         pass
 
+    # Pick the closest langauge based on the Accept Language header
     accept = request.META.get('HTTP_ACCEPT_LANGUAGE', '')
     for accept_lang, unused in parse_accept_lang_header(accept):
         if accept_lang == '*':
             break
 
+        # Kuma: Assert accept_lang fits the language code pattern
         # The regex check was added with a security fix:
         # https://www.djangoproject.com/weblog/2007/oct/26/security-fix/
         # In the Django version, non-matching accept_lang codes are skipped.
@@ -184,7 +191,7 @@ def get_language_from_request(request):
         except LookupError:
             continue
 
-    # Fallback to default settings.LANGUAGE_CODE.
+    # Kuma: Fallback to default settings.LANGUAGE_CODE.
     # Django supports a case when LANGUAGE_CODE is not in LANGUAGES
     # (see https://github.com/django/django/pull/824). but our LANGUAGE_CODE is
     # always the first entry in LANGUAGES.
@@ -199,16 +206,19 @@ def activate_language_from_request(request):
     """
     Activate the language, based on the request.
 
-    Based on Django 1.8.19's LocaleMiddleware.process_request from
+    Based on Django 1.11.16's LocaleMiddleware.process_request from
     django/middleware/locale, with these changes:
 
-    * Assume language prefix patterns are used.
+    * Assume language prefix patterns are used, with no implied default
+      language (prefix_default_language=True)
     * Use Kuma's language selection via our get_language_from_request.
-    * Set request.LANGUAGE_CODE to Kuma language code.
+    * Skip get_language_from_path, since used to determine if implied
+      default language is used.
+    * Set request.LANGUAGE_CODE to Kuma language code via get_language.
 
     This is in its own function so it can be called from the
     kuma.search tests to set the request language.
     """
     language = get_language_from_request(request)
     translation.activate(language)
-    request.LANGUAGE_CODE = language
+    request.LANGUAGE_CODE = get_language()

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -135,12 +135,21 @@ class LocaleMiddleware(MiddlewareBase):
     """
 
     def __call__(self, request):
+        """
+        Execute the middleware.
+
+        A more generic version is provided by MiddlewareMixin in Django.
+        """
         # Activate the language, and add LANGUAGE_CODE to the request.
+        # In Django, this is self.process_request()
         activate_language_from_request(request)
 
         response = self.get_response(request)
+        response = self.process_response(request, response)
+        return response
 
-        # Add Content-Language, convert some 404s to locale redirects.
+    def process_response(self, request, response):
+        """Add Content-Language, convert some 404s to locale redirects."""
         language = get_language()
         language_from_path = get_language_from_path(request.path_info)
         urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)

--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -124,14 +124,20 @@ class LocaleMiddleware(MiddlewareBase):
     translated to the language the user desires (if the language
     is available, of course).
 
-    Based on Django 1.8.19's LocaleMiddleware from
+    Based on Django 1.11.16's LocaleMiddleware from
     django/middleware/locale.py, with changes:
 
-    * Assume that locale prefixes are in use
-    * Use Kuma language codes (en-US) instead of Django's (en-us)
+    * Use MiddlewareBase, don't support old-style middleware
+    * Assume that locale prefixes, and no implied default locale, are in use
+    * Use Kuma language codes (en-US) instead of Django's (en-us),
+      via our get_language()
     * Use Kuma-prefered locales (zn-CN) instead of Django's (zn-Hans)
     * Don't include "Vary: Accept-Language" header
     * Add caching headers to locale redirects
+
+    The process_request logic, modified for Kuma language codes, is in
+    kuma.core.i18n.activate_language_from_request, so it can be called from
+    kuma.search tests.
     """
 
     def __call__(self, request):
@@ -153,25 +159,41 @@ class LocaleMiddleware(MiddlewareBase):
         language = get_language()
         language_from_path = get_language_from_path(request.path_info)
         urlconf = getattr(request, 'urlconf', settings.ROOT_URLCONF)
+
+        # Kuma: assume locale-prefix patterns, including default language
         if response.status_code == 404 and not language_from_path:
+            # Maybe the language code is missing in the URL? Try adding the
+            # language prefix and redirecting to that URL.
             language_path = '/%s%s' % (language, request.path_info)
             path_valid = is_valid_path(language_path, language, urlconf)
-            if (not path_valid and settings.APPEND_SLASH and
-                    not language_path.endswith('/')):
-                path_valid = is_valid_path("%s/" % language_path, language,
-                                           urlconf)
-
-            if path_valid:
-                script_prefix = get_script_prefix()
-                language_path = request.get_full_path().replace(
-                    script_prefix,
-                    '%s%s/' % (script_prefix, language),
-                    1
+            path_needs_slash = (
+                not path_valid and (
+                    settings.APPEND_SLASH and not language_path.endswith('/') and
+                    is_valid_path('%s/' % language_path, language, urlconf)
                 )
-                redirect = HttpResponseRedirect(language_path)
+            )
+
+            if path_valid or path_needs_slash:
+                script_prefix = get_script_prefix()
+                # Insert language after the script prefix and before the
+                # rest of the URL
+                language_url = (
+                    request.get_full_path(force_append_slash=path_needs_slash)
+                    .replace(
+                        script_prefix,
+                        '%s%s/' % (script_prefix, language),
+                        1
+                    ))
+                # Kuma: Add caching headers to redirect
+                redirect = HttpResponseRedirect(language_url)
                 add_shared_cache_control(redirect)
                 return redirect
 
+        # Kuma: Do not add 'Accept-Language' to Vary header
+        # if not (i18n_patterns_used and language_from_path):
+        #    patch_vary_headers(response, ('Accept-Language',))
+
+        # Kuma: Add a pragma, since never skipped
         # No views set this header, so the middleware always sets it. The code
         # could be replaced with an assertion, but that would deviate from
         # Django's version, and make the code brittle, so using a pragma

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -1,6 +1,7 @@
 import pytest
 
 from django.core.exceptions import ValidationError
+from django.utils.translation import deactivate_all
 
 from kuma.wiki.tests import revision
 
@@ -102,7 +103,7 @@ class TestUser(UserTestCase):
         rev = revision(save=True, is_approved=True)
         assert rev.pk in user.wiki_revisions().values_list('pk', flat=True)
 
-    def test_recovery_email(self):
+    def test_get_recovery_url(self):
         user = self.user_model.objects.get(username='testuser')
         user.set_unusable_password()
         user.save()
@@ -114,6 +115,19 @@ class TestUser(UserTestCase):
         user.refresh_from_db()
         url2 = user.get_recovery_url()
         assert url == url2
+
+    @pytest.mark.bug(1477016)
+    def test_get_recovery_url_no_active_translation(self):
+        """
+        When no translation is active, the locale is None.
+
+        This should default to /en-US/.
+        This happens in management commands, such as the Django shell.
+        """
+        user = self.user_model.objects.get(username='testuser')
+        deactivate_all()
+        url = user.get_recovery_url()
+        assert url.startswith('/None/users/account/recover/')
 
 
 class BanTestCase(UserTestCase):

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -119,15 +119,14 @@ class TestUser(UserTestCase):
     @pytest.mark.bug(1477016)
     def test_get_recovery_url_no_active_translation(self):
         """
-        When no translation is active, the locale is None.
+        When no translation is active, the locale is /en-US/.
 
-        This should default to /en-US/.
         This happens in management commands, such as the Django shell.
         """
         user = self.user_model.objects.get(username='testuser')
         deactivate_all()
         url = user.get_recovery_url()
-        assert url.startswith('/None/users/account/recover/')
+        assert url.startswith('/en-US/users/account/recover/')
 
 
 class BanTestCase(UserTestCase):

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -33,9 +33,9 @@ dennis==0.9 \
     --hash=sha256:f6487392ac91800c5f0684a99b404b7fd0f72ceb48faeb5a0ce4e2c24fb62d3f
 
 # Web framework for Python projects of a certain age
-Django==1.11.15 \
-    --hash=sha256:8176ac7985fe6737ce3d6b2531b4a2453cb7c3377c9db00bacb2b3320f4a1311 \
-    --hash=sha256:b18235d82426f09733d2de9910cee975cf52ff05e5f836681eb957d105a05a40
+Django==1.11.16 \
+    --hash=sha256:29268cc47816a44f27308e60f71da635f549c47d8a1d003b28de55141df75791 \
+    --hash=sha256:37f5876c1fbfd66085001f4c06fa0bf96ef05442c53daf8d4294b6f29e7fa6b8
 
 # 3rd party logins like Github
 # Code: https://github.com/pennersr/django-allauth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,9 @@ flake8-import-order==0.17.1 \
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin
-hashin==0.13.3 \
-    --hash=sha256:2ad38507e0edbd48a08b914e888e10a241485a8275050d54f648b17ea627b33c \
-    --hash=sha256:e841a0c55a51fb3a3b92d9aaa57e685421cc993db0f8bf5032a99871738fd636
+hashin==0.13.4 \
+    --hash=sha256:4e7731953dda1bbc1bbd11c80eef9bdcb2c0995be3a55807aa14991d197af6f9 \
+    --hash=sha256:a038ac6ff4bb881fe99b0c646c0624f803cd62486d461d82ed4fb6b2cce04e0f
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
[bug 1477016](https://bugzilla.mozilla.org/show_bug.cgi?id=1477016) is a bug introduced with the locale updates for Django 1.11. When generating URLs from a management command, no translation is active, and this appears as ``None`` in Django 1.11. When helping users recover their account, I often use management commands to generate and send profile recovery emails, and these emails contained invalid URLs with the locale set to '/None/'.

The change (maybe) is that Django's ``get_language()`` returns ``None`` when languages are deactivated. This is done by setting the active language to a class that returns ``None`` for the language code, avoiding falling back to the default language.

https://github.com/django/django/blob/bd197d3f927f6d17fc4738366126e06c6a95f366/django/utils/translation/trans_real.py#L251-L258

``deactivate_all()`` is explicitly called for some (all?) management commands:

https://github.com/django/django/blob/bd197d3f927f6d17fc4738366126e06c6a95f366/django/core/management/base.py#L317-L323

It looks like [further tuning is coming](https://docs.djangoproject.com/en/2.1/releases/2.1/#miscellaneous) in Django 2.1.

This PR adds a test for the behavior in bug 1477016, and updates to hashin 0.13.4 and Django 1.11.16 (both minor updates). It then updates the locale logic from Django 1.8 to 1.11:

* Sync ``LocaleRegexURLResolver`` with upstream, using ``settings.LANGUAGE_CODE`` when the active language is None. **This is the change that actually fixes bug 1477016**. The code now looks more like (ugly) upstream.
* Make ``LocaleMiddleware`` look a little more like Django's ``LocaleMiddleware``, by moving code to ``process_response`` method and documenting ``activate_language_from_request`` as customization of ``LocaleMiddleware.process_request``.
* Sync ``i18n_patterns`` with upstream, and check that the new 1.10 feature [prefix_default_language](https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#django.conf.urls.i18n.i18n_patterns) is *not* used. This feature allows an omitted language code in the URL to be treated as the default language, useful for projects converting to locale-prefixed URLs. Asserting that it is  ``True`` (prefix required for the default language) allows removal of some flexible logic in other code. I was thinking of using this new feature to make the homepage English by default for [bug 1441672](https://bugzilla.mozilla.org/show_bug.cgi?id=1441672), but it looks like it wouldn't quite work (Django uses the first pattern to determine if this feature is selected), but I have other ideas if this is prioritized.
* Use our ``getlanguage()`` in ``activate_language_from_request``, which should have the same effect as using ``language`` directly, but mirrors the Django logic. In general, if it looks uglier but does the same thing, it is because I was trying to make it look more like Django.
* Make ``is_valid_path`` look a little more like Django's ``is_valid_path``. It still requires customization for the the greedy ``mindtouch_to_kuma_redirect`` URL pattern, but swaps a request argument for a language code.
* Sync with Django 1.11's ``LocaleMiddleware.process_response``, which made [minor changes](https://github.com/django/django/blob/bd197d3f927f6d17fc4738366126e06c6a95f366/django/middleware/locale.py#L32-L60) in the logic for detecting and adding trailing slashes
* Add more in-code comments, prefixed with ``# Kuma:``, to describe the differences between Kuma's logic and Django's. This reflects where I found it challenging to determine what logic to bring over.
* Add some comments that I wish the Django code had, and reformat for 80 characters


