### PR TITLE
Bug 1509357: redirect En/ and EN/ to en-US/

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -89,19 +89,24 @@ class LocaleStandardizerMiddleware(MiddlewareBase):
 
         literal_from_path = request.path_info.split('/')[1]
         fixed_locale = None
+        lower_literal = literal_from_path.lower()
+        lower_language = language_from_path.lower()
         match = literal_from_path == language_from_path
-        lower_match = literal_from_path.lower() == language_from_path.lower()
-        if lower_match and (language_from_path != literal_from_path):
+        lower_match = lower_literal == lower_language
+
+        if not match and lower_match:
             # Convert locale prefix to the preferred case (en-us -> en-US)
             fixed_locale = language_from_path
-        elif literal_from_path.lower() in settings.LOCALE_ALIASES:
+        elif lower_literal in settings.LOCALE_ALIASES:
             # Fix special cases (cn -> zh-CN, zh-Hans -> zh-CN)
-            fixed_locale = settings.LOCALE_ALIASES[literal_from_path.lower()]
-        elif not match and literal_from_path.startswith(language_from_path):
+            fixed_locale = settings.LOCALE_ALIASES[lower_literal]
+        elif not match and lower_literal.startswith(lower_language):
             # Convert regional to generic locale prefix (fr-FR -> fr)
+            # Case-insensitive so FR-Fr also goes to fr
             fixed_locale = language_from_path
-        elif not match and language_from_path.startswith(literal_from_path):
+        elif not match and lower_language.startswith(lower_literal):
             # Convert generic to regional locale prefix (pt -> pt-PT)
+            # Case-insensitive so PT -> pt-PT and En -> en-US
             fixed_locale = language_from_path
 
         if fixed_locale:

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -36,6 +36,12 @@ PICKER_CASES = SIMPLE_ACCEPT_CASES + WEIGHTED_ACCEPT_CASES + (
 REDIRECT_CASES = [
     ('cn', 'zh-CN'),  # General to locale-specific in different general locale
     ('pt', 'pt-PT'),  # General to locale-specific
+    ('PT', 'pt-PT'),  # It does a case-insensitive comparison
+    ('fr-FR', 'fr'),  # Country-specific to language-only
+    ('Fr-fr', 'fr'),  # It does a case-insensitive comparison
+    ('en', 'en-US'),  # Ensure that en redirects to en-US, case insensitive
+    ('En', 'en-US'),
+    ('EN', 'en-US'),
     ('zh-Hans', 'zh-CN'),  # Django-preferred to Mozilla standard locale
     ('zh_tw', 'zh-TW'),  # Underscore and capitalization fix
 ] + [(orig, new) for (orig, new) in SIMPLE_ACCEPT_CASES if orig != new]
@@ -53,7 +59,7 @@ def test_locale_middleware_picker(accept_language, locale, client, db):
 
 @pytest.mark.parametrize('original,fixed', REDIRECT_CASES)
 def test_locale_middleware_fixer(original, fixed, client, db):
-    '''The LocaleMiddleware redirects for non-standard locale URLs.'''
+    '''The LocaleStandardizerMiddleware redirects non-standard locale URLs.'''
     response = client.get('/%s/' % original)
     assert response.status_code == 302
     assert response['Location'] == '/%s/' % fixed
@@ -61,7 +67,7 @@ def test_locale_middleware_fixer(original, fixed, client, db):
 
 
 def test_locale_middleware_fixer_confusion(client, db):
-    '''The LocaleMiddleware treats unknown locales as 404s.'''
+    '''The LocaleStandardizerMiddleware treats unknown locales as 404s.'''
     response = client.get('/xx/')
     assert response.status_code == 404
 


### PR DESCRIPTION
Kuma's locale middleware correctly detects the desired language when
non-standard capitalization is used. "En" is detected as "en-US",
"PT" is detected as "pt-PT", and "FR-FR" is detected as "fr". But even
though the language is corrected detected from the path, the
LocaleStandardizerMiddleware does a case-insensitive prefix match
between the path and the detected language and responds with a 404
in this case becasue "En" is not a prefix of "en-US" and because
"fr" is not a prefix of "FR-FR".

This patch modifies LocaleStandardizerMiddleware to do case-insensitive
comparisons so that locales like "En", "EN", "PT" and "FR-FR" that
previously gave unnecessary 404s now redirect to a canonical locale.

Note that the middleware has all along allowed locales like "en-U" to
redirect to "en-US". It probably shouldn't do that, but it does, so this
new addition of case-insensitive matching now means that "en-u" also
redirects to "en-US".

Test Plan:

Verify that the following URLs redirect to valid pages:

- https://developer.mozilla.org/En/docs/Web/CSS
- https://developer.mozilla.org/EN/docs/Web/CSS
- https://developer.mozilla.org/PT/docs/Web/CSS
- https://developer.mozilla.org/fr-FR/docs/Web/CSS