### PR TITLE
bug 1477468: add redirects for marionette

### DIFF
--- a/kuma/redirects/redirects.py
+++ b/kuma/redirects/redirects.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from functools import partial
+
 from redirect_urls import redirect as lib_redirect
 
 from kuma.core.decorators import shared_cache_control
@@ -824,9 +826,48 @@ for zone_root, wiki_slug, locales in zone_redirects:
             permanent=False,
             decorators=shared_cache_control_for_zones))
 
-redirectpatterns = scl3_redirectpatterns + zone_redirectpatterns + [
-    locale_redirect(
-        r'^fellowship',
-        '/docs/Archive/2015_MDN_Fellowship_Program',
-        permanent=True),
+marionette_client_docs_url = (
+    'https://marionette-client.readthedocs.io/en/latest/')
+marionette_docs_root_url = (
+    'https://firefox-source-docs.mozilla.org/testing/marionette/marionette/')
+marionette_redirect = partial(locale_redirect, re_flags='i',
+                              prepend_locale=False, permanent=True)
+
+marionette_redirectpatterns = [
+    marionette_redirect(r'docs/(?:Mozilla/QA/)?Marionette$',
+                        marionette_docs_root_url + 'index.html'),
+    marionette_redirect(r'docs/(?:Mozilla/QA/)?Marionette/Builds$',
+                        marionette_docs_root_url + 'Building.html'),
+    marionette_redirect(r'docs/(?:Mozilla/QA/)?Marionette/Client$',
+                        marionette_client_docs_url),
+    marionette_redirect(r'docs/Mozilla/QA/Marionette/Python_Client$',
+                        marionette_client_docs_url),
+    marionette_redirect(r'docs/(?:Mozilla/QA/)?Marionette/Developer_setup$',
+                        marionette_docs_root_url + 'Contributing.html'),
+    marionette_redirect(r'docs/Marionette_Test_Runner$',
+                        marionette_docs_root_url + 'PythonTests.html'),
+    marionette_redirect(r'docs/Mozilla/QA/Marionette/Marionette_Test_Runner$',
+                        marionette_docs_root_url + 'PythonTests.html'),
+    marionette_redirect(r'docs/(?:Mozilla/QA/)?Marionette/(?:MarionetteTestCase'
+                        r'|Marionette_Python_Tests|Running_Tests|Tests)$',
+                        marionette_docs_root_url + 'PythonTests.html'),
+    marionette_redirect(r'docs/Mozilla/QA/Marionette/Protocol$',
+                        marionette_docs_root_url + 'Protocol.html'),
+    marionette_redirect(r'docs/Mozilla/QA/Marionette/WebDriver/status$',
+                        'https://bugzilla.mozilla.org'
+                        '/showdependencytree.cgi?id=721859&hide_resolved=1'),
+    marionette_redirect(r'docs/Marionette/Debugging$',
+                        marionette_docs_root_url + 'Debugging.html'),
 ]
+
+redirectpatterns = (
+    scl3_redirectpatterns +
+    zone_redirectpatterns +
+    marionette_redirectpatterns +
+    [
+        locale_redirect(
+            r'^fellowship',
+            '/docs/Archive/2015_MDN_Fellowship_Program',
+            permanent=True),
+    ]
+)

--- a/tests/headless/map_301.py
+++ b/tests/headless/map_301.py
@@ -439,3 +439,37 @@ REDIRECT_URLS = list(flatten((
     url_test('/en-US/fellowship',
              '/en-US/docs/Archive/2015_MDN_Fellowship_Program'),
 )))
+
+marionette_client_docs_url = (
+    'https://marionette-client.readthedocs.io/en/latest/')
+marionette_docs_root_url = (
+    'https://firefox-source-docs.mozilla.org/testing/marionette/marionette/')
+marionette_locales = '{/en-US,/fr,/ja,/pl,/pt-BR,/ru,/zh-CN,}'
+marionette_base = marionette_locales + '/docs/Mozilla/QA/Marionette'
+marionette_multi_base = marionette_locales + '/docs/{Mozilla/QA/,}Marionette'
+marionette_python_tests = (
+    '{MarionetteTestCase,Marionette_Python_Tests,Running_Tests,Tests}')
+
+MARIONETTE_URLS = list(flatten((
+    url_test(marionette_multi_base, marionette_docs_root_url + 'index.html'),
+    url_test(marionette_multi_base + '/Builds',
+             marionette_docs_root_url + 'Building.html'),
+    url_test(marionette_multi_base + '/Client', marionette_client_docs_url),
+    url_test(marionette_multi_base + '/Developer_setup',
+             marionette_docs_root_url + 'Contributing.html'),
+    url_test(marionette_multi_base + '/' + marionette_python_tests,
+             marionette_docs_root_url + 'PythonTests.html'),
+    url_test(marionette_locales + '/docs/Marionette_Test_Runner',
+             marionette_docs_root_url + 'PythonTests.html'),
+    url_test(marionette_base + '/Marionette_Test_Runner',
+             marionette_docs_root_url + 'PythonTests.html'),
+    url_test(marionette_base + '/Protocol',
+             marionette_docs_root_url + 'Protocol.html'),
+    url_test(marionette_base + '/Python_Client',
+             marionette_client_docs_url),
+    url_test(marionette_base + '/WebDriver/status',
+             'https://bugzilla.mozilla.org'
+             '/showdependencytree.cgi?id=721859&hide_resolved=1'),
+    url_test(marionette_locales + '/docs/Marionette/Debugging',
+             marionette_docs_root_url + 'Debugging.html'),
+)))

--- a/tests/headless/test_redirects.py
+++ b/tests/headless/test_redirects.py
@@ -5,7 +5,8 @@ import pytest
 from utils.urls import assert_valid_url
 
 from .map_301 import (GITHUB_IO_URLS, LEGACY_URLS, MOZILLADEMOS_URLS,
-                      REDIRECT_URLS, SCL3_REDIRECT_URLS, ZONE_REDIRECT_URLS)
+                      MARIONETTE_URLS, REDIRECT_URLS, SCL3_REDIRECT_URLS,
+                      ZONE_REDIRECT_URLS)
 
 # while these test methods are similar, they're each testing a
 # subset of redirects, and it was easier to work with them separately.
