### PR TITLE
bug 1490727: Add new page for payment terms, for now just empty template

### DIFF
--- a/kuma/payments/jinja2/payments/payment_terms.html
+++ b/kuma/payments/jinja2/payments/payment_terms.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ page_title(_('MDN Payment terms')) }}{% endblock %}
+
+{% block site_meta %}
+    {{ super() }}
+    {% set seo_description = _('MDN Payment terms') %}
+    {% set social_title = _('MDN Payment terms') %}
+    <meta property="og:description" content="{{ seo_description }}">
+    <meta name="description" content="{{ seo_description }}">
+    <meta name="twitter:description" content="{{ seo_description }}">
+    <meta name="twitter:title" content="{{ social_title }}">
+    <meta property="og:title" content="{{ social_title }}">
+{% endblock %}
+
+
+{% block content %}
+
+    <h1>{{ _('MDN Payment terms') }}</h1>
+
+{% endblock %}

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -19,6 +19,16 @@ def test_contribute_view(mock_enabled, client, settings):
 
 @pytest.mark.django_db
 @mock.patch('kuma.payments.views.enabled')
+def test_payment_terms_view(mock_enabled, client, settings):
+    """If enabled, contribution page is returned."""
+    mock_enabled.return_value = True
+    response = client.get(reverse('payment_terms'))
+    assert_no_cache_header(response)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@mock.patch('kuma.payments.views.enabled')
 def test_thanks_view(mock_enabled, client, settings):
     """If enabled, contribution thank you page is returned."""
     mock_enabled.return_value = True

--- a/kuma/payments/urls.py
+++ b/kuma/payments/urls.py
@@ -14,5 +14,8 @@ lang_urlpatterns = [
         name='recurring_payment_initial'),
     url(r'^recurring/subscription/?$',
         views.contribute_recurring_payment_subscription,
-        name='recurring_payment_subscription')
+        name='recurring_payment_subscription'),
+    url(r'^terms/?$',
+        views.payment_terms,
+        name='payment_terms'),
 ]

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -128,3 +128,9 @@ def contribute_recurring_payment_subscription(request):
         'recurring_payment': True
     }
     return render(request, 'payments/payments.html', context)
+
+
+@skip_if_disabled
+@never_cache
+def payment_terms(request):
+    return render(request, 'payments/payment_terms.html')


### PR DESCRIPTION
This is only plain template which will be filled out with proper legal information.
Next step is to add this page as a link to checkbox form.