### PR TITLE
bug 1462400: fix test_robots for attachments domains

### DIFF
--- a/tests/headless/__init__.py
+++ b/tests/headless/__init__.py
@@ -5,12 +5,6 @@ import pytest
 pytest.register_assert_rewrite('utils.urls')
 
 
-# Untrusted attachments and samples domains that are indexed
-INDEXED_ATTACHMENT_DOMAINS = set((
-    'mdn.mozillademos.org',         # Main attachments domain
-    'mdn-demos-origin.moz.works',   # Attachments origin
-))
-
 # Kuma web domains that are indexed
 INDEXED_WEB_DOMAINS = set((
     'developer.mozilla.org',    # Main website, CDN origin

--- a/tests/headless/test_robots.py
+++ b/tests/headless/test_robots.py
@@ -3,7 +3,7 @@ from urlparse import urlsplit
 import pytest
 import requests
 
-from . import INDEXED_ATTACHMENT_DOMAINS, INDEXED_WEB_DOMAINS
+from . import INDEXED_WEB_DOMAINS
 
 
 @pytest.mark.smoke
@@ -16,9 +16,7 @@ def test_robots(any_host_url):
 
     urlbits = urlsplit(any_host_url)
     hostname = urlbits.netloc
-    if hostname in INDEXED_ATTACHMENT_DOMAINS:
-        assert response.content.strip() == ''
-    elif hostname in INDEXED_WEB_DOMAINS:
+    if hostname in INDEXED_WEB_DOMAINS:
         assert 'Sitemap: ' in response.content
         assert 'Disallow: /admin/\n' in response.content
     else:


### PR DESCRIPTION
This PR fixes the `test_robots` test within `tests/headless/test_robots.py` when run against https://developer.mozilla.org (typically via the `prod-integration-tests` branch), since only then was the attachment domain (`mdn.mozillademos.org`) provided as one of the values for the dynamic pytest fixture `any_host_url`. In that case, the attachment domain case should be handled the same as a non-indexed domain.