### PR TITLE
Bug 1532263 - Renders pre blocks correctly in English panel in translation/edit mode

### DIFF
--- a/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
+++ b/kuma/static/styles/components/wiki/edit/translate/translate-document.scss
@@ -3,10 +3,6 @@
     /* approved version of the article content */
     .translate-rendered {
         overflow-x: hidden;
-
-        pre {
-            white-space: normal;
-        }
     }
 
     /* translation interface has a number of headings that do not have icons


### PR DESCRIPTION
This glitch seems to have appeared during the last few days. Testing this change via devtools seems to work.
I don't have a local development environment so a validation from someone else is needed here.