### PR TITLE
bug 1529010: update kumascript module error handling

### DIFF
--- a/kuma/health/views.py
+++ b/kuma/health/views.py
@@ -12,7 +12,8 @@ from django.views.decorators.http import require_POST, require_safe
 from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
                                       NotFoundError)
 from raven.contrib.django.models import client
-from requests.exceptions import ConnectionError as Requests_ConnectionError
+from requests.exceptions import (ConnectionError as Requests_ConnectionError,
+                                 ReadTimeout)
 
 from kuma.users.models import User
 from kuma.wiki.kumascript import request_revision_hash
@@ -116,7 +117,7 @@ def status(request):
     }
     try:
         ks_response = request_revision_hash()
-    except Requests_ConnectionError:
+    except (Requests_ConnectionError, ReadTimeout):
         ks_response = None
     if not ks_response or ks_response.status_code != 200:
         ks_data['available'] = False

--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -202,11 +202,6 @@ ALLOWED_PROTOCOLS = [
 DIFF_WRAP_COLUMN = 65
 EXPERIMENT_TITLE_PREFIX = 'Experiment:'
 DOCUMENTS_PER_PAGE = 100
-KUMASCRIPT_TIMEOUT_ERROR = [
-    {"level": "error",
-     "message": "Request to Kumascript service timed out",
-     "args": ["TimeoutError"]}
-]
 _ks_urlbits = urlparse(settings.KUMASCRIPT_URL_TEMPLATE)
 KUMASCRIPT_BASE_URL = urlunparse((_ks_urlbits.scheme, _ks_urlbits.netloc,
                                   '', '', '', ''))


### PR DESCRIPTION
This PR arose out of the work to solve the 504 timeout errors described in [bug 1529010](https://bugzilla.mozilla.org/show_bug.cgi?id=1529010). It tightens the exceptions that are caught when performing `kumascript.get` and `kumascript.post` calls to only `requests.exceptions.ConnectionError` and `requests.exceptions.ReadTimeout` errors -- basically connection and timeout errors -- which currently are not caught at all when making `kumascript.post` calls for previews, while for `kumascript.get` calls, every `Exception` was caught. It also adds `requests.exceptions.ReadTimeout` errors to the errors that are handled when making calls to the `health.status` endpoint. It also adds new tests for the `kumascript.get` and `kumascript.post` functions.

This PR should eliminate Sentry errors like we saw recently when a user hit `/ja/docs/preview-wiki-content` and got a `requests.exceptions.ConnectTimeout` error (a sub-class of `requests.exceptions.ConnectionError`).

I simply wanted to get this done before it was forgotten. It's not urgent.