### PR TITLE
bug 1497646: Add CKEditor development mode

### DIFF
--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -32,3 +32,7 @@
 
 # Switch to SSL configuration at https://developer-local.allizom.org
 #COMPOSE_FILE=docker-compose.yml:docker-compose.ssl.yml
+
+# Developer CKEditor plugins
+# See https://kuma.readthedocs.io/en/latest/ckeditor.html
+#CKEDITOR_DEV=True

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ etc/nginx/ssl/developer.127.0.0.1.nip.io.crt
 etc/nginx/ssl/developer.127.0.0.1.nip.io.key
 humans.txt
 james.ini
+kuma/static/js/libs/ckeditor/source/ckeditor/
 kuma/static/js/libs/ckeditor/source/ckbuilder/
 mdn_sample_db.sql
 mdn_sample_db.sql.gz

--- a/docs/ckeditor.rst
+++ b/docs/ckeditor.rst
@@ -49,6 +49,35 @@ directory `/kuma/static/js/libs/ckeditor/source/ckeditor/plugins/`_.
 Once you've made changes to a plugin, be sure to build the editor and the static
 resources again, as described in `Building CKEditor`_.
 
+Interactively developing CKEditor plugins
+-----------------------------------------
+For small changes, it may be fastest to rebuild CKEditor for each change. For
+more involved changes, you can load CKEditor in development mode.
+
+To interactively develop CKEditor plugins, first download the CKEditor source
+code on the host system::
+
+    cd kuma/static/js/libs/ckeditor/source/
+    ./build.sh --download
+
+Enable development mode by adding a line to ``.env``::
+
+    CKEDITOR_DEV=True
+
+Restart Docker with ``docker-compose restart web`` to apply the new setting. This
+will switch to a mode where plugins are loaded dynamically, based on the list
+in `/kuma/wiki/jinja2/wiki/includes/ckeditor_scripts.html`_, and you can see
+your changes by reloading the browser.
+
+When you are done, disable development mode in ``.env``::
+
+    CKEDITOR_DEV=False  # Or comment out the line
+
+Restart Docker with ``docker-compose restart web``, and follow the instructions
+above for `Building CKEditor`_, to delete the CKEditor source code and
+rebuild CKEditor with your changes.
+
+
 Committing Changes
 ------------------
 When updating CKEditor, adding a plugin, or changing the configuration,
@@ -78,3 +107,5 @@ files are not expected.
 .. _wordcount: https://github.com/w8tcha/CKEditor-WordCount-Plugin
 .. _`/kuma/static/js/libs/ckeditor/source/ckeditor/plugins/`:
    https://github.com/mozilla/kuma/tree/master/kuma/static/js/libs/ckeditor/source/plugins
+.. _`/kuma/wiki/jinja2/wiki/includes/ckeditor_scripts.html`:
+   https://github.com/mozilla/kuma/tree/master/kuma/wiki/jinja2/wiki/includes/ckeditor_scripts.html

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -8,7 +8,12 @@
         {{ waffle.wafflejs() }}
 
         // This needs to be set before ckeditor.js loads
-        window.CKEDITOR_BASEPATH = '/static/js/libs/ckeditor/build/ckeditor/';
+        {%- if settings.CKEDITOR_DEV %}
+          {%- set ckeditor_basepath = static('js/libs/ckeditor/source/ckeditor/') %}
+        {%- else %}
+          {%- set ckeditor_basepath = static('js/libs/ckeditor/build/ckeditor/') %}
+        {%- endif %}
+        window.CKEDITOR_BASEPATH = '{{ ckeditor_basepath }}';
 
         // Site configuration
         win.mdn.ckeditor = {};

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -515,6 +515,8 @@ MAX_AVATAR_FILE_SIZE = 131072  # 100k, in bytes
 
 ROOT_URLCONF = 'kuma.urls'
 
