### PR TITLE
Fix Bug 1509833, ensure browser text labels are consistent across all pages for BCD tables

### DIFF
--- a/kuma/static/styles/components/compat-tables/bc-icons.scss
+++ b/kuma/static/styles/components/compat-tables/bc-icons.scss
@@ -4,18 +4,16 @@
 .bc-browsers {
     .bc-head-txt-label {
         display: inline-block;
-        margin: 0 0 0 50px;
+        bottom: 0;
+        margin: 0 0 20px 10px;
         padding: 0;
-        width: 140px;
-        height: 210px;
+        width: 20px;
+        height: 20px;
         transform: rotate(-90deg);
+        transform-origin: left;
         @include set-font-size($small-bump-font-size);
         text-align: left;
         white-space: nowrap;
-
-        @media #{$mq-tablet-only} {
-            margin-left: 42px;
-        }
 
         &:before {
             position: absolute;

--- a/kuma/static/styles/components/compat-tables/bc-table.scss
+++ b/kuma/static/styles/components/compat-tables/bc-table.scss
@@ -106,6 +106,8 @@ Table layout
 .bc-table .bc-browsers th {
     border-top: 0;
     padding: 3px 0;
+    height: 200px;
+    vertical-align: bottom;
     @include set-font-size(22px);
 }
 
@@ -206,6 +208,20 @@ tablet display
     /* tablet */
     @media #{$mq-tablet-only} {
         @include bc-table-tablet-display-grid();
+    }
+
+    @media #{$mq-tablet-small-desktop-only} {
+        /* At this breakpoint the table uses grid layout
+           where supported. This stops `vertical-align: bottom`
+           on `.bc-table .bc-browsers th` from working so, we need
+           to switch to this workaround to ensure the layout
+           still works. */
+        .bc-browsers {
+            .bc-head-txt-label {
+                position: relative;
+                bottom: -150px;
+            }
+        }
     }
 
     /* small desktop, but only if there's a left column */

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -205,6 +205,7 @@ $mq-mobile-and-up: 'all and (min-width: #{$mobile-starts})';
 $mq-large-desktop-only: 'all and (min-width: #{$small-desktop-ends})';
 $mq-small-desktop-only: 'all and (min-width: #{$small-desktop-starts}) and (max-width: #{$small-desktop-ends})';
 $mq-tablet-only: 'all and (min-width: #{$tablet-starts}) and (max-width: #{$tablet-ends})';
+$mq-tablet-small-desktop-only: 'all and (min-width: #{$tablet-starts}) and (max-width: #{$small-desktop-ends})';
 $mq-mobile-only: 'all and (min-width: #{$mobile-starts}) and (max-width: #{$mobile-ends})';
 $mq-small-mobile-only: 'all and (max-width: #{$small-mobile-ends})';
 


### PR DESCRIPTION
Problem is described here[https://github.com/mdn/sprints/issues/680] and in the screenshots below:

## Before

![screenshot 2019-01-04 at 16 33 41](https://user-images.githubusercontent.com/10350960/50693129-c0318b80-103e-11e9-9e39-dee0b2ae4763.png)

## After

![screenshot 2019-01-04 at 16 33 51](https://user-images.githubusercontent.com/10350960/50693140-c889c680-103e-11e9-9662-aa9e0b4e01cb.png)

Tested in Firefox, Chrome, Safari, Edge and IE11

@davidflanagan 	r?