### PR TITLE
bug 1441672: make locale redirects for the homepage permanent

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -190,7 +190,11 @@ class LocaleMiddleware(MiddlewareBase):
                         1
                     ))
                 # Kuma: Add caching headers to redirect
-                redirect = HttpResponseRedirect(language_url)
+                if request.path_info == '/':
+                    # Only the homepage should be redirected permanently.
+                    redirect = HttpResponsePermanentRedirect(language_url)
+                else:
+                    redirect = HttpResponseRedirect(language_url)
                 add_shared_cache_control(redirect)
                 return redirect
 

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -70,7 +70,7 @@ def test_locale_middleware_picker(accept_language, locale, client, db):
 @pytest.mark.parametrize('original,fixed', REDIRECT_CASES)
 def test_locale_middleware_fixer(original, fixed, client, db):
     '''The LocaleStandardizerMiddleware redirects non-standard locale URLs.'''
-    response = client.get('/%s/' % original)
+    response = client.get(('/%s/' % original) if original else '/')
     if original == '':
         # LocaleMiddleware handles this case, and it's a 301 instead
         # of a 302 since it's the homepage.

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -49,11 +49,19 @@ REDIRECT_CASES = [
 ] + [(orig, new) for (orig, new) in SIMPLE_ACCEPT_CASES if orig != new]
 
 
+def test_locale_middleware_redirect_when_not_homepage(client, db):
+    '''The LocaleMiddleware redirects via 302 when it's not the homepage.'''
+    response = client.get('/docs/Web/HTML')
+    assert response.status_code == 302
+    assert response['Location'] == '/en-US/docs/Web/HTML'
+    assert_shared_cache_header(response)
+
+
 @pytest.mark.parametrize('accept_language,locale', PICKER_CASES)
 def test_locale_middleware_picker(accept_language, locale, client, db):
     '''The LocaleMiddleware picks locale from the Accept-Language header.'''
     response = client.get('/', HTTP_ACCEPT_LANGUAGE=accept_language)
-    assert response.status_code == 302
+    assert response.status_code == 301
     url_locale = locale or 'en-US'
     assert response['Location'] == ('/%s/' % url_locale)
     assert_shared_cache_header(response)
@@ -63,7 +71,13 @@ def test_locale_middleware_picker(accept_language, locale, client, db):
 def test_locale_middleware_fixer(original, fixed, client, db):
     '''The LocaleStandardizerMiddleware redirects non-standard locale URLs.'''
     response = client.get('/%s/' % original)
-    assert response.status_code == 302
+    if original == '':
+        # LocaleMiddleware handles this case, and it's a 301 instead
+        # of a 302 since it's the homepage.
+        expected_status_code = 301
+    else:
+        expected_status_code = 302
+    assert response.status_code == expected_status_code
     assert response['Location'] == '/%s/' % fixed
     assert_shared_cache_header(response)
 
@@ -78,7 +92,7 @@ def test_locale_middleware_language_cookie(client, db):
     '''The LocaleMiddleware uses the language cookie over the header.'''
     client.cookies.load({settings.LANGUAGE_COOKIE_NAME: 'bn-BD'})
     response = client.get('/', HTTP_ACCEPT_LANGUAGE='fr')
-    assert response.status_code == 302
+    assert response.status_code == 301
     assert response['Location'] == '/bn-BD/'
     assert_shared_cache_header(response)
 


### PR DESCRIPTION
This PR changes locale-based redirects for the homepage from 302's to 301's for SEO reasons (see https://github.com/mdn/sprints/issues/932). All other endpoints are still redirected via 302 by `LocaleMiddleware`.

For reference, especially see:
- https://github.com/mdn/sprints/issues/932#issuecomment-466117128
- https://github.com/mdn/sprints/issues/932#issuecomment-466123774.

For the record, this was the description at the time this PR was originally submitted:

> This PR changes the redirects that `LocaleMiddleware` performs from 302's to 301's, per https://github.com/mdn/sprints/issues/932#issuecomment-462832669. My understanding is that this should be done for all paths without a locale, not just the homepage (so for example, https://developer.mozilla.org/docs/Web/Apps redirects with a 301 just like https://developer.mozilla.org/ would).
> 
> NOTE: Putting any SEO justifications aside, I have to admit that this feels wrong simply because we'd be making permanent any locale selected and stored in the language cookie (if there is one) or, failing that, the locale in the HTTP `Accept-Language` header, but perhaps that's outweighed by the SEO justifications.