### PR TITLE
bug 1490727: Update logic to correctly render the prompt for anon users.

### DIFF
--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -1,6 +1,7 @@
 {# Set URLs outside of translation block, to keep user's locale #}
 {% set payments_url = url('payments') %}
 {% set recurring_payment_subscription_url = url('recurring_payment_subscription') %}
+{% set recurring_payment_url = url('recurring_payment_initial') %}
 {% set faq_url = payments_url + "#contribute-faqs" %}
 {% set feedback_url = payments_url + "#contribute-feedback" %}
 
@@ -53,26 +54,30 @@
                             <a href="{{ payments_url }}" {% if not recurring_payment %} class="active" {% endif %}>
                                 {{_('One off payment')}}
                             </a>
-                            <a href="{{ recurring_payment_subscription_url }}" {% if recurring_payment %} class="active" {% endif %}>
+                            <a href="{{ recurring_payment_url }}" {% if recurring_payment %} class="active" {% endif %}>
                                 {{_('Monthly payment')}}
                             </a>
                         </div>
                         {# One Time payments form #}
-                        {% with form=form, payments_url=payments_url %}
-                            {%- include "payments/includes/payments-form.html" %}
-                        {% endwith %}
                         {% if recurring_payment %}
                             {% if user.username %}
                                 {% with form=form, is_popover=False, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url  %}
-                                    {#- include "payments/includes/payments-form.html" #}
+                                    {%- include "payments/includes/payments-form.html" %}
                                 {% endwith %}
                             {% else %}
                                 {% set github_url = provider_login_url('github', next=next_url) %}
-                                <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
-                                <a href="{{ github_url }}" class="payment-form-button" data-service="GitHub" rel="nofollow">
-                                    {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
-                                </a>
+                                <div class="align-center center">
+                                    <h4>{{_('You’re just a couple steps away.')}}</h4>
+                                    <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
+                                    <a href="{{ github_url }}" class="payment-form-button" data-service="GitHub" rel="nofollow">
+                                        {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
+                                    </a>
+                                </div>
                             {% endif %}
+                        {% else %}
+                            {% with form=form, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url %}
+                                {%- include "payments/includes/payments-form.html" %}
+                            {% endwith %}
                         {% endif %}
                     </div>
                 {% else %}


### PR DESCRIPTION
Fixes the logic to render the login prompt for anonymous users on the recurring payment panel.

**In this PR**
- https://trello.com/c/SQgMeAXd/11-as-an-anonymous-user-i-want-to-learn-why-i-have-to-log-in-to-github-so-that-i-dont-leave-the-process

**Screenshots**
![screenshot 2018-11-06 at 13 10 42](https://user-images.githubusercontent.com/11092019/48066650-13659a00-e1c6-11e8-827a-2c1ace84e7f4.png)
![screenshot 2018-11-06 at 13 11 06](https://user-images.githubusercontent.com/11092019/48066651-13659a00-e1c6-11e8-9f5a-72ffe2a4b782.png)
