### PR TITLE
Bug 879839 - Remove Summary style, rename SEO Summary option

### DIFF
--- a/kuma/wiki/jinja2/wiki/ckeditor_config.js
+++ b/kuma/wiki/jinja2/wiki/ckeditor_config.js
@@ -151,9 +151,8 @@
         { name: 'Warning Box', element: 'div', attributes: { 'class': 'blockIndicator warning', 'role': 'region', 'aria-label': gettext('Important note') }, type: 'wrap' },
         { name: 'Two Columns', element: 'div', attributes: { 'class': 'twocolumns' }, type: 'wrap' },
         { name: 'Three Columns', element: 'div', attributes: { 'class': 'threecolumns' }, type: 'wrap' },
-        { name: 'Article Summary', element: 'p', attributes: { 'class': 'summary' } },
         { name: 'Syntax Box', element: 'pre', attributes: { 'class': 'syntaxbox' } },
-        { name: 'SEO Summary', element: 'span', attributes: { 'class': 'seoSummary' } },
+        { name: 'Summary', element: 'span', attributes: { 'class': 'seoSummary' } },
         { name: 'Hidden When Reading', element: 'div', attributes: { 'class': 'hidden' }, type: 'wrap' }
       ]);
     }


### PR DESCRIPTION
This patch removes the "Summary" style we've decided not to
use anymore and renames the existing SEO summary
option to simply "Summary", per discussion held on Discourse:
https://is.gd/ss9I6r