### PR TITLE
bug 1483072: deploy to MozIT prod with usual settings

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -43,8 +43,7 @@ def get_target_name() {
 
 def get_target_script() {
     if (env.BRANCH_NAME == PROD_BRANCH_NAME) {
-        // TODO: After cutover to IT-owned services, just use 'prod'.
-        return is_mozmeao_pipeline() ? 'prod' : 'prod.mm'
+        return 'prod'
     }
     if (env.BRANCH_NAME == STAGE_BRANCH_NAME) {
         return 'stage'


### PR DESCRIPTION
This PR configures the deployments to the MozIT prod instance in the same manner as they're configured for MozMEAO prod. This can be merged at any time.