### PR TITLE
Bug 1490727: Cancel subscriptions when a user is deleted

### DIFF
--- a/kuma/payments/constants.py
+++ b/kuma/payments/constants.py
@@ -1,2 +1,4 @@
+from __future__ import unicode_literals
+
 CONTRIBUTION_BETA_FLAG = 'contrib_beta'
 RECURRING_PAYMENT_BETA_FLAG = 'recurring_payment_beta'

--- a/kuma/payments/context_processors.py
+++ b/kuma/payments/context_processors.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import json
 
 from django.conf import settings

--- a/kuma/payments/jinja2/payments/includes/payments-form.html
+++ b/kuma/payments/jinja2/payments/includes/payments-form.html
@@ -86,6 +86,6 @@
             oneTime: {{payments_form_donation_choices_json}},
             recurring: {{recurring_payment_form_donation_choices_json}}
         },
-        isAuthenticated: '{{user.is_authenticated()}}' === 'True'
+        isAuthenticated: '{{user.is_authenticated}}' === 'True'
     };
 </script>

--- a/kuma/payments/tasks.py
+++ b/kuma/payments/tasks.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import logging
 
 from celery.task import task

--- a/kuma/payments/tests/test_forms.py
+++ b/kuma/payments/tests/test_forms.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from decimal import Decimal
 
 import mock

--- a/kuma/payments/tests/test_utils.py
+++ b/kuma/payments/tests/test_utils.py
@@ -1,11 +1,8 @@
-import copy
-
 import mock
 
 from kuma.payments.utils import (
     cancel_stripe_customer_subscription,
-    get_stripe_customer_data,
-    stripe)
+    get_stripe_customer_data)
 
 
 # Subset of data returned for customer
@@ -22,51 +19,11 @@ simple_customer_data = {
 @mock.patch('stripe.Customer.retrieve', return_value=simple_customer_data)
 def test_get_stripe_customer_data(mock_retrieve):
     '''A customer's subscription can be retrieved.'''
-    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
+    data = get_stripe_customer_data('cust_id')
     assert data == {
         'stripe_plan_amount': 64,
         'stripe_card_last4': '0019',
         'active_subscriptions': True
-    }
-
-
-@mock.patch('stripe.Customer.retrieve',
-            side_effect=stripe.error.InvalidRequestError('bad stripe ID',
-                                                         'id'))
-def test_get_stripe_customer_data_invalid_request(mock_retrieve):
-    '''Blank info is returned for an invalid request.'''
-    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
-    assert data == {
-        'stripe_plan_amount': 0,
-        'stripe_card_last4': 0,
-        'active_subscriptions': False
-    }
-
-
-@mock.patch('stripe.Customer.retrieve')
-def test_get_stripe_customer_data_key_error(mock_retrieve):
-    '''Exceptions may cause partial data to be returned.'''
-    stripe_data = copy.deepcopy(simple_customer_data)
-    del stripe_data['sources']  # Will raise KeyError
-    mock_retrieve.return_value = stripe_data
-    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
-    assert data == {
-        'stripe_plan_amount': 64,
-        'stripe_card_last4': 0,
-        'active_subscriptions': True
-    }
-
-
-@mock.patch('stripe.Customer.retrieve')
-def test_get_stripe_customer_data_missing_data(mock_retrieve):
-    '''Missing data looks like a missing customer.'''
-    stripe_data = {'sources': None, 'subscription': None}
-    mock_retrieve.return_value = stripe_data
-    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
-    assert data == {
-        'stripe_plan_amount': 0,
-        'stripe_card_last4': 0,
-        'active_subscriptions': False
     }
 
 
@@ -75,8 +32,7 @@ def test_get_stripe_customer_data_missing_data(mock_retrieve):
             return_value=mock.Mock(spec_set=['delete']))
 def test_cancel_stripe_customer_subscription(mock_sub, mock_cust):
     '''A stripe customer's subscriptions can be cancelled.'''
