### PR TITLE
bug 1518482: block search results from google search

### DIFF
--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -99,6 +99,7 @@ Disallow: /media
 Disallow: /*move-requested
 Disallow: /*preview-wiki-content
 Disallow: /*profiles*/edit
+Disallow: /*/search
 Disallow: /skins
 Disallow: /*type=feed
 Disallow: /*users/


### PR DESCRIPTION
This PR disallows the search endpoint in `robots.txt` per recommendation of our SEO expert.

It has been tested via the [Google Search console's robots.txt Tester](https://www.google.com/webmasters/tools/robots-testing-tool?siteUrl=https://developer.mozilla.org/).

To test locally:
- Add `ALLOW_ROBOTS_WEB_DOMAINS=localhost:8000` to your `.env` file prior to `docker-compose up -d`
- Navigate to http://localhost:8000/robots.txt