### PR TITLE
Bug 1520616: require login for the revision dashboard

### DIFF
--- a/kuma/dashboards/views.py
+++ b/kuma/dashboards/views.py
@@ -31,9 +31,9 @@ def index(request):
     return render(request, 'dashboards/index.html')
 
 
-@shared_cache_control
-@vary_on_headers('X-Requested-With')
+@never_cache
 @require_GET
+@login_required
 def revisions(request):
     """Dashboard for reviewing revisions"""
 

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -11,8 +11,11 @@ from utils.decorators import (
 
 
 @pytest.mark.smoke
+@pytest.mark.login
 @pytest.mark.nondestructive
 def test_dashboard(base_url, selenium):
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_new_user()
     page = DashboardPage(selenium, base_url).open()
     first_row = page.first_row
     # ip toggle not present
@@ -26,8 +29,11 @@ def test_dashboard(base_url, selenium):
 
 
 @pytest.mark.smoke
+@pytest.mark.login
 @pytest.mark.nondestructive
 def test_dashboard_open_details(base_url, selenium):
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_new_user()
     page = DashboardPage(selenium, base_url).open()
     # no dashboard-details
     assert page.details_items_length is 0
@@ -41,8 +47,11 @@ def test_dashboard_open_details(base_url, selenium):
 
 
 @pytest.mark.smoke
+@pytest.mark.login
 @pytest.mark.nondestructive
 def test_dashboard_load_page_two(base_url, selenium):
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_new_user()
     page = DashboardPage(selenium, base_url).open()
     # save id of first revision on page one
     first_row_id = page.first_row_id
@@ -55,6 +64,7 @@ def test_dashboard_load_page_two(base_url, selenium):
 
 
 @pytest.mark.xfail(reason='bug 1405690: fails for some revision diffs')
+@pytest.mark.login
 @pytest.mark.smoke
 @pytest.mark.nondestructive
 def test_dashboard_overflow(base_url, selenium):
@@ -63,17 +73,11 @@ def test_dashboard_overflow(base_url, selenium):
 
     bug 1405690 - some content causes overflows
     """
+    admin = AdminLogin(selenium, base_url).open()
+    admin.login_new_user()
     page = DashboardPage(selenium, base_url).open()
     page.open_first_details()
     assert page.scroll_width <= page.client_width
-
-
-@pytest.mark.nondestructive
-@skip_if_not_maintenance_mode
-def test_dashboard_in_mm(base_url, selenium):
-    page = DashboardPage(selenium, base_url).open()
-    assert page.is_maintenance_mode_banner_displayed
-    assert not page.header.is_signin_displayed
 
 
 @pytest.mark.smoke

--- a/tests/headless/test_cdn.py
+++ b/tests/headless/test_cdn.py
@@ -136,6 +136,7 @@ def test_maintenance_mode(base_url, is_behind_cdn, is_maintenance_mode):
 @pytest.mark.nondestructive
 @pytest.mark.parametrize(
     'slug', ['/en-US/dashboards/spam',
+             '/en-US/dashboards/revisions',
              '/en-US/profile',
              '/en-US/docs/new?slug=test',
              '/en-US/docs/preview-wiki-content',
@@ -272,24 +273,6 @@ def test_no_locale_cached_302(base_url, is_behind_cdn, slug, zone):
     """
     response = assert_cached(base_url + slug.format(zone), 302, is_behind_cdn)
     assert response.headers['location'].startswith('/docs/')
-
-
-@pytest.mark.nondestructive
-def test_revisions_dashboard(base_url, is_behind_cdn, kuma_status):
-    """
-    Ensure that the revisions dashboard is cached, and forwards/caches
-    based-on the "X-Requested-With" header and any query parameters.
-    """
-    url = base_url + '/en-US/dashboards/revisions'
-    params = {'page': 2}
-    headers = {'X-Requested-With': 'XMLHttpRequest'}
-    response1 = assert_cached(url, 200, is_behind_cdn)
-    response2 = assert_cached(url, 200, is_behind_cdn, headers=headers)
-    response3 = assert_cached(url, 200, is_behind_cdn, headers=headers,
-                              params=params)
-    assert response3.content != response2.content
-    assert response3.content != response1.content
-    assert response2.content != response1.content
 
 
 @pytest.mark.nondestructive


### PR DESCRIPTION
We believe that scrapers/crawlers hitting the revision dashboard
(while ignoring our robots.txt file) are causing significant
database load that is reducing performance of the site.

This patch changes the dashboards/revisions endpoint to require
login and to not be cached. The changes to kuma/dashboards/views.py
are trivial; most of the changes are adjustments to tests.