### PR TITLE
Add some validation and success info on feedback form.

### DIFF
--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -243,6 +243,7 @@
                 <form id="faq-feedback" class="faq-feedback">
                     <textarea data-action="FAQ Any other questions" placeholder="{{_('Your feedback goes here')}}" name="faq-feedback" id="contribution-feedback" cols="30" rows="2"></textarea>
                     <button type="submit"> {{_('Send')}} {% include 'includes/icons/arrows/arrow.svg' %}</button>
+                    <span class="feedback-confirmation hidden" aria-hidden="true">{{_('Thank you for submitting your feedback.')}}</span>
                 </form>
             </div>
         </section>

--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -139,6 +139,7 @@
                     <h3>{{_('Is there anything else you’d like to know more about?')}}</h3>
                     <textarea data-action="Thank you Feedback" placeholder="{{_('Your feedback goes here')}}" name="thank-you-feedback" id="contribution-feedback" cols="30" rows="2"></textarea>
                     <button type="submit"> {{_('Send')}} {% include 'includes/icons/arrows/arrow.svg' %}</button>
+                    <span class="feedback-confirmation hidden" aria-hidden="true">{{_('Thank you for submitting your feedback.')}}</span>
                 </form>
             </div>
         </section>

--- a/kuma/static/js/payments-faq.js
+++ b/kuma/static/js/payments-faq.js
@@ -6,6 +6,7 @@
     var thumbsUp = faqContainer.find('.thumbs-up');
     var thumbsDown = faqContainer.find('.thumbs-down');
     var faqFeedback = faqContainer.find('#faq-feedback');
+    var faqFeedbackConfirmation = faqContainer.find('.feedback-confirmation');
 
     function sendAnalyticsVoteEvent(action, label ,value) {
         var event = {
@@ -44,12 +45,18 @@
         event.preventDefault();
 
         var feedback = document.getElementById('contribution-feedback').value;
-        if (feedback) {
+        if (feedback && feedback.trim !== '') {
             mdn.analytics.trackEvent({
                 category: 'payments',
                 action: 'FAQ - Any other questions',
                 label: feedback,
+            }, function() {
+                faqFeedbackConfirmation.get(0).classList.remove('hidden');
+                faqFeedbackConfirmation.get(0).removeAttribute('aria-hidden');
+                faqFeedback.get(0).classList.add('disabled');
             });
+        } else {
+            faqFeedback.get(0).classList.remove('disabled');
         }
     }
 

--- a/kuma/static/styles/components/payments/page.scss
+++ b/kuma/static/styles/components/payments/page.scss
@@ -135,4 +135,8 @@
             margin-top: 0;
         }
     }
+    .feedback-confirmation {
+        float: right;
+        color: $blue;
+    }
 }


### PR DESCRIPTION
No confirmation or validation is attached to the feedback form on the FAQ/confirmation/error pages

**in this pr**
- https://trello.com/c/zFm1s07N/70-bug-no-confirmation-received-for-feedback-message-sent

**notes for QA**
- [ ] entering no text or whitespace will not send the feedback
- [ ] clicking submit with text should show the confirmation
- [ ] after submitting it should not be possible to submit again (until page reload)
- [ ] after submitting form should be greyed out to denote inactivity 

![screenshot 2018-11-29 at 13 07 53](https://user-images.githubusercontent.com/11092019/49223831-ceeda880-f3d7-11e8-8e47-a29c217438e4.png)
