### PR TITLE
bug 1490727: prevent users from submittiing multiple subscriptions

### DIFF
--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -71,25 +71,38 @@
                                 </a>
                             </div>
                         {% endif %}
+                        {% if recurring_payment and user.stripe_customer_id and not is_popover %}
+                            <div id="already-sub-error" class="align-center login-prompt">
+                                <p>{{_('You already have a monthly payment set up to MDN.')}}</p>
+                                <p>
+                                    {{_('If you need help regarding this payment, please contact')}}
+                                    <a href="{{'mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL}}">{{settings.CONTRIBUTION_SUPPORT_EMAIL}}</a>
+                                </p>
+                            </div>
+                        {% else %}
+                            {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=True %}
+                                {%  include "payments/includes/payments-form.html" %}
+                            {% endwith %}
+                        {% endif %}
 
-                        {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, recurring_payment=recurring_payment, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=True %}
-                            {%  include "payments/includes/payments-form.html" %}
-                        {% endwith %}
-
-                        {% if not user.is_authenticated %}
-                            {% set github_url = provider_login_url('github', process='login') %}
-                            <div id="login-popover" class="hidden align-center login-prompt">
-                                <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
-                                <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
-                                    {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
-                                </a>
+                        {% if user.stripe_customer_id %}
+                            <div id="already-sub-error" class="hidden align-center login-prompt">
+                                <p>{{_('You already have a monthly payment set up to MDN.')}}</p>
+                                <p>
+                                    {{_('If you need help regarding this payment, please contact')}}
+                                    <a href="{{'mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL}}">{{settings.CONTRIBUTION_SUPPORT_EMAIL}}</a>
+                                </p>
                             </div>
                         {% endif %}
+
+                        {% set github_url = provider_login_url('github', process='login') %}
+                        <div id="login-popover" class="hidden align-center login-prompt">
+                            <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
+                            <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">
+                                {{ _('Sign in') }}{% include 'includes/icons/social/github.svg' %}
+                            </a>
+                        </div>
                     </div>
-                {% else %}
-                    {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=False %}
-                        {%- include "payments/includes/payments-form.html" %}
-                    {% endwith %}
                 {% endif %}
             </div>
         </div>

--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -103,6 +103,10 @@
                             </a>
                         </div>
                     </div>
+                {% else %}
+                    {% with form=form, default_payment_url=default_payment_url, is_popover=is_popover, payments_url=payments_url, recurring_payment_subscription_url=recurring_payment_subscription_url, recurring_payment_enabled=False %}
+                    {%- include "payments/includes/payments-form.html" %}
+                    {% endwith %}
                 {% endif %}
             </div>
         </div>

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -91,6 +91,6 @@
             oneTime: {{payments_form_donation_choices_json}},
             recurring: {{recurring_payment_form_donation_choices_json}}
         },
-        hasAuthenticatedUser: '{{user.is_authenticated()}}' === 'True'
+        isAuthenticated: '{{user.is_authenticated()}}' === 'True'
     };
 </script>

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -91,5 +91,6 @@
             oneTime: {{payments_form_donation_choices_json}},
             recurring: {{recurring_payment_form_donation_choices_json}}
         }
+        hasAuthenticatedUser: '{{user.is_authenticated()}}' === 'True'
     };
 </script>

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -90,7 +90,7 @@
         donationChoices: {
             oneTime: {{payments_form_donation_choices_json}},
             recurring: {{recurring_payment_form_donation_choices_json}}
-        }
+        },
         hasAuthenticatedUser: '{{user.is_authenticated()}}' === 'True'
     };
 </script>

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -87,7 +87,7 @@
 </form>
 <script>
     window.payments = {
-        donationChoices: {
+        paymentChoices: {
             oneTime: {{payments_form_donation_choices_json}},
             recurring: {{recurring_payment_form_donation_choices_json}}
         },

--- a/kuma/static/js/payments-confirmation.js
+++ b/kuma/static/js/payments-confirmation.js
@@ -30,7 +30,7 @@
 
     } else if (path.includes('/payments/recurring/success')) {
         mdn.analytics.trackEvent({
-            category: 'recurring payments',
+            category: 'Recurring payments',
             action: 'success',
             label: originalUserAuth,
             value: amountSubmitted

--- a/kuma/static/js/payments-confirmation.js
+++ b/kuma/static/js/payments-confirmation.js
@@ -11,6 +11,8 @@
         return;
     }
 
+    var originalUserAuth = localStorage.getItem('userAuthenticationOnFormSubmission');
+
     // Default to no data
     var amountSubmitted = submissionDetails.amount || 0;
     var submissionPage = submissionDetails.page || '';
@@ -26,6 +28,16 @@
             sessionStorage.removeItem(amountSubmittedStoreKey);
         });
 
+    } else if (path.includes('/payments/recurring/success')) {
+        mdn.analytics.trackEvent({
+            category: 'recurring payments',
+            action: 'success',
+            label: originalUserAuth,
+            value: amountSubmitted
+        }, function() {
+            localStorage.removeItem('userAuthenticationOnFormSubmission');
+        });
+
     } else if (path.includes('/payments/error')) {
         mdn.analytics.trackEvent({
             category: 'payments',
@@ -34,6 +46,15 @@
             value: amountSubmitted
         }, function() {
             sessionStorage.removeItem(amountSubmittedStoreKey);
+        });
+    } else if (path.includes('/payments/recurring/error')) {
+        mdn.analytics.trackEvent({
+            category: 'payments',
+            action: 'Payment failed',
+            label: originalUserAuth,
+            value: amountSubmitted
+        }, function() {
+            localStorage.removeItem('userAuthenticationOnFormSubmission');
         });
     }
 

