### PR TITLE
bug 1467520: bug 1467532: Resolve RemovedInDjango20Warnings

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -8,6 +8,8 @@ ENV NODE_VERSION=8.11.3 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     # disable this when preparing for Django upgrade
     PYTHONWARNINGS=ignore \
+    # enable this when preparing for Django upgrade
+    # PYTHONWARNINGS=all \
     # Kuma Pipeline definitions
     PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor \
     PIPELINE_CLEANCSS_BINARY=/usr/local/bin/cleancss \

--- a/jinja2/404.html
+++ b/jinja2/404.html
@@ -37,7 +37,7 @@
         <p class="notice">{{ _("This user's profile has been banned.") }}</p>
       {% endif %}
 
-      {% if not untrusted and not user.is_authenticated() %}
+      {% if not untrusted and not user.is_authenticated %}
       {% include "socialaccount/snippets/provider_list.html" %}
       {% endif %}
 

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -78,7 +78,7 @@
 
   {% block extrahead %}{% endblock %}
 </head>
-<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}{% if settings.MAINTENANCE_MODE %} maintenance-mode{% endif %}"{% if request.user and request.user.is_authenticated() %} data-login-service="{{ request.session.sociallogin_provider }}"{% endif %}>
+<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}{% if settings.MAINTENANCE_MODE %} maintenance-mode{% endif %}"{% if request.user and request.user.is_authenticated %} data-login-service="{{ request.session.sociallogin_provider }}"{% endif %}>
 
   {% include "includes/config.html" %}
 

--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -13,7 +13,7 @@
         ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
 
-        {% if request.user and request.user.is_authenticated() %}
+        {% if request.user and request.user.is_authenticated %}
             // dimension1 == 'Signed-In"
             ga('set', 'dimension1', 'Yes');
 
@@ -38,7 +38,7 @@
             ga('set', 'dimension12', '{{ analytics_page_revision }}');
         {%- endif %}
 
