### PR TITLE
Update ja.sccs to enable italic font style back

### DIFF
--- a/kuma/static/styles/locales/ja.scss
+++ b/kuma/static/styles/locales/ja.scss
@@ -45,10 +45,10 @@ Styles for Japanese
 }
 
 /* Bug 973171 */
-
+/** Back ground of Bug 973171 is obsolete already, the fix was for Windows XP, lacks Anti-Alias function **/
 * {
     /* !important required for locale specific override */
-    font-style: normal !important;  /* stylelint-disable-line declaration-no-important */
+    /* font-style: normal !important; */ /* stylelint-disable-line declaration-no-important */
 }
 
 


### PR DESCRIPTION
The reason for introducing font-style: normal !important is now (in 2019) obsolete, as wrote in line 48.