### PR TITLE
Bug 1496482, fix horizontal scrolling on mobile viewwports, landing page

### DIFF
--- a/kuma/static/styles/components/home/home-masthead.scss
+++ b/kuma/static/styles/components/home/home-masthead.scss
@@ -10,6 +10,7 @@ homepage masthead (search, feature callouts)
     padding-top: ($grid-spacing * 2);
     padding-bottom: ($grid-spacing * 2);
     text-align: center;
+    overflow: hidden;
 
     .masthead-background {
         position: absolute;


### PR DESCRIPTION
This prevents the hero area's background SVG from causing horizontal scrolling at small mobile viewports. @hobinjk r?