### PR TITLE
bug 1490727: Force en-US for some payments UI

### DIFF
--- a/kuma/core/i18n.py
+++ b/kuma/core/i18n.py
@@ -13,6 +13,8 @@ from django.utils import lru_cache, translation
 from django.utils.translation.trans_real import (
     check_for_language, get_languages as _django_get_languages,
     language_code_prefix_re, language_code_re, parse_accept_lang_header)
+from jinja2 import nodes
+from jinja2.ext import Extension
 
 
 def django_language_code_to_kuma(lang_code):
@@ -222,3 +224,45 @@ def activate_language_from_request(request):
     language = get_language_from_request(request)
     translation.activate(language)
     request.LANGUAGE_CODE = get_language()
+
+
+class TranslationExtension(Extension):
+    """
+    Provide a Jinja2 tag like Django's {% translation %} block
+
+    Usage:
+
+    {% translation 'en-US' %}
+      <p>_('This string is translatable, but displayed in English.')</p>
+    {% endtranslation %}
+
+    See Django documentation for details:
+    https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#switching-language-in-templates
+
+    Jinja2 has a parsing phase and then a rendering phase. This parses the {%
+    translation %} block as a CallBlock node that will override the translation
+    at render time. It is very similar to the example in the docs:
+
+    http://jinja.pocoo.org/docs/2.10/extensions/#module-jinja2.ext
+    """
+    tags = {'translation'}
+
+    def parse(self, parser):
+        """Parse a stream starting with {% translation %}."""
+        # Get the line number and desired language
+        lineno = next(parser.stream).lineno
+        block_language = parser.parse_expression()
+
+        # Parse the block body until {% endtranslation %}
+        body = parser.parse_statements(['name:endtranslation'],
+                                       drop_needle=True)
+
+        # Return a node that will render body in the desired translation
+        return nodes.CallBlock(self.call_method('_override', [block_language]),
+                               [], [], body).set_lineno(lineno)
+
+    def _override(self, block_language, caller):
+        """Render a {% translation %} block with the requested language."""
+        with translation.override(block_language):
+            value = caller()
+        return value

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -1,3 +1,4 @@
+{% translation 'en-US' %}{# Display in English until Q1 2019 #}
 <div id="contribution-popover-container" class="contribution-banner {% if is_popover %}contribution-popover is-collapsed is-hidden{% endif %}"{% if is_popover %} aria-expanded="false" aria-hidden="true"{% endif %}>
     {% if is_popover %}
         <div class="contribution-popover-actions">
@@ -88,3 +89,4 @@
         </div>
     </div>
 </div>
+{% endtranslation %}

--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -5,6 +5,7 @@
 {% block title %}{{ page_title(_('Thank You')) }}{% endblock %}
 
 {% block document_head %}
+  {% translation 'en-US' %}{# Display in English until Q1 2019 #}
     <div class="{% if status == 'succeeded' %} contribution-banner {% endif %}align-center">
         <div class="column-container">
             {% if status == 'succeeded' %}
@@ -63,6 +64,7 @@
             </div>
         </div>
     </div>
+  {% endtranslation %}
 {% endblock %}
 
 {% block content %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -614,6 +614,7 @@ TEMPLATES = [
                 'django_jinja.builtins.extensions.DjangoFiltersExtension',
                 'pipeline.jinja2.PipelineExtension',
                 'waffle.jinja.WaffleExtension',
+                'kuma.core.i18n.TranslationExtension',
             ],
         }
     },


### PR DESCRIPTION
We didn't intend to ship translations of the payments UI until next year, but it is live:

https://developer.mozilla.org/de/payments/

Rather than manually remove the translated strings, this PR adds a new tag pair ``{% translation 'en-US' %}``/``{% endtranslation %}`` that forces a locale for a block of markup. The goal is to retain translatable strings, but force English in some contexts:

* [ ] The banner (open or closed) is in English on the [homepage](http://localhost:8000/de/)
* [ ] The banner (open or closed) is in English on [wiki pages](http://localhost:8000/de/docs/Apps)
* [ ] The form is in English on the stand-alone page [/payments](http://localhost:8000/de/payments/), but the FAQ and Feedback form is localized
* [ ] Form validation errors, such as an invalid custom amount of 0.5, are displayed in English
* [ ] The [Thank You page](http://localhost:8000/de/payments/success) is in English, except for the Feedback section, which is localized
* [ ] The [Error page](http://localhost:8000/de/payments/error) is in English, except for the Feedback section, which is localized

To manually review, it is good to reproduce locally first:

* Checkout the master branch
* Checkout the current ``locale`` folder: ``git submodules update --init``
* [Build the localizations](https://kuma.readthedocs.io/en/latest/localization.html#build-the-localizations) to enable the latest translations.
* Set ``MDN_CONTRIBUTION=True``, ``STRIPE_PUBLIC_KEY``, and ``STRIPE_SECRET_KEY`` in ``.env``, ``make up`` to enable.
* If needed, log into MDN in development environment
* If needed, remove the local storage item ``contributionsPopoverDisabled``
* Confirm that the banner is in German on http://localhost:8000/de/

Once you have German locally, you can force English in the payments UI by checking out this branch, and running ``docker-compose restart web`` to force re-parsing of Jinja2 templates.

I've marked @escattone for review, but if @joshJarr wants to take a look, please do.