### PR TITLE
bug 1462400: fix test_header_signin and test_edit_sign_in

### DIFF
--- a/tests/functional/test_article.py
+++ b/tests/functional/test_article.py
@@ -69,10 +69,12 @@ def test_header_displays(base_url, selenium):
 @skip_if_maintenance_mode
 def test_header_signin(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
+    # avoid the task completion popup
+    page.disable_survey_popup()
     # click on sign in widget
-    page.header.trigger_signin()
-    # assert it's fowarded to github
-    assert 'https://github.com' in str(selenium.current_url)
+    page.header.signin_link.click()
+    # wait until it's fowarded to github
+    page.wait.until(lambda s: 'https://github.com' in s.current_url)
 
 
 @pytest.mark.smoke

--- a/tests/functional/test_article_edit.py
+++ b/tests/functional/test_article_edit.py
@@ -13,6 +13,8 @@ from utils.decorators import skip_if_maintenance_mode
 @skip_if_maintenance_mode
 def test_edit_sign_in(base_url, selenium):
     page = ArticlePage(selenium, base_url).open()
+    # avoid the task completion popup
+    page.disable_survey_popup()
     # click edit
     page.click_edit(False)
     # check prompted for sign in

--- a/tests/functional/test_home.py
+++ b/tests/functional/test_home.py
@@ -68,12 +68,10 @@ def test_header_tech_submenu(base_url, selenium):
 @skip_if_maintenance_mode
 def test_header_signin(base_url, selenium):
     page = HomePage(selenium, base_url).open()
-    old_url = selenium.current_url
     # click on sign in widget
-    page.header.trigger_signin()
-    # assert it's fowarded to github
-    page.wait.until(lambda s: s.current_url != old_url)
-    assert 'https://github.com' in str(selenium.current_url)
+    page.header.signin_link.click()
+    # wait until it's fowarded to github
+    page.wait.until(lambda s: 'https://github.com' in s.current_url)
 
 
 @pytest.mark.nondestructive

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -109,9 +109,6 @@ class BasePage(Page):
         def signin_link(self):
             return self.find_element(By.CSS_SELECTOR, self.SIGNIN_SELECTOR)
 
-        def trigger_signin(self):
-            self.signin_link.click()
-
         @property
         def is_signin_displayed(self):
             return self.signin_link.is_displayed()


### PR DESCRIPTION
Both of these tests:
- `tests/functional/test_article.py::test_header_signin`
- `tests/functional/test_article_edit.py::test_edit_sign_in`

would sometimes fail due to their buttons being obscured by the task-completion survey, so I disabled the survey prior to clicking. I also removed the `trigger_signin` method from the `Header` class, replacing it with `.signin_link.click()`, as I thought it was more direct and readable (i.e., the method led me to think it was doing something more than just clicking on the sign-in link).