### PR TITLE
Bug 1493499, add aria roles to notes/warning boxes inside ckeditor

### DIFF
--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -147,8 +147,8 @@
     if(!CKEDITOR.stylesSet.registered['default']) {
       CKEDITOR.stylesSet.add('default', [
         { name: 'None', element: 'p' },
-        { name: 'Note Box', element: 'div', attributes: { 'class': 'blockIndicator note' }, type: 'wrap' },
-        { name: 'Warning Box', element: 'div', attributes: { 'class': 'blockIndicator warning' }, type: 'wrap' },
+        { name: 'Note Box', element: 'div', attributes: { 'class': 'blockIndicator note', 'role': 'complementary' }, type: 'wrap' },
+        { name: 'Warning Box', element: 'div', attributes: { 'class': 'blockIndicator warning', 'role': 'region', 'aria-label': gettext('Important note') }, type: 'wrap' },
         { name: 'Two Columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
         { name: 'Three Columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },


### PR DESCRIPTION
To test this, edit a page on MDN. In CKEditor, choose the "Note" component from the `Styles` dropdown. Switch to the source output, confirm that the following is output:

```
<div class="note" role="complementary">
<p>&nbsp;</p>
</div>
```

Switch back to the WYSIWYG and add a "Warning" component. Switch to source and confirm that the output is as follows:

```
<div aria-label="Important note" class="warning" role="region">
<p>&nbsp;</p>
</div>
```

r?