### PR TITLE
bug 1490727:  Added a new set of analytics for recurring payments.

### DIFF
--- a/kuma/static/js/payments-confirmation.js
+++ b/kuma/static/js/payments-confirmation.js
@@ -29,6 +29,15 @@
         });
 
     } else if (path.includes('/payments/recurring/success') && win.mdn.features.localStorage) {
+        //  We're duplicating event semantics due to an Analytics issue with the event label
+        mdn.analytics.trackEvent({
+            category: 'Recurring payments v2',
+            action: 'success - ' + originalUserAuth,
+            label: originalUserAuth,
+            value: amountSubmitted
+        }, function() {
+            localStorage.removeItem('userAuthenticationOnFormSubmission');
+        });
         mdn.analytics.trackEvent({
             category: 'Recurring payments',
             action: 'success',
@@ -48,6 +57,15 @@
             sessionStorage.removeItem(amountSubmittedStoreKey);
         });
     } else if (path.includes('/payments/recurring/error') && win.mdn.features.localStorage) {
+        //  We're duplicating event semantics due to an Analytics issue with the event label
+        mdn.analytics.trackEvent({
+            category: 'Recurring payments v2',
+            action: 'Payment failed - ' + originalUserAuth,
+            label: originalUserAuth,
+            value: amountSubmitted
+        }, function() {
+            localStorage.removeItem('userAuthenticationOnFormSubmission');
+        });
         mdn.analytics.trackEvent({
             category: 'Recurring payments',
             action: 'Payment failed',

--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -167,9 +167,16 @@
             return;
         }
 
+        //  We're duplicating event semantics due to an Analytics issue with the event label
         mdn.analytics.trackEvent({
             category: 'Recurring payments',
             action: event.action,
+            label: win.payments.isAuthenticated ? 'authenticated' : 'anonymous',
+            value: event.value
+        });
+        mdn.analytics.trackEvent({
+            category: 'Recurring payments v2',
+            action: event.action + ' - ' + win.payments.isAuthenticated ? 'authenticated' : 'anonymous',
             label: win.payments.isAuthenticated ? 'authenticated' : 'anonymous',
             value: event.value
         });


### PR DESCRIPTION
We're having issues with analytics for recurring payments. The `Recurring payments > success` event has no label. The label is required for conversion rates as it contains the users authentication level.
The solution proposed is to create a new event that has the users authentication in the event action - as this seems more reliable.

We want to preserve the current setup so have added _Recurring payment v2_ event category that has the user's status in the event action.
Also to keep consistency I have added *all* _recurring payment v2_ events (inc banner shown/expanded) to include the users authentication level in the action.
With _recurring payment v2_ I have also kept the authenticated/anonymous label for filtering (if it ever decides to work again!)

All new events will look something like
```category: Recurring payments v2
action: success - authenticated, success - anonymous, banner shown - authenticated, banner shown - anonymous, etc...
label: authenticated, anonymous
value: {{amount in pennies, ie 1200}}```

**In this PR**
- https://trello.com/c/OLZjfV9d/97-as-a-po-i-want-to-be-able-to-report-on-conversion-rate-so-i-can-gauge-the-success-of-the-recurring-payments-experiment

**notes for qa**
- [ ] for every recurring payment event two events must be fired.
- [ ] events must contain information on the users authentication level