### PR TITLE
bug 948151: Adjust CSP for CDNs, Gravatar default image

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1266,6 +1266,7 @@ CSP_FRAME_SRC = [
 CSP_IMG_SRC = [
     SITE_URL,
     "data:",
+    PROTOCOL + "i2.wp.com",
     "https://secure.gravatar.com",
     "https://www.google-analytics.com",
     _PROD_ATTACHMENT_SITE_URL

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -46,8 +46,9 @@ PROTOCOL = config('PROTOCOL', default='https://')
 DOMAIN = config('DOMAIN', default='developer.mozilla.org')
 SITE_URL = config('SITE_URL', default=PROTOCOL + DOMAIN)
 PRODUCTION_DOMAIN = 'developer.mozilla.org'
+PRODUCTION_URL = 'https://' + PRODUCTION_DOMAIN
 STAGING_DOMAIN = 'developer.allizom.org'
-STAGING_URL = PROTOCOL + STAGING_DOMAIN
+STAGING_URL = 'https://' + STAGING_DOMAIN
 
 _PROD_INTERACTIVE_EXAMPLES = 'https://interactive-examples.mdn.mozilla.net'
 INTERACTIVE_EXAMPLES_BASE = config(
@@ -496,7 +497,12 @@ AUTHENTICATION_BACKENDS = (
 )
 AUTH_USER_MODEL = 'users.User'
 USER_AVATAR_PATH = 'uploads/avatars/'
-DEFAULT_AVATAR = STATIC_URL + 'img/avatar.png'
+
+if urlsplit(STATIC_URL).hostname in (None, 'localhost'):
+    # Gravatar needs a publicly available default image
+    DEFAULT_AVATAR = PRODUCTION_URL + '/static/img/avatar.png'
+else:
+    DEFAULT_AVATAR = STATIC_URL + 'img/avatar.png'
 
 AVATAR_SIZES = [  # in pixels
     34,   # wiki document page

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1254,17 +1254,17 @@ EMAIL_FILE_PATH = '/app/tmp/emails'
 # Content Security Policy (CSP)
 CSP_DEFAULT_SRC = ("'none'",)
 CSP_CONNECT_SRC = [
-    "'self'",
+    SITE_URL,
 ]
 CSP_FONT_SRC = [
-    "'self'",
+    SITE_URL,
 ]
 CSP_FRAME_SRC = [
     urlunsplit((scheme, netloc, '', '', ''))
     for scheme, netloc, ignored_path in ALLOWED_IFRAME_PATTERNS]
 
 CSP_IMG_SRC = [
-    "'self'",
+    SITE_URL,
     "data:",
     "https://secure.gravatar.com",
     "https://www.google-analytics.com",
@@ -1274,13 +1274,13 @@ if ATTACHMENT_SITE_URL not in (_PROD_ATTACHMENT_SITE_URL, SITE_URL):
     CSP_IMG_SRC.append(ATTACHMENT_SITE_URL)
 
 CSP_SCRIPT_SRC = [
-    "'self'",
+    SITE_URL,
     "www.google-analytics.com",
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
 ]
 CSP_STYLE_SRC = [
-    "'self'",
+    SITE_URL,
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
 ]


### PR DESCRIPTION
Use ``SITE_URL``, like ``https://developer.allizom.org``, instead of ``'site'``, in CSP rules, so that loading the origin domain doesn't generate CSP reports for assets.

The default image is loaded from https://i2.wp.com/developer.mozilla.org/static/img/avatar.png?ssl=1, so this needs to be in the ``img-src`` rule. 

Also, the avatar URL needs to be publicly accessible, so use the production URL in development, fixing [bug 1485073](https://bugzilla.mozilla.org/show_bug.cgi?id=1485073).