### PR TITLE
bug 1518482: remove some docs from sitemap

### DIFF
--- a/kuma/wiki/managers.py
+++ b/kuma/wiki/managers.py
@@ -29,6 +29,7 @@ class BaseDocumentManager(models.Manager):
                     .exclude(slug__startswith='User_talk:')
                     .exclude(slug__startswith='Template_talk:')
                     .exclude(slug__startswith='Project_talk:')
+                    .exclude(slug__startswith='Experiment:')
                     .order_by('slug'))
         if locale:
             docs = docs.filter(locale=locale)


### PR DESCRIPTION
This PR represents a small part of the work related to [bug 1518482](https://bugzilla.mozilla.org/show_bug.cgi?id=1518482), but I wanted to have something to show after a frustrating day of trying to make sense of SEO and Google's new and old search consoles (e.g., the new search console doesn't seem to show the 38K+ errors that the old one does).

This PR removes 101 Google Bot indexing errors of the category `Submitted URL blocked by robots.txt`, which means the URL is included within the `sitemap` but excluded by `robots.txt`. The main lot here are the document URL's with a slug that starts with `Experiment:` (100 of them). The mysterious one is the single URL https://developer.mozilla.org/en-US/docs/Mozilla/QA/Marionette/WebDriver/status (a redirect to a bugzilla page), which is not explicitly excluded by `robots.txt`, but the Google Search Console still complains.