--- a/kuma/static/js/payments-confirmation.js
+++ b/kuma/static/js/payments-confirmation.js
@@ -49,7 +49,7 @@
         });
     } else if (path.includes('/payments/recurring/error')) {
         mdn.analytics.trackEvent({
-            category: 'payments',
+            category: 'Recurring payments',
             action: 'Payment failed',
             label: originalUserAuth,
             value: amountSubmitted

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -179,6 +179,7 @@
         if (storeUserForLaterEvents) {
             var item = win.payments.isAuthenticated ? 'authenticated' : 'anonymous';
             localStorage.setItem('userAuthenticationOnFormSubmission', item);
+            triggerAnalyticEvents = false;
         }
     }
 

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -78,8 +78,10 @@
     var selectedAmount = 0;
     var submitted = false;
 
-    var paymentChoices = win.payments ? win.payments.donationChoices : null;
     var amountRadioInputs = doc.querySelectorAll('input[data-dynamic-choice-selector]');
+    var donationChoices = typeof window.payments !== 'undefined' && 'donationChoices' in window.payments
+        ? win.payments.donationChoices
+        : null;
 
     /* Following recurring payments flow the user may be redirected back to the form to submit payment.
        We're tracking this with a localstorage item as this should percist across various pages. */
@@ -166,16 +168,16 @@
         }
 
         mdn.analytics.trackEvent({
-            category: 'recuring payments',
+            category: 'Recurring payments',
             action: event.action,
-            label: win.payments.hasAuthenticatedUser ? 'authenticated' : 'anonymous',
+            label: win.payments.isAuthenticated ? 'authenticated' : 'anonymous',
             value: event.value
         });
 
         /* Save the user authentication level so that we can track conversion rates of
            authenticated vs anonymous users at a later stage in the payment flow. */
         if (storeUserForLaterEvents) {
-            var item = win.payments.hasAuthenticatedUser ? 'authenticated' : 'anonymous';
+            var item = win.payments.isAuthenticated ? 'authenticated' : 'anonymous';
             localStorage.setItem('userAuthenticationOnFormSubmission', item);
         }
     }
@@ -629,8 +631,8 @@
             // Change the form action to submit to the one-time payment view
             action = form.get(0).getAttribute('data-one-time-action');
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', paymentChoices.oneTime[i]);
-                radio.nextSibling.nodeValue = '$' + paymentChoices.oneTime[i];
+                radio.setAttribute('value', donationChoices.oneTime[i]);
+                radio.nextSibling.nodeValue = '$' + donationChoices.oneTime[i];
             });
 
             // Visually update the form
@@ -649,8 +651,8 @@
             // Change the form action to submit to the recurring subscription view
             action = form.get(0).getAttribute('data-recurring-action');
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', paymentChoices.recurring[i]);
-                radio.nextSibling.nodeValue = '$' + paymentChoices.recurring[i] + '/mo';
+                radio.setAttribute('value', donationChoices.recurring[i]);
+                radio.nextSibling.nodeValue = '$' + donationChoices.recurring[i] + '/mo';
             });
 
             // Visually update the form
@@ -677,8 +679,8 @@
         // Force options for popover
         if (currrentPaymentForm === 'recurring') {
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', paymentChoices.recurring[i]);
-                radio.nextSibling.nodeValue = '$' + paymentChoices.recurring[i] + '/mo';
+                radio.setAttribute('value', donationChoices.recurring[i]);
+                radio.nextSibling.nodeValue = '$' + donationChoices.recurring[i] + '/mo';
             });
 
             // Force required checkbox if recurring payment form

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -135,6 +135,38 @@
     // Set errors.
     form.find('.errorlist').prev().addClass('error');
 
