### PR TITLE
Bug 1492018: Prefer `.blockIndicator` for styling Note and Warning boxes

### DIFF
--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -147,8 +147,8 @@
     if(!CKEDITOR.stylesSet.registered['default']) {
       CKEDITOR.stylesSet.add('default', [
         { name: 'None', element: 'p' },
-        { name: 'Note Box', element: 'div', attributes: { 'class': 'note' }, type: 'wrap' },
-        { name: 'Warning Box', element: 'div', attributes: { 'class': 'warning' }, type: 'wrap' },
+        { name: 'Note Box', element: 'div', attributes: { 'class': 'blockIndicator note' }, type: 'wrap' },
+        { name: 'Warning Box', element: 'div', attributes: { 'class': 'blockIndicator warning' }, type: 'wrap' },
         { name: 'Two Columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
         { name: 'Three Columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
         { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },


### PR DESCRIPTION
I didn’t know how to do this in https://github.com/mozilla/kuma/pull/4979 until @schalkneethling opened https://github.com/mozilla/kuma/pull/5069.

review?(@chrisdavidmills, @jwhitlock)