### PR TITLE
bug 1490727:  Update copy for recurring payments FAQ and legal sections

### DIFF
--- a/kuma/payments/jinja2/payments/email/thank_you/email.html
+++ b/kuma/payments/jinja2/payments/email/thank_you/email.html
@@ -146,7 +146,8 @@
                                                               <p>
                                                                 {% trans url=support_mail_link, email=support_mail %}
                                                                     If you would like to cancel your monthly payment or apply for a refund, you are free to do so at any point.
-                                                                    Please contact <a href="{{ url }}">{{ email }}</a> to cancel and we won’t charge you for the following month.
+                                                                    Please contact <a href="{{ url }}">{{ email }}</a> to cancel. If you choose to cancel,
+                                                                    we will not charge your payment card for subsequent months.
                                                                 {% endtrans %}
                                                               </p>
                                                             </td>

--- a/kuma/payments/jinja2/payments/email/thank_you/plain.ltxt
+++ b/kuma/payments/jinja2/payments/email/thank_you/plain.ltxt
@@ -19,7 +19,7 @@ If you would like to manage your monthly payment, such as changing your card acc
 
 {{_('Cancelling your payments')}}
 {% trans %}
-If you would like to cancel your monthly payment, you are free to do so at any point. Please contact {{ support_mail }} to cancel.
+If you would like to cancel your monthly payment or apply for a refund, you are free to do so at any point. Please contact {{ support_mail }} to cancel. If you choose to cancel, we will not charge your payment card for subsequent months.
 {% endtrans %}
 
 {{_('Payment Terms')}}

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -35,9 +35,10 @@
         <p class="legal-copy">
             Payments are not tax deductible. Your payment details will be processed by
             <a href="https://stripe.com/" rel="noopener" target="_blank">Stripe</a>.
-            You can read our
-            <a href="{{ url('payment_terms') }}" rel="noopener" target="_blank">Payment terms</a>,
-            for more information.
+            You can see more information in our
+            <a href="{{ url('payment_terms') }}" target="_blank">Payment terms</a>,
+            and
+            <a href="https://www.mozilla.org/en-US/privacy/websites/" rel="noopener" target="_blank"></a>Privacy notice</a>
         </p>
         <input type="hidden" id="stripe_source_setup" value="1">
         {% set show_checkbox = recurring_payment or (is_popover and recurring_payment_enabled) %}

--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -211,9 +211,10 @@
                     <p>
                         {% trans url='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL,
                                  email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
-                            If you would like to cancel your monthly payment, you are free to do so at any point.
-                            Please contact <a href="{{ url }}">{{ email }}</a> to cancel.
-                            If you choose to cancel, we will not charge your payment card for subsequent months.
+                            If you would like to cancel your monthly payment or apply for a refund,
+                            you are free to do so at any point. Please contact
+                            <a href="{{ url }}">{{ email }}</a> to cancel. If you choose to cancel, we will not
+                            charge your payment card for subsequent months.
                         {% endtrans %}
                     </p>
                 {% endcall %}
@@ -224,10 +225,11 @@
                         {% endtrans %}
                     </p>
                 {% endcall %}
-                {%- call faq_entry(14, _("Does deleting my MDN account delete my subscription?")) %}
+                {%- call faq_entry(14, _("Does deleting my MDN account cancel my subscription?")) %}
                     <p>
                         {% trans %}
-                            When you request to cancel your account we will also delete your subscription
+                        When you request to delete your account we will also cancel your subscription
+                        and not charge you for the following month.
                         {% endtrans %}
                     </p>
                 {% endcall %}

--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -100,7 +100,8 @@
                                 {% trans url="mailto:" + settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Cancel%20monthly%20payment",
                                     email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
                                     If you would like to cancel your monthly payment or apply for a refund, you are free to do so at any point.
-                                    Please contact <a href="{{ url }}">{{ email }}</a> to cancel and we won’t charge you for the following month.
+                                    Please contact <a href="{{ url }}">{{ email }}</a> to cancel. If you choose to cancel, we will not charge your payment
+                                    card for subsequent months.
                                 {% endtrans %}
                             </p>
                         </div>


### PR DESCRIPTION
Simply updates copy to https://docs.google.com/document/d/1yxkNf4v82DvhXER4dSCAngllGZEiqJETNvot11ivNk4/

Updates some copy in the FAQ, Email, confirmation page and legal.
**In this PR**
- https://trello.com/c/OE9aWDi7/72-final-wording-changes