### PR TITLE
Fix the label of the seoSummary style to be just "Summary"

### DIFF
--- a/kuma/static/styles/wiki-wysiwyg.scss
+++ b/kuma/static/styles/wiki-wysiwyg.scss
@@ -32,7 +32,7 @@ body > h2 {
 
     &:before {
         @include set-font-size(10px);
-        content: 'SEO Summary';
+        content: 'Summary';
         position: absolute;
         top: -16px;
         left: 0;


### PR DESCRIPTION
In PR #5154, the name of the seoSummary class was changed
in the CKEditor menu to just "Summary". This patch makes
the same change to the CSS that is used to display the
style when in the editor, so that the label drawn above
the styled content says that instead of "SEO Summary".