### PR TITLE
bug 1490727: Remove clear field `x` from email input on IE on payments form.

### DIFF
--- a/kuma/static/styles/components/payments/form.scss
+++ b/kuma/static/styles/components/payments/form.scss
@@ -10,6 +10,11 @@
         text-align: center;
     }
 
+    // Remove 'x' from email input as it overlaps the hint action
+    input[type='email']::-ms-clear {
+        display: none;
+    }
+
     .legal-copy {
         font-size: 12px;
         font-weight: normal;


### PR DESCRIPTION
IE puts an `X` to the right of inputs in order to clear them.
This overlaps the `?` help text action on the email field, so we should disable the IE marker for this input.

**in this PR**
- https://trello.com/c/Vh52EyJj/96-internet-explorer-x-button-displayed-in-email-field-overlaps-the-button


**Screenshot of the bug:**
![screenshot 2018-11-29 at 13 13 41](https://user-images.githubusercontent.com/11092019/49224239-ce094680-f3d8-11e8-920d-065d274a8249.png)
