### PR TITLE
bug 1467518: update kuma.landing to better support Python3

### DIFF
--- a/kuma/landing/tests/test_utils.py
+++ b/kuma/landing/tests/test_utils.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import pytest
 
 from django.conf import settings

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf.urls import url
 
 from kuma.core.decorators import shared_cache_control

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.http import HttpResponse
 from django.shortcuts import redirect, render


### PR DESCRIPTION
This PR updates the `kuma.landing` app to better support Python3. The only changes here provide a string experience that is more consistent between Python2 and Python3.