### PR TITLE
bug 1503101: Fix hash link on pages without TOC

### DIFF
--- a/kuma/static/js/utils/utils.js
+++ b/kuma/static/js/utils/utils.js
@@ -50,7 +50,7 @@ window.mdn.utils = {
         var toc = document.getElementById('toc');
 
         // if page has a TOC,
-        if (toc !== undefined) {
+        if (toc) {
             // get and store the `offsetHeight`
             this.tocHeight = toc.offsetHeight;
             // and its sticky status


### PR DESCRIPTION
[Bugzilla 1503101](https://bugzilla.mozilla.org/show_bug.cgi?id=1503101)

This PR changes TOC existence check from `toc !== undefined` to truthy check, as [`document.getElementById()`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementById) returns `null`.

[Example of a page without TOC](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XUL/panel)