### PR TITLE
Fix Bug 1505486, reduce top margin for inline secureContext icon

### DIFF
--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -340,6 +340,15 @@ icons for both types of indicators
     @include indicator-svg-icon($path-to-svg-general-icons + 'lock.svg');
 }
 
+/* when used in inline indicator boxes */
+.inlineIndicator.secureContexts {
+    &:before {
+        background-size: 12px;
+        margin-top: 0;
+        width: 12px;
+        height: 16px;
+    }
+}
 
 /*
 Colours for both types


### PR DESCRIPTION
This reduces the top margin and overall sizing of the secure context icon when used inline.

Page to test: https://developer.mozilla.org/en-US/docs/Web/API/PaymentResponse

Before:

<img width="723" alt="screenshot 2018-11-12 at 14 09 06" src="https://user-images.githubusercontent.com/10350960/48347608-638da200-e687-11e8-9a08-3726c81e82e2.png">

After:

<img width="712" alt="screenshot 2018-11-12 at 14 26 45" src="https://user-images.githubusercontent.com/10350960/48347616-67b9bf80-e687-11e8-97cd-be15e75c724b.png">

@hobinjk r?