-    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
-                                               'beth')
+    cancel_stripe_customer_subscription('cust_id')
     mock_sub.return_value.delete.assert_called_once_with()
 
 
@@ -90,8 +46,7 @@ def test_cancel_stripe_customer_subscription(mock_sub, mock_cust):
                          mock.Mock(spec_set=['delete'])])
 def test_cancel_stripe_customer_multiple_subscriptions(mock_sub, mock_cust):
     '''A stripe customer's subscriptions can be cancelled.'''
-    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
-                                               'beth')
+    cancel_stripe_customer_subscription('cust_id')
     assert mock_sub.call_count == 2
 
 
@@ -100,24 +55,5 @@ def test_cancel_stripe_customer_multiple_subscriptions(mock_sub, mock_cust):
 @mock.patch('stripe.Subscription.retrieve', side_effect=Exception('Oops'))
 def test_cancel_stripe_customer_no_subscriptions(mock_sub, mock_cust):
     '''A stripe customer with no subscriptions returns True.'''
-    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
-                                               'beth')
+    cancel_stripe_customer_subscription('cust_id')
     assert not mock_sub.called
-
-
-@mock.patch('stripe.Customer.retrieve',
-            side_effect=stripe.error.InvalidRequestError('bad stripe ID',
-                                                         'id'))
-def test_cancel_stripe_customer_invalid_request(mock_cust):
-    '''An invalid call to the Stripe API returns False.'''
-    assert not cancel_stripe_customer_subscription('cust_id',
-                                                   'beth@example.com', 'beth')
-    assert mock_cust.called
-
-
-@mock.patch('stripe.Customer.retrieve', side_effect=ValueError('Oops'))
-def test_cancel_stripe_customer_other_exception(mock_cust):
-    '''An exception during processing returns False.'''
-    assert not cancel_stripe_customer_subscription('cust_id',
-                                                   'beth@example.com', 'beth')
-    assert mock_cust.called

