### PR TITLE
Dont send analytics if localstorage is disabled, send a default label if there is no user.

### DIFF
--- a/kuma/static/js/payments-confirmation.js
+++ b/kuma/static/js/payments-confirmation.js
@@ -28,11 +28,11 @@
             sessionStorage.removeItem(amountSubmittedStoreKey);
         });
 
-    } else if (path.includes('/payments/recurring/success')) {
+    } else if (path.includes('/payments/recurring/success') && win.mdn.features.localStorage) {
         mdn.analytics.trackEvent({
             category: 'Recurring payments',
             action: 'success',
-            label: originalUserAuth,
+            label: originalUserAuth || 'lost',
             value: amountSubmitted
         }, function() {
             localStorage.removeItem('userAuthenticationOnFormSubmission');
@@ -47,15 +47,14 @@
         }, function() {
             sessionStorage.removeItem(amountSubmittedStoreKey);
         });
-    } else if (path.includes('/payments/recurring/error')) {
+    } else if (path.includes('/payments/recurring/error') && win.mdn.features.localStorage) {
         mdn.analytics.trackEvent({
             category: 'Recurring payments',
             action: 'Payment failed',
-            label: originalUserAuth,
+            label: originalUserAuth || 'lost',
             value: amountSubmitted
         }, function() {
             localStorage.removeItem('userAuthenticationOnFormSubmission');
         });
     }
-
 })(window);


### PR DESCRIPTION
Analytics bug:
In GA we have 2 'payment success' events without labels, this may be because these 2 users have browser storage disabled, so the users original authentication level was not being pulled into the event label. 
This PR Prevents events from being fired if the users browser storage is disabled, and sends a default event label of 'lost' if we can't get the users authentication level.

**In this pr**

- https://trello.com/c/gGrrocTl/101-ga-success-event-doesnt-have-a-label


**QA notes**

- [ ] recurring payment analytics successful payment event should not be sent if browser storage is disabled.
- [ ] recurring payment banner shown/banner opened/form completed should not fire if browser storage is disabled.
- [ ] if browser storage is enabled completing a recurring payment should emit the success event with a label of 'authenticated' or 'anonymous', reflecting the users original state when completing the payment form. 