### PR TITLE
Bug 1522998: fix the CKEditor save buttons in maximized mode

### DIFF
--- a/kuma/static/js/wiki-edit.js
+++ b/kuma/static/js/wiki-edit.js
@@ -565,11 +565,29 @@
         // Keep track of editor dirtiness
         function checkEditorDirtiness() {
             var editorDirty = editor.checkDirty();
+            var $container = $form.find('.editor-container');
 
-            if (editorDirty) {
-                $form.find('.editor-container').addClass('dirty').trigger('mdn:dirty');
+            if ($container.length) {
+                if (editorDirty) {
+                    $container.addClass('dirty').trigger('mdn:dirty');
+                } else {
+                    $container.removeClass('dirty').trigger('mdn:clean');
+                }
             } else {
-                $form.find('.editor-container').removeClass('dirty').trigger('mdn:clean');
+                /*
+                 * When the editor is maximized, the container doesn't
+                 * exist in the form, but we still need to fire mdn:dirty
+                 * and mdn:clean events to enable and disable the save
+                 * buttons in the editor. Fortunately, those events are
+                 * handled on the form, so we just trigger the events
+                 * directly on the form in that case, and we don't
+                 * bother with adding and removing the 'dirty' class.
+                 */
+                if (editorDirty) {
+                    $form.trigger('mdn:dirty');
+                } else {
+                    $form.trigger('mdn:clean');
+                }
             }
         }
 


### PR DESCRIPTION
The CKEditor save buttons are enabled and disabled depending
on whether any of the content has changed. The JavaScript to do this
uses a jQuery find() function to locate a ".editor-container" element
within a form, and then dispatches dirty or clean events on that
container element.

This is fine in the normal case, but if the editor is maximized
then the DOM hierarchy changes and there is no .editor-container.
The find() call returns an empty array and the events are dispatched
on the zero elements in that array.

This patch adds a special case: when no container element is found,
we dispatch the required events directly on the form (which is where
the handlers for those events are installed.)