### PR TITLE
bug 957802: Fix comment for CONN_MAX_AGE

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -59,7 +59,7 @@ REVISION_HASH = config('REVISION_HASH', default='undefined')
 MANAGERS = ADMINS
 
 
-# CONN_MAX_AGE: 'persistent' to keep open connection, or max requests before
+# CONN_MAX_AGE: 'persistent' to keep open connection, or max seconds before
 # releasing. Default is 0 for a new connection per request.
 def parse_conn_max_age(value):
     try:


### PR DESCRIPTION
An integer value is the lifetime of a database connection, in seconds, not the number of requests before closing:

https://docs.djangoproject.com/en/1.11/ref/settings/#std:setting-CONN_MAX_AGE