### PR TITLE
Inline emotion styles

### DIFF
--- a/kuma/javascript/src/logo.jsx
+++ b/kuma/javascript/src/logo.jsx
@@ -1,21 +1,21 @@
 //@flow
 import * as React from 'react';
 
-const styles = {
-    logo: {
-        display: 'block',
-        height: 48,
-        width: 219,
-        marginTop: 15,
-        // The sprite image includes a mask, and is not itself 48px high
-        // so we need overflow to hide the mask.
-        overflow: 'hidden'
-    }
-};
 
 export default function Logo(props: {| url: string |}): React.Node {
     return (
-        <a css={styles.logo} href={props.url}>
+        <a
+            css={{
+                display: 'block',
+                height: 48,
+                width: 219,
+                marginTop: 15,
+                // The sprite image includes a mask, and is not itself 48px high
+                // so we need overflow to hide the mask.
+                overflow: 'hidden'
+            }}
+            href={props.url}
+        >
             <img src="/static/img/web-docs-sprite.svg" alt="MDN Web Docs" />
         </a>
     );


### PR DESCRIPTION
After speaking with one of the emotion core maintainers, he said inlining the styles can give the Babel plugin a better chance to optimise, and in the end it hoists anything it can't optimise anyway.