### PR TITLE
bug 1532147: Respect white spaces of localization source's code blocks

### DIFF
--- a/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
+++ b/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
@@ -1,12 +1,7 @@
 #translate-document {
-
     /* approved version of the article content */
     .translate-rendered {
         overflow-x: hidden;
-
-        pre {
-            white-space: normal;
-        }
     }
 
     /* translation interface has a number of headings that do not have icons


### PR DESCRIPTION
[Bugzilla 1532147](https://bugzilla.mozilla.org/show_bug.cgi?id=1532147)

This PR removes `white-space: normal` from `<pre>` blocks of localization source document.

![2019-03-03 225012](https://user-images.githubusercontent.com/9212605/53697237-c2338300-3e12-11e9-9fb3-9baa2fcbc531.jpg)
Currently all line breaks and multiple blanks are gone from source doc.

The issue itself had been gone for sometime by some reason I do not know. Now it's happening again.

The code has been there for a long time too; I wonder what was the reason for `white-space: normal`, and would removing it cause any side effects? (I don't think so...)