### PR TITLE
bug 924958: add JRE to KumaScript Docker image

### DIFF
--- a/docker/images/kumascript/Dockerfile
+++ b/docker/images/kumascript/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.14.2-slim
+FROM node:10.14.2
 
 RUN set -ex && \
     apt-get update && \
@@ -7,6 +7,7 @@ RUN set -ex && \
         mime-support \
         build-essential \
         python2.7 \
+        default-jre \
     && rm -rf /var/lib/apt/lists/*
 
 # remove the node user from the base package and add a non-priviledged user


### PR DESCRIPTION
This PR adds the default Java JRE to the KumaScript Docker image. The Java JRE is required to run the Nu HTML validator (https://github.com/validator/validator) which we're going to use to create a KumaScript test utility function that does HTML validation (PR coming soon) for use within tests for KumaScript macros.

The base image has been changed from the `slim` version (`10.14.2-slim`) to the `stretch` version (`10.14.2`) because the `default-jre` install fails with the `slim` version. It is possible to keep using the `slim` version, but it would require the "manual" creation of a man-page directory within the Dockerfile to accommodate the `default-jre` install, and in the interest of avoiding "manual", special-case tweaks, I decided to go with the `stretch` version to keep it simple and clean, at the expense  of a heavier image.