+
+    /**
+     * Emits an event for recurring payments
+     * @param {Object} event - The event to be emitted
+     * @param {string} event.action - The event's action name
+     * @param {number} [event.value] - the event's numerical value
+     */
+    function triggerRecurringPaymentEvent(event) {
+        mdn.analytics.trackEvent({
+            category: 'Recuring Payments',
+            action: event.action,
+            label: win.hasAuthenticatedUser ? 'authenticated' : 'anonymous',
+            value: event.value
+        });
+    }
+
+    /**
+     * Emits an event for recurring payments
+     * @param {Object} event - The event to be emitted
+     * @param {string} event.action - The event's action name
+     * @param {string} [event.label] - The event's label name
+     * @param {number} [event.value] - the event's numerical value
+     */
+    function triggerOneTimePaymentEvent(event) {
+        mdn.analytics.trackEvent({
+            category: 'payments',
+            action: event.action,
+            label: event.label,
+            value: event.value
+        });
+    }
+
     /**
      * Handles adjusting amount.
      * @param {jQuery.Event} event Event object.
@@ -156,8 +188,7 @@
             customAmountInput.val('');
 
             // Send GA Event.
-            mdn.analytics.trackEvent({
-                category: 'payments',
+            triggerOneTimePaymentEvent({
                 action: 'banner',
                 label: 'Amount radio selected',
                 value: event.target.value * 100
@@ -190,11 +221,8 @@
     function setFieldError(field) {
         $(field).addClass('error');
         $(field).next('.errorlist').remove();
-
         var error = $(field).attr('data-error-message');
-
         $('<ul class="errorlist"><li>' + error + '</li></ul>').insertAfter($(field));
-
     }
 
     /**
@@ -258,8 +286,7 @@
         }
 
         // Send GA Event.
-        mdn.analytics.trackEvent({
-            category: 'payments',
+        triggerOneTimePaymentEvent({
             action: 'submission',
             label: isPopoverBanner ? 'On pop over' : 'On FAQ page',
             value: selectedAmount * 100
@@ -285,8 +312,7 @@
                 closed: function() {
                     // Send GA Event.
                     if (!submitted) {
-                        mdn.analytics.trackEvent({
-                            category: 'payments',
+                        triggerOneTimePaymentEvent({
                             action: 'submission',
                             label: 'canceled'
                         });
@@ -353,7 +379,10 @@
      * also disables the submission button
      */
     function toggleScriptError() {
-        formButton.attr('disabled') ? formButton.removeAttr('disabled') : formButton.attr('disabled', 'true');
+        formButton.attr('disabled')
+            ? formButton.removeAttr('disabled')
+            : formButton.attr('disabled', 'true');
+
         formErrorMessage.toggle();
     }
 
@@ -399,8 +428,7 @@
             });
         });
 
-        mdn.analytics.trackEvent({
-            category: 'payments',
+        triggerOneTimePaymentEvent({
             action: 'banner',
             label: 'expand'
         });
@@ -435,8 +463,7 @@
         });
 
         // Send GA Event.
