### PR TITLE
Bug 1480106: Fix mobile BCD table support background and name overflow

### DIFF
--- a/kuma/static/styles/components/compat-tables/_vars.scss
+++ b/kuma/static/styles/components/compat-tables/_vars.scss
@@ -31,7 +31,7 @@ $bc-border-width-thin: 1px;
 $bc-border-width-thick: 2px;
 $bc-support: yes, no, partial, unknown;
 $bc-grid-spacing: 10px;
-$bc-mobile-icon-width: 50px;
+$bc-mobile-browser-width: 220px;
 
 $table-types: (
 	web: (

--- a/kuma/static/styles/components/compat-tables/bc-browser.scss
+++ b/kuma/static/styles/components/compat-tables/bc-browser.scss
@@ -14,7 +14,8 @@ Hide icons and show browser name in mobile view
         left: 0;
         padding-left: 6px;
         height: 25px;
-        width: 200px;
+        width: $bc-mobile-browser-width;
         color: $text-color;
+        white-space: nowrap;
     }
 }

--- a/kuma/static/styles/components/compat-tables/bc-supports.scss
+++ b/kuma/static/styles/components/compat-tables/bc-supports.scss
@@ -79,10 +79,10 @@ Supports colouring
 @media #{$mq-mobile-and-down} {
     /* centers the background accounting for space icons take on the left */
     td.bc-supports-partial {
-        background-position: calc(50% + #{$bc-mobile-icon-width / 2})  50%;
+        background-position: calc(50% + #{$bc-mobile-browser-width / 2})  50%;
     }
 
     td.bc-supports-no {
-        background-position: calc(50% + #{$bc-mobile-icon-width / 2})  50%, calc(50% + #{$bc-mobile-icon-width / 2})  50%;
+        background-position: calc(50% + #{$bc-mobile-browser-width / 2})  50%, calc(50% + #{$bc-mobile-browser-width / 2})  50%;
     }
 }

--- a/kuma/static/styles/components/compat-tables/bc-table.scss
+++ b/kuma/static/styles/components/compat-tables/bc-table.scss
@@ -246,10 +246,10 @@ mobile display
         max-width: 100%;
         display: block;
         box-sizing: border-box;
-        box-shadow: inset 220px 0 0 0 #eaeff2;
+        box-shadow: inset $bc-mobile-browser-width 0 0 0 #eaeff2;
         border-top: $bc-border-width-thin solid $bc-border-color;
         border-left: 0;
-        padding-left: 250px;
+        padding-left: $bc-mobile-browser-width + 30px;
         padding-right: $bc-grid-spacing;
         text-align: left;
     }


### PR DESCRIPTION
See [bug&nbsp;1480106](https://bugzil.la/1480106) for details.

Follow‑up to #4948, which didn’t correctly update the **No&nbsp;support** and **Partial&nbsp;support** backgrounds.

Also fixes the <q>Samsung&nbsp;Internet&nbsp;Android</q> text overflow bug.

review?(@jwhitlock, @escattone)

## Screenshots:
<details>
<summary>Before</summary>

![Kuma PR-5034 (Before)](https://user-images.githubusercontent.com/3889017/46772517-9f37f380-ccf8-11e8-8df0-4ea65f23cf99.png)

</details>
<details>
<summary>After</summary>

![Kuma PR-5034 (After)](https://user-images.githubusercontent.com/3889017/46772587-0655a800-ccf9-11e8-9203-ef91dc33cf15.png)

</details>