### PR TITLE
bug 1522718: Remove cache lock code

### DIFF
--- a/kuma/feeder/management/commands/update_feeds.py
+++ b/kuma/feeder/management/commands/update_feeds.py
@@ -5,7 +5,6 @@ import time
 
 from django.core.management.base import BaseCommand
 
-from kuma.core.utils import cache_lock
 from kuma.feeder.utils import update_feeds
 
 
@@ -18,7 +17,6 @@ class Command(BaseCommand):
             help='Fetch even disabled feeds.',
             action='store_true')
 
-    @cache_lock('kuma_feeder')
     def handle(self, *args, **options):
         """
         Locked command handler to avoid running this command more than once

--- a/kuma/wiki/exceptions.py
+++ b/kuma/wiki/exceptions.py
@@ -19,13 +19,6 @@ class DocumentRenderingInProgress(Exception):
     """
 
 
-class StaleDocumentsRenderingInProgress(Exception):
-    """
-    An attempt to render a stale page while a rendering is already in
-    progress is disallowed.
-    """
-
-
 class DocumentRenderedContentNotAvailable(Exception):
     """
     No rendered content available, and an attempt to render on the spot was


### PR DESCRIPTION
Simplify batch processing by removing the cache lock code. Code coverage also increases since there are no tests for this code.

The cache lock code was added in PR #2423, when rendering stale documents was expensive, and was being groomed to be the mechanism for mass document regeneration. With the changes of the past 5 years, this is no longer the case, and the risk of parallel re-render threads is less.

The cache was also used for feed processing, which could also be expensive. We currently only display the Hacks Blog feed, and do not intend to republish more feeds. Again, the risk of parallel feed fetching is much less for MDN and Hacks then it was 5 years ago.