### PR TITLE
Bug 1518844: change the link to report a content bug

### DIFF
--- a/jinja2/includes/header-main-nav.html
+++ b/jinja2/includes/header-main-nav.html
@@ -60,7 +60,7 @@
                       <a href="{{ wiki_url('MDN/Community') }}">{{ _('Join the MDN community') }}</a>
                   </li>
                   <li>
-                      <a target="_blank" rel="noopener" href="https://bugzilla.mozilla.org/form.doc?bug_file_loc={{ request.build_absolute_uri()|urlencode }}">{{ _('Report a content problem') }}
+                      <a target="_blank" rel="noopener" href="https://github.com/mdn/sprints/issues/new?template=issue-template.md&projects=mdn/sprints/2&labels=user-report&title={{ request.build_absolute_uri()|urlencode }}">{{ _('Report a content problem') }}
                           {% include 'includes/icons/general/external-link.svg' %}
                       </a>
                   </li>


### PR DESCRIPTION
This changes the href of the Feedback>Report a content issue link
so that users report bugs on github instead of in bugzilla.