### PR TITLE
Fix bug 1529886: Make `no‑line‑numbers` always hide the line numbers

### DIFF
--- a/kuma/static/js/libs/ckeditor/source/plugins/mdn-syntaxhighlighter/plugin.js
+++ b/kuma/static/js/libs/ckeditor/source/plugins/mdn-syntaxhighlighter/plugin.js
@@ -69,7 +69,7 @@ CKEDITOR.plugins.add('mdn-syntaxhighlighter', {
           if(!pre) return;
         }
 
-        pre.$.className = brushId == 'none' ? '' : 'brush: ' + brushId;
+        pre.$.className = brushId == 'none' ? '' : 'brush: ' + brushId + ';';
 
         // Refresh, because class change is not a context change,
         // so refresh will not be called automatically.

--- a/kuma/static/js/syntax-prism.js
+++ b/kuma/static/js/syntax-prism.js
@@ -7,6 +7,7 @@
     languages.js = languages.javascript;
     languages.cpp = languages.clike;
 
+    // Style all as HTML initially
     var defaultBrush = 'html';
 
     // Treat and highlight PRE elements!
@@ -14,20 +15,25 @@
         var $pre = $(this);
         var klass = $.trim($pre.attr('class'));
 
-        // Split on ';' to accommodate for old line numbering
         var brush = defaultBrush;
         var lineSearch;
 
         // If the PRE has a child <code> tag, it's likely a copy/pasted, already-prism'd code samples.
         // Bail to avoid an error
-        if($pre.find('code').length) {
+        if ($pre.find('code').length) {
             return;
         }
 
         // Parse classname to look for brush
         var brushSearch = klass.match(/brush: ?(.*)/);
-        if(brushSearch && brushSearch[1]) {
-            brush = $.trim(brushSearch[1].replace(';', ' ').split(' ')[0].toLowerCase());
+        if (brushSearch && brushSearch[1]) {
+            // Split on ';' to accommodate for old line numbering
+            brush = $.trim(
+                brushSearch[1]
+                    .replace(';', ' ')
+                    .split(' ')[0]
+                    .toLowerCase()
+            );
         }
 
         if (!$pre.hasClass('no-line-numbers')) {
@@ -35,20 +41,23 @@
             $pre.addClass('line-numbers');
         }
 
-        // Style all as HTML initially
-        $pre.addClass('language-' + defaultBrush);
-
-        // Format PRE content for Prism highlighting
-        $pre.html('<code class="language-' + brush + '">' + $.trim($pre.html()) + '</code>');
+        // Format <pre> content for Prism highlighting
+        $pre.html(
+            '<code class="' +
+                // Don't highlight languages unknown to Prism
+                (brush in languages ? 'language-' + brush : '') +
+                '">' +
+                $.trim($pre.html()) +
+                '</code>'
+        );
 
         // Do we need to highlight any lines?
         // Legacy format: highlight:[8,9,10,11,17,18,19,20]
         lineSearch = klass.match(/highlight:? ?\[(.*)\]/);
-        if(lineSearch && lineSearch[1]) {
+        if (lineSearch && lineSearch[1]) {
             $pre.attr('data-line', lineSearch[1]);
         }
     });
 
     Prism.highlightAll();
-
 })(jQuery);

--- a/kuma/static/styles/components/syntax/base.scss
+++ b/kuma/static/styles/components/syntax/base.scss
@@ -35,6 +35,11 @@ in syntax-prism.js to just add it to <pre>, it also wraps the contents of the
     pre.line-numbers {
         padding-left: 3.8em;
     }
+
+    /* Something caused .no-line-numbers to no longer be correctly respected */
+    pre.no-line-numbers .line-numbers-rows {
+        display: none;
+    }
 }
 
 /*


### PR DESCRIPTION
Fixes [bug 1529886](https://bugzilla.mozilla.org/show_bug.cgi?id=1529886)

See&nbsp;also https://github.com/mozilla/kuma/pull/5189