### PR TITLE
Bug 1510719: Remove remaining `.summary` special styling

### DIFF
--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -105,7 +105,6 @@ We cannot put these styles in the base/elements/ files because they don't apply 
 
         /* fix spacing and line if h2 directly follows a hr, summary, or blockquote */
         > hr,
-        > .summary,
         > blockquote {
             + h2 {
                 margin-top: ($grid-spacing + $section-border-width) * -1;

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -510,7 +510,8 @@ These are not dynamic but serve as mixins
 
     article > &:first-child,
     article > div:first-child:empty + &,
-    article > p:first-child:empty + & {
+    article > p:first-child:empty + &,
+    article > p:first-child:empty + p:empty + & {
         border-top-width: 0;
         padding-top: 0;
     }


### PR DESCRIPTION
Part of [bug 1510719](https://bugzilla.mozilla.org/show_bug.cgi?id=1510719)

This removes all remaining instances of&nbsp;`.summary` that were missed in&nbsp;https://github.com/mozilla/kuma/pull/5193.

review?(@schalkneethling)