### PR TITLE
Bug 1525719: configure Puente to extract strings from jsx files

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -672,6 +672,8 @@ PUENTE = {
             ('kuma/static/js/components/**.js', 'javascript'),
             ('kuma/static/js/libs/ckeditor/source/plugins/mdn-**/*.js',
              'javascript'),
+            ('kuma/javascript/src/**.js', 'javascript'),
+            ('kuma/javascript/src/**.jsx', 'javascript'),
         ],
     },
     'PROJECT': 'MDN',


### PR DESCRIPTION
This PR changes the Puente settings in kuma/settings/common.py so
that Puente can find and extract gettext() strings in the React-based
code in kuma/javascript/src/

Note that if we actually deploy this, we will cause work for localizers
for things like the React header components that we've been using as
test cases.