### PR TITLE
Bug 1493417: Remove rollout hack for new compat tables

### DIFF
--- a/kuma/static/styles/wiki-compat-tables.scss
+++ b/kuma/static/styles/wiki-compat-tables.scss
@@ -41,15 +41,3 @@ Footnotes & Legend
 GitHub link
 ====================================================================== */
 @import 'components/compat-tables/bc-github-link';
-
-/*
-Hack to support rollout of new compat tables, remove after pages re-generated
-====================================================================== */
-
-.bc-old {
-    display: none;
-}
-
-.bc-data.hidden {
-    display: block;
-}


### PR DESCRIPTION
Pages have been regenerated. The hack is no longer needed.