-        mdn.analytics.trackEvent({
-            category: 'payments',
+        triggerOneTimePaymentEvent({
             action: 'banner',
             label: 'collapse',
         });
@@ -452,8 +479,7 @@
         popoverBanner.attr('aria-hidden', true);
 
         // Send GA Event.
-        mdn.analytics.trackEvent({
-            category: 'payments',
+        triggerOneTimePaymentEvent({
             action: 'banner',
             label: 'close',
         });
@@ -509,15 +535,13 @@
         var value = parseFloat(event.target.value);
         if (!isNaN(value) && value >= 1) {
             // Send GA Event.
-            mdn.analytics.trackEvent({
-                category: 'payments',
+            triggerOneTimePaymentEvent({
                 action: 'banner',
                 label: 'custom amount',
                 value: Math.floor(value * 100)
             });
         } else {
-            mdn.analytics.trackEvent({
-                category: 'payments',
+            triggerOneTimePaymentEvent({
                 action: 'banner',
                 label: 'Invalid amount selected',
             });
@@ -628,11 +652,13 @@
 
     // Send to GA if popover is displayed.
     if (popoverBanner && popoverBanner.is(':visible')) {
-        mdn.analytics.trackEvent({
-            category: 'payments',
+        var event = {
             action: 'banner',
             label: 'shown',
-        });
+        };
+        currrentPaymentForm === 'recurring'
+            ? triggerRecurringPaymentEvent(event)
+            : triggerOneTimePaymentEvent(event);
     }
 
 })(document, window, jQuery);

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -144,7 +144,6 @@
         var closeButton = popoverBanner.find('#close-popover-button');
 
         checkPopoverDisabled();
-
     }
 
     // Set initial form selected amount state
@@ -152,11 +151,8 @@
         onAmountSelect({ target: defaultAmount.get(0) }, true);
     }
 
-
-
     // Set errors.
     form.find('.errorlist').prev().addClass('error');
-
 
     /**
      * Emits an event for recurring payments

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -144,10 +144,13 @@
         var closeButton = popoverBanner.find('#close-popover-button');
 
         checkPopoverDisabled();
+
     }
 
     // Set initial form selected amount state
-    onAmountSelect({ target: defaultAmount.get(0) });
+    if (defaultAmount.get(0)) {
+        onAmountSelect({ target: defaultAmount.get(0) }, true);
+    }
 
 
 
@@ -206,15 +209,15 @@
     /**
      * Handles adjusting amount.
      * @param {jQuery.Event} event Event object.
-     * @param {boolean} preventValidation  - stops validation displaying
+     * @param {boolean} automatedSelection  - stops validation and events being sent
      */
-    function onAmountSelect(event, preventValidation) {
+    function onAmountSelect(event, automatedSelection) {
         form.find('label.active').removeClass('active');
 
         clearFieldError(customAmountInput);
 
         // Validate against minimum value.
-        if (!preventValidation && (parseInt(event.target.value) < 1 || isNaN(event.target.value))) {
+        if (!automatedSelection && (parseInt(event.target.value) < 1 || isNaN(event.target.value))) {
             defaultAmount.prop('checked', true);
             setFieldError(customAmountInput);
         }
@@ -223,12 +226,14 @@
         if (event.target.type === 'radio') {
             customAmountInput.val('');
 
-            // Send GA Event.
-            triggerOneTimePaymentEvent({
-                action: 'banner',
-                label: 'Amount radio selected',
-                value: event.target.value * 100
-            });
+            if (!automatedSelection) {
+                // Send GA Event.
+                triggerOneTimePaymentEvent({
+                    action: 'banner',
+                    label: 'Amount radio selected',
+                    value: event.target.value * 100
+                });
+            }
 
             $(event.target).parent().addClass('active');
 
@@ -690,7 +695,7 @@
             // Ensure the new amount is reflected
             var checkedInput = form.find('input[type=\'radio\']:checked')[0];
             if (checkedInput) {
-                onAmountSelect({ target: checkedInput });
+                onAmountSelect({ target: checkedInput }, true);
             }
         }
     }
@@ -705,6 +710,10 @@
                 action: 'banner',
                 label: 'shown',
             });
+    } else if (!popoverBanner && currrentPaymentForm === 'recurring') {
+        triggerRecurringPaymentEvent({
+            action: 'banner shown on FAQ',
+        });
     }
 
 })(document, window, jQuery);

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -79,8 +79,8 @@
     var submitted = false;
 
     var amountRadioInputs = doc.querySelectorAll('input[data-dynamic-choice-selector]');
-    var donationChoices = typeof window.payments !== 'undefined' && 'donationChoices' in window.payments
-        ? win.payments.donationChoices
+    var paymentChoices = typeof window.payments !== 'undefined' && 'paymentChoices' in window.payments
+        ? win.payments.paymentChoices
         : null;
 
     /* Following recurring payments flow the user may be redirected back to the form to submit payment.
@@ -633,8 +633,8 @@
             // Change the form action to submit to the one-time payment view
             action = form.get(0).getAttribute('data-one-time-action');
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', donationChoices.oneTime[i]);
-                radio.nextSibling.nodeValue = '$' + donationChoices.oneTime[i];
+                radio.setAttribute('value', paymentChoices.oneTime[i]);
+                radio.nextSibling.nodeValue = '$' + paymentChoices.oneTime[i];
             });
 
             // Visually update the form
@@ -653,8 +653,8 @@
             // Change the form action to submit to the recurring subscription view
             action = form.get(0).getAttribute('data-recurring-action');
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', donationChoices.recurring[i]);
-                radio.nextSibling.nodeValue = '$' + donationChoices.recurring[i] + '/mo';
+                radio.setAttribute('value', paymentChoices.recurring[i]);
+                radio.nextSibling.nodeValue = '$' + paymentChoices.recurring[i] + '/mo';
             });
 
             // Visually update the form
@@ -669,6 +669,8 @@
         checkedInput = form.find('input[type=\'radio\']:checked')[0];
         if (checkedInput) {
             onAmountSelect({ target: {value: NaN}}, true);
+        } else if (customAmountInput.get(0).value) {
+            onAmountSelect({target: customAmountInput.get(0)});
         }
     }
 
@@ -681,8 +683,8 @@
         // Force options for popover
         if (currrentPaymentForm === 'recurring') {
             [].forEach.call(amountRadioInputs, function(radio, i) {
-                radio.setAttribute('value', donationChoices.recurring[i]);
-                radio.nextSibling.nodeValue = '$' + donationChoices.recurring[i] + '/mo';
+                radio.setAttribute('value', paymentChoices.recurring[i]);
+                radio.nextSibling.nodeValue = '$' + paymentChoices.recurring[i] + '/mo';
             });
 
             // Force required checkbox if recurring payment form

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -75,6 +75,7 @@
     var paymentTypeSwitch = doc.querySelectorAll('input[type=radio][name="payment_selector"]');
     var recurringConfirmationContainer = doc.getElementById('recurring-confirmation-container');
 
+    var alreadySubscribedErrorMessage = doc.getElementById('already-sub-error');
     var selectedAmount = 0;
     var submitted = false;
 
@@ -470,6 +471,11 @@
             });
         });
 
+        if (alreadySubscribedErrorMessage && currrentPaymentForm === 'recurring') {
+            form.get(0).classList.add('hidden');
+            alreadySubscribedErrorMessage.classList.remove('hidden');
+        }
+
         currrentPaymentForm === 'recurring'
             ? triggerRecurringPaymentEvent({
                 action: 'banner expanded',
@@ -515,6 +521,12 @@
         });
 
         $(doc).off('keydown.popoverCloseHandler');
+
+        // Ensure the form is displayed
+        form.get(0).classList.remove('hidden');
+        requestUserLogin ? requestUserLogin.classList.add('hidden') : null;
+        alreadySubscribedErrorMessage ? alreadySubscribedErrorMessage.classList.add('hidden') : null;
+
     }
 
     /**
@@ -642,6 +654,12 @@
             popoverBanner.get(0).classList.add('expanded');
             popoverBanner.get(0).classList.remove('expanded-extend');
 
+            // Ensure subscribed users can pay one-time payments
+            if (alreadySubscribedErrorMessage) {
+                form.get(0).classList.remove('hidden');
+                alreadySubscribedErrorMessage.classList.add('hidden');
+            }
+
         } else if (this.value === 'recurring' && currrentPaymentForm === 'one_time') {
             // Switch to recurring payment form only if we're not on the recurring payment form already.
             currrentPaymentForm = 'recurring';
@@ -660,6 +678,12 @@
             // Visually update the form
             form.get(0).classList.add('recurring-form');
             popoverBanner.get(0).classList.add('expanded-extend');
+
+            // Check us user already has a subscription and show error message
+            if (alreadySubscribedErrorMessage) {
+                form.get(0).classList.add('hidden');
+                alreadySubscribedErrorMessage.classList.remove('hidden');
+            }
         }
 
         // Update the form action


### PR DESCRIPTION
Needs analytic PR to be merged first. Awaiting sign off as to if this is the best solution!

Current problem: 
--------------------
- User attempts recurring payment with an invalid card (expired, wrong digits) and is sent to the error page (https://developer.allizom.org/en-US/payments/error)
- If the same user attempts to make a recurring payment again with a valid card, Stripe remembers the old card. The user is redirected to the error page again.
- So the user must take the step of contacting MDN support so they can remove the old card and allow payment with the new card.

Proposal:
------------------

- ~Solve root cause and prevent Stripe from holding onto old, invalid card details from first attempt. However, this requires a degree of card management which is non-trivial.~
- Provide more specific error pages that provide a more accurate description of the problem and how to solve it and prevent multiple subscriptions.

This PR Blocks users from making multiple subscriptions by preventing them form seeing the form if they have a subscription.
This is one potential solution for:

**In this PR**
- https://trello.com/c/gPej9FQ4/84-precent-users-from-making-multiple-subscriptions

**Notes for QA** 
- [ ] Create an account and subscribe to a recurring payment
- [ ] try to create another recurring payment with that same account
- [ ] you should be blocked with some information on how to contact support.
**screenshots**
![screenshot 2018-11-15 at 12 49 32](https://user-images.githubusercontent.com/11092019/48553948-f4a58880-e8d4-11e8-924b-239754bf1e97.png)
