### PR TITLE
Bug 1505084: update the KumaScript Dockerfile to install Node 10.13.0

### DIFF
--- a/docker/images/kumascript/Dockerfile
+++ b/docker/images/kumascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.10.0-slim
+FROM node:10.14.2-slim
 
 RUN set -ex && \
     apt-get update && \


### PR DESCRIPTION
https://github.com/mdn/kumascript/pull/1008 updates KumaScript to
use Node 10 instead of Node 8. This patch updates the KumaScript
Dockerfile in the Kuma repo to install Node 10 in the KumaScript image.