### PR TITLE
bug 1490727: Force form to remove custom amount on change.

### DIFF
--- a/kuma/static/js/payments-handler.js
+++ b/kuma/static/js/payments-handler.js
@@ -615,6 +615,8 @@
     function switchPaymentTypeHandler() {
         var action = form.get(0).getAttribute('action');
         var checkedInput = null;
+        customAmountInput.get(0).value = '';
+        selectedAmount = 0;
 
         if (this.value === 'one_time' && currrentPaymentForm === 'recurring') {
             // Switch to one-time payment form only if we're not on the one-time payment form already.


### PR DESCRIPTION
On the popover we should not persist the custom amount input.

**in this pr**
- https://trello.com/c/66tR9Dje/80-ui-banner-only-remembers-custom-amount-vs-faq-pages-dont-remember-either-predefined-or-custom-amounts
**notes for QA**
- [ ] on the popover banner when switching between amounts we should reset the custom amount input