### PR TITLE
bug 1522385: Enable italic text within syntaxbox for CJKT

### DIFF
--- a/kuma/static/styles/locales/ja.scss
+++ b/kuma/static/styles/locales/ja.scss
@@ -45,11 +45,17 @@ Styles for Japanese
 }
 
 /* Bug 973171 */
-
+/* stylelint-disable declaration-no-important */
 * {
     /* !important required for locale specific override */
-    font-style: normal !important;  /* stylelint-disable-line declaration-no-important */
+    font-style: normal !important;
 }
 
-
+/* Bug 1522385 */
+.syntaxbox {
+    var,
+    em {
+        font-style: italic !important;
+    }
+}
 /* stylelint-enable */

--- a/kuma/static/styles/locales/ko.scss
+++ b/kuma/static/styles/locales/ko.scss
@@ -26,12 +26,18 @@ Styles for Korean
        local('Malgun Gothic Bold');
 }
 
-
 /* Bug 973171 */
-
+/* stylelint-disable declaration-no-important */
 * {
     /* !important required for locale specific override */
-    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
+    font-style: normal !important;
 }
 
+/* Bug 1522385 */
+.syntaxbox {
+    var,
+    em {
+        font-style: italic !important;
+    }
+}
 /* stylelint-enable */

--- a/kuma/static/styles/locales/zh-CN.scss
+++ b/kuma/static/styles/locales/zh-CN.scss
@@ -29,12 +29,18 @@ Styles for Chinese (Simplified)
        local(DroidSansFallbackFull);
 }
 
-
 /* Bug 973171 */
-
+/* stylelint-disable declaration-no-important */
 * {
     /* !important required for locale specific override */
-    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
+    font-style: normal !important;
 }
 
+/* Bug 1522385 */
+.syntaxbox {
+    var,
+    em {
+        font-style: italic !important;
+    }
+}
 /* stylelint-enable */

--- a/kuma/static/styles/locales/zh-TW.scss
+++ b/kuma/static/styles/locales/zh-TW.scss
@@ -30,10 +30,17 @@ Styles for Tiwanese
 }
 
 /* Bug 973171 */
-
+/* stylelint-disable declaration-no-important */
 * {
     /* !important required for locale specific override */
-    font-style: normal !important; /* stylelint-disable-line declaration-no-important */
+    font-style: normal !important;
 }
 
+/* Bug 1522385 */
+.syntaxbox {
+    var,
+    em {
+        font-style: italic !important;
+    }
+}
 /* stylelint-enable */


### PR DESCRIPTION
[Bugzilla 1522385](https://bugzilla.mozilla.org/show_bug.cgi?id=1522385)

This PR overrides global `font-style: normal !important` of following locales, for `.syntaxbox > var` and `.syntaxbox > em`.

```
ja
ko
zh-CN
zh-TW
```

Why: To mark that certain keywords are programmer-specified contents, and can be changed.

Related issue: [973171: Don't use italic text in CJKT pages](https://bugzilla.mozilla.org/show_bug.cgi?id=973171)