### PR TITLE
bug 1332666: Update hashin, flake8, and dependencies

### DIFF
--- a/kuma/payments/context_processors.py
+++ b/kuma/payments/context_processors.py
@@ -1,9 +1,9 @@
 import json
 
+from django.conf import settings
+
 from .forms import ContributionForm, RecurringPaymentForm
 from .utils import enabled, popup_enabled, recurring_payment_enabled
-
-from django.conf import settings
 
 
 def global_contribution_form(request):

--- a/kuma/payments/utils.py
+++ b/kuma/payments/utils.py
@@ -1,5 +1,6 @@
-import stripe
 import logging
+
+import stripe
 from django.conf import settings
 from waffle import flag_is_active
 

--- a/kuma/payments/views.py
+++ b/kuma/payments/views.py
@@ -13,7 +13,9 @@ from kuma.core.decorators import login_required
 
 from .forms import ContributionForm, RecurringPaymentForm
 from .tasks import payments_thank_you_email
-from .utils import enabled, get_stripe_customer_data, cancel_stripe_customer_subscription
+from .utils import (cancel_stripe_customer_subscription,
+                    enabled,
+                    get_stripe_customer_data)
 
 
 def skip_if_disabled(func):

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -106,9 +106,9 @@ def provider_login_url(context, provider_id, **params):
     auth_params = params.get('auth_params', None)
     scope = params.get('scope', None)
     process = params.get('process', None)
-    if scope is '':
+    if scope == '':
         del params['scope']
-    if auth_params is '':
+    if auth_params == '':
         del params['auth_params']
     if 'next' not in params:
         next = get_request_param(request, 'next')

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -252,13 +252,15 @@ def get_seo_description(content, locale=None, strip_markup=True):
                     # because we don't want p's wrapped
                     # in DIVs ("<div class='warning'>") and pyQuery adds
                     # "<html><div>" wrapping to entire document
-                    if (text and len(text) and
+                    text_match = (
+                        text and len(text) and
                         'Redirect' not in text and
                         text.find(u'«') == -1 and
                         text.find('&laquo') == -1 and
-                            item.parents().length == 2):
-                                seo_summary = text.strip()
-                                break
+                        item.parents().length == 2)
+                    if text_match:
+                        seo_summary = text.strip()
+                        break
 
     if strip_markup:
         # Post-found cleanup
@@ -933,12 +935,14 @@ class SectionFilter(html5lib_Filter):
 
                 # If this is the first heading of the section and we want to
                 # omit it, note that we've found it
-                if (self.in_section and
+                is_first_heading = (
+                    self.in_section and
                     self.ignore_heading and
                     not self.already_ignored_header and
                     not self.heading_to_ignore and
-                        self._isHeading(token)):
-                            self.heading_to_ignore = token
+                    self._isHeading(token))
+                if is_first_heading:
+                    self.heading_to_ignore = token
 
             elif token['type'] == 'EndTag':
                 self.open_level -= 1

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -1105,28 +1105,28 @@ class PageMoveTests(UserTestCase):
 
     @pytest.mark.move
     def test_preserve_tags(self):
-            tags = "'moving', 'tests'"
-            rev = revision(title='Test page-move tag preservation',
-                           slug='page-move-tags',
-                           tags=tags,
-                           is_approved=True,
-                           save=True)
-            rev.review_tags.set('technical')
-            rev = Revision.objects.get(pk=rev.id)
+        tags = "'moving', 'tests'"
+        rev = revision(title='Test page-move tag preservation',
+                       slug='page-move-tags',
+                       tags=tags,
+                       is_approved=True,
+                       save=True)
+        rev.review_tags.set('technical')
+        rev = Revision.objects.get(pk=rev.id)
 
-            revision(title='New Top-level parent for tree moves',
-                     slug='new-top',
-                     is_approved=True,
-                     save=True)
+        revision(title='New Top-level parent for tree moves',
+                 slug='new-top',
+                 is_approved=True,
+                 save=True)
 
-            doc = rev.document
-            doc._move_tree('new-top/page-move-tags')
+        doc = rev.document
+        doc._move_tree('new-top/page-move-tags')
 
