### PR TITLE
Bug 1499455 - Hide code line numbers from screen reader.

### DIFF
--- a/kuma/static/js/libs/prism/prism-line-numbers.js
+++ b/kuma/static/js/libs/prism/prism-line-numbers.js
@@ -43,6 +43,8 @@ Prism.hooks.add('complete', function (env) {
 
 	lineNumbersWrapper = document.createElement('span');
 	lineNumbersWrapper.className = 'line-numbers-rows';
+	// Hide line numbers from screen readers.
+	lineNumbersWrapper.setAttribute("aria-hidden", "true");
 	lineNumbersWrapper.innerHTML = lines;
 
 	if (pre.hasAttribute('data-start')) {


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1499455

the span element with line-numbers-rows class is added by prism, and this looks like the code.
added `aria-hidden=true`

this at least skips the line number on Safari + VoiceOver
