### PR TITLE
Bug 1525719: create a non-production /ducks/ endpoint for the React spike

### DIFF
--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -104,12 +104,12 @@
 
     <!-- Header -->
     <header id="main-header" class="header-main">
-      <h2>&#x1f986;&nbsp;</h2>
       <a href="{{ url('home') }}" class="logo">{{ _('MDN Web Docs') }}</a>
       <div style="font: bold 26px/29px zillaslab;
                   background-color:black; color:white;
                   position:relative; left: -50px; height:29px; top:15px;
                   z-index:100">ducks&nbsp;</div>
+      <h2 style="position:absolute;height:48px;width:48px;line-height:55px;left:11px;top:-5px;z-index:100;background-color:black;transform:scale(-1,1)">&#8239;&#x1f986;&#8239;</h2>
       <div class="nav-toolbox-wrapper">
         {% include "includes/header-main-nav.html" %}
         {% include "includes/header-toolbox.html" %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -1,0 +1,178 @@
+{% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() in (settings.ATTACHMENT_ORIGIN, settings.ATTACHMENT_HOST)) %}
+
+<!DOCTYPE html>
+<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js">
+<head {%- if not untrusted %} prefix="og: http://ogp.me/ns#"{% endif %}>
+  <meta charset="utf-8">
+  {%- block experiment_js %}{% endblock %}
+  <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+  <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
+  <title>{% block title %}{{ _('MDN Web Docs') }}{% endblock %}</title>
+
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="robots" content=
+    {%- if request.get_host() in settings.ALLOW_ROBOTS_WEB_DOMAINS -%}
+        "{% block robots_value%}index, follow{% endblock %}"
+    {%- else -%}
+        "noindex, nofollow"
+    {%- endif -%}
+  >
+
+  {% include "includes/preload.html" %}
+
+  {%- if not untrusted %}
+    <link rel="home" href="{{ url('home') }}">
+    <link rel="license" href="#license">
+  {% endif %}
+
+  {% block site_css %}
+
+    {% stylesheet 'mdn' %}
+
+    {% for style in styles %}
+      {% stylesheet style %}
+    {% endfor %}
+  {% endblock %}
+
+  {%- if settings.MAINTENANCE_MODE %}
+    {% stylesheet 'maintenance-mode-global' %}
+  {%- endif %}
+
+  {#- If the stylesheet exists, include it. Otherwise, does nothing. #}
+  {% stylesheet 'locale-%s' % LANG %}
+
+  {% block site_analytics %}
+    {% include "includes/google_analytics.html" %}
+  {% endblock %}
+
+  {% block perfhead %}{% endblock %}
+
+  {%- if not untrusted %}
+    {%- block site_meta %}
+    <!-- common social tags -->
+    {% set social_logo = request.build_absolute_uri(static('img/opengraph-logo.png')) %}
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="{{ social_logo }}">
+    <meta property="og:site_name" content="{{ _('MDN Web Docs') }}">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:image" content="{{ social_logo }}">
+    <meta name="twitter:site" content="@MozDevNet">
+    <meta name="twitter:creator" content="@MozDevNet">
+    <link rel="search" type="application/opensearchdescription+xml" href="{{ settings.SITE_URL }}/{{ request.LANGUAGE_CODE }}/search/xml" title="{{ _('MDN Web Docs') }}">
+    {% endblock %}
+  {% endif %}
+  <!-- third-generation iPad with high-resolution Retina display: -->
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ static('img/favicon144.png') }}">
+  <!-- iPhone with high-resolution Retina display: -->
+  <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ static('img/favicon114.png') }}">
+  <!-- first- and second-generation iPad: -->
+  <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ static('img/favicon72.png') }}">
+  <!-- non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
+  <link rel="apple-touch-icon-precomposed" href="{{ static('img/favicon57.png') }}">
+  <!-- basic favicon -->
+  <link rel="shortcut icon" href="{{ favicon_url() }}">
+  <!--[if IE]>
+  <meta http-equiv="imagetoolbar" content="no">
+  {% javascript 'html5shiv' %}
+  <![endif]-->
+
+  {% block extrahead %}{% endblock %}
+</head>
+<body {% block body_attributes %}{% endblock %} class="{% block bodyclass %}{% endblock %}{% if settings.MAINTENANCE_MODE %} maintenance-mode{% endif %}"{% if request.user and request.user.is_authenticated %} data-login-service="{{ request.session.sociallogin_provider }}"{% endif %}>
+
+  {% include "includes/config.html" %}
+
+  {%- if settings.MAINTENANCE_MODE %}
+    <div class="global-notice maintenance-mode-notice">
+      <div class="wrap center">
+        <p>
+          <bdi>
+            {{ _('MDN is currently in read-only maintenance mode.') }}
+            {%- if not untrusted %}
+            <a href="{{ url('maintenance_mode') }}">{{ _('Learn more') }}</a>.
+            {%- endif %}
+          </bdi>
+        </p>
+      </div>
+    </div>
+  {%- else %}
+    {{ soapbox_messages(get_soapbox_messages(request.path)) }}
+  {%- endif %}
+
+  {%- if not untrusted %}
+    {% include "includes/a11y-nav.html" %}
+
+    <!-- Header -->
+    <header id="main-header" class="header-main">
+      <h2>&#x1f986;&nbsp;</h2>
+      <a href="{{ url('home') }}" class="logo">{{ _('MDN Web Docs') }}</a>
+      <div style="font: bold 26px/29px zillaslab;
+                  background-color:black; color:white;
+                  position:relative; left: -50px; height:29px; top:15px;
+                  z-index:100">ducks&nbsp;</div>
+      <div class="nav-toolbox-wrapper">
+        {% include "includes/header-main-nav.html" %}
+        {% include "includes/header-toolbox.html" %}
+      </div>
+      {% include "includes/nav-main-search.html" %}
+    </header>
+  {%- endif %} {# if not untrusted #}
+
+  <!-- Content will go here -->
+  <main id="content">
+      {% block document_head %}{% endblock %}
+      <div class="center clear">
+      {% block content %}{% endblock %}
+      </div>
+  </main>
+
+  {%- block contrib_popup %}{# Inject contributions popup where needed #}{% endblock %}
+
+  {%- if not untrusted %}
+  <!-- Footer -->
+    <footer id="nav-footer" class="nav-footer">
+      <div class="center">
+          {% include "includes/footer/mdn-footer.html" %}
+
+          {% include "includes/footer/moz-footer.html" %}
+
+          {% block lang_switcher %}
+            {% include "includes/lang_switcher.html" %}
+          {% endblock %}
+
+          {% block footer_copyright %}
+            <ul class="footer-tos">
+              <li><a href="https://www.mozilla.org/about/legal/terms/mozilla">{{ _('Terms') }}</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/">{{ _('Privacy') }}</a></li>
+              <li><a href="https://www.mozilla.org/privacy/websites/#cookies">{{ _('Cookies') }}</a></li>
+            </ul>
+
+            <div id="license" class="contentinfo">
+              {% trans copyright_url='/en-US/docs/MDN/About#Copyrights_and_licenses', thisyear=thisyear() %}
+                <p>&copy; 2005-{{ thisyear }} Mozilla and individual contributors.</p>
+                <p>Content is available under <a href="{{ copyright_url }}">these licenses</a>.</p>
+              {% endtrans %}
+            </div>
+          {% endblock %}
+      </div>
+    </footer>
+    {%- endif %} {# if not untrusted #}
+
+  <!-- site js -->
+  {% block site_js %}
+    <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
+
+    {{ providers_media_js() }}
+    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+    {% javascript 'main' %}
+    <script>
+    if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();
+  </script>
+    {% for script in scripts %}
+      {% javascript script %}
+    {% endfor %}
+  {% endblock %}
+
+  {% block js %}{% endblock %}
+</body>
+</html>

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -26,6 +26,7 @@ from kuma.search.urls import (
 from kuma.users.urls import lang_urlpatterns as users_lang_urlpatterns
 from kuma.wiki.admin import purge_view
 from kuma.wiki.urls import lang_urlpatterns as wiki_lang_urlpatterns
+from kuma.wiki.urls import react_document_urlpatterns as wiki_react_urlpatterns
 from kuma.wiki.views.document import as_json as document_as_json
 from kuma.wiki.views.legacy import mindtouch_to_kuma_redirect
 
@@ -89,6 +90,12 @@ urlpatterns += i18n_patterns(url(r'^search',
 urlpatterns += i18n_patterns(url(r'^docs.json$', document_as_json,
                                  name='wiki.json'))
 urlpatterns += i18n_patterns(url(r'^docs/', include(wiki_lang_urlpatterns)))
+
+# A special endpoint for our React spike, local and staging only
+if settings.DOMAIN != settings.PRODUCTION_DOMAIN:
+    urlpatterns += i18n_patterns(url(r'^ducks/',
+                                     include(wiki_react_urlpatterns)))
+
 urlpatterns += [url('', include('kuma.attachments.urls'))]
 urlpatterns += i18n_patterns(
     url(r'dashboards/?$', dashboards_index, name='dashboards.index'),

--- a/kuma/wiki/jinja2/wiki/react_base.html
+++ b/kuma/wiki/jinja2/wiki/react_base.html
@@ -14,18 +14,11 @@
 
 {% block site_css %}
     {{ super() }}
-
     {% stylesheet 'wiki' %}
-    {% stylesheet 'codepen-iex' %}
 
 {% endblock %}
 
 {% block site_js %}
     {{ super() }}
-
     {% javascript 'wiki' %}
-    {% javascript 'codepen-iex' %}
-
-    <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
-
 {% endblock %}

--- a/kuma/wiki/jinja2/wiki/react_base.html
+++ b/kuma/wiki/jinja2/wiki/react_base.html
@@ -1,0 +1,31 @@
+{% extends "react_base.html" %}
+
+{% block perfhead %}
+    {% include "wiki/includes/perf.html" %}
+{% endblock %}
+
+{% block experiment_js %}
+    {%- if not request.user.is_authenticated and
+           content_experiment and
+           not content_experiment.selection_is_valid %}
+        {% javascript content_experiment.id %}
+    {%- endif %}
+{% endblock %}
+
+{% block site_css %}
+    {{ super() }}
+
+    {% stylesheet 'wiki' %}
+    {% stylesheet 'codepen-iex' %}
+
+{% endblock %}
+
+{% block site_js %}
+    {{ super() }}
+
+    {% javascript 'wiki' %}
+    {% javascript 'codepen-iex' %}
+
+    <script async src="https://static.codepen.io/assets/embed/ei.js"></script>
+
+{% endblock %}

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -1,0 +1,350 @@
+{% extends "wiki/react_base.html" %}
+{% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
+
+{% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
+{% from "wiki/includes/buttons.html" import get_document_buttons with context %}
+{% from "wiki/includes/approvals.html" import get_approvals_html with context %}
+
+{% if fallback_reason == 'no_translation' %}
+  {% set help_link = url('wiki.translate', document_path=document.slug, locale=document.locale)|urlparams(tolocale=request.LANGUAGE_CODE) %}
+{% elif fallback_reason == 'translation_not_approved' %}
+  {% set help_link = url('wiki.translate', document_path=document.parent.slug, locale=document.parent.locale)|urlparams(tolocale=request.LANGUAGE_CODE) %}
+{% endif %}
+
+{% set is_archive = (document.slug == 'Archive') or document.slug.startswith('Archive/') %}
+{% set is_logged_in = request.user.is_authenticated %}
+{% set doc_abs_url = document.get_absolute_url() %}
+{% set canonical = doc_abs_url | absolutify %}
+
+{% set doc_edit_url = document.get_edit_url() %}
+{% if not is_logged_in %}
+  {% set doc_edit_url = url('account_login') + '?next=' + (doc_edit_url | urlencode) %}
+{% endif %}
+
+{% set current_revision = document.current_revision %}
+{% if (is_logged_in and current_revision) and (current_revision.needs_technical_review or current_revision.needs_editorial_review) %}
+  {% set approvals_html = get_approvals_html(document, request.user) %}
+{% endif %}
+
+{% set show_left = quick_links_html or approvals_html %}
+
+{% set buttons = get_document_buttons(document, help_link, other_translations) %}
+{% set crumbs = build_document_crumbs(document) %}
+
+
+{% set content_class = 'column-all' %}
+{% if show_left %}
+  {% set content_class = 'column-main' %}
+{% endif %}
+
+{% block robots_value %}
+  {%- if document.is_experiment or fallback_reason or not document_html -%}
+    noindex, nofollow
+  {%- else -%}
+    {{ super() }}
+  {%- endif -%}
+{% endblock %}
+
+{% block bodyclass %}document{% endblock %}
+{% block body_attributes %}data-slug="{{ document.slug }}" contextmenu="edit-history-menu" data-search-url="{{ search_url }}"{% endblock body_attributes %}
+
+{% block main_content_id %}document-main{% endblock %}
+
+{% block site_css %}
+    {{ super() }}
+    {% if is_archive %}
+      {% stylesheet 'archive' %}
+    {% endif %}
+{% endblock %}
+
+{% block extrahead %}
+  <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+  <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
+
+  <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.slug) | absolutify }}">
+  <link rel="canonical" href="{{ canonical }}" >
+
+  {# Google requires the current page to be referenced as an alternate too for SEO purposes see bug 1449210 #}
+  <link rel="alternate" hreflang="{{ document.locale }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
+  {% if other_translations %}
+    {% for translation in other_translations %}
+      <link rel="alternate" hreflang="{{ translation.locale }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
+    {% endfor %}
+  {% endif %}
+
+  <!-- document-specific social tags -->
+  <meta property="og:title" content="{{ document.title }}">
+  <meta property="og:url" content="{{ canonical }}">
+  <meta name="twitter:url" content="{{ canonical }}">
+  <meta name="twitter:title" content="{{ document.title }}">
+  {% if seo_summary %}
+  <meta property="og:description" content="{{ seo_summary }}">
+  <meta name="description" content="{{ seo_summary }}">
+  <meta name="twitter:description" content="{{ seo_summary }}">
+  {% endif %}
+{% endblock %}
+
+{% block lang_switcher %}
+  {% if (document.is_localizable or document.parent) and other_translations %}
+    <form class="languages go" method="get" action="{{ wiki_url('Web') }}">
+      <label for="language">{{ _('Other languages:') }}</label>
+      <select id="language" class="wiki-l10n" name="next" dir="ltr">
+        <option title="{{ get_locale_localized(document.locale) }}" data-locale="{{ document.locale }}" value="{{ doc_abs_url }}" selected>
+          {{ document.language }} ({{ document.locale }})
+        </option>
+        {% for translation in other_translations %}
+          <option title="{{ get_locale_localized(translation.locale) }}" data-locale="{{ document.locale }}" value="{{ translation.get_absolute_url() }}">
+            {{ translation.language }} ({{ translation.locale }})
+          </option>
+        {%- endfor %}
+      </select>
+      <noscript><button type="submit">{{ _('Go') }}</button></noscript>
+    </form>
+  {% endif %}
+{% endblock %}
+
+{% block document_head %}
+  <!-- heading -->
+  <div id="wiki-document-head" class="document-head">
+    <div class="center">
+      <div class="document-title">
+        <h1>{{ document.title }}</h1>
+      </div>
+
+      <!-- action buttons -->
+      <div class="document-actions">
+        {{ buttons }}
+      </div>
+    </div>
+  </div>
+  {% if toc_html %}
+  <div id="toc" class="toc">
+    <div class="center">
+      <div class="toc-head">{{ _("Jump to:") }}</div>
+        <ol class="toc-links">
+          {{ toc_html|safe }}
+        </ol>
+    </div>
+  </div>
+  {% endif %}
+{% endblock%}
+
+{% block content %}
+
+    <div class="wiki-main-content" id="document-main"><div class="center">
+      <!-- start the main content container -->
+        <div id="wiki-column-container" class="{% if show_left %}wiki-left-present{% else %}wiki-left-closed wiki-left-none{% endif %}">
+
+          <!-- content row with three strips -->
+          <div class="column-container column-container-reverse">
+
+            <!-- center: main article content -->
+            <div id="wiki-content" class="{{ content_class }} wiki-column text-content">
+
+              {% if settings.MAINTENANCE_MODE and render_raw_fallback %}
+                <div id="doc-render-raw-fallback" class="warning">
+                {% trans url='/maintenance-mode/' %}
+                  This document has not yet been rendered, and cannot be
+                  rendered while MDN is in <a href="{{ url }}">maintenance
+                  mode</a>. Please check back when maintenance has concluded.
+                {% endtrans %}
+                </div>
+              {% endif %}
+
+              {% if is_logged_in and document_html %}
+                {% if render_raw_fallback %}
+                  <div id="doc-render-raw-fallback" class="warning">
+                  {% trans url=doc_abs_url %}
+                    This document is being rendered for the first time by the system.
+                    Please <a href="{{ url }}">reload this page</a> in a few minutes
+                    to see full content.
+                  {% endtrans %}
+                  </div>
+                {% elif document.is_rendering_in_progress %}
+                  <div id="doc-rendering-in-progress" class="warning">
+                  {% trans url=doc_abs_url, started_at=document.render_started_at %}
+                    An update to this document
+                    <abbr title="{{ started_at }}">is currently in progress</abbr>.
+                    If the content below seems stale or if something is missing,
+                    please <a href="{{ url }}">reload this page</a> in a few minutes.
+                  {% endtrans %}
+                  </div>
+                {% elif document.is_rendering_scheduled and not kumascript_errors %}
+                  <div id="doc-rendering-scheduled" class="warning">
+                  {% trans url=doc_abs_url, scheduled_at=document.render_scheduled_at %}
+                    An update to this document
+                    <abbr title="{{ scheduled_at }}">has been scheduled</abbr>.
+                    If the content below seems stale or if something is missing,
+                    please <a href="{{ url }}">reload this page</a> in a few minutes.
+                  {% endtrans %}
+                  </div>
+                {% endif %}
+              {% endif %}
+              {% if document.is_experiment %}
+                <div id="doc-experiment" class="warning">
+                  {{ _("This is an experimental page.") }}
+                </div>
+              {% endif %}
+
+              {% if kumascript_errors %}
+                {% include 'wiki/includes/kumascript_errors.html' %}
+              {% endif %}
+
+              {% if document.parent_id and document.current_revision %}
+                {% if document.current_revision.localization_in_progress %}
+                  {% if not settings.MAINTENANCE_MODE and document.current_revision.translation_age >= 10 %}
+                    <div class="overheadIndicator translationInProgress"><p>{% trans translate_url=doc_edit_url %}
+                      This translation is incomplete. Please help <a href="{{ translate_url }}">translate this article</a> from English.
+                    {% endtrans %}</p></div>
+                  {% else %}
+                    <div class="overheadIndicator translationInProgress"><p>
+                      {{ _('This translation is in progress.') }}
+                    </p></div>
+                  {% endif %}
+                {% endif %}
+              {% endif %}
+              {% if not settings.MAINTENANCE_MODE and fallback_reason %}
+                <div id="doc-pending-fallback" class="warning">
+                  <p><bdi>{% trans help_link=help_link, locale=settings.LOCALES[request.LANGUAGE_CODE].native, parent_language=document.language %}
+                    Our volunteers haven't translated this article into <bdi>{{ locale }}</bdi> yet.
+                    <a href="{{ help_link }}" rel="nofollow">Join us and help get the job done!</a><br>
+                    You can also read the article in <a href="{{ doc_abs_url }}">{{ parent_language }}</a>.
+                  {% endtrans %}</bdi></p>
+                </div>
+              {% endif %}
+
+              <!-- just the article content -->
+              <article id="wikiArticle">
+                {% if not fallback_reason %}
+                  {% if not document_html %}
+                    {{ _("This article doesn't have any content yet.") }}
+                  {% else %}
+                    {{ body_html|safe }}
+                  {% endif %}
+                {% elif fallback_reason == 'no_translation' %}
+                  {{ body_html|safe }}
+                {% elif fallback_reason == 'translation_not_approved' %}
+                  {{ document.parent.html|safe }}
+                {% else %}
+                  {{ _("This article doesn't have approved content yet.") }}
+                {% endif %}
+              </article>
+
+              <!-- contributors -->
+              <div class="wiki-block contributors">
+                <h2 class="offscreen">{{ _('Document Tags and Contributors') }}</h2>
+                {% set tags = document.all_tags_name %}
+                {% include "wiki/includes/document_tag.html" %}
+
+                {% if has_contributors %}
+                  <div class="contributors-sub">
+                    {% include 'includes/icons/user/group.svg' %}
+                    <strong>{{ _('Contributors to this page:') }}</strong>
+                    {{ contributor_links(contributors) }}
+                  </div>
+                {% endif %}
+
+                {% if current_revision.creator %}
+                  <div class="contributors-sub">
+                    {% include 'includes/icons/general/clock.svg' %}
+                    <strong>{{ _('Last updated by:') }}</strong>
+                    <a href="{{ current_revision.creator.get_absolute_url() }}" rel="nofollow">{{ current_revision.creator }}</a>,
+                    {{ datetimeformat(current_revision.created, format='datetime') }}
+                  </div>
+                {% endif %}
+              </div>
+            </div>
+
+            {% if show_left %}
+              <!-- quick links and approvals strip -->
+              <div id="wiki-left" class="column-strip wiki-column">
+
+                <!-- crumbs -->
+                {{ crumbs }}
+
+                {% if quick_links_html %}
+                  <!-- quick links -->
+                  {{ get_document_quick_links(quick_links_html) }}
+                {% endif %}
+
+                <!-- approvals -->
+                {% if approvals_html %}
+                  {{ approvals_html }}
+                {% endif %}
+
+              </div>
+            {% endif %}
+          </div>
+        </div>
+      </div>
+    </div> <!-- ends "main-content" -->
+
+    {% if settings.NEWSLETTER and settings.NEWSLETTER_ARTICLE %}
+      <div class="newsletter-box">
+        {% include "includes/newsletter.html" %}
+      </div>
+    {% endif %}
+
+  <menu type="context" id="edit-history-menu">
+    <menuitem data-action="{{ doc_edit_url }}" label="{{_('Edit page')}}"></menuitem>
+    <menuitem data-action="{{ url('wiki.document_revisions', document.slug) }}" label="{{_('View page history')}}"></menuitem>
+  </menu>
+{% endblock %}
+
+{% block contrib_popup %}
+    {%- if contribution_popup %}
+        {%- with form=contribution_form, is_popover=True %}
+            {%- include "payments/includes/payments-banner.html" %}
+        {%- endwith %}
+    {%- endif %}
+{% endblock %}
+
+{% block js %}
+
+  {% if waffle.flag('section_edit') %}
+    <script>
+        (function($) {
+            $('#wikiArticle').children('h2[id]').each(function() {
+                var id = $(this).attr('id');
+                var href = '{{ doc_edit_url }}#' + id;
+                var pencil = window.mdnIcons ? window.mdnIcons.getIcon('pencil') : '';
+
+                $('<a>').attr({
+                    href: href,
+                    'class': 'button section-edit only-icon',
+                    'rel': 'nofollow, noindex'
+                })
+                .append(pencil)
+                .append($('<span>'))
+                .find('span')
+                .text(gettext('Edit'))
+                .end()
+                .on('click', function(e) {
+                    e.preventDefault();
+
+                    mdn.analytics.trackEvent({
+                        category: 'Section Edit',
+                        action: id
+                    }, function() {
+                        window.location = href;
+                    });
+                })
+                .appendTo(this);
+            });
+        })(jQuery);
+    </script>
+  {% endif %}
+
+  {% if waffle.flag('sg_task_completion') %}
+    {% javascript 'task-completion' %}
+  {% endif %}
+
+  {% if settings.NEWSLETTER and settings.NEWSLETTER_ARTICLE %}
+    {% javascript 'newsletter' %}
+  {% endif %}
+
+  {%- if contribution_popup %}
+    {% javascript 'payments' %}
+  {%- endif %}
+
+{% endblock %}

--- a/kuma/wiki/urls.py
+++ b/kuma/wiki/urls.py
@@ -8,7 +8,6 @@ from kuma.core.decorators import shared_cache_control
 from . import feeds, views
 from .constants import DOCUMENT_PATH_RE
 
-
 # These patterns inherit (?P<document_path>[^\$]+).
 document_patterns = [
     url(r'^$',
@@ -174,4 +173,12 @@ non_document_patterns = [
 lang_urlpatterns = non_document_patterns + [
     url(r'^(?P<document_path>%s)' % DOCUMENT_PATH_RE.pattern,
         include(document_patterns)),
+]
+
+# These are react-based endpoints for our React spike.
+# They will be triggered by URLs where /docs/ is replaced with /ducks/
+react_document_urlpatterns = [
+    url(r'^(?P<document_path>%s)$' % DOCUMENT_PATH_RE.pattern,
+        views.document.react_document,
+        name='wiki.react_document')
 ]


### PR DESCRIPTION
This patch adds a new /ducks/ url just like our existing /docs/ url
for wiki documents, except it has a duck in the header. The URL route
is not installed if we're in production so this should be safe. We
are going to use this new url for our experimentation with React.