### PR TITLE
bug 1490727: Fix issue with pre-filling fullname in recurring payment form

### DIFF
--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -105,7 +105,7 @@ def contribute_recurring_payment_subscription(request):
         }
     elif request.user.is_authenticated and request.user.email:
         initial_data = {
-            'name': request.user.fullname or request.user.username,
+            'name': request.user.fullname,
             'email': request.user.email,
         }
 


### PR DESCRIPTION
This is PR for:
https://trello.com/c/aMbsnmV4/89-full-name-field-is-automatically-filled-in-with-the-username-info-when-logged-in-user-has-no-name-set
