### PR TITLE
bug 1467532: Update to flake8 3.6.0, dependencies

### DIFF
--- a/kuma/dashboards/forms.py
+++ b/kuma/dashboards/forms.py
@@ -42,11 +42,11 @@ class RevisionDashboardForm(forms.Form):
     start_date = forms.DateField(
         required=False, label=_(u'Start Date:'),
         input_formats=['%m/%d/%Y'],
-        widget=forms.TextInput(attrs={'pattern': '\d{1,2}/\d{1,2}/\d{4}'}))
+        widget=forms.TextInput(attrs={'pattern': r'\d{1,2}/\d{1,2}/\d{4}'}))
     end_date = forms.DateField(
         required=False, label=_(u'End Date:'),
         input_formats=['%m/%d/%Y'],
-        widget=forms.TextInput(attrs={'pattern': '\d{1,2}/\d{1,2}/\d{4}'}))
+        widget=forms.TextInput(attrs={'pattern': r'\d{1,2}/\d{1,2}/\d{4}'}))
     preceding_period = forms.ChoiceField(
         choices=PERIOD_CHOICES,
         required=False,

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1484,18 +1484,18 @@ CONSTANCE_CONFIG = dict(
         "are removed from the file storage"
     ),
     KUMA_WIKI_IFRAME_ALLOWED_HOSTS=(
-        ('^https?\:\/\/'
-         '(stage-files.mdn.moz.works'               # Staging demos
-         '|mdn.mozillademos.org'                    # Production demos
-         '|testserver'                              # Unit test demos
-         '|localhost\:8000'                         # Docker development demos
-         '|localhost\:8080'                         # Embedded samples server
-         '|rpm.newrelic.com\/public\/charts\/.*'    # MDN/Kuma/Server_charts
-         '|(www.)?youtube.com\/embed\/(\.*)'        # Embedded videos
-         '|jsfiddle.net\/.*embedded.*'              # Embedded samples
-         '|mdn.github.io'                           # Embedded samples
-         '|interactive-examples.mdn.mozilla.net'    # Embedded samples
-         ')'),
+        (r'^https?\:\/\/'
+         r'(stage-files.mdn.moz.works'              # Staging demos
+         r'|mdn.mozillademos.org'                   # Production demos
+         r'|testserver'                             # Unit test demos
+         r'|localhost\:8000'                        # Docker development demos
+         r'|localhost\:8080'                        # Embedded samples server
+         r'|rpm.newrelic.com\/public\/charts\/.*'   # MDN/Kuma/Server_charts
+         r'|(www.)?youtube.com\/embed\/(\.*)'       # Embedded videos
+         r'|jsfiddle.net\/.*embedded.*'             # Embedded samples
+         r'|mdn.github.io'                          # Embedded samples
+         r'|interactive-examples.mdn.mozilla.net'   # Embedded samples
+         r')'),
         'Regex comprised of domain names that are allowed for IFRAME SRCs'
     ),
     GOOGLE_ANALYTICS_ACCOUNT=(

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -2,24 +2,24 @@ from decorator_include import decorator_include
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
+from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import render
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import RedirectView
 from django.views.static import serve
-from django.core.urlresolvers import reverse_lazy
 
 
 from kuma.attachments import views as attachment_views
-from kuma.payments import views as payment_views
-from kuma.payments.urls import (
-    lang_urlpatterns as payments_lang_urlpatterns)
 from kuma.core import views as core_views
 from kuma.core.decorators import shared_cache_control
 from kuma.core.urlresolvers import i18n_patterns
 from kuma.dashboards.urls import lang_urlpatterns as dashboards_lang_urlpatterns
 from kuma.dashboards.views import index as dashboards_index
 from kuma.landing.urls import lang_urlpatterns as landing_lang_urlpatterns
+from kuma.payments import views as payment_views
+from kuma.payments.urls import (
+    lang_urlpatterns as payments_lang_urlpatterns)
 from kuma.search.urls import (
     lang_base_urlpatterns as search_lang_base_urlpatterns,
     lang_urlpatterns as search_lang_urlpatterns)

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -187,10 +187,10 @@ futures==3.0.5 \
 # Code: https://github.com/elastic/elasticsearch-py
 # Changes: https://elasticsearch-py.readthedocs.io/en/master/Changelog.html
 # Docs: https://elasticsearch-py.readthedocs.io/en/master/
-# Extensions to datetime module
 elasticsearch==5.5.0 \
     --hash=sha256:a9d1dabc18c2b593b1be5c85b697af2bbfb094a7d9cca21c48ac323257e3e7a0 \
     --hash=sha256:d03379ef519dde70b3b842deb0df576520a7a4735abe1d5ec3f32f8e66899be2
+# Extensions to datetime module
 # Code: https://github.com/dateutil/dateutil/
 # Changes: https://dateutil.readthedocs.io/en/stable/changelog.html
 # Docs: https://dateutil.readthedocs.io/en/stable/
@@ -199,17 +199,27 @@ python-dateutil==2.7.3 \
     --hash=sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8
 
 # flake8
+#
+# Backport of Python 3 configparser, version tracks Python 3 versions
+# Code: https://bitbucket.org/ambv/configparser
 configparser==3.5.0 \
     --hash=sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a
+# McCabe complexity checker
+# Code: https://github.com/pycqa/mccabe
 mccabe==0.6.1 \
     --hash=sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42 \
     --hash=sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f
-pycodestyle==2.3.1 \
-    --hash=sha256:6c4245ade1edfad79c3446fadfc96b0de2759662dc29d07d80a6f27ad1ca6ba9 \
-    --hash=sha256:682256a5b318149ca0d2a9185d365d8864a768a28db66a84a2ea946bcc426766
-pyflakes==1.6.0 \
-    --hash=sha256:08bd6a50edf8cffa9fa09a463063c425ecaaf10d1eb0335a7e8b1401aef89e6f \
-    --hash=sha256:8d616a382f243dbf19b54743f280b80198be0bca3a5396f1d2e1fca6223e8805
+# Python style guide checker, formerly pep8
+# Code: https://github.com/pycqa/pycodestyle
+# Changes: https://pycodestyle.readthedocs.io/en/latest/developer.html#changes
+# Docs: https://pycodestyle.readthedocs.io/
+pycodestyle==2.4.0 \
+    --hash=sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0 \
+    --hash=sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83 \
+    --hash=sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a
+pyflakes==2.0.0 \
+    --hash=sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49 \
+    --hash=sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae
 
 # google-api-python-client
 httplib2==0.9.2 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,16 +21,16 @@ django-debug-toolbar==1.10.1 \
 # Code: https://github.com/PyCQA/flake8
 # Docs: http://flake8.readthedocs.io/en/latest/
 # Changes: http://flake8.readthedocs.io/en/latest/release-notes/index.html
-flake8==3.5.0 \
-    --hash=sha256:c7841163e2b576d435799169b78703ad6ac1bbb0f199994fc05f700b2a90ea37 \
-    --hash=sha256:7253265f7abd8b313e3892944044a365e3f4ac3fcdcfb4298f55ee9ddf188ba0
+flake8==3.6.0 \
+    --hash=sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670 \
+    --hash=sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2
 
 # Standardize Python import order
 # Code: https://github.com/PyCQA/flake8-import-order
-# Change: https://github.com/PyCQA/flake8-import-order/blob/master/CHANGELOG.rst
-flake8-import-order==0.17.1 \
-    --hash=sha256:40d2a39ed91e080f3285f4c16256b252d7c31070e7f11b7854415bb9f924ea81 \
-    --hash=sha256:68d430781a9ef15c85a0121500cf8462f1a4bc7672acb2a32bfdbcab044ae0b7
+# Changes: https://github.com/PyCQA/flake8-import-order/blob/master/CHANGELOG.rst
+flake8-import-order==0.18 \
+    --hash=sha256:9be5ca10d791d458eaa833dd6890ab2db37be80384707b0f76286ddd13c16cbf \
+    --hash=sha256:feca2fd0a17611b33b7fa84449939196c2c82764e262486d5c3e143ed77d387b
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin

--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -13,7 +13,8 @@ ARTICLE_NAME = 'Send feedback (about|on) MDN'
 def test_location(base_url, selenium):
     article_page = ArticlePage(selenium, base_url).open()
     page = article_page.header.open_feedback()
-    assert re.match(ARTICLE_NAME + ' - The MDN project \| MDN', selenium.title)
+    assert re.match(ARTICLE_NAME + r' - The MDN project \| MDN',
+                    selenium.title)
     assert re.match(ARTICLE_NAME, page.article_title_text)
     assert page.article_title_text in selenium.title
 

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -206,7 +206,7 @@ class BasePage(Page):
             # if base url was not part of string there's a leading / to remove
             path = re.sub(r'^/', '', path)
             # remove locale and following /
-            path = re.sub(r'^' + locale + '\/', '', path)
+            path = re.sub(r'^' + locale + r'\/', '', path)
             return path
 
         @wait_for_window

--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -15,7 +15,7 @@ def get_abs_url(url, base_url):
 def url_test(url, location=None, status_code=requests.codes.moved_permanently,
              req_headers=None, req_kwargs=None, resp_headers=None, query=None,
              follow_redirects=False, final_status_code=requests.codes.ok):
-    """
+    r"""
     Function for producing a config dict for the redirect test.
 
     You can use simple bash style brace expansion in the `url` and `location`

--- a/tox.ini
+++ b/tox.ini
@@ -84,7 +84,9 @@ exclude = **/migrations/**,.tox,*.egg,vendor
 # E501 - line too long (82 > 79 characters)
 # E731 - do not assign a lambda expression, use a def
 # F405 - name may be undefined, or defined from star imports: module
-ignore = E501,E731,F405
+# W504 - line break after binary operator
+#        conflicts with W503 (line break before binary operator)
+ignore = E501,E731,F405,W504
 # flake8-import-order settings
 import-order-style=edited
 application-import-names=kuma,pages,utils


### PR DESCRIPTION
Our TravisCI flake8 test installs the latest, and flake8 3.6.0 was released, so flake8 builds are busted for a while. This updates the libraries and makes the code work with the latest linters.

* flake8 3.5.0 → 3.6.0: Update dependencies, small fixes
* flake8-import-order 0.17.1 → 0.18: Python 3.7 support
* pycodestyle 2.3.1 → 2.4.0: Checks break after binary operator (``W504``), invalid escape sequences in string literals (``W605``).
* pyflakes 1.6.0 → 2.0.0: Checks unused exception binding, etc.

Update the code to mark regex with ``r''``, to avoid escape sequence checks. Add ``W504`` to the ignore list, since it conflicts with ``W503`` (break before binary operator).