### PR TITLE
bug 1518653: Update to Django 1.11.18, hashin 0.14.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -33,9 +33,9 @@ dennis==0.9 \
     --hash=sha256:f6487392ac91800c5f0684a99b404b7fd0f72ceb48faeb5a0ce4e2c24fb62d3f
 
 # Web framework for Python projects of a certain age
-Django==1.11.16 \
-    --hash=sha256:29268cc47816a44f27308e60f71da635f549c47d8a1d003b28de55141df75791 \
-    --hash=sha256:37f5876c1fbfd66085001f4c06fa0bf96ef05442c53daf8d4294b6f29e7fa6b8
+Django==1.11.18 \
+    --hash=sha256:73cca1dac154e749b39cc91a54dc876109eb0512a5c6804986495305047066a5 \
+    --hash=sha256:7ee7d93d407f082e3849c8d10da50ff5b488af37ed1b0066a22dee5f2709ed16
 
 # 3rd party logins like Github
 # Code: https://github.com/pennersr/django-allauth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,9 @@ flake8-import-order==0.18 \
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin
-hashin==0.13.4 \
-    --hash=sha256:4e7731953dda1bbc1bbd11c80eef9bdcb2c0995be3a55807aa14991d197af6f9 \
-    --hash=sha256:a038ac6ff4bb881fe99b0c646c0624f803cd62486d461d82ed4fb6b2cce04e0f
+hashin==0.14.1 \
+    --hash=sha256:43ae3277fbd937ba1c99bc3fef9e4dd2e68cd5f2eea8f60ebdb53d83983d861b \
+    --hash=sha256:5dbf06b2adc32e5e438b9b9b352622b787c8555d4a2aa88b38d64764526f81a1
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
* hashin 0.13.4 → [0.14.1](https://github.com/peterbe/hashin#version-history): Adds ``--update-all`` and ``--interactive`` (which look interesting), support  extras syntax, and threaded PyPI requests. I use ``hashin`` to generate these PRs, so I keep it up to date.
* Django 1.11.16 → 1.11.18: Addresses [GeoDjango bug](https://docs.djangoproject.com/en/2.1/releases/1.11.17/), Python 3.7 compat, and a [security issue in the default 404 handler](https://www.djangoproject.com/weblog/2019/jan/04/security-releases/) (which Kuma replaces). This should have no effect, but tools may complain we're missing a security update.

