### PR TITLE
bug 1518482: nofollow search pagination links

### DIFF
--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -165,12 +165,12 @@
 
             <div class="pager">
               {% if previous %}
-                <a class="button" href="{{ previous }}" id="search-result-previous">
+                <a class="button" href="{{ previous }}" id="search-result-previous" rel="nofollow">
                 {{ _('Previous') }}
                 </a>
               {% endif %}
               {% if next %}
-                <a class="button" href="{{ next }}" id="search-result-next">
+                <a class="button" href="{{ next }}" id="search-result-next" rel="nofollow">
                 {{ _('Next') }}
                 </a>
               {% endif %}


### PR DESCRIPTION
This PR blocks well-behaved crawlers from following the `Previous`/`Next` pagination buttons at the bottom of the search results page. From some research into the 429 errors that the Google Bot experiences when crawling MDN (mainly from users running searches), this should significantly reduce the number of times the Google Bot is rate-limited by the `search` endpoint. Currently, it appears that the crawler follows the pagination links until the end of the pagination, and is often rate-limited.