### PR TITLE
Bug 1518844, ensure focus is clearly indicated on amount radio buttons

### DIFF
--- a/__tests__/sass/mdn/_a11y-helpers-mixins-test.scss
+++ b/__tests__/sass/mdn/_a11y-helpers-mixins-test.scss
@@ -1,0 +1,15 @@
+@include describe('focus-visible') {
+    @include it(
+        'Returns a box-shadow style that is applied to elements that currently has focus'
+    ) {
+        @include assert {
+            @include output {
+                @include focus-visible();
+            }
+
+            @include expect {
+                box-shadow: 1px 1px 5px #2196f3, -1px -1px 5px #2196f3;
+            }
+        }
+    }
+}

--- a/__tests__/sass/test.scss
+++ b/__tests__/sass/test.scss
@@ -5,3 +5,4 @@
 
 /* Tests */
 @import 'mdn/typography-mixin-test';
+@import 'mdn/a11y-helpers-mixins-test';

--- a/kuma/static/js/components/payments/focus-visible.js
+++ b/kuma/static/js/components/payments/focus-visible.js
@@ -2,6 +2,9 @@
     'use strict';
     var contributeForm = document.getElementById('contribute-form');
 
+    /**
+     * Removes the `focus-visible` class form the current element
+     */
     function removeFocusVisible() {
         this.classList.remove('focus-visible');
         this.removeEventListener('focusout', removeFocusVisible);
@@ -11,6 +14,23 @@
     contributeForm.addEventListener('keyup', function(event) {
         var currentTarget = event.target;
         var targetType = currentTarget.type;
+
+        /* The key pressed was the tab key, or the left or right
+           arrow keys(used to cycle through radio buttons), and the
+           target field type is one of `radio` */
+        if (
+            (event.key === 'Tab' ||
+                event.key === 'ArrowLeft' ||
+                event.key === 'ArrowRight') &&
+            targetType === 'radio'
+        ) {
+            // get the parent label element
+            var radioButtonLabel = currentTarget.parentElement;
+            // add the `focus-visible` class
+            radioButtonLabel.classList.add('focus-visible');
+            // listen for when the field loses focus,
+            radioButtonLabel.addEventListener('focusout', removeFocusVisible);
+        }
 
         /* The key pressed was the tab key, and the target field
            type is one of `text`, `email`, or `number */

--- a/kuma/static/styles/components/payments/form.scss
+++ b/kuma/static/styles/components/payments/form.scss
@@ -319,5 +319,5 @@
 
 /* utility class for keyboard focus style */
 .focus-visible {
-    box-shadow: 1px 1px 5px #2196f3, -1px -1px 5px #2196f3;
+    @include focus-visible();
 }

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -44,6 +44,15 @@ Provides main mixins for use within the MDN theme.
     letter-spacing: -remify(-.05px);
 }
 
+/*
+Accessibility helpers
+====================================================================== */
+/* When changing the values of this mixin, remember to also update the
+   relevant test at __tests__/sass/mdn/_a11y-helpers-mixins-test.scss */
+@mixin focus-visible() {
+    box-shadow: 1px 1px 5px #2196f3, -1px -1px 5px #2196f3;
+}
+
 
 /*
 Vendor prefixes


### PR DESCRIPTION
Problem is described here(although not very clearly ;p)
https://github.com/mdn/sprints/issues/713

In essence, the problem is that even though the radio buttons do receive focus, and is navigable using the arrow keys, it is not clear when they have focus.

Here is the current behaviour on production. As can be seen, when focus is moved from the email field to the radio buttons, nothing actually indicates that the focus has moved to the `checked` radio button. It feels like focus moves from the email field, to someplace on the form, and then to the custom amount field.

![radio-fields-focus-current](https://user-images.githubusercontent.com/10350960/51323089-dc3a2180-1a6f-11e9-8bb1-7de5a3e942b9.gif)

Adding the `focus-visible` class with the clear focus ring solves the problem

![radio-fields-focus](https://user-images.githubusercontent.com/10350960/51322758-00493300-1a6f-11e9-8020-e0a97026d472.gif)

@davidflanagan r?