### PR TITLE
Bug 1522441, switch back to Github link from survey for BCD

### DIFF
--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -31,8 +31,7 @@
             },
             js: {
                 'syntax-prism': [{% javascript 'syntax-prism' %}],
-                'wiki-compat-tables': [{% javascript 'wiki-compat-tables' %}],
-                'wiki-compat-table-survey': [{% javascript 'wiki-compat-table-survey' %}]
+                'wiki-compat-tables': [{% javascript 'wiki-compat-tables' %}]
             }
         };
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -754,7 +754,6 @@ PIPELINE_CSS = {
     'wiki-compat-tables': {
         'source_filenames': (
             'styles/wiki-compat-tables.scss',
-            'styles/compat-table/components/compat-table-survey.scss',
         ),
         'output_filename': 'build/styles/wiki-compat-tables.css',
         'template_name': 'pipeline/javascript-array.jinja',
@@ -1051,13 +1050,6 @@ PIPELINE_JS = {
             'js/wiki-compat-tables.js',
         ),
         'output_filename': 'build/js/wiki-compat-tables.js',
-        'template_name': 'pipeline/javascript-array.jinja',
-    },
-    'wiki-compat-table-survey': {
-        'source_filenames': (
-            'js/compat-table/components/compat-table-survey.js',
-        ),
-        'output_filename': 'build/js/wiki-compat-table-survey.js',
         'template_name': 'pipeline/javascript-array.jinja',
     },
     'task-completion': {

--- a/kuma/static/js/wiki-compat-trigger.js
+++ b/kuma/static/js/wiki-compat-trigger.js
@@ -31,17 +31,7 @@
                 dataType: 'script',
                 cache: true
             }).then(function() {
-                var compatSurveyJS = mdn.assets.js['wiki-compat-table-survey'][0];
                 $('.bc-table').mozCompatTable();
-
-                // now load the survey JS
-                $.ajax({
-                    url: compatSurveyJS,
-                    dataType: 'script',
-                    cache: true
-                }).fail(function(jqXHR, textStatus, errorThrown) {
-                    console.error('Failed to load BCD survey JS: ' + textStatus + ': ', errorThrown);
-                });
             });
 
         }).appendTo(doc.head);

--- a/kuma/static/styles/wiki-compat-tables.scss
+++ b/kuma/static/styles/wiki-compat-tables.scss
@@ -40,8 +40,3 @@ Footnotes & Legend
 GitHub link
 ====================================================================== */
 @import 'components/compat-tables/bc-github-link';
-
-/*
-Survey
-====================================================================== */
-@import 'compat-table/components/compat-table-survey';


### PR DESCRIPTION
I decided the keep the JS and SCSS files in the codebase. Seeing that it is very generic, and we are bound to run another survey for BCD at some point, this will make it much faster to get it up and running.

Also, the code is not loaded anywhere, so there is no negative performance impact to keeping it.

@davidflanagan r?