### PR TITLE
Bug 1423716: stop adding the SEO root title to all document titles

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
+{% block title %}{{ page_title(document.title) }}{% endblock %}
 
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
 {% from "wiki/includes/buttons.html" import get_document_buttons with context %}

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -32,7 +32,6 @@ from ..events import EditDocumentEvent, EditDocumentInTreeEvent
 from ..forms import MIDAIR_COLLISION
 from ..models import Document, RevisionIP
 from ..templatetags.jinja_helpers import get_compare_url
-from ..views.document import _get_seo_parent_title
 
 
 class RedirectTests(UserTestCase, WikiTestCase):
@@ -562,13 +561,11 @@ class KumascriptIntegrationTests(UserTestCase, WikiTestCase):
 class DocumentSEOTests(UserTestCase, WikiTestCase):
     """Tests for the document seo logic"""
 
-    def test_get_seo_parent_doesnt_throw_404(self):
-        """bug 1190212"""
-        doc = document(save=True)
-        slug_dict = {'seo_root': 'Root/Does/Not/Exist'}
-        _get_seo_parent_title(doc, slug_dict, 'bn-BD')  # Should not raise Http404
-
-    def test_seo_title(self):
+    # NOTE(djf): In the past, we included the title of the "SEO Root"
+    # document in the title of every page, and this test tested for it.
+    # That feature has been removed now, and now this test verifies that
+    # the SEO root title does *not* appear in document titles.
+    def test_no_seo_title(self):
         self.client.login(username='admin', password='testpass')
 
         # Utility to make a quick doc
@@ -583,21 +580,21 @@ class DocumentSEOTests(UserTestCase, WikiTestCase):
 
         # Test nested document titles
         _make_doc('One', ['One | MDN'], 'one')
-        _make_doc('Two', ['Two - One | MDN'], 'one/two')
-        _make_doc('Three', ['Three - One | MDN'], 'one/two/three')
+        _make_doc('Two', ['Two | MDN'], 'one/two')
+        _make_doc('Three', ['Three | MDN'], 'one/two/three')
         _make_doc(u'Special Φ Char',
-                  [u'Special \u03a6 Char - One | MDN',
-                   u'Special \xce\xa6 Char - One | MDN'],
+                  [u'Special \u03a6 Char | MDN',
+                   u'Special \xce\xa6 Char | MDN'],
                   'one/two/special_char')
 
         # Additional tests for /Web/*  changes
         _make_doc('Firefox OS', ['Firefox OS | MDN'], 'firefox_os')
-        _make_doc('Email App', ['Email App - Firefox OS | MDN'],
+        _make_doc('Email App', ['Email App | MDN'],
                   'firefox_os/email_app')
         _make_doc('Web', ['Web | MDN'], 'Web')
         _make_doc('HTML', ['HTML | MDN'], 'Web/html')
-        _make_doc('Fieldset', ['Fieldset - HTML | MDN'], 'Web/html/fieldset')
-        _make_doc('Legend', ['Legend - HTML | MDN'],
+        _make_doc('Fieldset', ['Fieldset | MDN'], 'Web/html/fieldset')
+        _make_doc('Legend', ['Legend | MDN'],
                   'Web/html/fieldset/legend')
 
     def test_seo_script(self):

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -111,29 +111,6 @@ def _make_doc_structure(document, level, expand, depth):
     return result
 
 
-def _get_seo_parent_title(document, slug_dict, document_locale):
-    """
-    Get parent-title information for SEO purposes.
-    """
-    seo_doc_slug = slug_dict['seo_root']
-    seo_root_doc = None
-
-    if seo_doc_slug:
-        # If the SEO root doc is the parent topic, save a query
-        if document.parent_topic_id and document.parent_topic.slug == seo_doc_slug:
-            seo_root_doc = document.parent_topic
-        else:
-            try:
-                seo_root_doc = Document.objects.only('title').get(locale=document_locale, slug=seo_doc_slug)
-            except Document.DoesNotExist:
-                pass
-
-    if seo_root_doc:
-        return u' - {}'.format(seo_root_doc.title)
-    else:
-        return ''
-
-
 def _filter_doc_html(request, doc, doc_html, rendering_params):
     """
     Apply needed filtering/annotating operations to a Document's HTML.
@@ -705,10 +682,6 @@ def document(request, document_slug, document_locale):
         # Get the SEO summary
         seo_summary = doc.get_summary_text()
 
-        # Get the additional title information, if necessary.
-        seo_parent_title = _get_seo_parent_title(
-            original_doc, slug_dict, document_locale)
-
         # Retrieve pre-parsed content hunks
         quick_links_html = doc.get_quick_links_html()
         body_html = doc.get_body_html()
@@ -752,7 +725,6 @@ def document(request, document_slug, document_locale):
             ),
             'render_raw_fallback': rendering_params['render_raw_fallback'],
             'seo_summary': seo_summary,
-            'seo_parent_title': seo_parent_title,
             'share_text': share_text,
             'search_url': get_search_url_from_referer(request) or '',
             'analytics_page_revision': doc.current_revision_id,


### PR DESCRIPTION
We currently constuct the <title> of a document like this:

  `<title> - <SEO root document title> | MDN`

So for https://developer.mozilla.org/en-US/docs/Learn/CSS we have:

>  Learn to style HTML using CSS - Learn web development | MDN

This patch shortens the title by removing the SEO root title, leaving:

> Learn to style HTML using CSS | MDN