### PR TITLE
Bug 1525719: fix a JavaScript error for the /ducks/ URLs

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -938,7 +938,6 @@ PIPELINE_JS = {
             'js/components.js',
             'js/analytics.js',
             'js/main.js',
-            'js/components/nav-main-search.js',
             'js/auth.js',
             'js/highlight.js',
             'js/wiki-compat-trigger.js',


### PR DESCRIPTION
When I rewrote the header in React I removed the animated search box
but left the nav-main-search.js component in the bundle. In development
this caused a benign JavaScript error, but in production the error prevents
the execution of other JS in the same bundle and the header does not appear
at all. This patch just modifies bundle definition to remove that
now-unnecessary JavaScript file.