### PR TITLE
Bug 1488884: Fix Quicklinks `.toggle summary` color

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -50,8 +50,8 @@
     }
 
     /* toggles */
-    summary {
-        .toggle & {
+    .toggle {
+        summary {
             color: $text-color;
             display: inline-block;
 
@@ -63,10 +63,10 @@
                 top: 1px;
             }
         }
+    }
 
-        a {
-            margin-bottom: 0;
-        }
+    summary a {
+        display: inline;
     }
 
     details {


### PR DESCRIPTION
As it turns out:
```scss
.quick-links {
    summary {
        .toggle & {
            …
        }
    }
}
```
compiles to:
```css
.toggle .quick-links summary {
    …
}
```
instead of:
```css
.quick-links .toggle summary {
    …
}
```
which is why #5036 broke the `<summary>` text color.

review?(@schalkneethling)