--- a/kuma/payments/tests/test_utils.py
+++ b/kuma/payments/tests/test_utils.py
@@ -1,0 +1,134 @@
+import copy
+
+import mock
+
+from kuma.payments.utils import (
+    cancel_stripe_customer_subscription,
+    get_stripe_customer_data,
+    stripe)
+
+
+class SubscriptionDict(dict):
+    """Cheap version of Stripe's Subscription object.
+
+    Allows access like dict (data['id']) or property (data.id)
+    """
+    @property
+    def id(self):
+        return self['id']
+
+
+# Subset of data returned for customer
+# https://stripe.com/docs/api/customers/retrieve
+simple_customer_data = {
+    'sources': {'data': [{'card': {'last4': '0019'}}]},
+    'subscriptions': {'data': [SubscriptionDict({
+        'id': 'sub_id',
+        'plan': {'amount': 6400},
+    })]},
+}
+
+
+@mock.patch('stripe.Customer.retrieve', return_value=simple_customer_data)
+def test_get_stripe_customer_data(mock_retrieve):
+    '''A customer's subscription can be retrieved.'''
+    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
+    assert data == {
+        'stripe_plan_amount': 64,
+        'stripe_card_last4': '0019',
+        'active_subscriptions': True
+    }
+
+
+@mock.patch('stripe.Customer.retrieve',
+            side_effect=stripe.error.InvalidRequestError('bad stripe ID',
+                                                         'id'))
+def test_get_stripe_customer_data_invalid_request(mock_retrieve):
+    '''Blank info is returned for an invalid request.'''
+    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
+    assert data == {
+        'stripe_plan_amount': 0,
+        'stripe_card_last4': 0,
+        'active_subscriptions': False
+    }
+
+
+@mock.patch('stripe.Customer.retrieve')
+def test_get_stripe_customer_data_key_error(mock_retrieve):
+    '''Exceptions may cause partial data to be returned.'''
+    stripe_data = copy.deepcopy(simple_customer_data)
+    del stripe_data['sources']  # Will raise KeyError
+    mock_retrieve.return_value = stripe_data
+    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
+    assert data == {
+        'stripe_plan_amount': 64,
+        'stripe_card_last4': 0,
+        'active_subscriptions': True
+    }
+
+
+@mock.patch('stripe.Customer.retrieve')
+def test_get_stripe_customer_data_missing_data(mock_retrieve):
+    '''Missing data looks like a missing customer.'''
+    stripe_data = {'sources': None, 'subscription': None}
+    mock_retrieve.return_value = stripe_data
+    data = get_stripe_customer_data('cust_id', 'beth@example.com', 'beth')
+    assert data == {
+        'stripe_plan_amount': 0,
+        'stripe_card_last4': 0,
+        'active_subscriptions': False
+    }
+
+
+@mock.patch('stripe.Customer.retrieve', return_value=simple_customer_data)
+@mock.patch('stripe.Subscription.retrieve',
+            return_value=mock.Mock(spec_set=['delete']))
+def test_cancel_stripe_customer_subscription(mock_sub, mock_cust):
+    '''A stripe customer's subscriptions can be cancelled.'''
+    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
+                                               'beth')
+    mock_sub.return_value.delete.assert_called_once_with()
+
+
+@mock.patch('stripe.Customer.retrieve',
+            return_value={
+                'subscriptions': {'data': [
+                    SubscriptionDict({'id': 'sub_id1'}),
+                    SubscriptionDict({'id': 'sub_id2'}),
+                ]}})
+@mock.patch('stripe.Subscription.retrieve',
+            side_effect=[mock.Mock(spec_set=['delete']),
+                         mock.Mock(spec_set=['delete'])])
+def test_cancel_stripe_customer_multiple_subscriptions(mock_sub, mock_cust):
+    '''A stripe customer's subscriptions can be cancelled.'''
+    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
+                                               'beth')
+    assert mock_sub.call_count == 2
+
+
+@mock.patch('stripe.Customer.retrieve',
+            return_value={'subscriptions': {'data': []}})
+@mock.patch('stripe.Subscription.retrieve', side_effect=Exception('Oops'))
+def test_cancel_stripe_customer_no_subscriptions(mock_sub, mock_cust):
+    '''A stripe customer with no subscriptions returns True.'''
+    assert cancel_stripe_customer_subscription('cust_id', 'beth@example.com',
+                                               'beth')
+    assert not mock_sub.called
+
+
+@mock.patch('stripe.Customer.retrieve',
+            side_effect=stripe.error.InvalidRequestError('bad stripe ID',
+                                                         'id'))
+def test_cancel_stripe_customer_invalid_request(mock_cust):
+    '''An invalid call to the Stripe API returns False.'''
+    assert not cancel_stripe_customer_subscription('cust_id',
+                                                   'beth@example.com', 'beth')
+    assert mock_cust.called
+
+
+@mock.patch('stripe.Customer.retrieve', side_effect=ValueError('Oops'))
+def test_cancel_stripe_customer_other_exception(mock_cust):
+    '''An exception during processing returns False.'''
+    assert not cancel_stripe_customer_subscription('cust_id',
+                                                   'beth@example.com', 'beth')
+    assert mock_cust.called

