### PR TITLE
bug 957802: Update docs to use docker-compose exec

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -11,7 +11,7 @@ Kuma containers. Useful docker sub-commands::
     docker-compose exec web bash     # Start an interactive shell
     docker-compose logs web          # View logs from the web container
     docker-compose logs -f           # Continuously view logs from all containers
-    docker-compose restart seb       # Force a container to reload
+    docker-compose restart web       # Force a container to reload
     docker-compose stop              # Shutdown the containers
     docker-compose up -d             # Start the containers
     docker-compose rm                # Destroy the containers

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -5,13 +5,13 @@ Development
 Basic Docker usage
 ==================
 Edit files as usual on your host machine; the current directory is mounted
-via Docker host mounting at ``/app`` within the ``kuma_web_1`` and
-other containers. Useful docker sub-commands::
+via Docker host mounting at ``/app`` within various
+Kuma containers. Useful docker sub-commands::
 
-    docker exec -it kuma_web_1 bash  # Start an interactive shell
-    docker logs kuma_web_1           # View logs from the web container
+    docker-compose exec web bash     # Start an interactive shell
+    docker-compose logs web          # View logs from the web container
     docker-compose logs -f           # Continuously view logs from all containers
-    docker restart kuma_web_1        # Force a container to reload
+    docker-compose restart seb       # Force a container to reload
     docker-compose stop              # Shutdown the containers
     docker-compose up -d             # Start the containers
     docker-compose rm                # Destroy the containers
@@ -19,10 +19,10 @@ other containers. Useful docker sub-commands::
 There are ``make`` shortcuts on the host for frequent commands, such as::
 
     make up         # docker-compose up -d
-    make bash       # docker exec -it kuma_web_1 bash
-    make shell_plus # docker exec -it kuma_web_1 ./manage.py shell_plus
+    make bash       # docker-compose exec web bash
+    make shell_plus # docker-compose exec web ./manage.py shell_plus
 
-Run all commands in this doc in the ``kuma_web_1`` container after ``make bash``.
+Run all commands in this doc in the ``web`` service container after ``make bash``.
 
 Running Kuma
 ============
@@ -239,9 +239,13 @@ container's environment and settings are configured in ``docker-compose.yml``.
 The settings are "baked" into the containers created by ``docker-compose up``.
 
 To override a container's settings for development, use a local override file.
-For example, the ``web`` service runs in container ``kuma_web_1`` with the
+For example, the ``web`` service runs in container with the
 default command
 "``gunicorn -w 4 --bind 0.0.0.0:8000 --timeout=120 kuma.wsgi:application``".
+(The container has a name that begins with ``kuma_web_1_`` and
+ends with a string of random hex digits. You can look up the name of
+your particular container with ``docker ps | grep kuma_web``. You'll
+need this container name for some of the commands described below.)
 A useful alternative for debugging is to run a single-threaded process that
 loads the Werkzeug debugger on exceptions (see docs for runserver_plus_), and
 that allows for stepping through the code with a debugger.
@@ -255,7 +259,7 @@ To use this alternative, create an override file ``docker-compose.dev.yml``::
         tty: true
 
 
-This is similar to "``docker run -it <image> ./manage.py runserver_plus``",
+This is similar to "``docker run -it <container> ./manage.py runserver_plus``",
 using all the other configuration items in ``docker-compose.yml``.
 Apply the custom setting with::
 
@@ -264,7 +268,7 @@ Apply the custom setting with::
 You can then add ``pdb`` breakpoints to the code
 (``import pdb; pdb.set_trace``) and connect to the debugger with::
 
-    docker attach kuma_web_1
+    docker attach <container>
 
 To always include the override compose file, add it to your ``.env`` file::
 
@@ -320,7 +324,7 @@ To emulate production, and test compressed and hashed assets locally:
 
 #. Set the environment variable ``DEBUG=False``
 #. Start (``docker-compose up -d``) your Docker services.
-#. Run ``docker exec -e DJANGO_SETTINGS_MODULE=kuma.settings.prod kuma_web_1 make build-static``.
+#. Run ``docker-compose exec -e DJANGO_SETTINGS_MODULE=kuma.settings.prod web make build-static``.
 #. Restart the web process using ``docker-compose restart web``.
 
 Using secure cookies

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -324,7 +324,7 @@ To emulate production, and test compressed and hashed assets locally:
 
 #. Set the environment variable ``DEBUG=False``
 #. Start (``docker-compose up -d``) your Docker services.
-#. Run ``docker-compose exec -e DJANGO_SETTINGS_MODULE=kuma.settings.prod web make build-static``.
+#. Run ``docker-compose run --rm -e DJANGO_SETTINGS_MODULE=kuma.settings.prod web make build-static``.
 #. Restart the web process using ``docker-compose restart web``.
 
 Using secure cookies

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -58,22 +58,32 @@ Docker setup
 
         git clone --recursive https://github.com/mozilla/kuma.git
 
+   If you think you might be submitting pull requests, consider
+   forking the repository first, and then cloning your fork of it.
+
 #. Ensure you are in the existing or newly cloned kuma working copy::
 
         cd kuma
 
