### PR TITLE
bug 1490727: Align payment error page content to the centre.

### DIFF
--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -10,7 +10,7 @@
   {%- set recurring_payments_url = url('recurring_payment_initial') %}
   {%- set share_url = 'https://developer.mozilla.org' + payments_url %}
   {% translation 'en-US' %}{# Display in English until Q1 2019 #}
-    <div class="{% if status == 'succeeded' %} contribution-banner {% endif %} payment-confirmation">
+    <div class="{% if status == 'succeeded' %} contribution-banner {% endif %} payment-confirmation align-center">
         <div class="column-container">
             {% if status == 'succeeded' %}
                 <img src="{{ static('img/hero-dino-blank.png') }}" class="backdrop-image" alt="" role="presentation" />

--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -10,7 +10,7 @@
   {%- set recurring_payments_url = url('recurring_payment_initial') %}
   {%- set share_url = 'https://developer.mozilla.org' + payments_url %}
   {% translation 'en-US' %}{# Display in English until Q1 2019 #}
-    <div class="{% if status == 'succeeded' %} contribution-banner {% endif %} payment-confirmation align-center">
+    <div class="{% if status == 'succeeded' %}contribution-banner {% else %} align-center {% endif %} payment-confirmation">
         <div class="column-container">
             {% if status == 'succeeded' %}
                 <img src="{{ static('img/hero-dino-blank.png') }}" class="backdrop-image" alt="" role="presentation" />


### PR DESCRIPTION
Simply re-align the text to the centre.

**in this pr**
- https://trello.com/c/SMnw7COU/95-error-page-looks-off

Fixes this bug
![image](https://user-images.githubusercontent.com/11092019/49222427-b9767f80-f3d3-11e8-9ad5-bc0ca0b801a9.png)

