### PR TITLE
Bug 1522937, test three scenarios for hiding IEx

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1004,6 +1004,7 @@ PIPELINE_JS = {
             'js/utils/utils.js',
             'js/utils/post-message-handler.js',
             'js/wiki.js',
+            'js/utils/bug1522937-iex-test.js',
             'js/interactive.js',
             'js/wiki-samples.js',
             'js/wiki-toc.js',

--- a/kuma/static/js/utils/bug1522937-iex-test.js
+++ b/kuma/static/js/utils/bug1522937-iex-test.js
@@ -1,0 +1,25 @@
+(function() {
+    'use strict';
+
+    var iexIframe;
+    var url = document.location.href;
+    var pageName = url.substr(url.indexOf('box-shadow'));
+
+    if (pageName === 'box-shadow-display-none') {
+        iexIframe = document.querySelector('.interactive');
+
+        // just to be sure there is an iframe
+        if (iexIframe) {
+            iexIframe.classList.add('hidden');
+        }
+    } else if (pageName === 'box-shadow-display-none-empty-src') {
+        iexIframe = document.querySelector('.interactive');
+        // just to be sure there is an iframe
+        if (iexIframe) {
+            iexIframe.src = 'about:blank';
+            iexIframe.classList.add('hidden');
+        }
+    } else {
+        return;
+    }
+})();


### PR DESCRIPTION
The testing scenarios are described here:
https://github.com/mdn/sprints/issues/921#issuecomment-460967275

Pages for testing can be copied from production. These are:

* https://developer.mozilla.org/en-US/docs/User:schalkneethling/mobile/box-shadow-no-iex
* https://developer.mozilla.org/en-US/docs/User:schalkneethling/mobile/box-shadow-display-none
* https://developer.mozilla.org/en-US/docs/User:schalkneethling/mobile/box-shadow-display-none-empty-src

This is temporary while we gather some performance metrics. Once @atopal has sufficient data, we will back-out the script.

@davidflanagan r?