### PR TITLE
Bug 1521135, Stage A of codepen-iex implementation

### DIFF
--- a/__tests__/sass/mdn/_button-states-mixins-test.scss
+++ b/__tests__/sass/mdn/_button-states-mixins-test.scss
@@ -1,0 +1,15 @@
+@include describe('active-button-state') {
+    @include it(
+        'Returns an active button style that is applied to elements that are interactive and has focus'
+    ) {
+        @include assert {
+            @include output {
+                @include active-button-state();
+            }
+
+            @include expect {
+                box-shadow: 1px 1px 5px #212121, -1px -1px 5px #bdbdbd;
+            }
+        }
+    }
+}

--- a/__tests__/sass/test.scss
+++ b/__tests__/sass/test.scss
@@ -6,3 +6,4 @@
 /* Tests */
 @import 'mdn/typography-mixin-test';
 @import 'mdn/a11y-helpers-mixins-test';
+@import 'mdn/button-states-mixins-test';

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -697,6 +697,12 @@ PIPELINE_CSS = {
         'output_filename': 'build/styles/mdn.css',
         'variant': 'datauri',
     },
+    'codepen-iex': {
+        'source_filenames': (
+            'styles/components/codepen-iex/codepen-iex.scss',
+        ),
+        'output_filename': 'build/styles/codepen-iex.css',
+    },
     'jquery-ui': {
         'source_filenames': (
             'js/libs/jquery-ui-1.10.3.custom/css/ui-lightness/jquery-ui-1.10.3.custom.min.css',
@@ -931,6 +937,12 @@ PIPELINE_JS = {
         'extra_context': {
             'async': True,
         },
+    },
+    'codepen-iex': {
+        'source_filenames': (
+            'js/components/codepen-iex/codepen-iex.js',
+        ),
+        'output_filename': 'build/js/codepen-iex.js',
     },
     'dashboard': {
         'source_filenames': (

--- a/kuma/static/js/components/codepen-iex/codepen-iex.js
+++ b/kuma/static/js/components/codepen-iex/codepen-iex.js
@@ -1,0 +1,21 @@
+(function() {
+    'use strict';
+    var sampleCodeContainer = document.querySelector('.codepen-iex');
+
+    /* only execute the rest of the code if there
+       is a `sampleCodeContainer` on the page */
+    if (sampleCodeContainer) {
+        var tryItButton = document.createElement('button');
+        tryItButton.classList.add('tryit');
+        tryItButton.textContent = gettext('Try it live!');
+        sampleCodeContainer.appendChild(tryItButton);
+
+        // when the button is clicked
+        tryItButton.addEventListener('click', function() {
+            // call codepen to load the editor
+            window.__CPEmbed('.codepen-iex');
+            // hide the button
+            tryItButton.classList.add('hidden');
+        });
+    }
+})();

--- a/kuma/static/styles/components/codepen-iex/codepen-iex.scss
+++ b/kuma/static/styles/components/codepen-iex/codepen-iex.scss
@@ -1,0 +1,23 @@
+@import '../../includes/vars';
+@import '../../includes/mixins';
+
+.codepen-iex {
+    position: relative;
+
+    .tryit {
+        position: absolute;
+        top: 10px;
+        right: 10px;
+        background-color: #fff;
+        border: 3px solid #3d7e9a;
+        height: 2rem;
+        font-size: 1rem;
+        cursor: pointer;
+
+        &:hover,
+        &:focus,
+        &:active {
+            @include active-button-state();
+        }
+    }
+}

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -149,6 +149,15 @@ Links
     }
 }
 
+/*
+Button states
+====================================================================== */
+/* Used for :hover, :active, :focus states
+   When changing the values of this mixin, remember to also update the
+   relevant test at __tests__/sass/mdn/_button-states-mixins-test.scss */
+@mixin active-button-state() {
+    box-shadow: 1px 1px 5px #212121, -1px -1px 5px #bdbdbd;
+}
 
 /*
 Colours

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -80,6 +80,10 @@ ALLOWED_ATTRIBUTES['del'] = ['datetime']
 ALLOWED_ATTRIBUTES['meter'] += ['max', 'min', 'value', 'low', 'high', 'optimum',
                                 'form']
 ALLOWED_ATTRIBUTES['details'] += ['open']
+# attributes required for codepen-iex
+ALLOWED_ATTRIBUTES['div'] += ['data-prefill', 'data-height', 'data-editable',
+                              'data-default-tab', 'data-theme-id']
+ALLOWED_ATTRIBUTES['pre'] += ['data-lang']
 # MathML
 ALLOWED_ATTRIBUTES.update(dict((x, ['encoding', 'src']) for x in (
     'annotation', 'annotation-xml')))

--- a/kuma/wiki/jinja2/wiki/base.html
+++ b/kuma/wiki/jinja2/wiki/base.html
@@ -16,6 +16,7 @@
     {{ super() }}
 
     {% stylesheet 'wiki' %}
+    {% stylesheet 'codepen-iex' %}
 
 {% endblock %}
 
@@ -23,5 +24,8 @@
     {{ super() }}
 
     {% javascript 'wiki' %}
+    {% javascript 'codepen-iex' %}
+
+    <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
A description of this can be found here:
https://bugzilla.mozilla.org/show_bug.cgi?id=1521135

There is also another doc from @wbamberg that details the various stages. The PR addresses Stage A:
https://gist.github.com/wbamberg/ca85831ec166a0bfed4bbcc031d3bf73#stage-a-enable-mdn-codepen-integration

Here are a couple of screenshots showing the interaction:

On load:

![screenshot 2019-01-22 at 12 56 41](https://user-images.githubusercontent.com/10350960/51531443-1fb4d700-1e46-11e9-9007-0c02fcd6123d.png)

When hovering over the button:

![screenshot 2019-01-22 at 12 56 48](https://user-images.githubusercontent.com/10350960/51531459-26dbe500-1e46-11e9-8a55-c00951ec57b8.png)

After clicking the button

![screenshot 2019-01-22 at 12 57 00](https://user-images.githubusercontent.com/10350960/51531470-2e02f300-1e46-11e9-8e68-e1ec99967db4.png)

I used `/en-US/docs/Web/API/Document/querySelector` for the example. To test, you need to add the following code to the document via CKEditor(This is also how the writers will add the examples for Stage A):

```
<div class="codepen-iex" data-default-tab="js,result" data-editable="true" data-height="400" data-prefill="">
<pre class="hidden" data-lang="html">
&lt;button class="add-para"
    type="button"&gt;
Add para
&lt;/button&gt;
  </pre>

<pre class="static-sample-code" data-lang="js">
const addParaButton = document.querySelector('.add-para');

addParaButton.addEventListener('click', () =&gt; {
  const para = document.createElement('p');
  para.textContent = 'All work and no play makes Jack a dull boy.';
  document.body.appendChild(para);
});
  </pre>
</div>
```

Because of some of the `data-` attributes required for the Codepen integrations, I also had to update the `constants.py` file with the following:

```
# attributes required for codepen-iex
ALLOWED_ATTRIBUTES['div'] += ['data-prefill', 'data-height', 'data-editable',
                              'data-default-tab']
ALLOWED_ATTRIBUTES['pre'] += ['data-lang']
```

I also included the minified source from Codepen. We could elect to instead load this from their CDN if that makes more sense.

@davidflanagan @jwhitlock @wbamberg r?