-            moved_doc = Document.objects.get(pk=doc.id)
-            new_rev = moved_doc.current_revision
-            assert tags == new_rev.tags
-            assert (['technical'] ==
-                    [str(tag) for tag in new_rev.review_tags.all()])
+        moved_doc = Document.objects.get(pk=doc.id)
+        new_rev = moved_doc.current_revision
+        assert tags == new_rev.tags
+        assert (['technical'] ==
+                [str(tag) for tag in new_rev.review_tags.all()])
 
     @pytest.mark.move
     def test_move_tree_breadcrumbs(self):

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -201,9 +201,19 @@ python-dateutil==2.7.3 \
 # flake8
 #
 # Backport of Python 3 configparser, version tracks Python 3 versions
-# Code: https://bitbucket.org/ambv/configparser
-configparser==3.5.0 \
-    --hash=sha256:5308b47021bc2340965c371f0f058cc6971a04502638d4244225c49d80db273a
+# Code: https://github.com/jaraco/configparser
+# Changes: https://github.com/jaraco/configparser/blob/master/CHANGES.rst
+# Docs: https://docs.python.org/3/library/configparser.html
+configparser==3.7.1 \
+    --hash=sha256:c114ff90ee2e762db972fa205f02491b1f5cf3ff950decd8542c62970c9bedac \
+    --hash=sha256:df28e045fbff307a28795b18df6ac8662be3219435560ddb068c283afab1ea7a \
+    --hash=sha256:5bd5fa2a491dc3cfe920a3f2a107510d65eceae10e9c6e547b90261a4710df32
+# Advertise objects with a common interface
+# Code: https://github.com/takluyver/entrypoints
+# Docs: https://entrypoints.readthedocs.io/en/latest/
+entrypoints==0.3 \
+    --hash=sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19 \
+    --hash=sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451
 # McCabe complexity checker
 # Code: https://github.com/pycqa/mccabe
 mccabe==0.6.1 \
@@ -213,13 +223,15 @@ mccabe==0.6.1 \
 # Code: https://github.com/pycqa/pycodestyle
 # Changes: https://pycodestyle.readthedocs.io/en/latest/developer.html#changes
 # Docs: https://pycodestyle.readthedocs.io/
-pycodestyle==2.4.0 \
-    --hash=sha256:74abc4e221d393ea5ce1f129ea6903209940c1ecd29e002e8c6933c2b21026e0 \
-    --hash=sha256:cbc619d09254895b0d12c2c691e237b2e91e9b2ecf5e84c26b35400f93dcfb83 \
-    --hash=sha256:cbfca99bd594a10f674d0cd97a3d802a1fdef635d4361e1a2658de47ed261e3a
-pyflakes==2.0.0 \
-    --hash=sha256:9a7662ec724d0120012f6e29d6248ae3727d821bba522a0e6b356eff19126a49 \
-    --hash=sha256:f661252913bc1dbe7fcfcbf0af0db3f42ab65aabd1a6ca68fe5d466bace94dae
+pycodestyle==2.5.0 \
+    --hash=sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56 \
+    --hash=sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c
+# Checks Python source files for errors
+# Code: https://github.com/PyCQA/pyflakes
+# Changes: https://github.com/PyCQA/pyflakes/blob/master/NEWS.rst
+pyflakes==2.1.0 \
+    --hash=sha256:f277f9ca3e55de669fba45b7393a1449009cff5a37d1af10ebb76c52765269cd \
+    --hash=sha256:5e8c00e30c464c99e0b501dc160b13a14af7f27d4dffb529c556e30a159e231d
 
 # google-api-python-client
 httplib2==0.9.2 \

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,9 +21,9 @@ django-debug-toolbar==1.10.1 \
 # Code: https://github.com/PyCQA/flake8
 # Docs: http://flake8.readthedocs.io/en/latest/
 # Changes: http://flake8.readthedocs.io/en/latest/release-notes/index.html
