### PR TITLE
bug 1506521: Add --no-tty to GPG commands

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -40,8 +40,10 @@ RUN set -x \
 # ----------------------------------------------------------------------------
 # add node.js 8.x, copied from:
 #     https://github.com/nodejs/docker-node/blob/master/8/stretch/Dockerfile
-# but with package updates and version definitions moved above, and the node
-# user gets uid/gid 1001 rather than 1000.
+# but with:
+#  Package updates and version definitions moved above
+#  The node # user gets uid/gid 1001 rather than 1000
+#  Add --no-tty option to gpg to smooth creation of /root/.gnupg/trustdb.gpg
 # ----------------------------------------------------------------------------
 
 RUN groupadd --gid 1001 node \
@@ -59,9 +61,9 @@ RUN set -ex \
     77984A986EBC2AA786BC0F66B01FBB92821C587A \
     8FCCA13FEF1D0C2E91008E09770F7A9A5AE15600 \
   ; do \
-    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
-    gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
-    gpg --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
+    gpg --no-tty --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys "$key" || \
+    gpg --no-tty --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys "$key" || \
+    gpg --no-tty --keyserver hkp://pgp.mit.edu:80 --recv-keys "$key" ; \
   done
 
 RUN ARCH=  && dpkgArch="$(dpkg --print-architecture)" \


### PR DESCRIPTION
An unknown change (`gpg` did not update) is causing an error when trying to create `trustdb.gpg`:

```
gpg: cannot open '/dev/tty': No such device or address
```

Adding `--no-tty` allows the key download to continue successfully.

This began in 377ab2d5a72bb2e3e43eeb6d9a5c589693d5d790 from PR #5089.