### PR TITLE
Issue 683: Kuma-side changes for simplifying KumaScript

### DIFF
--- a/kuma/scrape/scraper.py
+++ b/kuma/scrape/scraper.py
@@ -36,6 +36,12 @@ class Requester(object):
         return self._session
 
     def request(self, path, raise_for_status=True, method='GET'):
+        # When doing a long-running recursive scrape, you may find
+        # it useful to uncomment the following two lines. The sleep
+        # helps to avoid rate-limiting, and the print allows you to
+        # monitor the progress of your scrape.
+        # time.sleep(1)
+        # print path
         url = self.base_url + path
         logger.debug("%s %s", method, url)
         attempts = 0

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -564,7 +564,7 @@ class Document(NotificationsMixin, models.Model):
             # A timeout of 0 should shortcircuit kumascript usage.
             self.rendered_html, self.rendered_errors = self.html, []
         else:
-            self.rendered_html, errors = kumascript.get(self, cache_control,
+            self.rendered_html, errors = kumascript.get(self,
                                                         base_url,
                                                         timeout=timeout)
             self.rendered_errors = errors and json.dumps(errors) or None

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -684,7 +684,7 @@ class DeferredRenderingTests(UserTestCase):
         config.KUMASCRIPT_TIMEOUT = 1.0
         rendered_content = self.rendered_content
 
-        def my_kumascript_get(self, cache_control, base_url, timeout):
+        def my_kumascript_get(self, base_url, timeout):
             time.sleep(1.0)
             return (rendered_content, None)
 

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -521,31 +521,21 @@ def test_kumascript_error_reporting(admin_client, root_doc, ks_toolbox,
     )
     mock_ks_config = mock.patch('kuma.wiki.kumascript.config', **ks_settings)
     with mock_ks_config:
+        mock_requests.post(
+            requests_mock.ANY,
+            text='HELLO WORLD',
+            headers=ks_toolbox.errors_as_headers,
+        )
+        mock_requests.get(
+            requests_mock.ANY,
+            **ks_toolbox.macros_response
+        )
         if endpoint == 'preview':
-            mock_requests.post(
-                requests_mock.ANY,
-                text='HELLO WORLD',
-                headers=ks_toolbox.errors_as_headers,
-            )
-            mock_requests.get(
-                requests_mock.ANY,
-                **ks_toolbox.macros_response
-            )
             response = admin_client.post(
                 reverse('wiki.preview'),
                 dict(content='anything truthy')
             )
         else:
-            mock_requests.get(
-                requests_mock.ANY,
-                [
-                    dict(
-                        text='HELLO WORLD',
-                        headers=ks_toolbox.errors_as_headers
-                    ),
-                    ks_toolbox.macros_response,
-                ]
-            )
             with mock.patch('kuma.wiki.models.config', **ks_settings):
                 response = admin_client.get(root_doc.get_absolute_url())
 

--- a/scripts/dump_local_db.sh
+++ b/scripts/dump_local_db.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+#################
+# Setup Variables
+#################
+
+if [ -z "$DATABASE_URL" ]; then
+    echo "DATABASE_URL must be a valid connection URL. Are you in the docker environment?"
+    exit 1
+fi
+
+# Parse DATABASE_URL for database connection parts
+# DATABASE_URL=mysql://root:kuma@mysql:3306/developer_mozilla_org
+DB_NAME=${DATABASE_URL##*/}      # Name is after final slash
+DB_URL_BASE=${DATABASE_URL%/*}   # Everything except the name
+DB_PORT=${DB_URL_BASE##*:}       # Capture port (3306)
+DB_TMP=${DB_URL_BASE%:*}         # Drop :3306 and...
+DB_TMP=${DB_TMP#*://}            # Drop mysql://
+DB_USER=${DB_TMP%:*}             # Capture user (root)
+DB_TMP=${DB_TMP#*:}              # Drop user
+DB_PASSWORD=${DB_TMP%@*}         # Capture password (kuma)
+DB_HOST=${DB_TMP#*@}             # Capture hostname (mysql)
+
+
+echo "*** Exporting to ${DB_NAME}.sql"
+# Export to SQL file
+mysqldump --host=$DB_HOST --user=$DB_USER --password=$DB_PASSWORD \
+  $DB_NAME > ${DB_NAME}.sql
+echo "*** Compressing to ${DB_NAME}.sql.gz"
+gzip ${DB_NAME}.sql

--- a/scripts/extract_documents.py
+++ b/scripts/extract_documents.py
@@ -1,0 +1,66 @@
+""" A script to extract raw and rendered versions of all documents in the db
+
+This script extracts documents from the db into a testdocs/ directory.
+It is intended for creating a test corpus and verifying that changes
+to kuma and/or kumascript do not cause rendering changes to the documents.
+
+In order to make it work it may be necessary to modify the KUMASCRIPT_TIMEOUT
+setting in kuma/settings/common.py to be at least 60 seconds
+"""
+
+import json
+import os
+import os.path
+import sys
+from datetime import datetime
+
+# Adjust the path so the imports below all work.
+sys.path[0] = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+import django
+from django.conf import settings
+
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'kuma.settings.testing')
+django.setup()
+
+import kuma.wiki.models
+import kuma.wiki.kumascript
+sys.exit(1)
+
+for d in kuma.wiki.models.Document.objects.all():
+    path = d.get_absolute_url()[1:]  + '.html' # strip off the leading /
+    rawfilename = os.path.join('./testdocs/raw', path)
+    rawdirname = os.path.dirname(rawfilename)
+    if not os.path.exists(rawdirname):
+        os.makedirs(rawdirname)
+
+    renderedfilename = os.path.join('./testdocs/rendered', path)
+    rendereddirname = os.path.dirname(renderedfilename)
+    if not os.path.exists(rendereddirname):
+        os.makedirs(rendereddirname)
+
+    print "writing {}: {}".format(rawfilename, len(d.html))
+    with open(rawfilename, 'w') as f:
+        f.write(d.html.encode('utf-8'))
+
+    print "starting render: {}".format(path)
+    start = datetime.now()
+    try:
+        rendered, errors = d.get_rendered()
+        end = datetime.now()
+        print "got rendered doc in: {}s".format(end-start)
+    except Exception as e:
+        print "writing rendering exception: {}".format(e)
+        with open(renderedfilename + ".exception", 'w') as f:
+            f.write(str(e).encode('utf-8'))
+        rendered = ""
+
+    if errors:
+        print "writing errors for: {}".format(path)
+        with open(renderedfilename + ".errors", 'w') as f:
+            f.write(json.dumps(errors).encode('utf-8'))
+
+    if rendered:
+        print "writing {}: {}".format(renderedfilename, len(rendered))
+        with open(renderedfilename, 'w') as f:
+            f.write(rendered.encode('utf-8'))


### PR DESCRIPTION
For https://github.com/mdn/sprints/issues/683 I'm trying to simplify
KumaScript. My first target is to remove the layers of HTTP caching
between Kuma and KumaScript so that I can try to remove the memcached
dependency (and save on hosting costs).

This patch is changes on the Kuma side to prepare for that refactoring.
First, the patch includes a couple of new scripts that I used to build
a test corpus of raw and rendered documents so I can be sure that my
KumaScript changes do not actually change how documents are rendered.

More substantially, this patch modifies kuma/wiki/kumascript.py to
change the get() function to actually make a POST request. This means
that the KumaScript no longer needs to support the GET request for
rendering