### PR TITLE
bug 1490727: Changed to pre-fill payment name only from MDN user fullname field

### DIFF
--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -34,7 +34,7 @@ def contribute(request):
     initial_data = {}
     if request.user.is_authenticated and request.user.email:
         initial_data = {
-            'name': request.user.fullname or request.user.username,
+            'name': request.user.fullname,
             'email': request.user.email,
         }
 
@@ -79,7 +79,7 @@ def contribute_recurring_payment_initial(request):
     initial_data = {}
     if request.user.is_authenticated and request.user.email:
         initial_data = {
-            'name': request.user.fullname or request.user.username,
+            'name': request.user.fullname,
             'email': request.user.email,
         }
 


### PR DESCRIPTION
This is PR for:

https://trello.com/c/Ek6n2n2C/19-as-a-user-i-can-see-information-about-recurring-payments-so-that-i-can-understand-how-recurring-payment-works

Quick change, right now payment Name field is pre-filled only from User fullname field.