### PR TITLE
bug 1510020: In absolutify, use settings.SITE_URL instead of Site.get_current()

### DIFF
--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -24,6 +24,7 @@ from kuma.spam.akismet import Akismet
 from kuma.spam.constants import SPAM_SUBMISSIONS_FLAG, SPAM_URL, VERIFY_URL
 from kuma.wiki.models import (Document, DocumentDeletionLog, Revision,
                               RevisionAkismetSubmission)
+from kuma.wiki.templatetags.jinja_helpers import absolutify
 from kuma.wiki.tests import document as create_document
 
 
@@ -723,43 +724,44 @@ class BanUserAndCleanupSummaryTestCase(SampleRevisionsMixin, UserTestCase):
               Name: {user.username}
               ID: {user.pk}
               Joined at: {date_joined}
-              Profile link: https://example.com/en-US/profiles/{user.username}
+              Profile link: {user_url}
 
             Submitted to Akismet as spam:
 
-              - {rev1.title} [https://example.com{rev1_url}]
-              - {rev2.title} [https://example.com{rev2_url}]
-              - {rev3.title} [https://example.com{rev3_url}]
+              - {rev1.title} [{rev1_url}]
+              - {rev2.title} [{rev2_url}]
+              - {rev3.title} [{rev3_url}]
 
             Deleted:
 
-              - {rev2.document.title} [https://example.com{rev2_doc_url}]
+              - {rev2.document.title} [{rev2_doc_url}]
 
             Reverted:
 
-              - {rev1.title} [https://example.com{rev1_url}]
+              - {rev1.title} [{rev1_url}]
 
             * NEEDS FOLLOW UP *
 
             Revisions skipped due to newer non-spam revision:
 
-              - {rev3.title} [https://example.com{rev3_url}]
+              - {rev3.title} [{rev3_url}]
 
             * NO ACTION TAKEN *
 
             Latest revision is non-spam:
 
-              - {rev3.title} [https://example.com{rev3_url}]
+              - {rev3.title} [{rev3_url}]
             """.format(
                 user=self.testuser,
+                user_url=absolutify(self.testuser.get_absolute_url()),
                 date_joined=tz.localize(self.testuser.date_joined).astimezone(utc),
                 rev1=spam_revision1[0],
                 rev2=spam_revision2[0],
                 rev3=spam_revision3[0],
-                rev1_url=spam_revision1[0].get_absolute_url(),
-                rev2_url=spam_revision2[0].get_absolute_url(),
-                rev3_url=spam_revision3[0].get_absolute_url(),
-                rev2_doc_url=spam_revision2[0].document.get_absolute_url()
+                rev1_url=absolutify(spam_revision1[0].get_absolute_url()),
+                rev2_url=absolutify(spam_revision2[0].get_absolute_url()),
+                rev3_url=absolutify(spam_revision3[0].get_absolute_url()),
+                rev2_doc_url=spam_revision2[0].document.get_full_url()
             ))
         )
 

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -368,7 +368,7 @@ class Document(NotificationsMixin, models.Model):
         Return None if the URL is a 404, the URL doesn't point to the right
         view, or the indicated document doesn't exist.
         To fetch all values of the returned Document not only ID,
-        set `id_only` to True.
+        set `id_only` to False.
         """
 
         try:

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -6,7 +6,7 @@ import re
 import jinja2
 from constance import config
 from cssselect.parser import SelectorSyntaxError
-from django.contrib.sites.models import Site
+from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.template import loader
 from django.utils import lru_cache
@@ -203,23 +203,15 @@ def tojson(value):
 
 
 @library.filter
-def absolutify(url, site=None):
-    """
-    Joins a base ``Site`` URL with a URL path.
-
-    If no site provided it gets the current site from Site.
-
-    """
+def absolutify(url):
+    """Joins settings.SITE_URL with a URL path."""
     if url.startswith('http'):
         return url
 
-    if not site:
-        site = Site.objects.get_current()
-
+    site = urlsplit(settings.SITE_URL)
     parts = urlsplit(url)
-
-    scheme = 'https'
-    netloc = site.domain
+    scheme = site.scheme
+    netloc = site.netloc
     path = parts.path
     query = parts.query
     fragment = parts.fragment

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -837,7 +837,7 @@ def test_annotate_links_existing_doc(root_doc, anchor, full_url, has_class):
     """Links to existing docs are unmodified."""
     if full_url == 'fullURL':
         url = root_doc.get_full_url()
-        assert url.startswith(AL_BASE_URL)
+        assert url.startswith(settings.SITE_URL)
     else:
         url = root_doc.get_absolute_url()
     if anchor == 'withAnchor':
@@ -847,8 +847,9 @@ def test_annotate_links_existing_doc(root_doc, anchor, full_url, has_class):
     else:
         link_class = ''
     html = normalize_html('<li><a %s href="%s"></li>' % (link_class, url))
-    actual_raw = parse(html).annotateLinks(base_url=AL_BASE_URL).serialize()
-    assert normalize_html(actual_raw) == html
+    actual_raw = normalize_html(
+        parse(html).annotateLinks(base_url=settings.SITE_URL).serialize())
+    assert actual_raw == html
 
 
 @pytest.mark.parametrize('has_class', ('hasClass', 'noClass'))

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -155,7 +155,7 @@ def test_edit_document_event_emails_on_create(mock_emails, create_revision):
         'default_locale': 'en-US',
         'headers': {
             'X-Kuma-Editor-Username': 'wiki_user',
-            'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+            'X-Kuma-Document-Url': create_revision.document.get_full_url(),
             'X-Kuma-Document-Title': 'Root Document',
             'X-Kuma-Document-Locale': 'en-US',
         }
@@ -187,7 +187,7 @@ def test_first_edit_email_on_create(create_revision):
                             ' creating: Root Document')
     assert mail.extra_headers == {
         'X-Kuma-Editor-Username': 'wiki_user',
-        'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+        'X-Kuma-Document-Url': create_revision.document.get_full_url(),
         'X-Kuma-Document-Title': 'Root Document',
         'X-Kuma-Document-Locale': 'en-US',
     }
@@ -207,7 +207,7 @@ def test_first_edit_email_on_translate(trans_revision):
                             ' creating: Racine du Document')
     assert mail.extra_headers == {
         'X-Kuma-Editor-Username': u'wiki_user',
-        'X-Kuma-Document-Url': u'https://example.com/fr/docs/Racine',
+        'X-Kuma-Document-Url': trans_revision.document.get_full_url(),
         'X-Kuma-Document-Title': 'Racine du Document',
         'X-Kuma-Document-Locale': 'fr',
     }
@@ -243,7 +243,7 @@ def test_spam_attempt_email_on_change(wiki_user, root_doc):
                             ' /en-US/docs/Root (Root Document)')
     assert mail.extra_headers == {
         'X-Kuma-Editor-Username': 'wiki_user',
-        'X-Kuma-Document-Url': 'https://example.com/en-US/docs/Root',
+        'X-Kuma-Document-Url': root_doc.get_full_url(),
         'X-Kuma-Document-Title': 'Root Document',
         'X-Kuma-Document-Locale': 'en-US',
     }

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
 
-import mock
 import pytest
-from django.contrib.sites.models import Site
 from django.template import TemplateDoesNotExist
 from pyquery import PyQuery as pq
 
@@ -33,17 +31,16 @@ def test_tojson():
      ('/woo?var=value', 'https://testserver/woo?var=value'),
      ('/woo?var=value#fragment', 'https://testserver/woo?var=value#fragment'),
      ))
-@mock.patch.object(Site.objects, 'get_current')
-def test_absolutify(get_current, path, abspath):
+def test_absolutify(settings, path, abspath):
     """absolutify adds the current site to paths without domains."""
-    get_current.return_value.domain = 'testserver'
+    settings.SITE_URL = 'https://testserver'
     assert absolutify(path) == abspath
 
 
-def test_absolutify_site():
-    """absolutify takes a Site object for the domain."""
-    site = Site(domain='otherserver')
-    assert absolutify('/woo', site) == 'https://otherserver/woo'
+def test_absolutify_dev(settings):
+    """absolutify uses http in development."""
+    settings.SITE_URL = 'http://localhost:8000'
+    assert absolutify('') == 'http://localhost:8000/'
 
 
 def test_include_svg_invalid_path():

--- a/kuma/wiki/tests/test_helpers.py
+++ b/kuma/wiki/tests/test_helpers.py
@@ -1,14 +1,13 @@
 # -*- coding: utf-8 -*-
+from datetime import datetime
+
 import mock
 import pytest
-
 from django.contrib.sites.models import Site
 from django.template import TemplateDoesNotExist
 from pyquery import PyQuery as pq
 
-from kuma.users.tests import UserTestCase
-
-from . import document, revision, WikiTestCase
+from ..models import Document, Revision
 from ..templatetags.jinja_helpers import (absolutify,
                                           include_svg,
                                           revisions_unified_diff,
@@ -16,28 +15,35 @@ from ..templatetags.jinja_helpers import (absolutify,
                                           wiki_url)
 
 
-class HelpTests(WikiTestCase):
+def test_tojson():
+    """tojson converts dicts to JSON objects with escaping."""
+    output = tojson({'title': '<script>alert("Hi!")</script>'})
+    expected = ('{"title": "&lt;script&gt;alert(&quot;Hi!&quot;)'
+                '&lt;/script&gt;"}')
+    assert output == expected
 
-    def test_tojson(self):
-        assert (tojson({'title': '<script>alert("Hi!")</script>'}) ==
-                '{"title": "&lt;script&gt;alert(&quot;Hi!&quot;)&lt;/script&gt;"}')
 
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_absolutify(self, get_current):
-        get_current.return_value.domain = 'testserver'
+@pytest.mark.parametrize(
+    'path,abspath',
+    (('', 'https://testserver/'),
+     ('/', 'https://testserver/'),
+     ('//', 'https://testserver/'),
+     ('/foo/bar', 'https://testserver/foo/bar'),
+     ('http://domain.com', 'http://domain.com'),
+     ('/woo?var=value', 'https://testserver/woo?var=value'),
+     ('/woo?var=value#fragment', 'https://testserver/woo?var=value#fragment'),
+     ))
+@mock.patch.object(Site.objects, 'get_current')
+def test_absolutify(get_current, path, abspath):
+    """absolutify adds the current site to paths without domains."""
+    get_current.return_value.domain = 'testserver'
+    assert absolutify(path) == abspath
 
-        assert absolutify('') == 'https://testserver/'
-        assert absolutify('/') == 'https://testserver/'
-        assert absolutify('//') == 'https://testserver/'
-        assert absolutify('/foo/bar') == 'https://testserver/foo/bar'
-        assert absolutify('http://domain.com') == 'http://domain.com'
 
-        site = Site(domain='otherserver')
-        assert absolutify('/woo', site) == 'https://otherserver/woo'
-
-        assert absolutify('/woo?var=value') == 'https://testserver/woo?var=value'
-        assert (absolutify('/woo?var=value#fragment') ==
-                'https://testserver/woo?var=value#fragment')
+def test_absolutify_site():
+    """absolutify takes a Site object for the domain."""
+    site = Site(domain='otherserver')
+    assert absolutify('/woo', site) == 'https://otherserver/woo'
 
 
 def test_include_svg_invalid_path():
@@ -63,39 +69,49 @@ def test_include_svg_replace_title(title):
     assert svg_title.text() == title
 
 
-class RevisionsUnifiedDiffTests(UserTestCase, WikiTestCase):
-
-    def test_from_revision_none(self):
-        rev = revision()
-        diff = revisions_unified_diff(None, rev)  # No AttributeError
-        assert diff == "Diff is unavailable."
-
-    def test_from_revision_non_ascii(self):
-        doc1 = document(title=u'Gänsefüßchen', save=True)
-        rev1 = revision(document=doc1, content=u'spam', save=True)
-        doc2 = document(title=u'Außendienstüberwachlösung', save=True)
-        rev2 = revision(document=doc2, content=u'eggs', save=True)
-        revisions_unified_diff(rev1, rev2)  # No UnicodeEncodeError
+def test_revisions_unified_diff_none(root_doc):
+    """Passing a None revision does not raise an AttributeError."""
+    diff = revisions_unified_diff(None, root_doc.current_revision)
+    assert diff == "Diff is unavailable."
 
 
-class SelectorContentFindTests(UserTestCase, WikiTestCase):
-    def test_selector_not_found_returns_empty_string(self):
-        doc_content = u'<div id="not-summary">Not the summary</div>'
-        doc1 = document(title=u'Test Missing Selector', save=True)
-        doc1.rendered_html = doc_content
-        doc1.save()
-        revision(document=doc1, content=doc_content, save=True)
-        content = selector_content_find(doc1, 'summary')
-        assert content == ''
+def test_revisions_unified_diff_non_ascii(wiki_user):
+    """Documents with non-ASCII titles do not have Unicode errors in diffs."""
+    title1 = u'Gänsefüßchen'
+    doc1 = Document.objects.create(
+        locale='en-US', slug=title1, title=title1)
+    rev1 = Revision.objects.create(
+        document=doc1,
+        creator=wiki_user,
+        content=u'<p>%s started...</p>' % title1,
+        title=title1,
+        created=datetime(2018, 11, 21, 18, 39))
 
-    def test_pyquery_bad_selector_syntax_returns_empty_string(self):
-        doc_content = u'<div id="not-suNot the summary</span'
-        doc1 = document(title=u'Test Missing Selector', save=True)
-        doc1.rendered_html = doc_content
-        doc1.save()
-        revision(document=doc1, content=doc_content, save=True)
-        content = selector_content_find(doc1, '.')
-        assert content == ''
+    title2 = u'Außendienstüberwachlösung'
+    doc2 = Document.objects.create(
+        locale='en-US', slug=title2, title=title2)
+    rev2 = Revision.objects.create(
+        document=doc2,
+        creator=wiki_user,
+        content=u'<p>%s started...</p>' % title2,
+        title=title1,
+        created=datetime(2018, 11, 21, 18, 41))
+
+    revisions_unified_diff(rev1, rev2)  # No UnicodeEncodeError
+
+
+def test_selector_content_find_not_found_returns_empty_string(root_doc):
+    """When the ID is not in the content, return an empty string."""
+    root_doc.rendered_html = root_doc.current_revision.content
+    content = selector_content_find(root_doc, 'summary')
+    assert content == ''
+
+
+def test_selector_content_find_bad_selector_returns_empty_string(root_doc):
+    """When the ID is invalid, return an empty string."""
+    root_doc.rendered_html = root_doc.current_revision.content
+    content = selector_content_find(root_doc, '.')
+    assert content == ''
 
 
 @pytest.mark.parametrize(

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -123,7 +123,7 @@ def test_document_redirect_rejects_invalid_url(db, url):
 
 def test_document_get_full_url(root_doc):
     """get_full_url returns full URLs."""
-    assert root_doc.get_full_url() == 'https://example.com/en-US/docs/Root'
+    assert root_doc.get_full_url() == settings.SITE_URL + '/en-US/docs/Root'
 
 
 def test_document_from_url(root_doc):

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -155,10 +155,17 @@ def test_document_from_url_revision_url_returns_none(create_revision):
     assert doc is None
 
 
-def test_document_from_url_full_url_returns_none(root_doc):
-    """from_url returns None for a full URL."""
-    doc = Document.from_url(root_doc.get_full_url())
-    assert doc is None
+def test_document_from_url_full_url_returns_doc(root_doc):
+    """from_url returns the document for a full URL."""
+    url = root_doc.get_full_url()
+    assert Document.from_url(url) == root_doc
+
+
+def test_document_from_url_other_url_returns_none(root_doc):
+    """from_url returns None for a different domain."""
+    assert settings.SITE_URL != 'https://example.com'
+    url = 'https://example.com' + root_doc.get_absolute_url()
+    assert Document.from_url(url) is None
 
 
 def test_document_get_redirect_document(root_doc):

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -25,8 +25,8 @@ class SitemapsTestCase(UserTestCase):
         for locale in set(locales):
             # we'll expect to see this locale in the sitemap index file
             expected_sitemap_locs.append(
-                "<loc>https://example.com/sitemaps/%s/sitemap.xml</loc>" %
-                locale
+                "<loc>%s/sitemaps/%s/sitemap.xml</loc>" %
+                (settings.SITE_URL, locale)
             )
             sitemap_path = os.path.join(settings.MEDIA_ROOT, 'sitemaps',
                                         locale, 'sitemap.xml')

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -675,8 +675,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
                        'form#wiki-page-edit textarea[name="content"]')) == 1
 
     @override_settings(TIDINGS_CONFIRM_ANONYMOUS_WATCHES=False)
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_new_revision_POST_document_with_current(self, get_current):
+    def test_new_revision_POST_document_with_current(self):
         """HTTP POST to new revision URL creates the revision on a document.
 
         The document in this case already has a current_revision, therefore
@@ -684,8 +683,6 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
 
         Also assert that the edited and reviewable notifications go out.
         """
-        get_current.return_value.domain = 'testserver'
-
         # Sign up for notifications:
         EditDocumentEvent.notify('sam@example.com', self.d).activate().save()
 
@@ -738,7 +735,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
 
         assert '%s changed %s.' % (unicode(self.username), unicode(self.d.title)) in edited_email.body
 
-        assert u'https://testserver/en-US/docs/%s$history' % self.d.slug in edited_email.body
+        assert (self.d.get_full_url() + u'$history') in edited_email.body
         assert 'utm_campaign=' in edited_email.body
 
     @mock.patch.object(EditDocumentEvent, 'fire')

--- a/kuma/wiki/tests/test_utils.py
+++ b/kuma/wiki/tests/test_utils.py
@@ -5,7 +5,6 @@ import os.path
 import mock
 import pytest
 from constance.test import override_config
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from googleapiclient.errors import HttpError
 from googleapiclient.http import HttpMockSequence
@@ -340,7 +339,7 @@ def test_get_doc_components_from_url_correct_required_locale(root_doc):
 
 def test_get_doc_components_from_url_check_host_same_domain(root_doc):
     """get_doc_components_from_url works with check_host and full local URL."""
-    url = 'http://' + settings.DOMAIN + root_doc.get_absolute_url()
+    url = root_doc.get_full_url()
     locale, path, slug = get_doc_components_from_url(url, check_host=True)
     assert locale == root_doc.locale
     assert path == '/docs/Root'

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -1978,10 +1978,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert rev_ip.referrer == 'http://localhost/'
 
     @pytest.mark.edit_emails
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_email_for_first_edits(self, get_current):
-        get_current.return_value.domain = 'dev.mo.org'
-
+    def test_email_for_first_edits(self):
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()
         slug = 'test-article-for-storing-revision-ip'
@@ -2016,8 +2013,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         def _check_message_for_headers(message, username):
             assert "%s made their first edit" % username in message.subject
             assert message.extra_headers == {
-                'X-Kuma-Document-Url':
-                    "https://dev.mo.org%s" % doc.get_absolute_url(),
+                'X-Kuma-Document-Url': doc.get_full_url(),
                 'X-Kuma-Editor-Username': username,
                 'X-Kuma-Document-Locale': doc.locale,
                 'X-Kuma-Document-Title': doc.title
@@ -2028,13 +2024,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         _check_message_for_headers(testuser_message, 'testuser')
         _check_message_for_headers(admin_message, 'admin')
 
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_email_for_watched_edits(self, get_current):
+    def test_email_for_watched_edits(self):
         """
         When a user edits a watched document, we should send an email to users
         who are watching it.
         """
-        get_current.return_value.domain = 'dev.mo.org'
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()
         rev = revision(save=True)
@@ -2090,13 +2084,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert 'sub-articles' not in message.body
 
     @pytest.mark.edit_emails
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_email_for_child_edit_in_watched_tree(self, get_current):
+    def test_email_for_child_edit_in_watched_tree(self):
         """
         When a user edits a child document in a watched document tree, we
         should send an email to users who are watching the tree.
         """
-        get_current.return_value.domain = 'dev.mo.org'
         root_doc, child_doc, grandchild_doc = create_document_tree()
 
         testuser2 = get_user(username='testuser2')
@@ -2119,13 +2111,11 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert 'sub-articles' in message.body
 
     @pytest.mark.edit_emails
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_email_for_grandchild_edit_in_watched_tree(self, get_current):
+    def test_email_for_grandchild_edit_in_watched_tree(self):
         """
         When a user edits a grandchild document in a watched document tree, we
         should send an email to users who are watching the tree.
         """
-        get_current.return_value.domain = 'dev.mo.org'
         root_doc, child_doc, grandchild_doc = create_document_tree()
 
         testuser2 = get_user(username='testuser2')
@@ -2146,14 +2136,12 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert 'sub-articles' in message.body
 
     @pytest.mark.edit_emails
-    @mock.patch.object(Site.objects, 'get_current')
-    def test_single_email_when_watching_doc_and_tree(self, get_current):
+    def test_single_email_when_watching_doc_and_tree(self):
         """
         When a user edits a watched document in a watched document tree, we
         should only send a single email to users who are watching both the
         document and the tree.
         """
-        get_current.return_value.domain = 'dev.mo.org'
         root_doc, child_doc, grandchild_doc = create_document_tree()
 
         testuser2 = get_user(username='testuser2')

--- a/kuma/wiki/utils.py
+++ b/kuma/wiki/utils.py
@@ -64,8 +64,9 @@ def get_doc_components_from_url(url, required_locale=None, check_host=True):
     # Extract locale and path from URL:
     parsed = urlparse(url)  # Never has errors AFAICT
     if check_host and parsed.netloc:
-        # Only allow redirects on our domain
-        if parsed.netloc != settings.DOMAIN:
+        # Only allow redirects on our site
+        site = urlparse(settings.SITE_URL)
+        if parsed.scheme != site.scheme or parsed.netloc != site.netloc:
             return False
 
     locale, path = split_path(parsed.path)


### PR DESCRIPTION
``absolutify`` is a Jinja2 filter and utility function that turns paths into absolute URLs. It currently uses ``Site.objects.get_current()`` to get the domain name, and assumes ``https`` is the protocol. This means tests assume the site prefix is ``https://example.com``, and require a database or to mock the ``get_current`` method. Also, when used locally, the link is ``https://localhost:8000``, and broken due to the ``https``. It also has some unneeded flexibility, to allow using a different ``Site`` object which is unused outside of tests.

Maybe for these reasons, lots of code now has custom methods for creating absolute URLs. I'd like to get back to One Way of doing this common operation.

This PR updates ``absolutify`` to use ``settings.SITE_URL``, which is ``https://localhost:8000`` in development, ``https://developer.127.0.0.1.nip.io`` when using the SSL config, ``https://developer.allizom.org`` in staging, and ``https://developer.mozilla.org`` in production.

There's a few test changes:
* All the remaining tests in ``wiki/tests/test_helpers.py``, including the ones for ``absolutify``, are converted to pytest-style.
* Some tests could be modified to pass before the change, and continue passing after the change.
* Other tests needed to be changed at the same time as the switch to ``settings.SITE_URL``.