+CKEDITOR_DEV = config('CKEDITOR_DEV', default=False, cast=bool)
+
 STATICFILES_FINDERS = (
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
@@ -1078,20 +1080,6 @@ PIPELINE_JS = {
         'extra_context': {
             'async': True,
         },
-    },
-    'ckeditor-prod': {
-        'source_filenames': (
-            'js/libs/ckeditor/build/ckeditor/ckeditor.js',
-            'js/libs/ckeditor/build/ckeditor/adapters/jquery.js',
-        ),
-        'output_filename': 'build/js/ckeditor-prod.js',
-    },
-    'ckeditor-dev': {
-        'source_filenames': (
-            'js/libs/ckeditor/source/ckeditor/ckeditor.js',
-            'js/libs/ckeditor/source/ckeditor/adapters/jquery.js',
-        ),
-        'output_filename': 'build/js/ckeditor-dev.js',
     },
     'html5shiv': {
         'source_filenames': (

--- a/kuma/static/js/libs/ckeditor/source/build.sh
+++ b/kuma/static/js/libs/ckeditor/source/build.sh
@@ -5,6 +5,12 @@
 # Build CKEditor for Kuma.
 # Based on https://github.com/ckeditor/ckeditor-presets/blob/master/build.sh
 
+BUILD_IT=1
+if [ "$1" == "--download" ]; then
+    BUILD_IT=0
+    shift
+fi
+
 CKEDITOR_VERSION="4.5.10"
 
 CKBUILDER_VERSION="2.3.1"
@@ -18,8 +24,13 @@ WORDCOUNT_VERSION="v1.16"
 
 set -e
 
-echo "CKEditor Builder"
-echo "========================"
+if [ $BUILD_IT -eq 1 ]; then
+  echo "CKEditor Builder"
+  echo "================"
+else
+  echo "CKEditor Downloader"
+  echo "==================="
+fi
 
 target="../build"
 
@@ -109,22 +120,26 @@ download_plugin "wordcount" $WORDCOUNT_VERSION "https://github.com/w8tcha/CKEdit
 cp -R plugins/* ckeditor/plugins/
 
 
-echo ""
-echo "Deleting $target..."
-rm -rf $target
+if [ $BUILD_IT -eq 1 ]; then
+  echo ""
+  echo "Deleting $target..."
+  rm -rf $target
 
+  # Run the builder.
+  echo ""
+  echo "Building the package..."
 
-# Run the builder.
-echo ""
-echo "Building the package..."
-
-java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target \
+  java -jar ckbuilder/$CKBUILDER_VERSION/ckbuilder.jar --build ckeditor $target \
 	-s --version="$CKEDITOR_VERSION" --revision $rev --build-config build-config.js --overwrite --no-tar --no-zip "$@"
 
+  echo "Removing added plugins..."
+  rm -rf ckeditor/
 
-echo "Removing added plugins..."
-rm -rf ckeditor/
-
-echo ""
-echo "Build created into the \"$target\" directory."
-echo ""
+  echo ""
+  echo "Build created into the \"$target\" directory."
+  echo ""
+else
+  echo ""
+  echo "Sources downloaded."
+  echo ""
+fi

--- a/kuma/wiki/jinja2/wiki/includes/ckeditor_scripts.html
+++ b/kuma/wiki/jinja2/wiki/includes/ckeditor_scripts.html
@@ -1,18 +1,37 @@
-<!-- Production ready CKEditor scripts -->
-{% javascript 'ckeditor-prod' %}
-
-<!-- Development version -->
-{#
-{% javascript 'ckeditor-dev' %}
-#}
-<script>
-  // Define the path to non-core plugins.
-  (
-    'scayt,wsc,mdn-attachment,mdn-format,mdn-sticky-toolbar,mdn-image-attachment,mdn-link-customization,' +
-    'mdn-link-launch,mdn-redirect,mdn-sample-finder,mdn-sampler,mdn-spell,mdn-syntaxhighlighter,' +
-    'mdn-system-integration,mdn-table-customization,mdn-toggle-block,mdn-wrapstyle,descriptionlist,' +
-    'tablesort,texzilla,mdn-youtube'
-  ).split(',').forEach(function(pluginName) {
-    CKEDITOR.plugins.addExternal(pluginName, '{{ MEDIA_URL }}js/libs/ckeditor/source/plugins/' + pluginName + '/');
-  });
-</script>
+{%- if settings.CKEDITOR_DEV %}
+  {# Development CKEditor #}
+  <script src="{{ static('js/libs/ckeditor/source/ckeditor/ckeditor.js') }}"></script>
+  <script src="{{ static('js/libs/ckeditor/source/ckeditor/adapters/jquery.js') }}"></script>
+  {%- set pluginList=[
+     'descriptionlist',
+     'mdn-attachment',
+     'mdn-format',
+     'mdn-image-attachment',
+     'mdn-link-customization',
+     'mdn-link-launch',
+     'mdn-redirect',
+     'mdn-sample-finder',
+     'mdn-sampler',
+     'mdn-spell',
+     'mdn-sticky-toolbar',
+     'mdn-syntaxhighlighter',
+     'mdn-system-integration',
+     'mdn-table-customization',
+     'mdn-toggle-block',
+     'mdn-wrapstyle',
+     'mdn-youtube',
+     'scayt',
+     'tablesort',
+     'texzilla',
+     'wsc',
+    ] %}
+  <script>
+    {%- for pluginName in pluginList %}
+      CKEDITOR.plugins.addExternal('{{ pluginName }}', '{{ static('js/libs/ckeditor/source/plugins/' + pluginName + '/') }}');
+    {%- endfor %}
+  </script>
+{%- else %}
+  {# Production CKEditor scripts #}
+  <script src="{{ static('js/libs/ckeditor/build/ckeditor/ckeditor.js') }}"></script>
+  <script src="{{ static('js/libs/ckeditor/build/ckeditor/adapters/jquery.js') }}"></script>
+{%- endif %}


### PR DESCRIPTION
There was some code to support CKEditor in development mode, however this code was broken. This gets it working, and fixes some leftovers from SCL3, such as using ``MEDIA_URL``.

Add a environment variable ``CKEDITOR_DEV`` that enables development mode for CKEditor. The developer must also download the CKEditor source code, using ``build.sh --download``. This runs the CKEditor source, and loads the plugins at runtime. The developer must still build the production assets to commit the changes.

This also drops the Django pipeline bundles for CKEditor, and instead always loads the two scripts when editing.

**However**, I'm not sure this is the right approach. If instead we only support a full build of CKEditor, then we could drop most of this change, only keeping a couple of ``<script>`` tags in ``wiki/includes/ckeditor_scripts.html``.