### PR TITLE
Bug 1498685, remove smooth scrolling

### DIFF
--- a/kuma/static/styles/base/elements/document.scss
+++ b/kuma/static/styles/base/elements/document.scss
@@ -5,7 +5,6 @@ Styles for overall document.  Minimally styles the canvas.
 html {
     background: #fff;
     color: $text-color;
-    scroll-behavior: smooth;
 }
 
 body {


### PR DESCRIPTION
As mentioned in https://bugzilla.mozilla.org/show_bug.cgi?id=1498685, smooth scrolling in Chrome can trigger motion sickness in some users. This removes the scrolling behaviour and switching back to normal.