### PR TITLE
bug 1518482: nofollow links to user profiles

### DIFF
--- a/kuma/attachments/jinja2/attachments/includes/attachment_list.html
+++ b/kuma/attachments/jinja2/attachments/includes/attachment_list.html
@@ -112,9 +112,7 @@
           </td>
           <td>{{ datetimeformat(attachment.file.modified, format='datetime') }}</td>
           <td>
-            <a href="{{ attachment.file.current_revision.creator.get_absolute_url() }}"
-               {%- if not attachment.file.current_revision.creator.is_active %} rel="nofollow"{% endif -%}
-               >{{ user_display(attachment.file.current_revision.creator) }}</a>
+            <a href="{{ attachment.file.current_revision.creator.get_absolute_url() }}" rel="nofollow">{{ user_display(attachment.file.current_revision.creator) }}</a>
           </td>
           <td>
           {% if is_original %}

--- a/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
+++ b/kuma/dashboards/jinja2/dashboards/includes/revision_dashboard_body.html
@@ -45,9 +45,7 @@
                         {{ format_comment(revision) }}
                     </td>
                     <td class="dashboard-author">
-                        <a href="{{ revision.creator.get_absolute_url() }}"
-                           {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
-                           >{{ revision.creator }}</a><br>
+                        <a href="{{ revision.creator.get_absolute_url() }}" rel="nofollow">{{ revision.creator }}</a><br>
                         {% if show_ips %}
                             {% set revision_ip = revision.revisionip_set.first() %}
                             {% if revision_ip %}

--- a/kuma/wiki/jinja2/wiki/confirm_document_delete.html
+++ b/kuma/wiki/jinja2/wiki/confirm_document_delete.html
@@ -16,17 +16,13 @@
     <h1>{{ _('Delete') }} <a href="{{ document.get_absolute_url() }}">{{ document.title }}</a></h1>
 
     <strong>{{ _('Creator') }}</strong>
-    <p><a href="{{ revision.creator.get_absolute_url() }}"
-          {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
-          >{{ user_display(revision.creator) }}</a></p>
+    <p><a href="{{ revision.creator.get_absolute_url() }}" rel="nofollow">{{ user_display(revision.creator) }}</a></p>
 
     <strong>{{ _('Creation Date') }}</strong>
     <p>{{ datetimeformat(revision.created, format='longdatetime') }}</p>
 
     <strong>{{ _('Last Change By') }}</strong>
-    <p><a href="{{ document.current_revision.creator.get_absolute_url() }}"
-          {%- if not document.current_revision.creator.is_active %} rel="nofollow"{% endif -%}
-          >{{ user_display(document.current_revision.creator) }}</a></p>
+    <p><a href="{{ document.current_revision.creator.get_absolute_url() }}" rel="nofollow">{{ user_display(document.current_revision.creator) }}</a></p>
 
     <strong>{{ _('Last Change Date') }}</strong>
     <p>{{ datetimeformat(document.current_revision.created, format='longdatetime') }}</p>

--- a/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
+++ b/kuma/wiki/jinja2/wiki/confirm_revision_revert.html
@@ -20,9 +20,7 @@
         <div>{{ document.title }}</div>
 
         <label><strong>{{ _('Creator') }}</strong></label>
-        <div><a href="{{ revision.creator.get_absolute_url() }}"
-                {%- if not revision.creator.is_active %} rel="nofollow"{% endif -%}
-                >{{ revision.creator }}</a></div>
+        <div><a href="{{ revision.creator.get_absolute_url() }}" rel="nofollow">{{ revision.creator }}</a></div>
         <label><strong>{{ _('Date') }}</strong></label>
         <div>{{ datetimeformat(revision.created, format='longdatetime') }}</div>
         <label><strong>{{ _('Content') }}</strong></label>

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -243,9 +243,7 @@
                   <div class="contributors-sub">
                     {% include 'includes/icons/general/clock.svg' %}
                     <strong>{{ _('Last updated by:') }}</strong>
-                    <a href="{{ current_revision.creator.get_absolute_url() }}"
-                       {%- if not current_revision.creator.is_active %} rel="nofollow"{% endif -%}
-                       >{{ current_revision.creator }}</a>,
+                    <a href="{{ current_revision.creator.get_absolute_url() }}" rel="nofollow">{{ current_revision.creator }}</a>,
                     {{ datetimeformat(current_revision.created, format='datetime') }}
                   </div>
                 {% endif %}

--- a/kuma/wiki/jinja2/wiki/edit.html
+++ b/kuma/wiki/jinja2/wiki/edit.html
@@ -54,10 +54,9 @@
                   <p>
                   {% trans id=original_revision.id,
                            user_profile_url=original_revision.creator.get_absolute_url(),
-                           rel='' if original_revision.creator.is_active else 'rel="nofollow"',
                            user=original_revision.creator,
                            date=datetimeformat(original_revision.created, format='longdatetime') %}
-                     Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
+                     Revision {{ id }} by <a href="{{ user_profile_url }}" rel="nofollow">{{ user }}</a> on {{ date }}
                   {% endtrans %}
                   </p>
               </div>
@@ -71,9 +70,8 @@
                 {% trans id=current_revision.id,
                          user_profile_url=current_revision.creator.get_absolute_url(),
                          user=current_revision.creator,
-                         rel='' if current_revision.creator.is_active else 'rel="nofollow"',
                          date=datetimeformat(current_revision.created, format='longdatetime') %}
-                   Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
+                   Revision {{ id }} by <a href="{{ user_profile_url }}" rel="nofollow">{{ user }}</a> on {{ date }}
                 {% endtrans %}
                 </p>
               </div>

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -40,9 +40,8 @@
           {% trans id=revision_from.id,
                    user_profile_url=revision_from.creator.get_absolute_url(),
                    user=revision_from.creator,
-                   rel='' if revision_from.creator.is_active else 'rel="nofollow"',
                    date=datetimeformat(revision_from.created, format='longdatetime') %}
-             Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
+             Revision {{ id }} by <a href="{{ user_profile_url }}" rel="nofollow">{{ user }}</a> on {{ date }}
           {% endtrans %}
           </p>
         </div>
@@ -56,9 +55,8 @@
           {% trans id=revision_to.id,
                    user_profile_url=revision_to.creator.get_absolute_url(),
                    user=revision_to.creator,
-                   rel='' if revision_to.creator.is_active else 'rel="nofollow"',
                    date=datetimeformat(revision_to.created, format='longdatetime') %}
-                   Revision {{ id }} by <a href="{{ user_profile_url }}" {{ rel }}>{{ user }}</a> on {{ date }}
+                   Revision {{ id }} by <a href="{{ user_profile_url }}" rel="nofollow">{{ user }}</a> on {{ date }}
           {% endtrans %}
           </p>
         </div>
@@ -100,7 +98,7 @@
 
 {% macro contributor_links(contributors) -%}
     {% for contributor in contributors %}
-        <a href="{{ url('users.user_detail', username=contributor.username) }}">{{ contributor.username }}</a>{% if not loop.last %}, {% endif %}
+        <a href="{{ url('users.user_detail', username=contributor.username) }}" rel="nofollow">{{ contributor.username }}</a>{% if not loop.last %}, {% endif %}
     {% endfor %}
 {%- endmacro %}
 

--- a/kuma/wiki/jinja2/wiki/list/revisions.html
+++ b/kuma/wiki/jinja2/wiki/list/revisions.html
@@ -63,9 +63,7 @@
                 <a href="{{ url('wiki.revision', rev.document.slug, rev.id, locale=rev.document.locale) }}" rel="nofollow">{{ datetimeformat(rev.created, format='datetime') }}</a>
               </div>
               <div class="revision-list-cell revision-list-creator">
-                <a href="{{ rev.creator.get_absolute_url() }}"
-                   {%- if not rev.creator.is_active %} rel="nofollow"{% endif -%}
-                   >{{ rev.creator }}</a>
+                <a href="{{ rev.creator.get_absolute_url() }}" rel="nofollow">{{ rev.creator }}</a>
               </div>
               <div class="revision-list-cell revision-list-comment">
                 {% if rev.document.locale != document.locale %}


### PR DESCRIPTION
This PR is another contribution towards the work of https://github.com/mdn/sprints/issues/751 ([bug 1518482](https://bugzilla.mozilla.org/show_bug.cgi?id=1518482)). It addresses some of the 502/504 errors, specifically the ones related to the `users.user_detail` endpoint (e.g., https://developer.mozilla.org/en-US/profiles/myf). That endpoint is not without cost, as it makes a query for the user's most recent revisions, has little to no worth in terms of SEO, and yet is crawled on every document page (the contributor links at the bottom). This PR adds `rel="nofollow"` to all links to user profiles on MDN. The main benefit will be from the document pages (since they're loaded with `index, follow` for the robots `meta` tag). Most, if not all, of the other changes were done for consistency, as they were mostly loaded within a robots `meta` tag context of `noindex, nofollow` already.