### PR TITLE
Bug 1492018: Remove `.banner` and `.badge` style classes

### DIFF
--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -17,7 +17,6 @@ block indicators aka banners
 .blockIndicator,
 .overheadIndicator,
 .standardNoteBlock,
-.banner,
 .inheritsbox,
 .notice,
 .note,
@@ -212,8 +211,7 @@ inline indicators aka badges
 ====================================================================== */
 
 .inlineIndicator,
-.indicatorInHeadline,
-.badge {
+.indicatorInHeadline {
     @extend %indicator-inline;
     @extend %indicator-inline-icon;
 }


### PR DESCRIPTION
This removes the `.banner` and `.badge` style classes, which are no longer in use on MDN:
- https://developer.mozilla.org/search?locale=*&css_classnames=banner&topic=none
- https://developer.mozilla.org/search?locale=*&css_classnames=badge&topic=none

Part&nbsp;of [bug&nbsp;1492018](https://bugzil.la/1492018).
Follow‑up to #4979 and mdn/kumascript#830.

---

review?(@schalkneethling)