### PR TITLE
bug 1490727: Recurrent payment force GitHub redirect

### DIFF
--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -1,8 +1,11 @@
 {# Set URLs outside of translation block, to keep user's locale #}
 {% set payments_url = url('payments') %}
 {% set recurring_payment_subscription_url = url('recurring_payment_subscription') %}
+{% set recurring_payment_initial_url = url('recurring_payment_initial') %}
 {% set faq_url = payments_url + "#contribute-faqs" %}
 {% set feedback_url = payments_url + "#contribute-feedback" %}
+{% set account_login_url = url('account_login') %}
+{% set github_next_url = account_login_url + '?next=' + recurring_payment_subscription_url %}
 
 {% translation 'en-US' %}{# Display in English until Q1 2019 #}
     <div id="contribution-popover-container"
@@ -53,26 +56,31 @@
                             <a href="{{ payments_url }}" {% if not recurring_payment %} class="active" {% endif %}>
                                 {{_('One off payment')}}
                             </a>
-                            <a href="{{ recurring_payment_subscription_url }}" {% if recurring_payment %} class="active" {% endif %}>
+                            <a href="{{ recurring_payment_initial_url }}" {% if recurring_payment %} class="active" {% endif %}>
                                 {{_('Monthly payment')}}
                             </a>
                         </div>
-                        {# One Time payments form #}
-                        {% with form=form, payments_url=payments_url %}
-                            {%- include "payments/includes/payments-form.html" %}
-                        {% endwith %}
+
                         {% if recurring_payment %}
-                            {% if user.username %}
+                            {% if user.is_authenticated %}
                                 {% with form=form, is_popover=False, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url  %}
-                                    {#- include "payments/includes/payments-form.html" #}
+                                    {%  include "payments/includes/payments-form.html" %}
                                 {% endwith %}
                             {% else %}
-                                {% set github_url = provider_login_url('github', next=next_url) %}
+                                {% with form=form, hide_submit=True, is_popover=False, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url  %}
+                                    {%  include "payments/includes/payments-form.html" %}
+                                {% endwith %}
+                                {% set github_url = provider_login_url('github', process='login') %}
                                 <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
-                                <a href="{{ github_url }}" class="payment-form-button" data-service="GitHub" rel="nofollow">
+                                <a href="{{ github_url }}" id="id_github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
                                     {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
                                 </a>
                             {% endif %}
+                        {% else %}
+                            {# One Time payments form #}
+                            {% with form=form, payments_url=payments_url %}
+                                {% include "payments/includes/payments-form.html" %}
+                            {% endwith %}
                         {% endif %}
                     </div>
                 {% else %}

--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -71,10 +71,12 @@
                                     {%  include "payments/includes/payments-form.html" %}
                                 {% endwith %}
                                 {% set github_url = provider_login_url('github', process='login') %}
-                                <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
-                                <a href="{{ github_url }}" id="id_github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
-                                    {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
-                                </a>
+                                <div id="login-popover" class="hidden align-center login-prompt">
+                                    <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
+                                    <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
+                                        {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
+                                    </a>
+                                </div>
                             {% endif %}
                         {% else %}
                             {# One Time payments form #}

--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -67,7 +67,7 @@
                                     {%  include "payments/includes/payments-form.html" %}
                                 {% endwith %}
                             {% else %}
-                                {% with form=form, hide_submit=True, is_popover=False, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url  %}
+                                {% with form=form, is_popover=False, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url  %}
                                     {%  include "payments/includes/payments-form.html" %}
                                 {% endwith %}
                                 {% set github_url = provider_login_url('github', process='login') %}

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -65,11 +65,12 @@
             <span class="hide-collapse">
                 {{_('Pay <span data-dynamic-amount>%(amount)s</span>', amount="$64") }}
             </span>
-        </button>
-        <div class="payment-details">
-            <img src="{{ static('img/payment-type-mastercard-1x.png') }}" srcset="{{ static('img/payment-type-mastercard-1x.png') }}, {{ static('img/payment-type-mastercard-2x.png') }} 2x" alt="{{ _('We accept Mastercard payments') }}" title="{{ _('We accept Mastercard payments') }}">
-            <img src="{{ static('img/payment-type-visa-1x.png') }}" srcset="{{ static('img/payment-type-visa-1x.png') }}, {{ static('img/payment-type-visa-2x.png') }} 2x" alt="{{ _('We accept Visa payments') }}" title="{{ _('We accept Visa payments') }}">
-            <img src="{{ static('img/payment-type-american-express-1x.png') }}" srcset="{{ static('img/payment-type-american-express-1x.png') }}, {{ static('img/payment-type-american-express-2x.png') }} 2x" alt="{{ _('We accept American Express payments') }}" title="{{ _('We accept American Express payments') }}">
-        </div>
+            </button>
+            <div class="payment-details">
+                <img src="{{ static('img/payment-type-mastercard-1x.png') }}" srcset="{{ static('img/payment-type-mastercard-1x.png') }}, {{ static('img/payment-type-mastercard-2x.png') }} 2x" alt="{{ _('We accept Mastercard payments') }}" title="{{ _('We accept Mastercard payments') }}">
+                <img src="{{ static('img/payment-type-visa-1x.png') }}" srcset="{{ static('img/payment-type-visa-1x.png') }}, {{ static('img/payment-type-visa-2x.png') }} 2x" alt="{{ _('We accept Visa payments') }}" title="{{ _('We accept Visa payments') }}">
+                <img src="{{ static('img/payment-type-american-express-1x.png') }}" srcset="{{ static('img/payment-type-american-express-1x.png') }}, {{ static('img/payment-type-american-express-2x.png') }} 2x" alt="{{ _('We accept American Express payments') }}" title="{{ _('We accept American Express payments') }}">
+            </div>
+        {% endif %}
     </div>
 </form>

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -58,9 +58,7 @@
         <li>{{_('There has been an issue, please try again later.')}}</li>
     </ul>
     <div class="form-footer">
-        <button class="payment-form-button"
-            {% if request.user.is_authenticated or not recurring_payment and not request.user.is_authenticated %} type="button" id="stripe_submit"
-            {% else %} type="submit" {% endif %}>
+        <button class="payment-form-button" type="button" id="stripe_submit">
             <span class="hide-expand">{{_('Support MDN')}} {% include 'includes/icons/arrows/chevron-up.svg' %}</span>
             <span class="hide-collapse">
                 {{_('Pay <span data-dynamic-amount>%(amount)s</span>', amount="$64") }}
@@ -71,6 +69,5 @@
                 <img src="{{ static('img/payment-type-visa-1x.png') }}" srcset="{{ static('img/payment-type-visa-1x.png') }}, {{ static('img/payment-type-visa-2x.png') }} 2x" alt="{{ _('We accept Visa payments') }}" title="{{ _('We accept Visa payments') }}">
                 <img src="{{ static('img/payment-type-american-express-1x.png') }}" srcset="{{ static('img/payment-type-american-express-1x.png') }}, {{ static('img/payment-type-american-express-2x.png') }} 2x" alt="{{ _('We accept American Express payments') }}" title="{{ _('We accept American Express payments') }}">
             </div>
-        {% endif %}
     </div>
 </form>

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -256,7 +256,7 @@
 
         if (requestUserLogin) {
             requestUserLogin.classList.remove('hidden');
-            form.addClass('hidden');
+            form.get(0).classList.add('hidden');
             return;
         }
 
@@ -468,12 +468,15 @@
         }
     }
 
-    function redirectUserToLogin(event){
+    /**
+     * Removed popover hidden state in local storge.
+     */
+    function redirectUserToLogin(event) {
         event.preventDefault();
         var gitHubLink = $(this).attr('href');
         var gitHubNext = $(this).data('next');
         var getFormFields = form.serialize();
-        gitHubLink = gitHubLink + '&next='+ gitHubNext + '?' + encodeURIComponent(getFormFields);
+        gitHubLink += '&next='+ gitHubNext + '?' + encodeURIComponent(getFormFields);
         window.location.href = encodeURI(gitHubLink);
     }
 

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -68,6 +68,8 @@
     var amountToUpdate = form.find('[data-dynamic-amount]');
 
     var isRecurringPayment = form.attr('data-payment-type') === 'recurring';
+    var GithubRedirectPayment = $('#id_github_redirect_payment');
+
     var submitted = false;
 
     /**
@@ -458,7 +460,17 @@
         }
     }
 
+    function modifyGithubLink(event){
+        event.preventDefault();
+        var gitHubLink = $(this).attr('href');
+        var gitHubNext = $(this).data('next');
+        var getFormFields = form.serialize();
+        gitHubLink = gitHubLink + '&next='+ gitHubNext + '?' + encodeURIComponent(getFormFields);
+        window.location.href = encodeURI(gitHubLink);
+    }
+
     // Register event handlers and set things up.
+    GithubRedirectPayment.on('click', modifyGithubLink);
     formButton.click(onFormButtonClick);
     amountRadio.change(onAmountSelect);
     customAmountInput.on('input', onAmountSelect);

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -68,7 +68,9 @@
     var amountToUpdate = form.find('[data-dynamic-amount]');
 
     var isRecurringPayment = form.attr('data-payment-type') === 'recurring';
-    var GithubRedirectPayment = $('#id_github_redirect_payment');
+
+    var requestUserLogin = doc.getElementById('login-popover');
+    var githubRedirectButton = doc.getElementById('github_redirect_payment');
 
     var submitted = false;
 
@@ -251,6 +253,12 @@
             label: isPopoverBanner ? 'On pop over' : 'On FAQ page',
             value: selectedAmount * 100
         });
+
+        if (requestUserLogin) {
+            requestUserLogin.classList.remove('hidden');
+            form.addClass('hidden');
+            return;
+        }
 
         if (stripeHandler !== null) {
             // On success open Stripe Checkout modal.
@@ -460,7 +468,7 @@
         }
     }
 
-    function modifyGithubLink(event){
+    function redirectUserToLogin(event){
         event.preventDefault();
         var gitHubLink = $(this).attr('href');
         var gitHubNext = $(this).data('next');
@@ -470,7 +478,9 @@
     }
 
     // Register event handlers and set things up.
-    GithubRedirectPayment.on('click', modifyGithubLink);
+    if (requestUserLogin) {
+        $(githubRedirectButton).on('click', redirectUserToLogin);
+    }
     formButton.click(onFormButtonClick);
     amountRadio.change(onAmountSelect);
     customAmountInput.on('input', onAmountSelect);

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -477,7 +477,7 @@
         var gitHubLink = $(this).attr('href');
         var gitHubNext = $(this).data('next');
         var getFormFields = form.serialize();
-        gitHubLink += '&next='+ gitHubNext + '?' + encodeURIComponent(getFormFields);
+        gitHubLink += '&next=' + gitHubNext + '?' + encodeURIComponent(getFormFields);
         window.location.href = encodeURI(gitHubLink);
     }
 

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -469,7 +469,8 @@
     }
 
     /**
-     * Removed popover hidden state in local storge.
+     * Builds correct URL param and directs to GitHub for authentication.
+     * @param {jQuery.Event} event Event object.
      */
     function redirectUserToLogin(event) {
         event.preventDefault();

--- a/kuma/static/styles/components/payments/banner.scss
+++ b/kuma/static/styles/components/payments/banner.scss
@@ -179,6 +179,10 @@
         }
     }
 
+    .login-prompt {
+        padding: 20px;
+    }
+
     .payments-switch {
         border: 2px solid #333;
         border-radius: 50px;


### PR DESCRIPTION
**In this PR**
https://trello.com/c/SQgMeAXd/11-as-an-anonymous-user-i-want-to-learn-why-i-have-to-log-in-to-github-so-that-i-dont-leave-the-process

** notes for QA **
- [ ] ensure that the recurring payment form cannot be submitted until users login
- [ ] ensure one-time payment form still works for both anonymous and authed users
- [ ] ensure recurring payment form redirects to github and back to the FAQ page
- [ ] ensure form data is preserved

**Screenshot**
![screenshot 2018-11-08 at 18 26 08](https://user-images.githubusercontent.com/11092019/48219417-5ff6d400-e384-11e8-9071-812312695317.png)
