### PR TITLE
bug 1523273: Wrap test IDs in tuple for Py3 compat

### DIFF
--- a/kuma/wiki/tests/test_models_document.py
+++ b/kuma/wiki/tests/test_models_document.py
@@ -45,7 +45,7 @@ def doc_with_sections(root_doc, wiki_user):
 
 @pytest.mark.parametrize('locales,expected_results',
                          HREFLANG_TEST_CASES.values(),
-                         ids=HREFLANG_TEST_CASES.keys())
+                         ids=tuple(HREFLANG_TEST_CASES.keys()))
 def test_document_get_hreflang(root_doc, locales, expected_results):
     docs = [
         Document.objects.create(
@@ -62,7 +62,7 @@ def test_document_get_hreflang(root_doc, locales, expected_results):
 
 @pytest.mark.parametrize('locales,expected_results',
                          HREFLANG_TEST_CASES.values(),
-                         ids=HREFLANG_TEST_CASES.keys())
+                         ids=tuple(HREFLANG_TEST_CASES.keys()))
 def test_document_get_hreflang_with_other_locales(root_doc, locales,
                                                   expected_results):
     for locale, expected_result in zip(locales, expected_results):

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -832,7 +832,7 @@ def test_self_redirect_supression(mock_kumascript_get, constance_config,
 
 @pytest.mark.parametrize('locales,expected_results',
                          HREFLANG_TEST_CASES.values(),
-                         ids=HREFLANG_TEST_CASES.keys())
+                         ids=tuple(HREFLANG_TEST_CASES.keys()))
 def test_hreflang(client, root_doc, locales, expected_results):
     docs = [
         Document.objects.create(


### PR DESCRIPTION
``pytest`` tries to index the IDs parameter, and ``dict.keys()`` returns an iterator that doesn't support indexing in Python3. Wrap ``keys()`` in a ``tuple`` so it works in Python 2 and 3.