@@ -61,5 +62,14 @@ def test_slc3_redirects(url, base_url):
 @pytest.mark.parametrize('url', ZONE_REDIRECT_URLS,
                          ids=[item['url'] for item in ZONE_REDIRECT_URLS])
 def test_zone_redirects(url, base_url):
+    url['base_url'] = base_url
+    assert_valid_url(**url)
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+@pytest.mark.parametrize('url', MARIONETTE_URLS,
+                         ids=[item['url'] for item in MARIONETTE_URLS])
+def test_marionette_redirects(url, base_url):
     url['base_url'] = base_url
     assert_valid_url(**url)


### PR DESCRIPTION
This PR addresses [bug 1477468](https://bugzilla.mozilla.org/show_bug.cgi?id=1477468). One of the assumptions I've made is that the ultimate goal is to remove all of the Marionette documents from MDN, so I've not depended upon the existence of Marionette documents when constructing the external redirects. For example, there are existing documents, like https://developer.mozilla.org/en-US/docs/Marionette and https://developer.mozilla.org/en-US/docs/Marionette/Builds, that are in-content redirects to their respective documents https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette and https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Builds, but I've created explicit external redirects for them as well as their targets.

As part of the work towards this PR, I've deleted (hard deleted) the following documents from https://developer.mozilla.org:

- [x] https://developer.mozilla.org/fr/docs/Mozilla/QA/Marionette
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette
- [x] https://developer.mozilla.org/pl/docs/Mozilla/QA/Marionette
- [x] https://developer.mozilla.org/pt-BR/docs/Mozilla/QA/Marionette
- [x] https://developer.mozilla.org/ru/docs/Marionette
- [x] https://developer.mozilla.org/zh-CN/docs/Mozilla/QA/Marionette
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/Builds
- [x] https://developer.mozilla.org/ru/docs/Marionette/Builds
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/Connecting_to_B2G
- [x] https://developer.mozilla.org/pt-BR/docs/Mozilla/QA/Marionette/Conectando_ao_B2G
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/Developer_setup
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/Marionette_JavaScript_Tests
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/Running_Tests
- [x] https://developer.mozilla.org/fr/docs/Mozilla/QA/Marionette/WebDriver
- [x] https://developer.mozilla.org/ja/docs/Mozilla/QA/Marionette/WebDriver
- [x] https://developer.mozilla.org/pl/docs/Mozilla/QA/Marionette/WebDriver
- [x] https://developer.mozilla.org/zh-CN/docs/Mozilla/QA/Marionette/WebDriver
- [x] https://developer.mozilla.org/pl/docs/Mozilla/QA/Marionette/WebDriver/status
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Connecting_to_B2G (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Connecting_to_B2G which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Emulator (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Emulator which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/EmulatorBattery (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/EmulatorBattery which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Marionette (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette which doesn't exist)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Marionette_JavaScript_Tests (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette_JavaScript_Tests which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Marionette_JavaScript_Tools (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette_JavaScript_Tools which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Marionette_Python_Tests/Emulator_Integrated_Tests (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette_Python_Tests/Emulator_Integrated_Tests which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Performance_tests (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Performance_tests which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Python_Marionette (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Python_Marionette which had been deleted)
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Setup (was a redirect to https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Setup which had been deleted)

So this PR adds the following external redirects as well as tests for them:
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/index.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Builds --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Building.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Client --> https://marionette-client.readthedocs.io/en/latest/
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Python_Client --> https://marionette-client.readthedocs.io/en/latest/
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Developer_setup --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Contributing.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/MarionetteTestCase --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette_Python_Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Marionette_Test_Runner --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Running_Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/Protocol --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Protocol.html
- [x] https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status --> https://bugzilla.mozilla.org/showdependencytree.cgi?id=721859&hide_resolved=1
- [x] https://developer.mozilla.org/en-US/docs/Marionette --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/index.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Builds --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Building.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Client --> https://marionette-client.readthedocs.io/en/latest/
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Debugging --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Debugging.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Developer_setup --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/Contributing.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/MarionetteTestCase --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Marionette_Python_Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Running_Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette/Tests --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html
- [x] https://developer.mozilla.org/en-US/docs/Marionette_Test_Runner --> https://firefox-source-docs.mozilla.org/testing/marionette/marionette/PythonTests.html

This PR does not address a Marionette document that still exists on MDN (https://developer.mozilla.org/en-US/docs/Marionette/B2Gisms) that perhaps should be redirected somewhere as well. I've requested feedback from @andreastt about that within the Bugzilla bug.