### PR TITLE
(fix) - Bug 1504238, interactive examples and content area has gotten narrower

### DIFF
--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -174,18 +174,19 @@ break points
 - divide pixels by browser default font size (16px)
 - and multiply by 1em to convert unit to em.
 */
-$max-width-default: (1399px / $base-font-size) * 1em;
-$small-desktop-ends: (1199px / $base-font-size) * 1em;
-$tablet-ends: (1023px / $base-font-size) * 1em;
-$mobile-ends: (767px / $base-font-size) * 1em;
-$small-mobile-ends: (479px / $base-font-size) * 1em;
+$browser-default-font-size: 16px;
+$max-width-default: (1399px / $browser-default-font-size) * 1em;
+$small-desktop-ends: (1199px / $browser-default-font-size) * 1em;
+$tablet-ends: (1023px / $browser-default-font-size) * 1em;
+$mobile-ends: (767px / $browser-default-font-size) * 1em;
+$small-mobile-ends: (479px / $browser-default-font-size) * 1em;
 
 $small-desktop-starts: $tablet-ends + .001em;
 $tablet-starts: $mobile-ends + .001em;
 $mobile-starts: $small-mobile-ends + .001em;
 
-$navigation-break-ends: (1100px / $base-font-size) * 1em;
-$navigation-block-ends: (850px / $base-font-size) * 1em;
+$navigation-break-ends: (1100px / $browser-default-font-size) * 1em;
+$navigation-block-ends: (850px / $browser-default-font-size) * 1em;
 
 $navigation-break-starts: $navigation-block-ends + .001em;
 


### PR DESCRIPTION
This resolves the problem as described in Sprints issue 608, and diagnosed here:
https://app.zenhub.com/workspaces/mdn-sprint-board-5ab3d23fd0f4ea53b0022a61/issues/mdn/sprints/608#issuecomment-437789094

@jwhitlock @hobinjk r?