### PR TITLE
bug 1483072: update prod attachment origin

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1165,7 +1165,7 @@ _PROD_ATTACHMENT_HOST = 'mdn.mozillademos.org'
 _PROD_ATTACHMENT_SITE_URL = 'https://' + _PROD_ATTACHMENT_HOST
 ATTACHMENT_HOST = config('ATTACHMENT_HOST', default=_PROD_ATTACHMENT_HOST)
 ATTACHMENT_SITE_URL = PROTOCOL + ATTACHMENT_HOST
-_PROD_ATTACHMENT_ORIGIN = 'mdn-demos-origin.moz.works'
+_PROD_ATTACHMENT_ORIGIN = 'demos-origin.mdn.mozit.cloud'
 ATTACHMENT_ORIGIN = config('ATTACHMENT_ORIGIN', default=_PROD_ATTACHMENT_ORIGIN)
 
 # This should never be false for the production and stage deployments.

--- a/tests/headless/__init__.py
+++ b/tests/headless/__init__.py
@@ -7,8 +7,8 @@ pytest.register_assert_rewrite('utils.urls')
 
 # Untrusted attachments and samples domains that are indexed
 INDEXED_ATTACHMENT_DOMAINS = set((
-    'mdn.mozillademos.org',         # Main attachments domain
-    'mdn-demos-origin.moz.works',   # Attachments origin
+    'mdn.mozillademos.org',          # Main attachments domain
+    'demos-origin.mdn.mozit.cloud',  # Attachments origin
 ))
 
 # Kuma web domains that are indexed


### PR DESCRIPTION
Thanks to @jwhitlock, who pointed out that we're not serving the correct `robots.txt` file for the attachments domain. We should be serving an empty string for `robots.txt` for `mdn.mozillademos.org` (and its origin `demos-origin.mdn.mozit.cloud`), but instead we've been serving `ROBOTS_GO_AWAY_TXT` since we cut-over to the MozIT-based infrastructure. That was my fault for overlooking the need for this update during the cut-over. This PR corrects that oversight.