-        {%- if request.user and not request.user.is_authenticated() and
+        {%- if request.user and not request.user.is_authenticated and
                content_experiment and
                content_experiment.selection_is_valid %}
             // dimension15 == “a/b test variation”, user scope

--- a/jinja2/includes/header-toolbox.html
+++ b/jinja2/includes/header-toolbox.html
@@ -1,6 +1,6 @@
 <div id="toolbox" class="toolbox">
   <ul>
-    {% if user.is_authenticated() %}
+    {% if user.is_authenticated %}
         <li class="nav-tools">
             <a href="{{ wiki_url('MDN/Doc_status') }}">
                 {{ _('Tools') }}{% include 'includes/icons/arrows/caret-down.svg' %}

--- a/jinja2/includes/login.html
+++ b/jinja2/includes/login.html
@@ -1,5 +1,5 @@
 <div class="login">
-    {% if user.is_authenticated() %}
+    {% if user.is_authenticated %}
         <a class="user-url" href="{{ user.get_absolute_url() }}">
             <img src="{{ gravatar_url(user.email, size=50) }}" alt="{{ user_display(user) }}" width="50" height="50" class="login-photo avatar" />
             <span class="login-name">{{ user_display(user) }}</span>

--- a/kuma/authkeys/tests/test_decorators.py
+++ b/kuma/authkeys/tests/test_decorators.py
@@ -42,10 +42,10 @@ def test_auth_key_decorator(user_auth_key, settings, use_valid_key,
     assert bar == 'bar'
 
     if maintenance_mode or not (use_valid_key and use_valid_secret):
-        assert not request.user.is_authenticated()
+        assert not request.user.is_authenticated
         assert request.authkey is None
     else:
-        assert request.user.is_authenticated()
+        assert request.user.is_authenticated
         assert request.user == user_auth_key.user
         assert request.authkey
         assert request.authkey == user_auth_key.key
@@ -65,5 +65,5 @@ def test_auth_key_decorator_with_invalid_header(user_auth_key, settings):
     fake_view(request, 'foo', 'bar')
 
     # The user should not be authenticated and no error should be raised.
-    assert not request.user.is_authenticated()
+    assert not request.user.is_authenticated
     assert request.authkey is None

--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -81,7 +81,7 @@ def user_access_decorator(redirect_func, redirect_url_func, deny_func=None,
 
 def logout_required(redirect):
     """Requires that the user *not* be logged in."""
-    redirect_func = lambda u: u.is_authenticated()
+    redirect_func = lambda u: u.is_authenticated
     if hasattr(redirect, '__call__'):
         return user_access_decorator(
             redirect_func, redirect_field=None,
@@ -95,9 +95,9 @@ def login_required(func, login_url=None, redirect=REDIRECT_FIELD_NAME,
                    only_active=True):
     """Requires that the user is logged in."""
     if only_active:
-        redirect_func = lambda u: not (u.is_authenticated() and u.is_active)
+        redirect_func = lambda u: not (u.is_authenticated and u.is_active)
     else:
-        redirect_func = lambda u: not u.is_authenticated()
+        redirect_func = lambda u: not u.is_authenticated
     redirect_url_func = lambda: login_url
     return user_access_decorator(redirect_func, redirect_field=redirect,
                                  redirect_url_func=redirect_url_func)(func)
@@ -107,7 +107,7 @@ def permission_required(perm, login_url=None, redirect=REDIRECT_FIELD_NAME,
                         only_active=True):
     """A replacement for django.contrib.auth.decorators.permission_required
     that doesn't ask authenticated users to log in."""
-    redirect_func = lambda u: not u.is_authenticated()
+    redirect_func = lambda u: not u.is_authenticated
     if only_active:
         deny_func = lambda u: not (u.is_active and u.has_perm(perm))
     else:
@@ -120,7 +120,7 @@ def permission_required(perm, login_url=None, redirect=REDIRECT_FIELD_NAME,
 
 
 def is_superuser(u):
-    if u.is_authenticated():
+    if u.is_authenticated:
         if u.is_superuser:
             return True
         raise PermissionDenied

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -327,7 +327,7 @@ def get_unique(content_type, object_pk, name=None, request=None,
     * None, ip, user_agent, unique_MD5_hash
     """
     if request:
-        if request.user.is_authenticated():
+        if request.user.is_authenticated:
             user = request.user
             ip = user_agent = None
         else:
@@ -398,7 +398,7 @@ def format_date_time(request, value, format='shortdatetime'):
 
     user = request.user
     try:
-        if user.is_authenticated() and user.timezone:
+        if user.is_authenticated and user.timezone:
             user_tz = timezone(user.timezone)
             tzvalue = user_tz.normalize(tzvalue.astimezone(user_tz))
     except AttributeError:

--- a/kuma/dashboards/jinja2/dashboards/includes/watch_approved.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/watch_approved.html
@@ -1,4 +1,4 @@
-{% if user.is_authenticated() %}
+{% if user.is_authenticated %}
   {% if is_watching_approved %}
     <form action="{{ url('wiki.approved_unwatch') }}" method="post">
       {% csrf_token %}

--- a/kuma/dashboards/jinja2/dashboards/includes/watch_locale.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/watch_locale.html
@@ -1,4 +1,4 @@
-{% if user.is_authenticated() %}
+{% if user.is_authenticated %}
   {% if is_watching_locale %}
     <form action="{{ url('wiki.locale_unwatch') }}" method="post">
       {% csrf_token %}

--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -113,7 +113,7 @@ def revisions(request):
                  'deleted', 'locale', 'slug')))
 
     show_spam_submission = (
-        request.user.is_authenticated() and
+        request.user.is_authenticated and
         request.user.has_perm('wiki.add_revisionakismetsubmission'))
     if show_spam_submission:
         revisions = revisions.prefetch_related('akismet_submissions')

--- a/kuma/users/adapters.py
+++ b/kuma/users/adapters.py
@@ -202,7 +202,7 @@ class KumaSocialAccountAdapter(DefaultSocialAccountAdapter):
         Returns the default URL to redirect to after successfully
         connecting a social account.
         """
-        assert request.user.is_authenticated()
+        assert request.user.is_authenticated
         user_url = reverse('users.user_edit',
                            kwargs={'username': request.user.username})
         return user_url

--- a/kuma/users/jinja2/account/password_reset.html
+++ b/kuma/users/jinja2/account/password_reset.html
@@ -6,7 +6,7 @@
 <div class="text-content readable-line-length">
 
   <h1>{{ _("Password Reset") }}</h1>
-  {% if user.is_authenticated() %}
+  {% if user.is_authenticated %}
   {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
 

--- a/kuma/users/jinja2/account/password_reset_done.html
+++ b/kuma/users/jinja2/account/password_reset_done.html
@@ -7,7 +7,7 @@
 
   <h1>{{ _("Password Reset") }}</h1>
 
-  {% if user.is_authenticated() %}
+  {% if user.is_authenticated %}
   {% include "account/snippets/already_logged_in.html" %}
   {% endif %}
 

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -145,7 +145,7 @@ def social_accounts(user):
         {% if accounts %} -- if there is at least one social account
     """
     accounts = {}
-    if not user.is_authenticated():
+    if not user.is_authenticated:
         return accounts
     for account in user.socialaccount_set.all().iterator():
         providers = accounts.setdefault(account.provider, [])

--- a/kuma/wiki/jinja2/wiki/base.html
+++ b/kuma/wiki/jinja2/wiki/base.html
@@ -5,7 +5,7 @@
 {% endblock %}
 
 {% block experiment_js %}
-    {%- if not request.user.is_authenticated() and
+    {%- if not request.user.is_authenticated and
            content_experiment and
            not content_experiment.selection_is_valid %}
         {% javascript content_experiment.id %}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -12,7 +12,7 @@
 {% endif %}
 
 {% set is_archive = (document.slug == 'Archive') or document.slug.startswith('Archive/') %}
-{% set is_logged_in = request.user.is_authenticated() %}
+{% set is_logged_in = request.user.is_authenticated %}
 {% set doc_abs_url = document.get_absolute_url() %}
 {% set canonical = doc_abs_url | absolutify %}
 

--- a/kuma/wiki/jinja2/wiki/includes/approvals.html
+++ b/kuma/wiki/jinja2/wiki/includes/approvals.html
@@ -1,5 +1,5 @@
 {% macro get_approvals_html(document, user) %}
-  {% if user.is_authenticated() and document.current_revision %}
+  {% if user.is_authenticated and document.current_revision %}
     {% if document.current_revision.needs_technical_review or document.current_revision.needs_editorial_review %}
     <section class="page-meta reviews">
       <p>{{ _('This article needs these reviews:') }}</p>

--- a/kuma/wiki/jinja2/wiki/includes/buttons.html
+++ b/kuma/wiki/jinja2/wiki/includes/buttons.html
@@ -56,7 +56,7 @@
       </li>
       {% endif %}
 
-        {% if user.is_authenticated() and document %}
+        {% if user.is_authenticated and document %}
         <li>
             <button id="watch-menu" class="only-icon" aria-haspopup="true" aria-owns="watch-menu-submenu" aria-expanded="false">
                 {% include 'includes/icons/tools/eye.svg' %}
@@ -82,11 +82,11 @@
                     <div class="title">{{ _('Advanced') }}</div>
                     <ul>
                         <li><a href="{{ url('wiki.document_revisions', document.slug) }}" rel="nofollow">{{_('History')}}</a></li>
-                        {% if user.is_authenticated() %}
+                        {% if user.is_authenticated %}
                             <li><a href="{{ url('wiki.create') }}?parent={{ document.id }}" rel="nofollow">{{ _('New sub-article') }}</a></li>
                             <li><a href="{{ url('wiki.create') }}?clone={{ document.id }}{% if document.parent_topic %}&amp;parent={{ document.parent_topic.id }}{% endif %}" rel="nofollow">{{ _('Clone this article') }}</a></li>
                         {% endif %}
-                        {% if user.is_authenticated() and user.has_perm('wiki.move_tree') %}
+                        {% if user.is_authenticated and user.has_perm('wiki.move_tree') %}
                             <li><a href="{{ url('wiki.move', document.slug, locale=document.locale) }}" rel="nofollow">{{ _('Move this article') }}</a></li>
                         {% endif %}
                         {% if user.is_superuser %}

--- a/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
+++ b/kuma/wiki/jinja2/wiki/includes/kumascript_errors.html
@@ -7,7 +7,7 @@
 }}
 
 </p>
-{% if request.user.is_authenticated() %}
+{% if request.user.is_authenticated %}
   <button type="button" class="kserrors-details-toggle" data-alternate-message="{{ _('Hide error information') }}">
     {{ ngettext(
       'More information about this error',

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -103,7 +103,7 @@
       var $pagination = $('.pagination');
       var $next = $pagination.find('.next');
 
-      {% set class='hidden' if not request.user.is_authenticated() %}
+      {% set class='hidden' if not request.user.is_authenticated %}
 
       if($next.length) {
         $pagination.append('<li title="{{ _('Sign in to view all history') }}"><a href="?limit=all" id="pagination-all" class="{{ class }}" rel="nofollow">{{ _('View All') }}</a></li>');

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -63,7 +63,7 @@ def _get_html_and_errors(request, doc, rendering_params):
 
     # A logged-in user can schedule a full re-render with Shift-Reload
     cache_control = None
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         # Shift-Reload sends Cache-Control: no-cache
         ua_cc = request.META.get('HTTP_CACHE_CONTROL')
         if ua_cc == 'no-cache':
@@ -166,7 +166,7 @@ def _filter_doc_html(request, doc, doc_html, rendering_params):
     # If this user can edit the document, inject section editing links.
     # TODO: Rework so that this happens on the client side?
     if ((rendering_params['edit_links'] or not rendering_params['raw']) and
-            request.user.is_authenticated()):
+            request.user.is_authenticated):
         tool.injectSectionEditingLinks(doc.slug, doc.locale)
 
     doc_html = tool.serialize()
@@ -470,7 +470,7 @@ def as_json(request, document_slug=None, document_locale=None):
                       .serialize())
 
     stale = True
-    if request.user.is_authenticated():
+    if request.user.is_authenticated:
         # A logged-in user can demand fresh data with a shift-refresh
         # Shift-Reload sends Cache-Control: no-cache
         ua_cc = request.META.get('HTTP_CACHE_CONTROL')
@@ -637,7 +637,7 @@ def document(request, document_slug, document_locale):
             # request parameters.
             if (any([request.GET.get(param, None)
                      for param in ('raw', 'include', 'nocreate')]) or
-                    not request.user.is_authenticated()):
+                    not request.user.is_authenticated):
                 raise Http404
 
             # The user may be trying to create a child page; if a parent exists
@@ -762,7 +762,7 @@ def document(request, document_slug, document_locale):
         }
         response = render(request, 'wiki/document.html', context)
 
-    if ks_errors or request.user.is_authenticated():
+    if ks_errors or request.user.is_authenticated:
         add_never_cache_headers(response)
 
     # We're doing this to prevent any unknown intermediate public HTTP caches
@@ -788,7 +788,7 @@ def document_api(request, document_slug, document_locale):
     View/modify the content of a wiki document, or create a new wiki document.
     """
     if request.method == 'PUT':
-        if not (request.authkey and request.user.is_authenticated()):
+        if not (request.authkey and request.user.is_authenticated):
             raise PermissionDenied
         return _document_api_PUT(request, document_slug, document_locale)
 

--- a/kuma/wiki/views/list.py
+++ b/kuma/wiki/views/list.py
@@ -168,7 +168,7 @@ def revisions(request, document_slug, document_locale):
 
     # Process the requested page size
     per_page = request.GET.get('limit', 10)
-    if not request.user.is_authenticated() and per_page == 'all':
+    if not request.user.is_authenticated and per_page == 'all':
         return render(request, '403.html',
                       {'reason': 'revisions_login_required'}, status=403)
 

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -41,8 +41,8 @@ Django==1.11.16 \
 # Code: https://github.com/pennersr/django-allauth
 # Changes: https://django-allauth.readthedocs.io/en/latest/release-notes.html
 # Docs: https://django-allauth.readthedocs.io/en/latest/
-django-allauth==0.34.0 \
-    --hash=sha256:95a9f7fbebe3e97ce3a541d213fc52492b50dac92f0f91483f58949189e5aa4f
+django-allauth==0.38.0 \
+    --hash=sha256:45661b6fe308466154adf54461679fab6f0c6850b10c56dc322fbbb9d47e03d9
 
 # Refresh stale cache items asynchronously
 # Code: https://github.com/codeinthehole/django-cacheback


### PR DESCRIPTION
To upgrade Kuma to Django 2.0, we need to address multiple warnings.

- 15971ffd7a8915cec67b3138a1424930472dc27b fix the issues within our code.
- f5b781577b56119c434264d0415783c24e7d263f updates django-allauth to a version which is Django 2.0 ready.
- 377ab2d5a72bb2e3e43eeb6d9a5c589693d5d790 address an issue with the Docker build and introduce `PYTHONWARNINGS=all` for documentation purposes.

# Next steps:
- [ ] Update `django-ratelimit` which is responsible for most of the remaining warnings, there is currently no release compatible with Django 2.0 (see: https://github.com/jsocol/django-ratelimit/issues/146 however the master tree is compatible with Django 2.0 according to: https://github.com/jsocol/django-ratelimit/pull/136/files)
- [ ] Find a bug number for this PR or open a bug and reference it for this PR

# Remaining warnings:
After the `django-ratelimit` update, the remaining warnings are coming from `django-tidings` but will disappear automatically when we update to Django 2.0 (see: https://github.com/mozilla/django-tidings/blob/master/tidings/compat.py)

# Personal opinion:
I am not sure it is worth waiting for a `django-ratelimit` release to merge this, but I believe we should take contact with the module maintainer to see if a release can be made.