-#. Initialize and customize ``.env``. Linux users should set the ``UID``
-   parameter in ``.env``
-   (i.e. change ``#UID=1000`` to ``UID=1000``) to avoid file permission
-   issues when mixing ``docker-compose`` and ``docker`` commands::
+#. Initialize and customize ``.env``::
 
         cp .env-dist.dev .env
         vim .env  # Or your favorite editor
+
+   Linux users should set the ``UID`` parameter in ``.env``
+   (i.e. change ``#UID=1000`` to ``UID=1000``) to avoid file
+   permission issues when mixing ``docker-compose`` and ``docker``
+   commands. MacOS users do not need to change any of the defaults to
+   get started. Note that there are settings in this file that can be
+   useful when debugging, however.
 
 #. Pull the Docker images and build the containers::
 
         docker-compose pull
         docker-compose build
+
+   (The ``build`` command is effectively a no-op at this point because
+   the ``pull`` command just downloaded pre-built docker images.)
 
 #. Start the containers in the background::
 
@@ -85,34 +95,23 @@ Docker setup
 .. _post-install instructions: https://docs.docker.com/engine/installation/linux/linux-postinstall/
 .. _docker as non-root: https://docs.docker.com/engine/installation/linux/linux-postinstall/
 
-The following instructions assume that you are running from a folder named
-``kuma``, so that the containers created are named ``kuma_web_1``,
-``kuma_worker_1``, etc.  If you run from another folder, like ``mdn``, the
-containers will be named ``mdn_web_1``, ``mdn_worker_1``, etc. Adjust the
-command accordingly, or force the ``kuma`` name with::
-
-        docker-compose up -d -p kuma
-
 .. _provision-the-database:
 
 Load the sample database
 ========================
-Download and load the sample database::
+
+Download the sample database with either of the following ``wget`` or
+``curl`` (installed by default on macOS) commands::
 
     wget -N https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
-    docker exec -i kuma_web_1 bash -c "zcat | ./manage.py dbshell" < mdn_sample_db.sql.gz
-
-Alternatively, you can use ``curl`` (installed by default on macOS)::
-
     curl -O https://mdn-downloads.s3-us-west-2.amazonaws.com/mdn_sample_db.sql.gz
-    docker exec -i kuma_web_1 bash -c "zcat | ./manage.py dbshell" < mdn_sample_db.sql.gz
 
-It takes a few seconds to load, with this expected output::
+Next, upload that sample database into the Kuma web container with::
 
-    mysql: [Warning] Using a password on the command line interface can be insecure.
+    docker-compose exec web bash -c "zcat mdn_sample_db.sql.gz | ./manage.py dbshell"
 
-This command can be adjusted to restore from an uncompressed database, or
-directly from a ``mysqldump`` command.
+(This command can be adjusted to restore from an uncompressed database, or
+directly from a ``mysqldump`` command.)
 
 Then run the following command::
 
@@ -125,7 +124,7 @@ Compile locales
 Localized string databases are included in their source form, and need to be
 compiled to their binary form::
 
-    docker exec -i kuma_web_1 make localecompile
+    docker-compose exec web make localecompile
 
 Dozens of lines of warnings will be printed::
 
@@ -153,7 +152,7 @@ Generate static assets
 Static assets such as CSS and JS are included in source form, and need to be
 compiled to their final form::
 
-    docker exec -i kuma_web_1 make build-static
+    docker-compose web make build-static
 
 A few thousand lines will be printed, like::
 
@@ -216,7 +215,7 @@ password access for local development.
 
 If you want to create a new admin account, use ``createsuperuser``::
 
-    docker exec -it kuma_web_1 ./manage.py createsuperuser
+    docker-compose exec web ./manage.py createsuperuser
 
 This will prompt you for a username, email address (a fake address like
 ``admin@example.com`` will work), and a password.
@@ -267,7 +266,7 @@ top of any page.
 With social accounts are enabled, you can disable the admin password in the
 Django shell::
 
-    docker exec -it kuma_web_1 ./manage.py shell_plus
+    docker-compose exec web ./manage.py shell_plus
     >>> me = User.objects.get(username='admin_username')
     >>> me.set_unusable_password()
     >>> me.save()
@@ -280,21 +279,21 @@ Django shell::
 Interact with the Docker containers
 ===================================
 The current directory is mounted as the ``/app`` folder in the web and worker
-containers (``kuma_web_1`` and ``kuma_worker_1``). Changes made to your local
+containers. Changes made to your local
 directory are usually reflected in the running containers. To force the issue,
-the container can be restarted::
+the containers for specified services can be restarted::
 
-    docker restart kuma_web_1 kuma_worker_1
+    docker-compose restart web worker
 
 You can connect to a running container to run commands. For example, you can
 open an interactive shell in the web container::
 
-    docker exec -it kuma_web_1 /bin/bash
+    docker-compose exec web /bin/bash
     make bash  # Same command, less typing
 
 To view the logs generated by a container::
 
-    docker logs kuma_web_1
+    docker-compose logs web
 
 To continuously view logs from all containers::
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -152,7 +152,7 @@ Generate static assets
 Static assets such as CSS and JS are included in source form, and need to be
 compiled to their final form::
 
-    docker-compose web make build-static
+    docker-compose exec web make build-static
 
 A few thousand lines will be printed, like::
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,7 +3,7 @@
 
 # These should stay synced with other requirements files
 Babel==2.2.0
-Jinja2==2.8
+Jinja2==2.10
 MarkupSafe==0.23
 pytz==2018.5
 six==1.11.0


### PR DESCRIPTION
docker-compose 1.23.0 changed the way containers are named to add a
random string of hexadecimal digits to each name, so the instructions
in docs/installation.rst that use the `docker exec -i <container_name>`
form no longer work since the container name is not predictable.

This patch updates those commands to use `docker-compose exec <service>`
instead.

The patch also updates requirements/docs.txt to keep the version of
Jinja2 in sync with what is in requires/default.txt

Test Plan:
- `cd docs; make html` and verify that the generated file looks right.
- install a new copy of Kuma, following these revised instructions