--- a/kuma/payments/tests/test_utils.py
+++ b/kuma/payments/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import mock
 
 from kuma.payments.utils import (

--- a/kuma/payments/tests/test_utils.py
+++ b/kuma/payments/tests/test_utils.py
@@ -8,24 +8,14 @@ from kuma.payments.utils import (
     stripe)
 
 
-class SubscriptionDict(dict):
-    """Cheap version of Stripe's Subscription object.
-
-    Allows access like dict (data['id']) or property (data.id)
-    """
-    @property
-    def id(self):
-        return self['id']
-
-
 # Subset of data returned for customer
 # https://stripe.com/docs/api/customers/retrieve
 simple_customer_data = {
     'sources': {'data': [{'card': {'last4': '0019'}}]},
-    'subscriptions': {'data': [SubscriptionDict({
+    'subscriptions': {'data': [{
         'id': 'sub_id',
         'plan': {'amount': 6400},
-    })]},
+    }]},
 }
 
 
@@ -92,10 +82,9 @@ def test_cancel_stripe_customer_subscription(mock_sub, mock_cust):
 
 @mock.patch('stripe.Customer.retrieve',
             return_value={
-                'subscriptions': {'data': [
-                    SubscriptionDict({'id': 'sub_id1'}),
-                    SubscriptionDict({'id': 'sub_id2'}),
-                ]}})
+                'subscriptions': {'data': [{'id': 'sub_id1'},
+                                           {'id': 'sub_id2'},
+                                           ]}})
 @mock.patch('stripe.Subscription.retrieve',
             side_effect=[mock.Mock(spec_set=['delete']),
                          mock.Mock(spec_set=['delete'])])

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -199,7 +199,6 @@ def test_recurring_payment_management_no_customer_id(enabled_, get, user_client)
             ' name="stripe_cancel_subscription"') not in content
     assert "You have no active subscriptions." in content
     assert_no_cache_header(response)
-    assert response.status_code == 200
 
 
 @pytest.mark.django_db
@@ -219,7 +218,6 @@ def test_recurring_payment_management_api_failure(enabled_, get, stripe_user, us
             ' name="stripe_cancel_subscription"') not in content
     assert "You have no active subscriptions." in content
     assert_no_cache_header(response)
-    assert response.status_code == 200
 
 
 @pytest.mark.django_db

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -7,6 +7,13 @@ from kuma.core.tests import assert_no_cache_header
 from kuma.core.urlresolvers import reverse
 
 
+@pytest.fixture
+def stripe_user(wiki_user):
+    wiki_user.stripe_customer_id = 'fakeCustomerID123'
+    wiki_user.save()
+    return wiki_user
+
+
 @pytest.mark.django_db
 @mock.patch('kuma.payments.views.enabled', return_value=True)
 def test_payments_view(mock_enabled, client, settings):
