### PR TITLE
Fix "?redirect=no" for document-based redirects (bug 1404669)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,7 +102,7 @@ services:
       - log__console=true
       - log__file=
       - server__template_root_dir=macros
-      - server__document_url_template=http://api:8000/en-US/docs/{path}?raw=1
+      - server__document_url_template=http://api:8000/en-US/docs/{path}?raw=1&redirect=no
       - server__memcache__server=memcached:11211
       - server__template_class=EJSTemplate
       - server__autorequire__mdn=MDN:Common

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -34,53 +34,6 @@ from ..models import Document, RevisionIP
 from ..templatetags.jinja_helpers import get_compare_url
 
 
-class RedirectTests(UserTestCase, WikiTestCase):
-    """Tests for the REDIRECT wiki directive"""
-
-    def test_redirect_suppression(self):
-        """The document view shouldn't redirect when passed redirect=no."""
-        rev = revision(is_approved=True, save=True,
-                       content='REDIRECT <a class="redirect" '
-                               'href="/en-US/docs/blah">smoo</a>')
-        url = rev.document.get_absolute_url() + '?redirect=no'
-        response = self.client.get(url, follow=True)
-        self.assertContains(response, 'REDIRECT ')
-
-    def test_redirects_only_internal(self):
-        """Ensures redirects cannot be used to link to other sites"""
-        rev = revision(is_approved=True, save=True,
-                       content='REDIRECT <a class="redirect" '
-                               'href="//davidwalsh.name">DWB</a>')
-        url = rev.document.get_absolute_url()
-        response = self.client.get(url, follow=True)
-        self.assertContains(response, 'DWB')
-
-    def test_redirects_only_internal_2(self):
-        """Ensures redirects cannot be used to link to other sites"""
-        rev = revision(is_approved=True, save=True,
-                       content='REDIRECT <a class="redirect" '
-                               'href="http://davidwalsh.name">DWB</a>')
-        url = rev.document.get_absolute_url()
-        response = self.client.get(url, follow=True)
-        self.assertContains(response, 'DWB')
-
-    def test_self_redirect_suppression(self):
-        """The document view shouldn't redirect to itself."""
-        slug = 'redirdoc'
-        html = ('REDIRECT <a class="redirect" href="/en-US/docs/%s">smoo</a>' %
-                slug)
-
-        doc = document(title='blah', slug=slug, html=html, save=True,
-                       locale=settings.WIKI_DEFAULT_LANGUAGE)
-        revision(document=doc, content=html, is_approved=True, save=True)
-
-        response = self.client.get(doc.get_absolute_url(), follow=True)
-        assert 200 == response.status_code
-        response_html = pq(response.content)
-        article_body = to_html(response_html.find('#wikiArticle'))
-        self.assertHTMLEqual(html, article_body)
-
-
 class ViewTests(UserTestCase, WikiTestCase):
     fixtures = UserTestCase.fixtures + ['wiki/documents.json']
 

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -3,6 +3,8 @@ from urlparse import urlsplit
 
 import pytest
 import requests
+from pyquery import PyQuery
+
 
 from . import INDEXED_WEB_DOMAINS
 
@@ -45,6 +47,34 @@ def test_document(base_url, is_indexed):
         assert content == 'index, follow'
     else:
         assert content == 'noindex, nofollow'
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+def test_document_based_redirection(base_url):
+    """Ensure that content-based redirects properly redirect."""
+    url = base_url + '/en-US/docs/MDN/Promote'
+    resp = requests.get(url)
+    assert resp.status_code == 200
+    assert len(resp.history) == 1
+    assert resp.history[0].status_code == 301
+    assert resp.url == base_url + '/en-US/docs/MDN/About/Promote'
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+def test_document_based_redirection_suppression(base_url):
+    """
+    Ensure that the redirect directive and not the content of the target
+    page is displayed when content-based redirects are suppressed.
+    """
+    url = base_url + '/en-US/docs/MDN/Promote?redirect=no'
+    resp = requests.get(url)
+    assert resp.status_code == 200
+    assert not resp.history
+    body = PyQuery(resp.text)('#wikiArticle')
+    assert body.text().startswith('REDIRECT ')
+    assert body.find('a[href="/en-US/docs/MDN/About/Promote"]')
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
See [bug 1404669](https://bugzilla.mozilla.org/show_bug.cgi?id=1404669) for more context.

This PR:
- fixes `?redirect=no` handling for content-based redirects within the development environment (it does not fix the bug for the stage and production environments, for that and for a fuller explanation of this bug and its resolution, see https://github.com/mdn/infra/pull/168)
- since no current unit or functional tests are able to detect this bug, adds two headless functional tests, one of which specifically checks for this bug, that can be run against the sample, stage, and production databases
- refactors the existing content-based redirection tests into the `pytest` style

This PR is a companion to https://github.com/mdn/infra/pull/168, and if approved, should be merged along with that PR before making a deployment.

When testing, after powering-up your development environment with `docker-compose up -d`, the first run of:
```sh
pytest --base-url http://localhost:8000 tests/headless/test_endpoints.py::test_document_based_redirection_suppression
```
should fail, since the stale, incorrect, rendered content is still saved on the `/en-US/docs/MDN/Promote` document. Re-render that document:
```sh
docker-compose exec web ./manage.py render_document /en-US/docs/MDN/Promote
```
and then the test should run successfully.

I believe there are 12 documents within the sample database that are content-based redirects. We might want to consider creating a new sample database once this PR and https://github.com/mdn/infra/pull/168 have been deployed.