### PR TITLE
Revert "Bug 1423716: stop adding the SEO root title to all document titles"

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -1,5 +1,5 @@
 {% extends "wiki/base.html" %}
-{% block title %}{{ page_title(document.title) }}{% endblock %}
+{% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
 {% from "wiki/includes/buttons.html" import get_document_buttons with context %}

--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -13,7 +13,8 @@ ARTICLE_NAME = 'Send feedback (about|on) MDN'
 def test_location(base_url, selenium):
     article_page = ArticlePage(selenium, base_url).open()
     page = article_page.header.open_feedback()
-    assert re.match(ARTICLE_NAME + r' \| MDN', selenium.title)
+    assert re.match(ARTICLE_NAME + r' - The MDN project \| MDN',
+                    selenium.title)
     assert re.match(ARTICLE_NAME, page.article_title_text)
     assert page.article_title_text in selenium.title
 


### PR DESCRIPTION
This reverts commits ff5f81e65c22ddb530a3a2355caee138a4a3f569
and 5fdf95cae312cbddaceb89be32370c7fe4ec27e2.