### PR TITLE
Bug 1518844, remove focus rings from focusable elements, except for keyboard users

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -959,6 +959,7 @@ PIPELINE_JS = {
     },
     'payments': {
         'source_filenames': (
+            'js/components/payments/focus-visible.js',
             'js/components/payments/payments-handler-utils.js',
             'js/components/payments/payments-handler.js',
             'js/components/payments/payments-faq.js',

--- a/kuma/static/js/components/payments/focus-visible.js
+++ b/kuma/static/js/components/payments/focus-visible.js
@@ -1,0 +1,29 @@
+(function() {
+    'use strict';
+    var contributeForm = document.getElementById('contribute-form');
+
+    function removeFocusVisible() {
+        this.classList.remove('focus-visible');
+        this.removeEventListener('focusout', removeFocusVisible);
+    }
+
+    // When a keyup event is triggered on the contribute form,
+    contributeForm.addEventListener('keyup', function(event) {
+        var currentTarget = event.target;
+        var targetType = currentTarget.type;
+
+        /* The key pressed was the tab key, and the target field
+           type is one of `text`, `email`, or `number */
+        if (
+            event.key === 'Tab' &&
+            (targetType === 'text' ||
+                targetType === 'email' ||
+                targetType === 'number')
+        ) {
+            // add the `focus-visible` class.
+            currentTarget.classList.add('focus-visible');
+            // listen for when the field loses focus,
+            currentTarget.addEventListener('focusout', removeFocusVisible);
+        }
+    });
+})();

--- a/kuma/static/styles/components/payments/banner.scss
+++ b/kuma/static/styles/components/payments/banner.scss
@@ -28,6 +28,13 @@
     overflow: hidden;
     position: relative;
 
+    .contribute-lead-in h4,
+    .cta-link {
+        &:focus {
+            outline: 0;
+        }
+    }
+
     // Additional styling for when the banner acts a popover and is fixed to the
     // bottom of the viewport.
     &.contribution-popover {

--- a/kuma/static/styles/components/payments/form.scss
+++ b/kuma/static/styles/components/payments/form.scss
@@ -125,6 +125,16 @@
             padding-left: 12px;
             width: 100%;
 
+            &:focus {
+                outline: 0;
+            }
+
+            /* undo the above outline style when a user is navigating using the keyboard,
+               and the element receiving focus would normally receive specific focus styling */
+            &:focus-visible { /* stylelint-disable-line selector-pseudo-class-no-unknown */
+                outline: unset;
+            }
+
             &.error {
                 border-color: $error;
                 color: $error;
@@ -315,4 +325,9 @@
             display: inline-block;
         }
     }
+}
+
+/* utility class for keyboard focus style */
+.focus-visible {
+    box-shadow: 1px 1px 5px #2196f3, -1px -1px 5px #2196f3;
 }


### PR DESCRIPTION
Problem described in https://github.com/mdn/sprints/issues/705

We can eventually get rid of the JS once `:focus-visible` has wide enough browser support. You can read more on `:focus-visible` here:
https://drafts.csswg.org/selectors-4/#the-focus-visible-pseudo

@davidflanagan r?