### PR TITLE
 Bug 1512490: Add Prism syntax definition for EJS

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "html5shiv": "3.6.2",
         "jquery": "2.2.0",
-        "prism": "1.2.0",
+        "prism": "1.15.0",
         "selectivizr": "https://github.com/keithclark/selectivizr.git#1.0.2"
     },
     "install": {
@@ -19,6 +19,7 @@
                 "bower_components/prism/components/prism-css.js",
                 "bower_components/prism/components/prism-clike.js",
                 "bower_components/prism/components/prism-javascript.js",
+                "bower_components/prism/components/prism-json.js",
                 "bower_components/prism/components/prism-css-extras.js",
                 "bower_components/prism/components/prism-rust.js",
                 "bower_components/prism/plugins/line-highlight/prism-line-highlight.js",

--- a/bower.json
+++ b/bower.json
@@ -4,6 +4,7 @@
         "html5shiv": "3.6.2",
         "jquery": "2.2.0",
         "prism": "1.15.0",
+        "prism-ejs-language": "https://github.com/dutchenkoOleg/prism-ejs-language.git#ff0ccdf0422de25551a0ee93061dbe1bb156784a",
         "selectivizr": "https://github.com/keithclark/selectivizr.git#1.0.2"
     },
     "install": {
@@ -29,6 +30,7 @@
                 "bower_components/prism/plugins/line-highlight/prism-line-highlight.css",
                 "bower_components/prism/plugins/line-numbers/prism-line-numbers.css"
             ],
+            "prism-ejs-language": "bower_components/prism-ejs-language/prism-ejs-language.js",
             "selectivizr": "bower_components/selectivizr/selectivizr.js"
         }
     }

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -987,6 +987,7 @@ PIPELINE_JS = {
             "js/libs/prism/prism-css.js",
             "js/libs/prism/prism-clike.js",
             "js/libs/prism/prism-javascript.js",
+            "js/libs/prism/prism-json.js",
             "js/libs/prism/prism-css-extras.js",
             "js/libs/prism/prism-rust.js",
             "js/libs/prism/prism-line-highlight.js",

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -992,6 +992,7 @@ PIPELINE_JS = {
             "js/libs/prism/prism-rust.js",
             "js/libs/prism/prism-line-highlight.js",
             "js/libs/prism/prism-line-numbers.js",
+            "js/libs/prism-ejs-language/prism-ejs-language.js",
 
             'js/prism-mdn/components/prism-json.js',
             'js/syntax-prism.js',

--- a/kuma/static/js/libs/prism-ejs-language/prism-ejs-language.js
+++ b/kuma/static/js/libs/prism-ejs-language/prism-ejs-language.js
@@ -1,0 +1,53 @@
+(function () {
+	'use strict';
+
+	if (typeof Prism === 'undefined') {
+		console.log('Prism is not defined');
+		return false;
+	}
+
+	if (!Prism.languages.markup || !Prism.languages.javascript) {
+		console.log('prism-ejs-language required markup and javascript languages');
+		return false;
+	}
+
+	Prism.languages.ejs = Prism.languages.extend('markup', {
+		'comment': /(<%%?#)[\s\S]*?([-]?%%?>)/g,
+		'punctuation': /(<%%?[-|=|_]?|[-|_]?%%?>|\/?>)/g,
+		'entity': /&#?[\da-z]{1,8};/i,
+		'attr-name': {
+			pattern: /[^\s>\/]+/,
+			inside: {
+				'namespace': /^[^\s>\/:]+:/,
+				'tag': {
+					pattern: /<\w+/,
+					inside: {
+						punctuation: /^</
+					}
+				},
+				'attr-value': {
+					pattern: /=(?:("|')(?:\\[\s\S]|(?!\1)[^\\])*\1|[^\s'">=]+)/i,
+					inside: {
+						'punctuation': [
+							/^=/,
+							{
+								pattern: /(^|[^\\])["']/,
+								lookbehind: true
+							}
+						]
+					}
+				},
+				'punctuation': /=/
+			}
+		}
+	});
+
+	Prism.languages.insertBefore('ejs', 'tag', {
+		script: {
+			pattern: /(<%%?[-|=|_]?)[\s\S]*?(?=[-|_]?%%?>)/i,
+			lookbehind: !0,
+			inside: Prism.languages.javascript,
+			alias: 'language-javascript'
+		}
+	});
+}());

--- a/kuma/static/js/libs/prism/prism-json.js
+++ b/kuma/static/js/libs/prism/prism-json.js
@@ -1,0 +1,14 @@
+Prism.languages.json = {
+	'property': /"(?:\\.|[^\\"\r\n])*"(?=\s*:)/i,
+	'string': {
+		pattern: /"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
+		greedy: true
+	},
+	'number': /\b0x[\dA-Fa-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:[Ee][+-]?\d+)?/,
+	'punctuation': /[{}[\]);,]/,
+	'operator': /:/g,
+	'boolean': /\b(?:true|false)\b/i,
+	'null': /\bnull\b/i
+};
+
+Prism.languages.jsonp = Prism.languages.json;

--- a/kuma/static/js/prism-mdn/components/prism-json.js
+++ b/kuma/static/js/prism-mdn/components/prism-json.js
@@ -1,4 +1,4 @@
-Prism.languages.json = Prism.languages.extend('javascript');
-Prism.languages.insertBefore('json', 'string', {
-    'key': /("|')(\\?.)*?\1(\s+)?\:/g
-});
+Prism.languages.json.property = {
+    pattern: Prism.languages.json.property,
+    alias: 'key'
+};

--- a/kuma/static/styles/libs/prism/prism.css
+++ b/kuma/static/styles/libs/prism/prism.css
@@ -7,9 +7,9 @@
 code[class*="language-"],
 pre[class*="language-"] {
 	color: black;
+	background: none;
 	text-shadow: 0 1px white;
 	font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-	direction: ltr;
 	text-align: left;
 	white-space: pre;
 	word-spacing: normal;
@@ -62,6 +62,7 @@ pre[class*="language-"] {
 :not(pre) > code[class*="language-"] {
 	padding: .1em;
 	border-radius: .3em;
+	white-space: normal;
 }
 
 .token.comment,
@@ -103,7 +104,7 @@ pre[class*="language-"] {
 .token.url,
 .language-css .token.string,
 .style .token.string {
-	color: #a67f59;
+	color: #9a6e3a;
 	background: hsla(0, 0%, 100%, .5);
 }
 
@@ -113,7 +114,8 @@ pre[class*="language-"] {
 	color: #07a;
 }
 
-.token.function {
+.token.function,
+.token.class-name {
 	color: #DD4A68;
 }
 


### PR DESCRIPTION
See [bug&nbsp;1512490](https://bugzilla.mozilla.org/show_bug.cgi?id=1512490) for details.

Also updates PrismJS to version 1.15, which adds official support for JSON syntax highlighting.

review?(@davidflanagan, @Elchi3, @jwhitlock, @wbamberg)