### PR TITLE
bug 1483072: stop pushing images from MozMEAO Jenkins

### DIFF
--- a/Jenkinsfiles/default.groovy
+++ b/Jenkinsfiles/default.groovy
@@ -2,16 +2,19 @@ stage('Test') {
     utils.compose_test()
 }
 
-stage('Build & push kuma_base image') {
-    utils.sh_with_notify(
-        'make build-base push-base',
-        'Build and push of commit-tagged Kuma base image'
-    )
-}
+// TODO: After cutover to IT-owned services, remove this condition.
+if (!utils.is_mozmeao_pipeline()) {
+    stage('Build & push kuma_base image') {
+        utils.sh_with_notify(
+            'make build-base push-base',
+            'Build and push of commit-tagged Kuma base image'
+        )
+    }
 
-stage('Build & push kuma image') {
-    utils.sh_with_notify(
-        'make build-kuma push-kuma',
-        "Build & push of commit-tagged Kuma image"
-    )
+    stage('Build & push kuma image') {
+        utils.sh_with_notify(
+            'make build-kuma push-kuma',
+            "Build & push of commit-tagged Kuma image"
+        )
+    }
 }

--- a/Jenkinsfiles/master.groovy
+++ b/Jenkinsfiles/master.groovy
@@ -9,13 +9,16 @@ stage('Test') {
     utils.compose_test()
 }
 
-stage('Build & push images') {
-    utils.sh_with_notify(
-        'make build-kuma push-kuma',
-        "Build & push of commit-tagged Kuma image"
-    )
-    utils.sh_with_notify(
-        'make push-base VERSION=latest',
-        'Push of latest-tagged Kuma base image'
-    )
+// TODO: After cutover to IT-owned services, remove this condition.
+if (!utils.is_mozmeao_pipeline()) {
+    stage('Build & push images') {
+        utils.sh_with_notify(
+            'make build-kuma push-kuma',
+            "Build & push of commit-tagged Kuma image"
+        )
+        utils.sh_with_notify(
+            'make push-base VERSION=latest',
+            'Push of latest-tagged Kuma base image'
+        )
+    }
 }


### PR DESCRIPTION
Correction for #5044. Since we're no longer pushing images to both quay.io (from the MozMEAO Jenkins service) and DockerHub (from the MozIT Jenkins service), but to DockerHub only, stop pushing images altogether when we are running on the MozMEAO Jenkins service.

This approach has already been tested in a replay on the MozMEAO Jenkins service.

Hide whitespace changes when reviewing.