-flake8==3.6.0 \
-    --hash=sha256:6a35f5b8761f45c5513e3405f110a86bea57982c3b75b766ce7b65217abe1670 \
-    --hash=sha256:c01f8a3963b3571a8e6bd7a4063359aff90749e160778e03817cd9b71c9e07d2
+flake8==3.7.3 \
+    --hash=sha256:806ec5785af23b4d9f3224a47cdd73714528923fccc95cc13cb1b74ba19c1820 \
+    --hash=sha256:b70f13ee944e536f22becfd716802b1f2fa4ca5ff7aea2c6423567569004f732
 
 # Standardize Python import order
 # Code: https://github.com/PyCQA/flake8-import-order

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,9 @@ flake8-import-order==0.18 \
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin
-hashin==0.14.1 \
-    --hash=sha256:43ae3277fbd937ba1c99bc3fef9e4dd2e68cd5f2eea8f60ebdb53d83983d861b \
-    --hash=sha256:5dbf06b2adc32e5e438b9b9b352622b787c8555d4a2aa88b38d64764526f81a1
+hashin==0.14.4 \
+    --hash=sha256:db4b1568f947066354b8c3abb11a23780468f5471300e4c6c0b848ee6bdd5aca \
+    --hash=sha256:bee9823a515ec3a15ca0c652385a5dcb0e57496316592e6267be4c1e1ff7bd40
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \

--- a/tests/functional/test_dashboard.py
+++ b/tests/functional/test_dashboard.py
@@ -22,7 +22,7 @@ def test_dashboard(base_url, selenium):
     # spam ham button not present
     assert not first_row.is_spam_ham_button_present
     # no dashboard-details
-    assert page.details_items_length is 0
+    assert page.details_items_length == 0
 
 
 @pytest.mark.smoke
@@ -33,11 +33,11 @@ def test_dashboard_open_details(base_url, selenium):
     admin.login_new_user()
     page = DashboardPage(selenium, base_url).open()
     # no dashboard-details
-    assert page.details_items_length is 0
+    assert page.details_items_length == 0
     # click first cell
     page.open_first_details()
     # dashboard-details exist and are visible
-    assert page.details_items_length is 1
+    assert page.details_items_length == 1
     assert page.is_first_details_displayed
     # contains a diff
     page.wait_for_first_details_diff_displayed()

--- a/tests/headless/test_cdn.py
+++ b/tests/headless/test_cdn.py
@@ -240,8 +240,8 @@ def test_cached(base_url, is_behind_cdn, is_local_url, is_searchable, slug):
 def test_cached_301(base_url, is_behind_cdn, is_local_url, slug):
     """Ensure that these requests that should return 301 are cached."""
     if is_local_url and any(slug.startswith(p) for p in ('/files/', '/@api/')):
-            pytest.xfail('attachments are typically not served from a '
-                         'local development instance')
+        pytest.xfail('attachments are typically not served from a '
+                     'local development instance')
     assert_cached(base_url + slug, 301, is_behind_cdn)
 
 

--- a/tests/pages/dashboard.py
+++ b/tests/pages/dashboard.py
@@ -84,8 +84,7 @@ class DashboardPage(BasePage):
         try:
             self.wait.until(lambda s: int(
                             self.find_element(*self._revision_page_input)
-                            .get_attribute('value'))
-                            is not 1)
+                            .get_attribute('value')) != 1)
         except TimeoutException:
             if self.selenium._is_remote and self.selenium.name == 'firefox':
                 pytest.xfail("Known issue with AJAX refresh"

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ passenv =
 
 [testenv:flake8]
 basepython = python2.7
-deps = flake8
+deps = -rrequirements/dev.txt
 commands = make lint
 whitelist_externals = make
 


### PR DESCRIPTION
Package updates:

* hashin 0.14.1 → 0.14.4: Comment parsing fix for ``--update-all``, add ``--index-url`` to use different PyPI server.
* flake8 3.6.0 → 3.7.3: Add support for per-file ignores
* configparser 3.5.0 → 3.7.1: Sync with Python 3.7.2
* pycodestyle 2.4.0 → 2.5.0: Check for over-indented blocks (``E117``)
* pyflakes 2.0.0 → 2.1.0: Check for "``is``" with string and integer literals, other Python 3.x support

Add a new dependency for flake8:

* entrypoints 0.3: Advertise objects with a common interface

The flake8 update raised several new warnings, and I've made small changes to the code to fix them. I've also fixed issues with import order that weren't detected by TravisCI.

I've updated ``tox.ini`` so that we won't get automatic flake8 updates anymore 😿 but we will get import order checked 😸. 