### PR TITLE
bug 1508268: Do not load queryset before paginate

### DIFF
--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -52,7 +52,7 @@ def is_untrusted(request):
 
 def paginate(request, queryset, per_page=20):
     """Get a Paginator, abstracting some common paging actions."""
-    paginator = Paginator(list(queryset), per_page)
+    paginator = Paginator(queryset, per_page)
 
     # Get the page from the request, make sure it's an int.
     try:


### PR DESCRIPTION
Revert 25041d4bb5d406e362ddc08df6fa3b0a4ba72569, which processed the queryset with list before paginating it, for Python 3 compatibility.

I suspect the Py3 change is instead the unit tests for pagination.