### PR TITLE
bug 1332666: Security updates for Python packages Django, Werkzeug

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -33,9 +33,12 @@ dennis==0.9 \
     --hash=sha256:f6487392ac91800c5f0684a99b404b7fd0f72ceb48faeb5a0ce4e2c24fb62d3f
 
 # Web framework for Python projects of a certain age
-Django==1.11.18 \
-    --hash=sha256:73cca1dac154e749b39cc91a54dc876109eb0512a5c6804986495305047066a5 \
-    --hash=sha256:7ee7d93d407f082e3849c8d10da50ff5b488af37ed1b0066a22dee5f2709ed16
+# Code: https://github.com/django/django
+# Changes: https://docs.djangoproject.com/en/2.1/releases/
+# Docs: https://docs.djangoproject.com
+Django==1.11.20 \
+    --hash=sha256:0a73696e0ac71ee6177103df984f9c1e07cd297f080f8ec4dc7c6f3fb74395b5 \
+    --hash=sha256:43a99da08fee329480d27860d68279945b7d8bf7b537388ee2c8938c709b2041
 
 # 3rd party logins like Github
 # Code: https://github.com/pennersr/django-allauth

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -68,6 +68,9 @@ urlwait==0.4 \
     --hash=sha256:395fc0c2a7f9736858a2c2f449aa20c6e9da1f86bfc2d1fda4f2f5b78a5c115a
 
 # Enables ./manage.py runserver_plus with in-browser exception debugging
-Werkzeug==0.11.4 \
-    --hash=sha256:7db3cb2d4725be0680abf64a45b18229186f03ad8b9989abbe053f9357b17b37 \
- --hash=sha256:e48fb7e3f2bb5a740dd9a666624699a4d83e2e028555f9c46bcc8ecfc2cd8c32
+# Code: https://github.com/pallets/werkzeug
+# Changes: https://github.com/pallets/werkzeug/blob/master/CHANGES.rst
+# Docs: http://werkzeug.pocoo.org/docs/0.14/
+Werkzeug==0.14.1 \
+    --hash=sha256:d5da73735293558eb1651ee2fddc4d0dedcfa06538b8813a2e20011583c9e49b \
+    --hash=sha256:c3fd7a7d41976d9f44db327260e263132466836cef6f91512889ed60ad26557c

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -34,9 +34,9 @@ flake8-import-order==0.18 \
 
 # Calculate hashes for pip 8.x+
 # Code: https://github.com/peterbe/hashin
-hashin==0.14.4 \
-    --hash=sha256:db4b1568f947066354b8c3abb11a23780468f5471300e4c6c0b848ee6bdd5aca \
-    --hash=sha256:bee9823a515ec3a15ca0c652385a5dcb0e57496316592e6267be4c1e1ff7bd40
+hashin==0.14.5 \
+    --hash=sha256:dbace6900d8de44f3106a64496803e45843cf4974755613db811a487fadbf4c6 \
+    --hash=sha256:fe764df71cabbbddfa72aa4d6685581c932bb5cf9100ddee6b2b04f3446ae2f7
 
 # Test mocks, added to the Python 3 standard library
 mock==1.3.0 \


### PR DESCRIPTION
* [hashin 0.14.4 → 0.14.5](https://github.com/peterbe/hashin#version-history): Sort hashes for reliable ordering (used to update requirements)
* [Django 1.11.18 → 1.11.20](https://docs.djangoproject.com/en/dev/releases/1.11.19/): Address memory exhaustion issue with very long or large Decimal value (CVE-2019-6975)
* [Werkzeug 1.11.4 → 1.14.1](https://github.com/pallets/werkzeug/blob/master/CHANGES.rst): Many fixes and changes. Add some XSS protection to the in-browser debugger.

Note: Werzeug is used with ``./manage.py runserver_plus``, which allows interactive debugging of a single threaded server (see [Customizing the Docker environment](https://kuma.readthedocs.io/en/latest/development.html#customizing-the-docker-environment)). It is not used in production. [Requires.io](https://requires.io/github/mozilla/kuma/requirements/?branch=master) is flagging it as needing an update for a security issue.