### PR TITLE
bug 1520574: Reduce file data passed to kumascript

### DIFF
--- a/kuma/wiki/kumascript.py
+++ b/kuma/wiki/kumascript.py
@@ -65,17 +65,8 @@ def post(request, content, locale=settings.LANGUAGE_CODE):
 
 def _get_attachment_metadata_dict(attachment):
     current_revision = attachment.current_revision
-    try:
-        filesize = current_revision.file.size
-    except OSError:
-        filesize = 0
     return {
-        'title': current_revision.title,
-        'description': current_revision.description,
         'filename': current_revision.filename,
-        'size': filesize,
-        'author': current_revision.creator.username,
-        'mime': current_revision.mime_type,
         'url': attachment.get_file_url(),
     }
 
@@ -137,7 +128,6 @@ def get(document, cache_control, base_url, timeout=None):
             locale=document.locale,
             title=document.title,
             files=files,
-            attachments=files,  # Just for sake of verbiage?
             slug=document.slug,
             tags=list(document.tags.names()),
             review_tags=list(document.current_revision.review_tags.names()),


### PR DESCRIPTION
With [node 10.14.0](
https://nodejs.org/en/blog/vulnerability/november-2018-security-releases/#denial-of-service-with-large-http-headers-cve-2018-1212), there is an 8K limit to HTTP headers. When file data is base64-encoded as a header, it can grow beyond 8K for some pages with 10 or more attachments. This results in a 400 error when rendering.

Reduce the attachment metadata to the filename and URL, which are the two attributes used by [Embed_text](https://github.com/mdn/kumascript/blob/master/macros/Embed_text.ejs) and [EmbedSVG](
https://github.com/mdn/kumascript/blob/master/macros/EmbedSVG.ejs), the only macros that use this data. Also, drop the "attachments" header, which encodes the same data but is unused.

This is a first step to removing these macros and no longer passing attachment data in the default environment.

To test:
1) In the development environment with the current code, edit an existing document and create an attachment with a very long description. I pasted the source of [docs/development.rst](https://raw.githubusercontent.com/mozilla/kuma/master/docs/development.rst).
2) Make a small change to start a render. A KumaScript error will be returned, ``Unexpected response from Kumascript service: 400``.
3) Switch to this code, force-refresh or make another small change. The page will render.