### PR TITLE
Bug 1530782 - Skip adding line numbers if <pre> has no-line-numbers

### DIFF
--- a/kuma/static/js/libs/prism/prism-line-numbers.js
+++ b/kuma/static/js/libs/prism/prism-line-numbers.js
@@ -73,12 +73,17 @@
 
 		// works only for <code> wrapped inside <pre> (not inline)
 		var pre = env.element.parentNode;
+		if (!pre || !/pre/i.test(pre.nodeName)) {
+			return;
+		}
+		// If either <pre> or <code> has no-line-numbers class, ignore it.
+		var noClsReg = /\s*\bno-line-numbers\b\s*/;
+		if (noClsReg.test(pre.className) || noClsReg.test(env.element.className)) {
+			return;
+		}
+		// Require line-numbers class either in <pre> or <code>.
 		var clsReg = /\s*\bline-numbers\b\s*/;
-		if (
-			!pre || !/pre/i.test(pre.nodeName) ||
-			// Abort only if nor the <pre> nor the <code> have the class
-			(!clsReg.test(pre.className) && !clsReg.test(env.element.className))
-		) {
+		if (!clsReg.test(pre.className) && !clsReg.test(env.element.className)) {
 			return;
 		}
 


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1530782

line-numbers plugin was checking `line-numbers` class, but the pattern also matches to `no-line-numbers`.
for simplicity (without introducing more complicated pattern), just added another check for `no-line-numbers`.
