### PR TITLE
bug 1467532: Update to requests 2.20.1, requirements

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -58,9 +58,9 @@ pyasn1==0.1.9 \
 # Code: https://github.com/urllib3/urllib3
 # Changes: https://github.com/urllib3/urllib3/blob/master/CHANGES.rst
 # Docs: https://urllib3.readthedocs.io/en/latest/
-urllib3==1.22 \
-    --hash=sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b \
-    --hash=sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f
+urllib3==1.24.1 \
+    --hash=sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39 \
+    --hash=sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22
 
 
 # bleach
@@ -480,21 +480,21 @@ contextlib2==0.5.1 \
 #
 # Mozilla's CA bundle
 # Code: https://github.com/certifi/python-certifi
-certifi==2018.1.18 \
-    --hash=sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296 \
-    --hash=sha256:ledbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d
+certifi==2018.10.15 \
+    --hash=sha256:339dc09518b07e2fa7eda5450740925974815557727d6bd35d319c1524a04a4c \
+    --hash=sha256:6d58c986d22b038c8c0df30d639f23a3e6d172a05c3583e766f4c0b785c0986a
 # Character encoding detector
 # Code: https://github.com/chardet/chardet
 # Docs: https://chardet.readthedocs.io/en/latest/
 chardet==3.0.4 \
-    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691 \
-    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae
+    --hash=sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae \
+    --hash=sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691
 # Support for i18n domain names, IDNA 2008
 # Code: https://github.com/kjd/idna
 # Changes: https://github.com/kjd/idna/blob/master/HISTORY.rst
-idna==2.6 \
-    --hash=sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4 \
-    --hash=sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f
+idna==2.7 \
+    --hash=sha256:156a6814fb5ac1fc6850fb002e0852d56c0c8d2531923a51032d1b70760e186e \
+    --hash=sha256:684a38a6f903c1d71d6d5fac066b58d7768af4de2b832e426ec79c30daa94a16
 
 
 # tox

--- a/requirements/default_and_test.txt
+++ b/requirements/default_and_test.txt
@@ -9,14 +9,14 @@ pyquery==1.4.0 \
     --hash=sha256:07987c2ed2aed5cba29ff18af95e56e9eb04a2249f42ce47bddfb37f487229a3 \
     --hash=sha256:4771db76bd14352eba006463656aef990a0147a0eeaf094725097acfa90442bf
 
-# Better HTTP requests. Used to talk to GitHub, KumaScript, Akismet.
+# Better HTTP requests. Used to talk to GitHub, KumaScript, Akismet, Stripe.
 # Used by the scraper and headless tests.
 # Code: https://github.com/requests/requests
-# Changes: https://github.com/requests/requests/blob/master/HISTORY.rst
+# Changes: https://github.com/requests/requests/blob/master/HISTORY.md
 # Docs: http://docs.python-requests.org/en/master/
-requests==2.18.4 \
-    --hash=sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b \
-    --hash=sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e
+requests==2.20.1 \
+    --hash=sha256:65b3a120e4329e33c9889db89c80976c5272f56ea92d3e74da8a463992e3ff54 \
+    --hash=sha256:ea881206e59f41dbd0bd445437d792e43906703fff75ca8ff43ccdb11f33f263
 
 # Python 2 and 3 compatibility utilities
 # Code: https://github.com/benjaminp/six


### PR DESCRIPTION
* requests: 2.18.4 → [2.20.1](https://github.com/requests/requests/blob/master/HISTORY.md): security fix for authorization header on https to http redirects, content-type parsing is case insensitive, other fixes.

Update the requirements for requests as well:

* certifi 2018.1.18 → [2018.10.15](https://github.com/certifi/python-certifi): Update to latest release
* idna 2.6 → [2.7](https://github.com/kjd/idna/blob/master/HISTORY.rst): Unicode 10.0, reject dot-prefixed domains
* urllib3 1.22 → [1.24.1](https://github.com/urllib3/urllib3/blob/master/CHANGES.rst): Support for dropping headers on redirect, drop Python 2.6 and 3.3 support, other fixes