### PR TITLE
bug 1518482: nofollow search results

### DIFF
--- a/kuma/search/jinja2/search/results.html
+++ b/kuma/search/jinja2/search/results.html
@@ -17,7 +17,7 @@
   {% endif %}
 {% endblock %}
 
-{% block robots_value %}noindex, follow{% endblock %}
+{% block robots_value %}noindex, nofollow{% endblock %}
 
 {% block bodyclass %}search-results search-results-no-demo search-navigator-flush{% endblock %}
 


### PR DESCRIPTION
This work stems from the recommendation from our SEO expert to disallow the search results page. Since it doesn't seem possible to disallow the search results page via `robots.txt` (see #5221), the next best thing is to disallow it via the `robots` `meta` tag. We're already blocking indexing on the search results page via the `robots` `meta` tag, but let's add `nofollow` to make it complete.