### PR TITLE
bug 1490727: Add cancelation ability while deleting User through Django signals

### DIFF
--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -1,7 +1,13 @@
+import stripe
+import logging
 from django.conf import settings
 from waffle import flag_is_active
 
 from .constants import CONTRIBUTION_BETA_FLAG, RECURRING_PAYMENT_BETA_FLAG
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+
+log = logging.getLogger('kuma.payments.utils')
 
 
 def enabled(request):
@@ -20,3 +26,53 @@ def recurring_payment_enabled(request):
     """Returns True if recurring payment is enabled for the user."""
     return (popup_enabled(request) and
             flag_is_active(request, RECURRING_PAYMENT_BETA_FLAG))
+
+
+def get_stripe_customer_data(stripe_customer_id, email, username):
+    stripe_data = {
+        'stripe_plan_amount': 0,
+        'stripe_card_last4': 0,
+        'active_subscriptions': False
+    }
+    try:
+        customer = stripe.Customer.retrieve(stripe_customer_id)
+        stripe_data['active_subscriptions'] = True if customer['subscriptions']['data'] else False
+        if customer['subscriptions']['data']:
+            stripe_data['stripe_plan_amount'] = customer['subscriptions']['data'][0]['plan']['amount'] / 100
+        if customer['sources']['data']:
+            stripe_data['stripe_card_last4'] = customer['sources']['data'][0]['card']['last4']
+    except stripe.error.InvalidRequestError as e:
+        log.error(
+            'Stripe subscription cancellation: Invalid parameters were supplied to Stripe API: {} [{}] {}'.format(
+                username,
+                email,
+                e
+            )
+        )
+    except Exception as e:
+        log.error(
+            'Stripe subscription cancellation: something went wrong: {} [{}] {}'.format(username, email, e)
+        )
+    return stripe_data
+
+
+def cancel_stripe_customer_subscription(stripe_customer_id, email, username):
+    try:
+        customer = stripe.Customer.retrieve(stripe_customer_id)
+        for sub in customer['subscriptions']['data']:
+            s = stripe.Subscription.retrieve(sub.id)
+            s.delete()
+        return True
+    except stripe.error.InvalidRequestError as e:
+        log.error(
+            'Stripe subscription cancellation: Invalid parameters were supplied to Stripe API: {} [{}] {}'.format(
+                username,
+                email,
+                e
+            )
+        )
+    except Exception as e:
+        log.error(
+            'Stripe subscription cancellation: something went wrong: {} [{}] {}'.format(username, email, e)
+        )
+    return False

--- a/kuma/users/signal_handlers.py
+++ b/kuma/users/signal_handlers.py
@@ -1,3 +1,5 @@
+import stripe
+import logging
 from allauth.account.signals import email_confirmed, user_signed_up
 from allauth.socialaccount.signals import social_account_removed
 from django.conf import settings
@@ -10,10 +12,13 @@ from waffle import switch_is_active
 
 from kuma.core.urlresolvers import reverse
 from kuma.wiki.jobs import DocumentContributorsJob
+from kuma.payments.utils import cancel_stripe_customer_subscription
 
 from .jobs import UserGravatarURLJob
 from .models import User, UserBan
 from .tasks import send_welcome_email
+
+log = logging.getLogger('kuma.users.signal_handlers')
 
 
 @receiver(post_save, sender=User, dispatch_uid='users.user.post_save')
@@ -118,3 +123,19 @@ def invalidate_document_contribution(user):
     job = DocumentContributorsJob()
     for doc_id in doc_ids:
         job.invalidate(doc_id)
+
+
+@receiver(post_delete, sender=User, dispatch_uid='users.user.post_delete')
+def on_user_delete(sender, instance, **kwargs):
+    """
+    A signal handler to be called after deleting a user.
+
+    Invalidate all User stripe subscriptions if stripe customer ID exists
+    """
+    user = instance
+    if user.stripe_customer_id:
+        cancel_stripe_customer_subscription(
+            user.stripe_customer_id,
+            user.email,
+            user.username
+        )

--- a/kuma/users/signal_handlers.py
+++ b/kuma/users/signal_handlers.py
@@ -1,5 +1,3 @@
-import stripe
-import logging
 from allauth.account.signals import email_confirmed, user_signed_up
 from allauth.socialaccount.signals import social_account_removed
 from django.conf import settings
@@ -17,8 +15,6 @@ from kuma.payments.utils import cancel_stripe_customer_subscription
 from .jobs import UserGravatarURLJob
 from .models import User, UserBan
 from .tasks import send_welcome_email
-
-log = logging.getLogger('kuma.users.signal_handlers')
 
 
 @receiver(post_save, sender=User, dispatch_uid='users.user.post_save')


### PR DESCRIPTION
This is PR for:
https://trello.com/c/eqa0Zh7e/20-as-an-mdn-admin-i-want-to-be-prevented-from-deleting-a-subscribers-mdn-account-so-that-i-can-stop-their-subscription-first

Now when User is deleted all his subscriptions will be canceled.

Just for the record, there are two functions from other work which is not merged yet but is useful for this functionality (kuma/payments/utils.py): 
- cancel_stripe_customer_subscription
- get_stripe_customer_data
Code is the same so there shouldn't be a problem with merging it.