### PR TITLE
bug 1487403: Update to clean-css-cli 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -973,22 +973,49 @@
         }
       }
     },
-    "clean-css": {
-      "version": "3.4.28",
-      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-3.4.28.tgz",
-      "integrity": "sha1-vxlF6C/ICPVWlebd6uwBQA79A/8=",
+    "clean-css-cli": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/clean-css-cli/-/clean-css-cli-4.2.1.tgz",
+      "integrity": "sha512-ST2yi9F2kAmLRs9phSpGRUm44SbRy29QGm1OuAKfTU0KCLilFMTcz+/Fxhbdi5GrsjIMhTBdFUQhc55CjM3Isw==",
       "requires": {
+        "clean-css": "4.2.1",
         "commander": "2.8.1",
-        "source-map": "0.4.4"
+        "glob": "7.1.3"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+        "clean-css": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+          "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
           "requires": {
-            "amdefine": "1.0.1"
+            "source-map": "0.6.1"
           }
+        },
+        "glob": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.3.3",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "precommit": "npm run eslint && npm run stylelint"
   },
   "dependencies": {
-    "clean-css": "3.4.28",
+    "clean-css-cli": "4.2.1",
     "node-sass": "4.9.2",
     "stylelint": "9.3.0",
     "eslint": "5.1.0",


### PR DESCRIPTION
Update from clean-css 3.4.28 to clean-css-cli 4.2.1. There are [several changes in this version](https://www.npmjs.com/package/clean-css-cli#important-40-breaking-changes). Our code will need changes for the new version, which only runs in [production asset mode](https://kuma.readthedocs.io/en/latest/development.html#generating-production-assets). **This PR doesn't have these changes yet.**

@schalkneethling, you expressed some interest in working on this. Take a look and see if you think it would fit in the time you have available in Q4.

Here's a development / test process:

1. Get up-to-date Docker images, either with a [Kuma reset](https://kuma.readthedocs.io/en/latest/troubleshooting.html#kuma-reset) or manually:

```
git checkout master
git pull
VERSION=latest make build-base
```

2. Delete or move the static assets folder

```
mv static static-old
```

3. [Generate production assets](https://kuma.readthedocs.io/en/latest/development.html#generating-production-assets), rebuilding ``static``.

4. Move that folder to ``static-3``:

```
mv static static-3
```

5. Check out this branch, and rebuild the Docker images:

```
git fetch jwhitlock
git checkout clean-css-4-1487403
VERSION=latest make build-base
```

6. Generate production assets again. It should fail when generating a file like ``build/styles/locale-ln.css``:

```
Post-processing 'build/styles/locale-ln.css' failed!

Traceback (most recent call last):
  File "manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/local/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/usr/local/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 199, in handle
    collected = self.collect()
  File "/usr/local/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 145, in collect
    raise processed
ValueError: The file 'build/fonts/locales/ZillaSlab-Regular.subset.woff2' could not be found with <kuma.core.pipeline.storage.ManifestPipelineStorage object at 0x7fcd97743ad0>.
Makefile:51: recipe for target 'collectstatic' failed
```

7. Move that partial folder for safe-keeping and reference:

```
mv static static-4
```

I used ``opendiff`` from XCode to compare the two directories. Looking at the built file ``static-4/build/styles/locale-ln.css``, the difference is the relative path to the font files. With the ``clean-css 3.4.28`` dependencies, the (pretty-printed) output is:

```
@font-face{
    font-family:zillaslab;
    font-display:'fallback';
    src:url(../../fonts/locales/ZillaSlab-Regular.subset.woff2) format("woff2"),url(../../fonts/locales/ZillaSlab-Regular.subset.woff) format("woff");
    font-weight:400;
    font-style:normal
}
@font-face{
    font-family:zillaslab;
    font-display:'optional';
    src:url(../../fonts/locales/ZillaSlab-Bold.subset.woff2) format("woff2"),url(../../fonts/locales/ZillaSlab-Bold.subset.woff) format("woff");
    font-weight:700;
    font-style:normal
}
```

With ``clean-css-cli 4.2.1``, the ``src:url()`` paths go up one less directory, and so Django can't find the file to replace the path with the hashed version:

```
@font-face{
    font-family:zillaslab;
    font-display:fallback;
    src:url(../fonts/locales/ZillaSlab-Regular.subset.woff2) format("woff2"),url(../fonts/locales/ZillaSlab-Regular.subset.woff) format("woff");
    font-weight:400;
    font-style:normal
}
@font-face{
    font-family:zillaslab;
    font-display:optional;
    src:url(../fonts/locales/ZillaSlab-Bold.subset.woff2) format("woff2"),url(../fonts/locales/ZillaSlab-Bold.subset.woff) format("woff");
    font-weight:700;
    font-style:normal
}
```

This may be a simple configuration change for ``clean-css``, or it may require adjusting all the relative paths in CSS files.