### PR TITLE
Bug 1523643, heading link widget breaks to new line on mobile

### DIFF
--- a/kuma/static/styles/components/wiki/content/collapsible.scss
+++ b/kuma/static/styles/components/wiki/content/collapsible.scss
@@ -4,7 +4,7 @@ h2 > .collapse-trigger {
     background-color: inherit;
     border: inherit;
     color: inherit;
-    display: block;
+    display: inline-block;
     font-family: inherit;
     font-weight: normal;
     letter-spacing: inherit;
@@ -14,12 +14,12 @@ h2 > .collapse-trigger {
     position: relative;
     text-decoration: inherit;
     text-align: left;
-    width: 100%;
 
     /* add toggle symbol */
     &:before {
         margin-right: 10px;
         @include set-bidi-icon($path-to-svg-arrow-icons + 'caret-right.svg', $path-to-svg-arrow-icons + 'caret-left.svg', auto, auto, 8px);
+        background-position: 0 5px;
         cursor: pointer;
     }
 


### PR DESCRIPTION
Before:

![screenshot 2019-02-11 at 14 03 18](https://user-images.githubusercontent.com/10350960/52562041-e4367880-2e05-11e9-8eed-b0b5e60ce79c.png)

After:

![screenshot 2019-02-11 at 14 03 03](https://user-images.githubusercontent.com/10350960/52562054-eac4f000-2e05-11e9-8b80-2ac816f61a99.png)

@davidflanagan r?