### PR TITLE
bug 1523273: use proper hreflang values

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -220,7 +220,8 @@ def compose_test() {
     // Run the "smoke" tests with no external dependencies.
     sh_with_notify("${dc} run noext", 'Smoke tests')
     // Build the static assets required for many tests.
-    sh_with_notify("${dc} run noext make build-static", 'Build static assets')
+    sh_with_notify("${dc} run noext make localecompile build-static",
+                   'Compile locales and build static assets')
     // Run the Kuma tests, building the mysql image before starting.
     sh_with_notify("${dc} build mysql", 'Build mysql')
     sh_with_notify("${dc} run test", 'Kuma tests')

--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -1,7 +1,7 @@
 {% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() in (settings.ATTACHMENT_ORIGIN, settings.ATTACHMENT_HOST)) %}
 
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js">
+<html lang="{% block lang %}{{ LANG }}{% endblock %}" dir="{{ DIR }}" class="no-js">
 <head {%- if not untrusted %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -1,7 +1,7 @@
 {% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and (request.get_host() in (settings.ATTACHMENT_ORIGIN, settings.ATTACHMENT_HOST)) %}
 
 <!DOCTYPE html>
-<html lang="{{ LANG }}" dir="{{ DIR }}" class="no-js">
+<html lang="{% block lang %}{{ LANG }}{% endblock %}" dir="{{ DIR }}" class="no-js">
 <head {%- if not untrusted %} prefix="og: http://ogp.me/ns#"{% endif %}>
   <meta charset="utf-8">
   {%- block experiment_js %}{% endblock %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -221,6 +221,15 @@ ACCEPTED_LOCALES = (
     'zu',       # Zulu
 )
 
+# When there are multiple options for a given language, this gives the
+# preferred locale for that language (language => preferred locale).
+PREFERRED_LOCALE = {
+    'bn': 'bn-BD',
+    'pt': 'pt-PT',
+    'sr': 'sr',
+    'zh': 'zh-CN',
+}
+
 # Locales being considered for MDN. This makes the UI strings available for
 # localization in Pontoon, but pages can not be translated into this language.
 # https://developer.mozilla.org/en-US/docs/MDN/Contribute/Localize/Starting_a_localization

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -1,4 +1,5 @@
 {% extends "wiki/base.html" %}
+{% block lang %}{{ document.get_hreflang(all_locales) }}{% endblock %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
@@ -65,10 +66,10 @@
   <link rel="canonical" href="{{ canonical }}" >
 
   {# Google requires the current page to be referenced as an alternate too for SEO purposes see bug 1449210 #}
-  <link rel="alternate" hreflang="{{ document.locale }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
+  <link rel="alternate" hreflang="{{ document.get_hreflang(all_locales) }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
   {% if other_translations %}
     {% for translation in other_translations %}
-      <link rel="alternate" hreflang="{{ translation.locale }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
+      <link rel="alternate" hreflang="{{ translation.get_hreflang(all_locales) }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
     {% endfor %}
   {% endif %}
 

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -1,4 +1,5 @@
 {% extends "wiki/react_base.html" %}
+{% block lang %}{{ document.get_hreflang(all_locales) }}{% endblock %}
 {% block title %}{{ page_title(document.title + seo_parent_title) }}{% endblock %}
 
 {% from "wiki/includes/document_macros.html" import build_document_crumbs, get_document_quick_links, document_watch, contributor_links with context %}
@@ -65,10 +66,10 @@
   <link rel="canonical" href="{{ canonical }}" >
 
   {# Google requires the current page to be referenced as an alternate too for SEO purposes see bug 1449210 #}
-  <link rel="alternate" hreflang="{{ document.locale }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
+  <link rel="alternate" hreflang="{{ document.get_hreflang(all_locales) }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
   {% if other_translations %}
     {% for translation in other_translations %}
-      <link rel="alternate" hreflang="{{ translation.locale }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
+      <link rel="alternate" hreflang="{{ translation.get_hreflang(all_locales) }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
     {% endfor %}
   {% endif %}
 

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -13,6 +13,25 @@ from kuma.core.tests import get_user, KumaTestCase
 from ..models import Document, Revision
 
 
+HREFLANG_TEST_CASES = {
+    'no-country': [['ar', 'af', 'zu'], ['ar', 'af', 'zu']],
+    'single-country': [['fy-NL', 'ga-IE', 'hi-IN', 'sv-SE'],
+                       ['fy', 'ga', 'hi', 'sv']],
+    'bn-preferred-only': [['bn-BD'], ['bn']],
+    'bn-non-preferred-only': [['bn-IN'], ['bn']],
+    'bn-both': [['bn-BD', 'bn-IN'], ['bn', 'bn-IN']],
+    'pt-preferred-only': [['pt-PT'], ['pt']],
+    'pt-non-preferred-only': [['pt-BR'], ['pt']],
+    'pt-both': [['pt-PT', 'pt-BR'], ['pt', 'pt-BR']],
+    'sr-preferred-only': [['sr'], ['sr']],
+    'sr-non-preferred-only': [['sr-Latn'], ['sr']],
+    'sr-both': [['sr', 'sr-Latn'], ['sr', 'sr-Latn']],
+    'zh-preferred-only': [['zh-CN'], ['zh']],
+    'zh-non-preferred-only': [['zh-TW'], ['zh']],
+    'zh-both': [['zh-CN', 'zh-TW'], ['zh', 'zh-TW']],
+}
+
+
 class WikiTestCase(KumaTestCase):
     """Base TestCase for the wiki app test cases."""
 

--- a/kuma/wiki/tests/test_models_document.py
+++ b/kuma/wiki/tests/test_models_document.py
@@ -73,10 +73,10 @@ def test_document_get_hreflang_with_other_locales(root_doc, locales,
             rendered_html='<p>...</p>',
             parent=root_doc
         )
-        with mock.patch.object(doc, 'get_other_translations',
-                               return_value=()) as mocked_method:
+        method = 'get_other_translations'
+        exc = Exception('"{!r}.{}" unexpectedly called'.format(doc, method))
+        with mock.patch.object(doc, method, side_effect=exc):
             assert doc.get_hreflang(locales) == expected_result
-            assert not mocked_method.called
 
 
 def test_get_json_data_cached_parsed_json(root_doc):

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -731,6 +731,8 @@ def document(request, document_slug, document_locale):
         other_translations = original_doc.get_other_translations(
             fields=['title', 'locale', 'slug', 'parent']
         )
+        all_locales = (set([original_doc.locale]) |
+                       set(trans.locale for trans in other_translations))
 
         # Bundle it all up and, finally, return.
         context = {
@@ -759,6 +761,7 @@ def document(request, document_slug, document_locale):
             'analytics_en_slug': en_slug,
             'content_experiment': rendering_params['experiment'],
             'other_translations': other_translations,
+            'all_locales': all_locales,
         }
         response = render(request, 'wiki/document.html', context)
 
@@ -920,6 +923,8 @@ def react_document(request, document_slug, document_locale):
         other_translations = original_doc.get_other_translations(
             fields=['title', 'locale', 'slug', 'parent']
         )
+        all_locales = (set([original_doc.locale]) |
+                       set(trans.locale for trans in other_translations))
 
         # Bundle it all up and, finally, return.
         context = {
@@ -948,6 +953,7 @@ def react_document(request, document_slug, document_locale):
             'analytics_en_slug': en_slug,
             'content_experiment': rendering_params['experiment'],
             'other_translations': other_translations,
+            'all_locales': all_locales,
         }
         response = render(request, 'wiki/react_document.html', context)
 

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -103,4 +103,4 @@ def test_hreflang_basic(base_url):
     assert resp.status_code == 200
     html = PyQuery(resp.text)
     assert html.attr('lang') == 'en'
-    assert html.find('head > link[hreflang="{}"][href="{}"]'.format('en', url))
+    assert html.find('head > link[hreflang="en"][href="{}"]'.format(url))

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -92,3 +92,15 @@ def test_home(base_url, is_indexed):
         assert content == 'index, follow'
     else:
         assert content == 'noindex, nofollow'
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
+def test_hreflang_basic(base_url):
+    """Ensure that we're specifying the correct value for lang and hreflang."""
+    url = base_url + '/en-US/docs/Web/HTTP'
+    resp = requests.get(url)
+    assert resp.status_code == 200
+    html = PyQuery(resp.text)
+    assert html.attr('lang') == 'en'
+    assert html.find('head > link[hreflang="{}"][href="{}"]'.format('en', url))

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals = make
 deps =
     -rrequirements/dev.txt
 commands =
-    make build-static clean
+    make localecompile build-static clean
     pytest --cov=kuma kuma
 passenv =
     DATABASE_URL
@@ -20,7 +20,7 @@ whitelist_externals = make
 deps =
     -rrequirements/dev.txt
 commands =
-    make compilejsi18n collectstatic clean
+    make localecompile build-static clean
     pytest --cov=kuma --maxfail=10 kuma
 passenv =
     DATABASE_URL
@@ -67,7 +67,7 @@ commands =
     docker-compose up -d mysql  # Init DB (can be slow)
     docker-compose build web    # Rebuild w/ new reqs, Dockerfile-base
     docker-compose up -d        # Startup remaining services
-    docker-compose exec -T web make build-static
+    docker-compose exec -T web make localecompile build-static clean
     docker-compose exec web ./manage.py migrate
     docker-compose exec -T web make test
     docker-compose stop         # Useful for local development


### PR DESCRIPTION
This PR updates the way `hreflang` values are set for documents. For reference, see [bug 1523273](https://bugzilla.mozilla.org/show_bug.cgi?id=1523273). There's one special case that made this more challenging. The special case is that the `hreflang` value for any given document sometimes depends on the other translations that are available for that document. For example, if the document is available in both the `pt-BR` and `pt-PT` locales, the `hreflang` value for the `pt-BR` document would be `pt-BR`, like this:

```
<link rel="canonical" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">
<link rel="alternate" hreflang="en" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">
<link rel="alternate" hreflang="pt-BR" href="https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">
<link rel="alternate" hreflang="pt" href="https://developer.mozilla.org/pt-PT/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">
```

but if the document is only available in the `pt-BR` locale, the `hreflang` value for the `pt-BR` document becomes `pt`, like this:

```
<link rel="canonical" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">
<link rel="alternate" hreflang="en" href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">
<link rel="alternate" hreflang="pt" href="https://developer.mozilla.org/pt-BR/docs/Web/JavaScript/Reference/Global_Objects/Array" title="Array">
```

See the code and comments on the `get_hreflang` method I added to the `Document` class for more details.

This PR also updates how the `lang` attribute of the `html` element gets set ([the bug mentions that it should match the `hreflang` value of the document](https://bugzilla.mozilla.org/show_bug.cgi?id=1523273#c8)).