### PR TITLE
bug 1490727: Round floating point amounts to 2 decimal places

### DIFF
--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -227,7 +227,7 @@
                 triggerOneTimePaymentEvent({
                     action: 'banner',
                     label: 'Amount radio selected',
-                    value: event.target.value * 100
+                    value: (selectedAmount * 100).toFixed(0)
                 });
             }
 
@@ -238,7 +238,7 @@
             form.find('input[type=\'radio\']:checked').prop('checked', false);
         }
 
-        selectedAmount = event.target.value % 1 === 0 ? event.target.value : parseFloat(event.target.value).toFixed(2);
+        selectedAmount = event.target.value % 1 === 0 ? parseInt(event.target.value) : parseFloat(event.target.value).toFixed(2);
         var newValue = (selectedAmount < 1 || isNaN(selectedAmount)) ? '' : '$' + selectedAmount;
         amountToUpdate.html(newValue);
 
@@ -326,12 +326,12 @@
         currrentPaymentForm === 'recurring'
             ? triggerRecurringPaymentEvent({
                 action: 'Form completed',
-                value: (selectedAmount * 100).toFixed(2)
+                value: (selectedAmount * 100).toFixed(0)
             }, true)
             : triggerOneTimePaymentEvent({
                 action: 'submission',
                 label: isPopoverBanner ? 'On pop over' : 'On FAQ page',
-                value: (selectedAmount * 100).toFixed(2)
+                value:  (selectedAmount * 100).toFixed(0)
             });
 
         if (requestUserLogin && currrentPaymentForm === 'recurring') {
@@ -349,7 +349,7 @@
                 zipCode: true,
                 allowRememberMe: false,
                 panelLabel: currrentPaymentForm === 'recurring' ? 'Pay {{amount}}/month' : 'Pay',
-                amount: (selectedAmount * 100).toFixed(2),
+                amount: parseInt((selectedAmount * 100).toFixed(0)),
                 email: $(emailField).val(),
                 closed: function() {
                     // Send GA Event.
@@ -584,7 +584,7 @@
             triggerOneTimePaymentEvent({
                 action: 'banner',
                 label: 'custom amount',
-                value: Math.floor(value * 100)
+                value: (value * 100).toFixed(0)
             });
         } else {
             triggerOneTimePaymentEvent({

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -238,14 +238,13 @@
             form.find('input[type=\'radio\']:checked').prop('checked', false);
         }
 
-        var calcAmount = Math.floor(event.target.value * 100) / 100;
-        selectedAmount = calcAmount % 1 === 0 ? calcAmount : calcAmount.toFixed(2);
+        selectedAmount = event.target.value % 1 === 0 ? event.target.value : parseFloat(event.target.value).toFixed(2);
         var newValue = (selectedAmount < 1 || isNaN(selectedAmount)) ? '' : '$' + selectedAmount;
         amountToUpdate.html(newValue);
 
         // Explicitly add `/month` on the payment button for the banner
         newValue += currrentPaymentForm === 'recurring'
-        && newValue
+        && newValue !== ''
         && isPopoverBanner
             ? '/month'
             : '';

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -331,7 +331,7 @@
             : triggerOneTimePaymentEvent({
                 action: 'submission',
                 label: isPopoverBanner ? 'On pop over' : 'On FAQ page',
-                value:  (selectedAmount * 100).toFixed(0)
+                value: (selectedAmount * 100).toFixed(0)
             });
 
         if (requestUserLogin && currrentPaymentForm === 'recurring') {

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -238,7 +238,8 @@
             form.find('input[type=\'radio\']:checked').prop('checked', false);
         }
 
-        selectedAmount = (Math.floor(event.target.value * 100) / 100);
+        var calcAmount = Math.floor(event.target.value * 100) / 100;
+        selectedAmount = calcAmount % 1 === 0 ? calcAmount : calcAmount.toFixed(2);
         var newValue = (selectedAmount < 1 || isNaN(selectedAmount)) ? '' : '$' + selectedAmount;
         amountToUpdate.html(newValue);
 

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -326,12 +326,12 @@
         currrentPaymentForm === 'recurring'
             ? triggerRecurringPaymentEvent({
                 action: 'Form completed',
-                value: selectedAmount * 100
+                value: (selectedAmount * 100).toFixed(2)
             }, true)
             : triggerOneTimePaymentEvent({
                 action: 'submission',
                 label: isPopoverBanner ? 'On pop over' : 'On FAQ page',
-                value: selectedAmount * 100
+                value: (selectedAmount * 100).toFixed(2)
             });
 
         if (requestUserLogin && currrentPaymentForm === 'recurring') {
@@ -349,7 +349,7 @@
                 zipCode: true,
                 allowRememberMe: false,
                 panelLabel: currrentPaymentForm === 'recurring' ? 'Pay {{amount}}/month' : 'Pay',
-                amount: (selectedAmount * 100),
+                amount: (selectedAmount * 100).toFixed(2),
                 email: $(emailField).val(),
                 closed: function() {
                     // Send GA Event.


### PR DESCRIPTION
This PR simply ensures we represent pennies to the correct place, ie 1.2 to  $1.20

**in this PR**
- https://trello.com/c/Kw80DkXl/58-bug-fractional-custom-amounts-should-be-displayed-as-000

**Notes for QA**
- [ ] A custom amount like 2.5 should show as "Pay $2.50" on the button, not "Pay $2.5".
- [ ] Ensure this is also represented on the stripe overlay and the overlay and button are the same amount
- [ ] Ensure in the legal copy for recurring payments this is displayed to 2 decimal places too.
