### PR TITLE
bug 1490727: Add waffle flag for recurring payments

### DIFF
--- a/kuma/payments/constants.py
+++ b/kuma/payments/constants.py
@@ -1,1 +1,2 @@
 CONTRIBUTION_BETA_FLAG = 'contrib_beta'
+RECURRING_PAYMENT_BETA_FLAG = 'recurring_payment_beta'

--- a/kuma/payments/context_processors.py
+++ b/kuma/payments/context_processors.py
@@ -1,5 +1,5 @@
 from .forms import ContributionForm
-from .utils import enabled, popup_enabled
+from .utils import enabled, popup_enabled, recurring_payment_enabled
 
 
 def global_contribution_form(request):
@@ -7,6 +7,7 @@ def global_contribution_form(request):
     if enabled(request):
         return {
             'contribution_enabled': True,
+            'contribution_recurring_payment_enabled': recurring_payment_enabled(request),
             'contribution_popup': popup_enabled(request),
             'contribution_form': ContributionForm(),
             'hide_cta': True,

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from waffle import flag_is_active
 
-from .constants import CONTRIBUTION_BETA_FLAG
+from .constants import CONTRIBUTION_BETA_FLAG, RECURRING_PAYMENT_BETA_FLAG
 
 
 def enabled(request):
@@ -14,3 +14,10 @@ def popup_enabled(request):
     return (enabled(request) and
             hasattr(request, 'user') and
             flag_is_active(request, CONTRIBUTION_BETA_FLAG))
+
+
+def recurring_payment_enabled(request):
+    """Returns True if recurring payment is enabled for the user."""
+    return (enabled(request) and
+            hasattr(request, 'user') and
+            flag_is_active(request, RECURRING_PAYMENT_BETA_FLAG))


### PR DESCRIPTION
As a MDN developer, I can enable recurring payment flow for some users.

- [ ] add new waffle flag "recurring_payment_beta"

to be able to view recurring payments "recurring_payment_beta" will have to be added to database under Waffle Flags through Django Admin.