### PR TITLE
Bug 1510719, remove special styling for summary class

### DIFF
--- a/kuma/static/styles/components/wiki/content/summary.scss
+++ b/kuma/static/styles/components/wiki/content/summary.scss
@@ -1,6 +1,0 @@
-/*
-wiki summary, usually displays at the top of the article
-********************************************************************** */
-.summary {
-    @include callout();
-}

--- a/kuma/static/styles/wiki.scss
+++ b/kuma/static/styles/wiki.scss
@@ -69,7 +69,6 @@ Styling for article content
 @import 'components/wiki/content/moreinfo';
 @import 'components/wiki/content/originaldocinfo';
 @import 'components/wiki/content/pull-aside';
-@import 'components/wiki/content/summary';
 @import 'components/wiki/customcss';
 @import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';


### PR DESCRIPTION
This changes sections marked with the class `summary` from

![screenshot 2019-01-16 at 10 37 49](https://user-images.githubusercontent.com/10350960/51236529-0bbb3200-197b-11e9-844f-b5331346d87c.png)

to 

![screenshot 2019-01-16 at 10 37 56](https://user-images.githubusercontent.com/10350960/51236538-11187c80-197b-11e9-9174-e0f7722afd6c.png)

As discussed in https://bugzilla.mozilla.org/show_bug.cgi?id=1510719 and https://discourse.mozilla.org/t/css-and-class-confusion-summary-vs-seosummary/30588/14

@wbamberg @davidflanagan r?