### PR TITLE
bug 1518482: disallow search in robots.txt

### DIFF
--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -102,7 +102,8 @@ Disallow: /*profiles*/edit
 Disallow: /skins
 Disallow: /*type=feed
 Disallow: /*users/
-'''
+''' + '\n'.join('Disallow: /{locale}/search'.format(locale=locale)
+                for locale in settings.ENABLED_LOCALES)
 
 ROBOTS_GO_AWAY_TXT = '''\
 User-Agent: *


### PR DESCRIPTION
This PR disallows the search endpoint in `robots.txt` per recommendation of our SEO expert. It is the rebirth of #5221, but with a new approach to disallowing the search endpoint in the `robots.txt` file such that valid document pages whose slug includes `/search` will not be included.

It has been tested using the [Google Search console's robots.txt Tester](https://www.google.com/webmasters/tools/robots-testing-tool?siteUrl=https://developer.mozilla.org/).

To test locally:
- Add `ALLOW_ROBOTS_WEB_DOMAINS=localhost:8000` to your `.env` file prior to `docker-compose up -d`
- Navigate to http://localhost:8000/robots.txt