@@ -176,10 +183,9 @@ def test_template_render_not_logged_in_payment_view(mock_enabled, client, settin
 
 @pytest.mark.django_db
 @mock.patch('kuma.payments.views.enabled', return_value=True)
-@mock.patch('kuma.payments.views.cancel_stripe_customer_subscription', return_value=True)
 @mock.patch('kuma.payments.views.get_stripe_customer_data', return_value=True)
-def test_recurring_payment_management_no_customer_id(enabled_, get, cancel_, user_client, client, settings):
-    """The recurring payments form succeeds with a valid Stripe token."""
+def test_recurring_payment_management_no_customer_id(enabled_, get, user_client):
+    """The recurring payments page shows there are no active subscriptions."""
     response = user_client.get(reverse('recurring_payment_management'))
     assert response.status_code == 200
     assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' not in response.content
@@ -190,35 +196,83 @@ def test_recurring_payment_management_no_customer_id(enabled_, get, cancel_, use
 
 @pytest.mark.django_db
 @mock.patch('kuma.payments.views.enabled', return_value=True)
-@mock.patch('kuma.payments.views.cancel_stripe_customer_subscription', return_value=True)
+@mock.patch('kuma.payments.views.get_stripe_customer_data',
+            return_value={'stripe_plan_amount': 0,
+                          'stripe_card_last4': 0,
+                          'active_subscriptions': False
+                          })
+def test_recurring_payment_management_api_failure(enabled_, get, user_client):
+    """The page shows no active subscriptions if the API fails."""
+    response = user_client.get(reverse('recurring_payment_management'))
+    assert response.status_code == 200
+    assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' not in response.content
+    assert "You have no active subscriptions." in response.content
+    assert_no_cache_header(response)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@mock.patch('kuma.payments.views.enabled', return_value=True)
 @mock.patch('kuma.payments.views.get_stripe_customer_data', return_value={
     'stripe_plan_amount': 64,
     'stripe_card_last4': 1234,
     'active_subscriptions': True
 })
-def test_recurring_payment_management_customer_id(enabled_, get, cancel_, client, wiki_user, settings):
-    """The recurring payments form succeeds with a valid Stripe token."""
-    wiki_user.stripe_customer_id = 'fakeCustomerID123'
-    wiki_user.set_password('password')
-    wiki_user.save()
-    client.login(username=wiki_user.username, password='password')
-    response = client.get(reverse('recurring_payment_management'))
+def test_recurring_payment_management_customer_id(enabled_, get, user_client, stripe_user):
+    """The recurring payments page shows there are active subscriptions."""
+    response = user_client.get(reverse('recurring_payment_management'))
     assert response.status_code == 200
     assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' in response.content
-
     assert_no_cache_header(response)
-    response = client.post(
+
+
+@pytest.mark.django_db
+@mock.patch('kuma.payments.views.enabled', return_value=True)
+@mock.patch('kuma.payments.views.cancel_stripe_customer_subscription', return_value=True)
+@mock.patch('kuma.payments.views.get_stripe_customer_data', return_value={
+    'stripe_plan_amount': 0,
+    'stripe_card_last4': 0,
+    'active_subscriptions': False
+})
+def test_recurring_payment_management_cancel(enabled_, get, cancel_, user_client, stripe_user):
+    """A subscription can be cancelled from the recurring payments page."""
+    response = user_client.post(
         reverse('recurring_payment_management'),
         data={'stripe_cancel_subscription': ''}
     )
     assert response.status_code == 200
+    assert cancel_.called
+    assert get.called
+    text = 'Your monthly subscription has been successfully canceled'
+    assert text in response.content
+
+
+@pytest.mark.django_db
+@mock.patch('kuma.payments.views.enabled', return_value=True)
+@mock.patch('kuma.payments.views.cancel_stripe_customer_subscription', return_value=False)
+@mock.patch('kuma.payments.views.get_stripe_customer_data', return_value={
+    'stripe_plan_amount': 64,
+    'stripe_card_last4': '1234',
+    'active_subscriptions': True
+})
+def test_recurring_payment_management_cancel_fails(enabled_, get, cancel_, user_client, stripe_user):
+    """A message is displayed if cancelling fails."""
+    response = user_client.post(
+        reverse('recurring_payment_management'),
+        data={'stripe_cancel_subscription': ''}
+    )
+    assert response.status_code == 200
+    assert cancel_.called
+    assert get.called
+    text = 'There was a problem canceling your subscription'
+    assert text in response.content
 
 
 @pytest.mark.django_db
 @mock.patch('kuma.payments.views.enabled', return_value=True)
 @mock.patch('kuma.payments.views.cancel_stripe_customer_subscription', return_value=True)
 @mock.patch('kuma.payments.views.get_stripe_customer_data', return_value=True)
-def test_recurring_payment_management_not_logged_in(enabled_, get, cancel_, client, settings):
+def test_recurring_payment_management_not_logged_in(enabled_, get, cancel_, client):
     """The recurring payments form succeeds with a valid Stripe token."""
     response = client.get(reverse('recurring_payment_management'))
     assert response.status_code == 302

--- a/kuma/payments/tests/test_views.py
+++ b/kuma/payments/tests/test_views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import mock
 import pytest
 import stripe
@@ -137,15 +139,16 @@ def test_template_render_logged_in_recurring_payment_initial_view(mock_enabled, 
     response = user_client.get(reverse('recurring_payment_initial'))
     assert_no_cache_header(response)
     assert response.status_code == 200
-    assert '<input type="hidden"' in response.content
-    assert 'id="id_stripe_token"' in response.content
-    assert 'id="stripe_source_setup"' in response.content
-    assert 'id="id_stripe_public_key"' in response.content
-    assert '<form id="contribute-form"' in response.content
-    assert '<input type="email"' in response.content
-    assert 'id="id_donation_amount"' in response.content
-    assert 'id="id_donation_choices"' in response.content
-    assert 'id="id_accept_checkbox"' in response.content
+    content = response.content.decode(response.charset)
+    assert '<input type="hidden"' in content
+    assert 'id="id_stripe_token"' in content
+    assert 'id="stripe_source_setup"' in content
+    assert 'id="id_stripe_public_key"' in content
+    assert '<form id="contribute-form"' in content
+    assert '<input type="email"' in content
+    assert 'id="id_donation_amount"' in content
+    assert 'id="id_donation_choices"' in content
+    assert 'id="id_accept_checkbox"' in content
 
 
 @pytest.mark.django_db
@@ -155,14 +158,15 @@ def test_template_render_not_logged_in_recurring_payment_initial_view(mock_enabl
     response = client.get(reverse('recurring_payment_initial'))
     assert_no_cache_header(response)
     assert response.status_code == 200
-    assert '<input type="hidden"' in response.content
-    assert 'id="id_stripe_token"' not in response.content
-    assert 'id="stripe_source_setup"' in response.content
-    assert 'id="id_stripe_public_key"' not in response.content
-    assert '<form id="contribute-form"' in response.content
-    assert '<input type="email"' in response.content
-    assert 'id="id_donation_amount"' in response.content
-    assert 'id="id_donation_choices"' in response.content
+    content = response.content.decode(response.charset)
+    assert '<input type="hidden"' in content
+    assert 'id="id_stripe_token"' not in content
+    assert 'id="stripe_source_setup"' in content
+    assert 'id="id_stripe_public_key"' not in content
+    assert '<form id="contribute-form"' in content
+    assert '<input type="email"' in content
+    assert 'id="id_donation_amount"' in content
+    assert 'id="id_donation_choices"' in content
 
 
 @pytest.mark.django_db
@@ -172,14 +176,15 @@ def test_template_render_not_logged_in_payment_view(mock_enabled, client, settin
     response = client.get(reverse('payments'))
     assert_no_cache_header(response)
     assert response.status_code == 200
-    assert '<input type="hidden"' in response.content
-    assert 'id="id_stripe_token"' in response.content
-    assert 'id="id_stripe_public_key"' in response.content
-    assert '<form id="contribute-form"' in response.content
-    assert '<input type="email"' in response.content
-    assert 'id="id_donation_amount"' in response.content
-    assert 'id="id_donation_choices"' in response.content
-    assert 'id="id_accept_checkbox"' in response.content
+    content = response.content.decode(response.charset)
+    assert '<input type="hidden"' in content
+    assert 'id="id_stripe_token"' in content
+    assert 'id="id_stripe_public_key"' in content
+    assert '<form id="contribute-form"' in content
+    assert '<input type="email"' in content
+    assert 'id="id_donation_amount"' in content
+    assert 'id="id_donation_choices"' in content
+    assert 'id="id_accept_checkbox"' in content
 
 
 @pytest.mark.django_db
@@ -189,8 +194,10 @@ def test_recurring_payment_management_no_customer_id(enabled_, get, user_client)
     """The recurring payments page shows there are no active subscriptions."""
     response = user_client.get(reverse('recurring_payment_management'))
     assert response.status_code == 200
-    assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' not in response.content
-    assert "You have no active subscriptions." in response.content
+    content = response.content.decode(response.charset)
+    assert ('<button id="id_stripe_cancel_subscription"'
+            ' name="stripe_cancel_subscription"') not in content
+    assert "You have no active subscriptions." in content
     assert_no_cache_header(response)
     assert response.status_code == 200
 
@@ -207,8 +214,10 @@ def test_recurring_payment_management_api_failure(enabled_, get, stripe_user, us
     """The page shows no active subscriptions if ID is unknown."""
     response = user_client.get(reverse('recurring_payment_management'))
     assert response.status_code == 200
-    assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' not in response.content
-    assert "You have no active subscriptions." in response.content
+    content = response.content.decode(response.charset)
+    assert ('<button id="id_stripe_cancel_subscription"'
+            ' name="stripe_cancel_subscription"') not in content
+    assert "You have no active subscriptions." in content
     assert_no_cache_header(response)
     assert response.status_code == 200
 
@@ -224,7 +233,9 @@ def test_recurring_payment_management_customer_id(enabled_, get, user_client, st
     """The recurring payments page shows there are active subscriptions."""
     response = user_client.get(reverse('recurring_payment_management'))
     assert response.status_code == 200
-    assert '<button id="id_stripe_cancel_subscription" name="stripe_cancel_subscription"' in response.content
+    content = response.content.decode(response.charset)
+    assert ('<button id="id_stripe_cancel_subscription"'
+            ' name="stripe_cancel_subscription"') in content
     assert_no_cache_header(response)
 
 
@@ -246,7 +257,8 @@ def test_recurring_payment_management_cancel(enabled_, get, cancel_, user_client
     assert cancel_.called
     assert get.called
     text = 'Your monthly subscription has been successfully canceled'
-    assert text in response.content
+    content = response.content.decode(response.charset)
+    assert text in content
 
 
 @pytest.mark.django_db
@@ -272,7 +284,8 @@ def test_recurring_payment_management_cancel_fails(enabled_, get, cancel_, user_
     assert cancel_.called
     assert get.called
     text = 'There was a problem canceling your subscription'
-    assert text in response.content
+    content = response.content.decode(response.charset)
+    assert text in content
 
 
 @pytest.mark.django_db

--- a/kuma/payments/urls.py
+++ b/kuma/payments/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from . import views

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -61,7 +61,7 @@ def cancel_stripe_customer_subscription(stripe_customer_id, email, username):
     try:
         customer = stripe.Customer.retrieve(stripe_customer_id)
         for sub in customer['subscriptions']['data']:
-            s = stripe.Subscription.retrieve(sub.id)
+            s = stripe.Subscription.retrieve(sub['id'])
             s.delete()
         return True
     except stripe.error.InvalidRequestError as e:

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -1,5 +1,3 @@
-import logging
-
 import stripe
 from django.conf import settings
 from waffle import flag_is_active
@@ -7,8 +5,6 @@ from waffle import flag_is_active
 from .constants import CONTRIBUTION_BETA_FLAG, RECURRING_PAYMENT_BETA_FLAG
 
 stripe.api_key = settings.STRIPE_SECRET_KEY
-
-log = logging.getLogger('kuma.payments.utils')
 
 
 def enabled(request):
@@ -29,51 +25,25 @@ def recurring_payment_enabled(request):
             flag_is_active(request, RECURRING_PAYMENT_BETA_FLAG))
 
 
-def get_stripe_customer_data(stripe_customer_id, email, username):
+def get_stripe_customer_data(stripe_customer_id):
+    """Return select Stripe customer data as a simple dictionary."""
     stripe_data = {
         'stripe_plan_amount': 0,
         'stripe_card_last4': 0,
         'active_subscriptions': False
     }
-    try:
-        customer = stripe.Customer.retrieve(stripe_customer_id)
-        stripe_data['active_subscriptions'] = True if customer['subscriptions']['data'] else False
-        if customer['subscriptions']['data']:
-            stripe_data['stripe_plan_amount'] = customer['subscriptions']['data'][0]['plan']['amount'] / 100
-        if customer['sources']['data']:
-            stripe_data['stripe_card_last4'] = customer['sources']['data'][0]['card']['last4']
-    except stripe.error.InvalidRequestError as e:
-        log.error(
-            'Stripe subscription cancellation: Invalid parameters were supplied to Stripe API: {} [{}] {}'.format(
-                username,
-                email,
-                e
-            )
-        )
-    except Exception as e:
-        log.error(
-            'Stripe subscription cancellation: something went wrong: {} [{}] {}'.format(username, email, e)
-        )
+    customer = stripe.Customer.retrieve(stripe_customer_id)
+    stripe_data['active_subscriptions'] = True if customer['subscriptions']['data'] else False
+    if customer['subscriptions']['data']:
+        stripe_data['stripe_plan_amount'] = customer['subscriptions']['data'][0]['plan']['amount'] / 100
+    if customer['sources']['data']:
+        stripe_data['stripe_card_last4'] = customer['sources']['data'][0]['card']['last4']
     return stripe_data
 
 
-def cancel_stripe_customer_subscription(stripe_customer_id, email, username):
-    try:
-        customer = stripe.Customer.retrieve(stripe_customer_id)
-        for sub in customer['subscriptions']['data']:
-            s = stripe.Subscription.retrieve(sub['id'])
-            s.delete()
-        return True
-    except stripe.error.InvalidRequestError as e:
-        log.error(
-            'Stripe subscription cancellation: Invalid parameters were supplied to Stripe API: {} [{}] {}'.format(
-                username,
-                email,
-                e
-            )
-        )
-    except Exception as e:
-        log.error(
-            'Stripe subscription cancellation: something went wrong: {} [{}] {}'.format(username, email, e)
-        )
-    return False
+def cancel_stripe_customer_subscription(stripe_customer_id):
+    """Delete all subscriptions for a Stripe customer."""
+    customer = stripe.Customer.retrieve(stripe_customer_id)
+    for sub in customer['subscriptions']['data']:
+        s = stripe.Subscription.retrieve(sub['id'])
+        s.delete()

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import stripe
 from django.conf import settings
 from waffle import flag_is_active

--- a/kuma/users/tests/test_signal_handlers.py
+++ b/kuma/users/tests/test_signal_handlers.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+
+import mock
+import pytest
+from stripe.error import InvalidRequestError
+
+from kuma.users.models import User
+
+
+@pytest.fixture
+def payments_user(db, django_user_model):
+    return User.objects.create(
+        username='payments_user',
+        email='payer@example.com',
+        date_joined=datetime(2019, 1, 17, 15, 42),
+        stripe_customer_id='cust_test123')
+
+
+@mock.patch('kuma.users.signal_handlers.cancel_stripe_customer_subscription')
+def test_unsubscribe_payments_on_user_delete(mock_cancel, payments_user):
+    """A stripe subscription is cancelled when the user is deleted."""
+    payments_user.delete()
+    mock_cancel.assert_called_once_with('cust_test123')
+    assert not User.objects.filter(username='payments_user').exists()
+
+
+@mock.patch('kuma.users.signal_handlers.cancel_stripe_customer_subscription',
+            side_effect=InvalidRequestError(
+                'No such customer: cust_test123',
+                param='id',
+                code='resourse_missing',
+                http_status=404))
+def test_unsubscribe_payments_on_user_delete_fails(mock_cancel, payments_user):
+    """If stripe subscription cancellation fails, do not delete User."""
+    with pytest.raises(InvalidRequestError):
+        payments_user.delete()
+    mock_cancel.assert_called_once_with('cust_test123')


### PR DESCRIPTION
*This is an update of PR #5139 after rebasing on current master.*

When a User is deleted all subscriptions will be canceled. This uses the utility function ``cancel_stripe_customer_subscription``, which is also used when a User cancels their subscription subscription.

I changed a few other things as well, which could be broken up into more PRs if this one is too big:

* The utility functions ``get_stripe_customer_data`` and ``cancel_stripe_customer_subscription`` took a username and email, for the sole purpose of logging them if Stripe returned an error. I've removed the error handling from these functions and moved it to the ``recurring_payment_management`` view, which is the only function that uses these utilities.
* I've adjusted the error handling as well, to gracefully handle all Stripe API errors by logging them and acting like the user has no subscription. Previously any error, including syntax errors, would be treated the same way.
* Added error-handling tests for the view, and tests for the utility functions I touched.
* Fixed Django 1.11 deprecations and Python 3 issues