### PR TITLE
Update ja.sccs to enable italic font style back

### DIFF
--- a/kuma/static/styles/locales/ja.scss
+++ b/kuma/static/styles/locales/ja.scss
@@ -44,14 +44,8 @@ Styles for Japanese
        local('IPA P Gothic');
 }
 
-/* Bug 973171 */
-/* stylelint-disable declaration-no-important */
-* {
-    /* !important required for locale specific override */
-    font-style: normal !important;
-}
-
 /* Bug 1522385 */
+/* stylelint-disable declaration-no-important */
 .syntaxbox {
     var,
     em {


### PR DESCRIPTION
The reason for introducing font-style: normal !important is now obsolete, as wrote in line 49.

Now I hope I'm doing this right, after #5219 