### PR TITLE
Bug 1525719: Query user data on the client side with new whoami API

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ kuma/static/js/utils/perf.min.js
 kuma/static/js/utils/perf-post-message-handler.min.js
 kuma/static/layout-tests/js/*.js
 kuma/javascript/dist/*.js
+kuma/javascript/src/flow-typed

--- a/.flowconfig
+++ b/.flowconfig
@@ -4,6 +4,7 @@
 [include]
 
 [libs]
+kuma/javascript/src/flow-typed
 
 [lints]
 

--- a/kuma/javascript/src/current-user.jsx
+++ b/kuma/javascript/src/current-user.jsx
@@ -1,0 +1,53 @@
+// @flow
+import * as React from 'react';
+import { useState, useEffect } from 'react';
+
+export type UserData = {
+    username: ?string,
+    isAuthenticated: boolean,
+    isBetaTester: boolean,
+    isStaff: boolean,
+    isSuperuser: boolean,
+    timezone: ?string,
+    gravatarUrl: {
+        small: ?string,
+        large: ?string
+    }
+};
+
+const defaultUserData: UserData = {
+    username: null,
+    isAuthenticated: false,
+    isBetaTester: false,
+    isStaff: false,
+    isSuperuser: false,
+    timezone: null,
+    gravatarUrl: { small: null, large: null }
+};
+
+const context = React.createContext<?UserData>(defaultUserData);
+
+function Provider(props: { children: React.Node }): React.Node {
+    const [userData, setUserData] = useState<?UserData>(null);
+    useEffect(() => {
+        fetch('/api/v1/whoami')
+            .then(response => response.json())
+            .then(data => {
+                setUserData({
+                    username: data.username,
+                    isAuthenticated: data.is_authenticated,
+                    isBetaTester: data.is_beta_tester,
+                    isStaff: data.is_staff,
+                    isSuperuser: data.is_super_user,
+                    timezone: data.timezone,
+                    gravatarUrl: data.gravatar_url
+                });
+            });
+    }, []); // empty array means we only fetch on mount, not on every render
+
+    return (
+        <context.Provider value={userData}>{props.children}</context.Provider>
+    );
+}
+
+export default { context, defaultUserData, Provider };

--- a/kuma/javascript/src/current-user.test.js
+++ b/kuma/javascript/src/current-user.test.js
@@ -1,0 +1,94 @@
+//@flow
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+
+import CurrentUser from './current-user.jsx';
+
+describe('CurrentUser', () => {
+    test('context works', () => {
+        const P = CurrentUser.context.Provider;
+        const C = CurrentUser.context.Consumer;
+        const contextConsumer = jest.fn();
+        const userData = {
+            ...CurrentUser.defaultUserData,
+            username: 'testing'
+        };
+
+        create(
+            <P value={userData}>
+                <C>{contextConsumer}</C>
+            </P>
+        );
+
+        // We expect that the consumer <C> will get the user data from
+        // the provider <P> and pass it to the child function. This is
+        // just verifying that we're using the React context API correctly.
+        expect(contextConsumer.mock.calls.length).toBe(1);
+        expect(contextConsumer.mock.calls[0][0]).toEqual(userData);
+    });
+
+    // This test passes but causes a warning message from
+    // react-test-render about needing to make changes inside of an
+    // act() call. Unfortunately, the change in question appears to be
+    // the asyncronous resolution of the json promise, and I can't get
+    // the warning to go away even with a really convoluted fetch()
+    // mock. I think this is related to
+    // https://github.com/facebook/react/issues/14769 and hopefully a
+    // version of act() that can take async methods will fix the
+    // issue.
+    test('Provider fetches user data', done => {
+        const P = CurrentUser.Provider;
+        const C = CurrentUser.context.Consumer;
+        const contextConsumer = jest.fn();
+        const userData = {
+            ...CurrentUser.defaultUserData,
+            username: 'testing',
+            isStaff: true
+        };
+
+        // In this test we want to verify that CurrentUser.Provider is
+        // fetching user data from an API. So we need to mock fetch().
+        global.fetch = jest.fn(() => {
+            return Promise.resolve({
+                json: () =>
+                    Promise.resolve({
+                        // We expect the server to send JSON data
+                        // using snake_case
+                        /* eslint-disable camelcase */
+                        username: 'testing',
+                        is_authenticated: false,
+                        is_beta_tester: false,
+                        is_staff: true,
+                        is_super_user: false,
+                        timezone: null,
+                        gravatar_url: { small: null, large: null }
+                        /* eslint-enable camelcase */
+                    })
+            });
+        });
+
+        act(() => {
+            create(
+                <P>
+                    <C>{contextConsumer}</C>
+                </P>
+            );
+        });
+
+        // To start, we expect the contextConsumer function to be called
+        // with the default null value. And we expect our fetch() mock to
+        // be called when the component is first mounted, too.
+        expect(contextConsumer).toHaveBeenCalledTimes(1);
+        expect(contextConsumer).toHaveBeenCalledWith(null);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch).toHaveBeenCalledWith('/api/v1/whoami');
+
+        // After the fetch succeeds, we expect contextConsumer to be
+        // called again with the fetched userdata
+        process.nextTick(() => {
+            expect(contextConsumer).toHaveBeenCalledTimes(2);
+            expect(contextConsumer.mock.calls[1][0]).toEqual(userData);
+            done();
+        });
+    });
+});

--- a/kuma/javascript/src/flow-typed/npm/jest_v24.x.x.js
+++ b/kuma/javascript/src/flow-typed/npm/jest_v24.x.x.js
@@ -1,0 +1,1183 @@
+type JestMockFn<TArguments: $ReadOnlyArray<*>, TReturn> = {
+  (...args: TArguments): TReturn,
+  /**
+   * An object for introspecting mock calls
+   */
+  mock: {
+    /**
+     * An array that represents all calls that have been made into this mock
+     * function. Each call is represented by an array of arguments that were
+     * passed during the call.
+     */
+    calls: Array<TArguments>,
+    /**
+     * An array that contains all the object instances that have been
+     * instantiated from this mock function.
+     */
+    instances: Array<TReturn>,
+    /**
+     * An array that contains all the object results that have been
+     * returned by this mock function call
+     */
+    results: Array<{ isThrow: boolean, value: TReturn }>,
+  },
+  /**
+   * Resets all information stored in the mockFn.mock.calls and
+   * mockFn.mock.instances arrays. Often this is useful when you want to clean
+   * up a mock's usage data between two assertions.
+   */
+  mockClear(): void,
+  /**
+   * Resets all information stored in the mock. This is useful when you want to
+   * completely restore a mock back to its initial state.
+   */
+  mockReset(): void,
+  /**
+   * Removes the mock and restores the initial implementation. This is useful
+   * when you want to mock functions in certain test cases and restore the
+   * original implementation in others. Beware that mockFn.mockRestore only
+   * works when mock was created with jest.spyOn. Thus you have to take care of
+   * restoration yourself when manually assigning jest.fn().
+   */
+  mockRestore(): void,
+  /**
+   * Accepts a function that should be used as the implementation of the mock.
+   * The mock itself will still record all calls that go into and instances
+   * that come from itself -- the only difference is that the implementation
+   * will also be executed when the mock is called.
+   */
+  mockImplementation(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a function that will be used as an implementation of the mock for
+   * one call to the mocked function. Can be chained so that multiple function
+   * calls produce different results.
+   */
+  mockImplementationOnce(
+    fn: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Accepts a string to use in test result output in place of "jest.fn()" to
+   * indicate which mock function is being referenced.
+   */
+  mockName(name: string): JestMockFn<TArguments, TReturn>,
+  /**
+   * Just a simple sugar function for returning `this`
+   */
+  mockReturnThis(): void,
+  /**
+   * Accepts a value that will be returned whenever the mock function is called.
+   */
+  mockReturnValue(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for only returning a value once inside your mock
+   */
+  mockReturnValueOnce(value: TReturn): JestMockFn<TArguments, TReturn>,
+  /**
+   * Sugar for jest.fn().mockImplementation(() => Promise.resolve(value))
+   */
+  mockResolvedValue(value: TReturn): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.resolve(value))
+   */
+  mockResolvedValueOnce(
+    value: TReturn
+  ): JestMockFn<TArguments, Promise<TReturn>>,
+  /**
+   * Sugar for jest.fn().mockImplementation(() => Promise.reject(value))
+   */
+  mockRejectedValue(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+  /**
+   * Sugar for jest.fn().mockImplementationOnce(() => Promise.reject(value))
+   */
+  mockRejectedValueOnce(value: TReturn): JestMockFn<TArguments, Promise<any>>,
+};
+
+type JestAsymmetricEqualityType = {
+  /**
+   * A custom Jasmine equality tester
+   */
+  asymmetricMatch(value: mixed): boolean,
+};
+
+type JestCallsType = {
+  allArgs(): mixed,
+  all(): mixed,
+  any(): boolean,
+  count(): number,
+  first(): mixed,
+  mostRecent(): mixed,
+  reset(): void,
+};
+
+type JestClockType = {
+  install(): void,
+  mockDate(date: Date): void,
+  tick(milliseconds?: number): void,
+  uninstall(): void,
+};
+
+type JestMatcherResult = {
+  message?: string | (() => string),
+  pass: boolean,
+};
+
+type JestMatcher = (
+  actual: any,
+  expected: any
+) => JestMatcherResult | Promise<JestMatcherResult>;
+
+type JestPromiseType = {
+  /**
+   * Use rejects to unwrap the reason of a rejected promise so any other
+   * matcher can be chained. If the promise is fulfilled the assertion fails.
+   */
+  rejects: JestExpectType,
+  /**
+   * Use resolves to unwrap the value of a fulfilled promise so any other
+   * matcher can be chained. If the promise is rejected the assertion fails.
+   */
+  resolves: JestExpectType,
+};
+
+/**
+ * Jest allows functions and classes to be used as test names in test() and
+ * describe()
+ */
+type JestTestName = string | Function;
+
+/**
+ *  Plugin: jest-styled-components
+ */
+
+type JestStyledComponentsMatcherValue =
+  | string
+  | JestAsymmetricEqualityType
+  | RegExp
+  | typeof undefined;
+
+type JestStyledComponentsMatcherOptions = {
+  media?: string,
+  modifier?: string,
+  supports?: string,
+};
+
+type JestStyledComponentsMatchersType = {
+  toHaveStyleRule(
+    property: string,
+    value: JestStyledComponentsMatcherValue,
+    options?: JestStyledComponentsMatcherOptions
+  ): void,
+};
+
+/**
+ *  Plugin: jest-enzyme
+ */
+type EnzymeMatchersType = {
+  // 5.x
+  toBeEmpty(): void,
+  toBePresent(): void,
+  // 6.x
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmptyRender(): void,
+  toContainMatchingElement(selector: string): void,
+  toContainMatchingElements(n: number, selector: string): void,
+  toContainExactlyOneMatchingElement(selector: string): void,
+  toContainReact(element: React$Element<any>): void,
+  toExist(): void,
+  toHaveClassName(className: string): void,
+  toHaveHTML(html: string): void,
+  toHaveProp: ((propKey: string, propValue?: any) => void) &
+    ((props: {}) => void),
+  toHaveRef(refName: string): void,
+  toHaveState: ((stateKey: string, stateValue?: any) => void) &
+    ((state: {}) => void),
+  toHaveStyle: ((styleKey: string, styleValue?: any) => void) &
+    ((style: {}) => void),
+  toHaveTagName(tagName: string): void,
+  toHaveText(text: string): void,
+  toHaveValue(value: any): void,
+  toIncludeText(text: string): void,
+  toMatchElement(
+    element: React$Element<any>,
+    options?: {| ignoreProps?: boolean, verbose?: boolean |}
+  ): void,
+  toMatchSelector(selector: string): void,
+  // 7.x
+  toHaveDisplayName(name: string): void,
+};
+
+// DOM testing library extensions https://github.com/kentcdodds/dom-testing-library#custom-jest-matchers
+type DomTestingLibraryType = {
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBeInTheDocument(): void,
+  toBeVisible(): void,
+  toContainElement(element: HTMLElement | null): void,
+  toContainHTML(htmlText: string): void,
+  toHaveAttribute(name: string, expectedValue?: string): void,
+  toHaveClass(...classNames: string[]): void,
+  toHaveFocus(): void,
+  toHaveFormValues(expectedValues: { [name: string]: any }): void,
+  toHaveStyle(css: string): void,
+  toHaveTextContent(
+    content: string | RegExp,
+    options?: { normalizeWhitespace: boolean }
+  ): void,
+  toBeInTheDOM(): void,
+};
+
+// Jest JQuery Matchers: https://github.com/unindented/custom-jquery-matchers
+type JestJQueryMatchersType = {
+  toExist(): void,
+  toHaveLength(len: number): void,
+  toHaveId(id: string): void,
+  toHaveClass(className: string): void,
+  toHaveTag(tag: string): void,
+  toHaveAttr(key: string, val?: any): void,
+  toHaveProp(key: string, val?: any): void,
+  toHaveText(text: string | RegExp): void,
+  toHaveData(key: string, val?: any): void,
+  toHaveValue(val: any): void,
+  toHaveCss(css: { [key: string]: any }): void,
+  toBeChecked(): void,
+  toBeDisabled(): void,
+  toBeEmpty(): void,
+  toBeHidden(): void,
+  toBeSelected(): void,
+  toBeVisible(): void,
+  toBeFocused(): void,
+  toBeInDom(): void,
+  toBeMatchedBy(sel: string): void,
+  toHaveDescendant(sel: string): void,
+  toHaveDescendantWithText(sel: string, text: string | RegExp): void,
+};
+
+// Jest Extended Matchers: https://github.com/jest-community/jest-extended
+type JestExtendedMatchersType = {
+  /**
+   * Note: Currently unimplemented
+   * Passing assertion
+   *
+   * @param {String} message
+   */
+  //  pass(message: string): void;
+
+  /**
+   * Note: Currently unimplemented
+   * Failing assertion
+   *
+   * @param {String} message
+   */
+  //  fail(message: string): void;
+
+  /**
+   * Use .toBeEmpty when checking if a String '', Array [] or Object {} is empty.
+   */
+  toBeEmpty(): void,
+
+  /**
+   * Use .toBeOneOf when checking if a value is a member of a given Array.
+   * @param {Array.<*>} members
+   */
+  toBeOneOf(members: any[]): void,
+
+  /**
+   * Use `.toBeNil` when checking a value is `null` or `undefined`.
+   */
+  toBeNil(): void,
+
+  /**
+   * Use `.toSatisfy` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean`.
+   * @param {Function} predicate
+   */
+  toSatisfy(predicate: (n: any) => boolean): void,
+
+  /**
+   * Use `.toBeArray` when checking if a value is an `Array`.
+   */
+  toBeArray(): void,
+
+  /**
+   * Use `.toBeArrayOfSize` when checking if a value is an `Array` of size x.
+   * @param {Number} x
+   */
+  toBeArrayOfSize(x: number): void,
+
+  /**
+   * Use `.toIncludeAllMembers` when checking if an `Array` contains all of the same members of a given set.
+   * @param {Array.<*>} members
+   */
+  toIncludeAllMembers(members: any[]): void,
+
+  /**
+   * Use `.toIncludeAnyMembers` when checking if an `Array` contains any of the members of a given set.
+   * @param {Array.<*>} members
+   */
+  toIncludeAnyMembers(members: any[]): void,
+
+  /**
+   * Use `.toSatisfyAll` when you want to use a custom matcher by supplying a predicate function that returns a `Boolean` for all values in an array.
+   * @param {Function} predicate
+   */
+  toSatisfyAll(predicate: (n: any) => boolean): void,
+
+  /**
+   * Use `.toBeBoolean` when checking if a value is a `Boolean`.
+   */
+  toBeBoolean(): void,
+
+  /**
+   * Use `.toBeTrue` when checking a value is equal (===) to `true`.
+   */
+  toBeTrue(): void,
+
+  /**
+   * Use `.toBeFalse` when checking a value is equal (===) to `false`.
+   */
+  toBeFalse(): void,
+
+  /**
+   * Use .toBeDate when checking if a value is a Date.
+   */
+  toBeDate(): void,
+
+  /**
+   * Use `.toBeFunction` when checking if a value is a `Function`.
+   */
+  toBeFunction(): void,
+
+  /**
+   * Use `.toHaveBeenCalledBefore` when checking if a `Mock` was called before another `Mock`.
+   *
+   * Note: Required Jest version >22
+   * Note: Your mock functions will have to be asynchronous to cause the timestamps inside of Jest to occur in a differentJS event loop, otherwise the mock timestamps will all be the same
+   *
+   * @param {Mock} mock
+   */
+  toHaveBeenCalledBefore(mock: JestMockFn<any, any>): void,
+
+  /**
+   * Use `.toBeNumber` when checking if a value is a `Number`.
+   */
+  toBeNumber(): void,
+
+  /**
+   * Use `.toBeNaN` when checking a value is `NaN`.
+   */
+  toBeNaN(): void,
+
+  /**
+   * Use `.toBeFinite` when checking if a value is a `Number`, not `NaN` or `Infinity`.
+   */
+  toBeFinite(): void,
+
+  /**
+   * Use `.toBePositive` when checking if a value is a positive `Number`.
+   */
+  toBePositive(): void,
+
+  /**
+   * Use `.toBeNegative` when checking if a value is a negative `Number`.
+   */
+  toBeNegative(): void,
+
+  /**
+   * Use `.toBeEven` when checking if a value is an even `Number`.
+   */
+  toBeEven(): void,
+
+  /**
+   * Use `.toBeOdd` when checking if a value is an odd `Number`.
+   */
+  toBeOdd(): void,
+
+  /**
+   * Use `.toBeWithin` when checking if a number is in between the given bounds of: start (inclusive) and end (exclusive).
+   *
+   * @param {Number} start
+   * @param {Number} end
+   */
+  toBeWithin(start: number, end: number): void,
+
+  /**
+   * Use `.toBeObject` when checking if a value is an `Object`.
+   */
+  toBeObject(): void,
+
+  /**
+   * Use `.toContainKey` when checking if an object contains the provided key.
+   *
+   * @param {String} key
+   */
+  toContainKey(key: string): void,
+
+  /**
+   * Use `.toContainKeys` when checking if an object has all of the provided keys.
+   *
+   * @param {Array.<String>} keys
+   */
+  toContainKeys(keys: string[]): void,
+
+  /**
+   * Use `.toContainAllKeys` when checking if an object only contains all of the provided keys.
+   *
+   * @param {Array.<String>} keys
+   */
+  toContainAllKeys(keys: string[]): void,
+
+  /**
+   * Use `.toContainAnyKeys` when checking if an object contains at least one of the provided keys.
+   *
+   * @param {Array.<String>} keys
+   */
+  toContainAnyKeys(keys: string[]): void,
+
+  /**
+   * Use `.toContainValue` when checking if an object contains the provided value.
+   *
+   * @param {*} value
+   */
+  toContainValue(value: any): void,
+
+  /**
+   * Use `.toContainValues` when checking if an object contains all of the provided values.
+   *
+   * @param {Array.<*>} values
+   */
+  toContainValues(values: any[]): void,
+
+  /**
+   * Use `.toContainAllValues` when checking if an object only contains all of the provided values.
+   *
+   * @param {Array.<*>} values
+   */
+  toContainAllValues(values: any[]): void,
+
+  /**
+   * Use `.toContainAnyValues` when checking if an object contains at least one of the provided values.
+   *
+   * @param {Array.<*>} values
+   */
+  toContainAnyValues(values: any[]): void,
+
+  /**
+   * Use `.toContainEntry` when checking if an object contains the provided entry.
+   *
+   * @param {Array.<String, String>} entry
+   */
+  toContainEntry(entry: [string, string]): void,
+
+  /**
+   * Use `.toContainEntries` when checking if an object contains all of the provided entries.
+   *
+   * @param {Array.<Array.<String, String>>} entries
+   */
+  toContainEntries(entries: [string, string][]): void,
+
+  /**
+   * Use `.toContainAllEntries` when checking if an object only contains all of the provided entries.
+   *
+   * @param {Array.<Array.<String, String>>} entries
+   */
+  toContainAllEntries(entries: [string, string][]): void,
+
+  /**
+   * Use `.toContainAnyEntries` when checking if an object contains at least one of the provided entries.
+   *
+   * @param {Array.<Array.<String, String>>} entries
+   */
+  toContainAnyEntries(entries: [string, string][]): void,
+
+  /**
+   * Use `.toBeExtensible` when checking if an object is extensible.
+   */
+  toBeExtensible(): void,
+
+  /**
+   * Use `.toBeFrozen` when checking if an object is frozen.
+   */
+  toBeFrozen(): void,
+
+  /**
+   * Use `.toBeSealed` when checking if an object is sealed.
+   */
+  toBeSealed(): void,
+
+  /**
+   * Use `.toBeString` when checking if a value is a `String`.
+   */
+  toBeString(): void,
+
+  /**
+   * Use `.toEqualCaseInsensitive` when checking if a string is equal (===) to another ignoring the casing of both strings.
+   *
+   * @param {String} string
+   */
+  toEqualCaseInsensitive(string: string): void,
+
+  /**
+   * Use `.toStartWith` when checking if a `String` starts with a given `String` prefix.
+   *
+   * @param {String} prefix
+   */
+  toStartWith(prefix: string): void,
+
+  /**
+   * Use `.toEndWith` when checking if a `String` ends with a given `String` suffix.
+   *
+   * @param {String} suffix
+   */
+  toEndWith(suffix: string): void,
+
+  /**
+   * Use `.toInclude` when checking if a `String` includes the given `String` substring.
+   *
+   * @param {String} substring
+   */
+  toInclude(substring: string): void,
+
+  /**
+   * Use `.toIncludeRepeated` when checking if a `String` includes the given `String` substring the correct number of times.
+   *
+   * @param {String} substring
+   * @param {Number} times
+   */
+  toIncludeRepeated(substring: string, times: number): void,
+
+  /**
+   * Use `.toIncludeMultiple` when checking if a `String` includes all of the given substrings.
+   *
+   * @param {Array.<String>} substring
+   */
+  toIncludeMultiple(substring: string[]): void,
+};
+
+interface JestExpectType {
+  not: JestExpectType &
+    EnzymeMatchersType &
+    DomTestingLibraryType &
+    JestJQueryMatchersType &
+    JestStyledComponentsMatchersType &
+    JestExtendedMatchersType;
+  /**
+   * If you have a mock function, you can use .lastCalledWith to test what
+   * arguments it was last called with.
+   */
+  lastCalledWith(...args: Array<any>): void;
+  /**
+   * toBe just checks that a value is what you expect. It uses === to check
+   * strict equality.
+   */
+  toBe(value: any): void;
+  /**
+   * Use .toBeCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toBeCalledWith(...args: Array<any>): void;
+  /**
+   * Using exact equality with floating point numbers is a bad idea. Rounding
+   * means that intuitive things fail.
+   */
+  toBeCloseTo(num: number, delta: any): void;
+  /**
+   * Use .toBeDefined to check that a variable is not undefined.
+   */
+  toBeDefined(): void;
+  /**
+   * Use .toBeFalsy when you don't care what a value is, you just want to
+   * ensure a value is false in a boolean context.
+   */
+  toBeFalsy(): void;
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThan.
+   */
+  toBeGreaterThan(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeGreaterThanOrEqual.
+   */
+  toBeGreaterThanOrEqual(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeLessThan.
+   */
+  toBeLessThan(number: number): void;
+  /**
+   * To compare floating point numbers, you can use toBeLessThanOrEqual.
+   */
+  toBeLessThanOrEqual(number: number): void;
+  /**
+   * Use .toBeInstanceOf(Class) to check that an object is an instance of a
+   * class.
+   */
+  toBeInstanceOf(cls: Class<*>): void;
+  /**
+   * .toBeNull() is the same as .toBe(null) but the error messages are a bit
+   * nicer.
+   */
+  toBeNull(): void;
+  /**
+   * Use .toBeTruthy when you don't care what a value is, you just want to
+   * ensure a value is true in a boolean context.
+   */
+  toBeTruthy(): void;
+  /**
+   * Use .toBeUndefined to check that a variable is undefined.
+   */
+  toBeUndefined(): void;
+  /**
+   * Use .toContain when you want to check that an item is in a list. For
+   * testing the items in the list, this uses ===, a strict equality check.
+   */
+  toContain(item: any): void;
+  /**
+   * Use .toContainEqual when you want to check that an item is in a list. For
+   * testing the items in the list, this matcher recursively checks the
+   * equality of all fields, rather than checking for object identity.
+   */
+  toContainEqual(item: any): void;
+  /**
+   * Use .toEqual when you want to check that two objects have the same value.
+   * This matcher recursively checks the equality of all fields, rather than
+   * checking for object identity.
+   */
+  toEqual(value: any): void;
+  /**
+   * Use .toHaveBeenCalled to ensure that a mock function got called.
+   */
+  toHaveBeenCalled(): void;
+  toBeCalled(): void;
+  /**
+   * Use .toHaveBeenCalledTimes to ensure that a mock function got called exact
+   * number of times.
+   */
+  toHaveBeenCalledTimes(number: number): void;
+  toBeCalledTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveBeenNthCalledWith(nthCall: number, ...args: Array<any>): void;
+  nthCalledWith(nthCall: number, ...args: Array<any>): void;
+  /**
+   *
+   */
+  toHaveReturned(): void;
+  toReturn(): void;
+  /**
+   *
+   */
+  toHaveReturnedTimes(number: number): void;
+  toReturnTimes(number: number): void;
+  /**
+   *
+   */
+  toHaveReturnedWith(value: any): void;
+  toReturnWith(value: any): void;
+  /**
+   *
+   */
+  toHaveLastReturnedWith(value: any): void;
+  lastReturnedWith(value: any): void;
+  /**
+   *
+   */
+  toHaveNthReturnedWith(nthCall: number, value: any): void;
+  nthReturnedWith(nthCall: number, value: any): void;
+  /**
+   * Use .toHaveBeenCalledWith to ensure that a mock function was called with
+   * specific arguments.
+   */
+  toHaveBeenCalledWith(...args: Array<any>): void;
+  toBeCalledWith(...args: Array<any>): void;
+  /**
+   * Use .toHaveBeenLastCalledWith to ensure that a mock function was last called
+   * with specific arguments.
+   */
+  toHaveBeenLastCalledWith(...args: Array<any>): void;
+  lastCalledWith(...args: Array<any>): void;
+  /**
+   * Check that an object has a .length property and it is set to a certain
+   * numeric value.
+   */
+  toHaveLength(number: number): void;
+  /**
+   *
+   */
+  toHaveProperty(propPath: string, value?: any): void;
+  /**
+   * Use .toMatch to check that a string matches a regular expression or string.
+   */
+  toMatch(regexpOrString: RegExp | string): void;
+  /**
+   * Use .toMatchObject to check that a javascript object matches a subset of the properties of an object.
+   */
+  toMatchObject(object: Object | Array<Object>): void;
+  /**
+   * Use .toStrictEqual to check that a javascript object matches a subset of the properties of an object.
+   */
+  toStrictEqual(value: any): void;
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(propertyMatchers?: any, name?: string): void;
+  /**
+   * This ensures that an Object matches the most recent snapshot.
+   */
+  toMatchSnapshot(name: string): void;
+
+  toMatchInlineSnapshot(snapshot?: string): void;
+  toMatchInlineSnapshot(propertyMatchers?: any, snapshot?: string): void;
+  /**
+   * Use .toThrow to test that a function throws when it is called.
+   * If you want to test that a specific error gets thrown, you can provide an
+   * argument to toThrow. The argument can be a string for the error message,
+   * a class for the error, or a regex that should match the error.
+   *
+   * Alias: .toThrowError
+   */
+  toThrow(message?: string | Error | Class<Error> | RegExp): void;
+  toThrowError(message?: string | Error | Class<Error> | RegExp): void;
+  /**
+   * Use .toThrowErrorMatchingSnapshot to test that a function throws a error
+   * matching the most recent snapshot when it is called.
+   */
+  toThrowErrorMatchingSnapshot(): void;
+  toThrowErrorMatchingInlineSnapshot(snapshot?: string): void;
+}
+
+type JestObjectType = {
+  /**
+   *  Disables automatic mocking in the module loader.
+   *
+   *  After this method is called, all `require()`s will return the real
+   *  versions of each module (rather than a mocked version).
+   */
+  disableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of disableAutomock
+   */
+  autoMockOff(): JestObjectType,
+  /**
+   * Enables automatic mocking in the module loader.
+   */
+  enableAutomock(): JestObjectType,
+  /**
+   * An un-hoisted version of enableAutomock
+   */
+  autoMockOn(): JestObjectType,
+  /**
+   * Clears the mock.calls and mock.instances properties of all mocks.
+   * Equivalent to calling .mockClear() on every mocked function.
+   */
+  clearAllMocks(): JestObjectType,
+  /**
+   * Resets the state of all mocks. Equivalent to calling .mockReset() on every
+   * mocked function.
+   */
+  resetAllMocks(): JestObjectType,
+  /**
+   * Restores all mocks back to their original value.
+   */
+  restoreAllMocks(): JestObjectType,
+  /**
+   * Removes any pending timers from the timer system.
+   */
+  clearAllTimers(): void,
+  /**
+   * Returns the number of fake timers still left to run.
+   */
+  getTimerCount(): number,
+  /**
+   * The same as `mock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  doMock(moduleName: string, moduleFactory?: any): JestObjectType,
+  /**
+   * The same as `unmock` but not moved to the top of the expectation by
+   * babel-jest.
+   */
+  dontMock(moduleName: string): JestObjectType,
+  /**
+   * Returns a new, unused mock function. Optionally takes a mock
+   * implementation.
+   */
+  fn<TArguments: $ReadOnlyArray<*>, TReturn>(
+    implementation?: (...args: TArguments) => TReturn
+  ): JestMockFn<TArguments, TReturn>,
+  /**
+   * Determines if the given function is a mocked function.
+   */
+  isMockFunction(fn: Function): boolean,
+  /**
+   * Given the name of a module, use the automatic mocking system to generate a
+   * mocked version of the module for you.
+   */
+  genMockFromModule(moduleName: string): any,
+  /**
+   * Mocks a module with an auto-mocked version when it is being required.
+   *
+   * The second argument can be used to specify an explicit module factory that
+   * is being run instead of using Jest's automocking feature.
+   *
+   * The third argument can be used to create virtual mocks -- mocks of modules
+   * that don't exist anywhere in the system.
+   */
+  mock(
+    moduleName: string,
+    moduleFactory?: any,
+    options?: Object
+  ): JestObjectType,
+  /**
+   * Returns the actual module instead of a mock, bypassing all checks on
+   * whether the module should receive a mock implementation or not.
+   */
+  requireActual(moduleName: string): any,
+  /**
+   * Returns a mock module instead of the actual module, bypassing all checks
+   * on whether the module should be required normally or not.
+   */
+  requireMock(moduleName: string): any,
+  /**
+   * Resets the module registry - the cache of all required modules. This is
+   * useful to isolate modules where local state might conflict between tests.
+   */
+  resetModules(): JestObjectType,
+
+  /**
+   * Creates a sandbox registry for the modules that are loaded inside the
+   * callback function. This is useful to isolate specific modules for every
+   * test so that local module state doesn't conflict between tests.
+   */
+  isolateModules(fn: () => void): JestObjectType,
+
+  /**
+   * Exhausts the micro-task queue (usually interfaced in node via
+   * process.nextTick).
+   */
+  runAllTicks(): void,
+  /**
+   * Exhausts the macro-task queue (i.e., all tasks queued by setTimeout(),
+   * setInterval(), and setImmediate()).
+   */
+  runAllTimers(): void,
+  /**
+   * Exhausts all tasks queued by setImmediate().
+   */
+  runAllImmediates(): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   */
+  advanceTimersByTime(msToRun: number): void,
+  /**
+   * Executes only the macro task queue (i.e. all tasks queued by setTimeout()
+   * or setInterval() and setImmediate()).
+   *
+   * Renamed to `advanceTimersByTime`.
+   */
+  runTimersToTime(msToRun: number): void,
+  /**
+   * Executes only the macro-tasks that are currently pending (i.e., only the
+   * tasks that have been queued by setTimeout() or setInterval() up to this
+   * point)
+   */
+  runOnlyPendingTimers(): void,
+  /**
+   * Explicitly supplies the mock object that the module system should return
+   * for the specified module. Note: It is recommended to use jest.mock()
+   * instead.
+   */
+  setMock(moduleName: string, moduleExports: any): JestObjectType,
+  /**
+   * Indicates that the module system should never return a mocked version of
+   * the specified module from require() (e.g. that it should always return the
+   * real module).
+   */
+  unmock(moduleName: string): JestObjectType,
+  /**
+   * Instructs Jest to use fake versions of the standard timer functions
+   * (setTimeout, setInterval, clearTimeout, clearInterval, nextTick,
+   * setImmediate and clearImmediate).
+   */
+  useFakeTimers(): JestObjectType,
+  /**
+   * Instructs Jest to use the real versions of the standard timer functions.
+   */
+  useRealTimers(): JestObjectType,
+  /**
+   * Creates a mock function similar to jest.fn but also tracks calls to
+   * object[methodName].
+   */
+  spyOn(
+    object: Object,
+    methodName: string,
+    accessType?: 'get' | 'set'
+  ): JestMockFn<any, any>,
+  /**
+   * Set the default timeout interval for tests and before/after hooks in milliseconds.
+   * Note: The default timeout interval is 5 seconds if this method is not called.
+   */
+  setTimeout(timeout: number): JestObjectType,
+};
+
+type JestSpyType = {
+  calls: JestCallsType,
+};
+
+/** Runs this function after every test inside this context */
+declare function afterEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before every test inside this context */
+declare function beforeEach(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function after all tests have finished inside this context */
+declare function afterAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** Runs this function before any tests have started inside this context */
+declare function beforeAll(
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+
+/** A context for grouping tests together */
+declare var describe: {
+  /**
+   * Creates a block that groups together several related tests in one "test suite"
+   */
+  (name: JestTestName, fn: () => void): void,
+
+  /**
+   * Only run this describe block
+   */
+  only(name: JestTestName, fn: () => void): void,
+
+  /**
+   * Skip running this describe block
+   */
+  skip(name: JestTestName, fn: () => void): void,
+
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>,
+    timeout?: number
+  ) => void,
+};
+
+/** An individual test unit */
+declare var it: {
+  /**
+   * An individual test unit
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  (
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+
+  /**
+   * Only run this test
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  only(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): {
+    each(
+      ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+    ): (
+      name: JestTestName,
+      fn?: (...args: Array<any>) => ?Promise<mixed>,
+      timeout?: number
+    ) => void,
+  },
+
+  /**
+   * Skip running this test
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  skip(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+
+  /**
+   * Highlight planned tests in the summary output
+   *
+   * @param {String} Name of Test to do
+   */
+  todo(name: string): void,
+
+  /**
+   * Run the test concurrently
+   *
+   * @param {JestTestName} Name of Test
+   * @param {Function} Test
+   * @param {number} Timeout for the test, in milliseconds.
+   */
+  concurrent(
+    name: JestTestName,
+    fn?: (done: () => void) => ?Promise<mixed>,
+    timeout?: number
+  ): void,
+
+  /**
+   * each runs this test against array of argument arrays per each run
+   *
+   * @param {table} table of Test
+   */
+  each(
+    ...table: Array<Array<mixed> | mixed> | [Array<string>, string]
+  ): (
+    name: JestTestName,
+    fn?: (...args: Array<any>) => ?Promise<mixed>,
+    timeout?: number
+  ) => void,
+};
+
+declare function fit(
+  name: JestTestName,
+  fn: (done: () => void) => ?Promise<mixed>,
+  timeout?: number
+): void;
+/** An individual test unit */
+declare var test: typeof it;
+/** A disabled group of tests */
+declare var xdescribe: typeof describe;
+/** A focused group of tests */
+declare var fdescribe: typeof describe;
+/** A disabled individual test */
+declare var xit: typeof it;
+/** A disabled individual test */
+declare var xtest: typeof it;
+
+type JestPrettyFormatColors = {
+  comment: { close: string, open: string },
+  content: { close: string, open: string },
+  prop: { close: string, open: string },
+  tag: { close: string, open: string },
+  value: { close: string, open: string },
+};
+
+type JestPrettyFormatIndent = string => string;
+type JestPrettyFormatRefs = Array<any>;
+type JestPrettyFormatPrint = any => string;
+type JestPrettyFormatStringOrNull = string | null;
+
+type JestPrettyFormatOptions = {|
+  callToJSON: boolean,
+  edgeSpacing: string,
+  escapeRegex: boolean,
+  highlight: boolean,
+  indent: number,
+  maxDepth: number,
+  min: boolean,
+  plugins: JestPrettyFormatPlugins,
+  printFunctionName: boolean,
+  spacing: string,
+  theme: {|
+    comment: string,
+    content: string,
+    prop: string,
+    tag: string,
+    value: string,
+  |},
+|};
+
+type JestPrettyFormatPlugin = {
+  print: (
+    val: any,
+    serialize: JestPrettyFormatPrint,
+    indent: JestPrettyFormatIndent,
+    opts: JestPrettyFormatOptions,
+    colors: JestPrettyFormatColors
+  ) => string,
+  test: any => boolean,
+};
+
+type JestPrettyFormatPlugins = Array<JestPrettyFormatPlugin>;
+
+/** The expect function is used every time you want to test a value */
+declare var expect: {
+  /** The object that you want to make assertions against */
+  (
+    value: any
+  ): JestExpectType &
+    JestPromiseType &
+    EnzymeMatchersType &
+    DomTestingLibraryType &
+    JestJQueryMatchersType &
+    JestStyledComponentsMatchersType &
+    JestExtendedMatchersType,
+
+  /** Add additional Jasmine matchers to Jest's roster */
+  extend(matchers: { [name: string]: JestMatcher }): void,
+  /** Add a module that formats application-specific data structures. */
+  addSnapshotSerializer(pluginModule: JestPrettyFormatPlugin): void,
+  assertions(expectedAssertions: number): void,
+  hasAssertions(): void,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
+  objectContaining(value: Object): Object,
+  /** Matches any received string that contains the exact expected string. */
+  stringContaining(value: string): string,
+  stringMatching(value: string | RegExp): string,
+  not: {
+    arrayContaining: (value: $ReadOnlyArray<mixed>) => Array<mixed>,
+    objectContaining: (value: {}) => Object,
+    stringContaining: (value: string) => string,
+    stringMatching: (value: string | RegExp) => string,
+  },
+};
+
+// TODO handle return type
+// http://jasmine.github.io/2.4/introduction.html#section-Spies
+declare function spyOn(value: mixed, method: string): Object;
+
+/** Holds all functions related to manipulating test runner */
+declare var jest: JestObjectType;
+
+/**
+ * The global Jasmine object, this is generally not exposed as the public API,
+ * using features inside here could break in later versions of Jest.
+ */
+declare var jasmine: {
+  DEFAULT_TIMEOUT_INTERVAL: number,
+  any(value: mixed): JestAsymmetricEqualityType,
+  anything(): any,
+  arrayContaining(value: Array<mixed>): Array<mixed>,
+  clock(): JestClockType,
+  createSpy(name: string): JestSpyType,
+  createSpyObj(
+    baseName: string,
+    methodNames: Array<string>
+  ): { [methodName: string]: JestSpyType },
+  objectContaining(value: Object): Object,
+  stringMatching(value: string): string,
+};

--- a/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
@@ -7,14 +7,32 @@ exports[`Dropdown closed and open snapshots 1`] = `
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 18px;
   font-weight: bold;
-  padding: 5px 10px;
+  line-height: 48px;
+  white-space: nowrap;
+  padding: 0 10px;
+  margin: 0;
   border: none;
 }
 
 .emotion-2:hover {
   background-color: #eee;
+}
+
+.emotion-2:focus {
+  outline-offset: -3px;
 }
 
 .emotion-0 {
@@ -46,14 +64,32 @@ exports[`Dropdown closed and open snapshots 2`] = `
 }
 
 .emotion-2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 18px;
   font-weight: bold;
-  padding: 5px 10px;
+  line-height: 48px;
+  white-space: nowrap;
+  padding: 0 10px;
+  margin: 0;
   border: none;
 }
 
 .emotion-2:hover {
   background-color: #eee;
+}
+
+.emotion-2:focus {
+  outline-offset: -3px;
 }
 
 .emotion-0 {
@@ -99,7 +135,7 @@ exports[`Dropdown closed and open snapshots 2`] = `
     </span>
   </button>
   <ul
-    className="emotion-4 emotion-5"
+    className="dropdown-menu emotion-4 emotion-5"
   >
     <li>
       foo

--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -42,14 +42,32 @@ exports[`Header snapshot 1`] = `
 }
 
 .emotion-5 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 18px;
   font-weight: bold;
-  padding: 5px 10px;
+  line-height: 48px;
+  white-space: nowrap;
+  padding: 0 10px;
+  margin: 0;
   border: none;
 }
 
 .emotion-5:hover {
   background-color: #eee;
+}
+
+.emotion-5:focus {
+  outline-offset: -3px;
 }
 
 .emotion-3 {
@@ -114,20 +132,35 @@ exports[`Header snapshot 1`] = `
 }
 
 .emotion-29 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 18px;
   font-weight: bold;
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
+  line-height: 48px;
+  padding: 0 8px;
 }
 
 .emotion-29:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
+  background-color: #eee;
+}
+
+.emotion-29:focus {
+  outline-offset: -3px;
 }
 
 .emotion-28 {
-  vertical-align: -6px;
+  margin-left: 5px;
 }
 
 <div

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -1,21 +1,242 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Login snapshot 1`] = `
+exports[`Login component when user is logged in 1`] = `
+.emotion-5 {
+  position: relative;
+  pointer-events: auto;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 48px;
+  white-space: nowrap;
+  padding: 0 10px;
+  margin: 0;
+  border: none;
+}
+
+.emotion-3:hover {
+  background-color: #eee;
+}
+
+.emotion-3:focus {
+  outline-offset: -3px;
+}
+
+.emotion-0 {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
 .emotion-1 {
+  font-size: 12px;
+  padding-left: 2px;
+}
+
+<div
+  className="emotion-5 emotion-6"
+>
+  <button
+    className="emotion-3 emotion-4"
+    onClick={[Function]}
+  >
+    <img
+      alt="test-username"
+      className="emotion-0"
+      src="test-url"
+    />
+    <span
+      className="emotion-1 emotion-2"
+    >
+      ▼
+    </span>
+  </button>
+</div>
+`;
+
+exports[`Login component when user is logged in 2`] = `
+.emotion-8 {
+  position: relative;
+  pointer-events: auto;
+}
+
+.emotion-3 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  font-size: 18px;
+  font-weight: bold;
+  line-height: 48px;
+  white-space: nowrap;
+  padding: 0 10px;
+  margin: 0;
+  border: none;
+}
+
+.emotion-3:hover {
+  background-color: #eee;
+}
+
+.emotion-3:focus {
+  outline-offset: -3px;
+}
+
+.emotion-0 {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+}
+
+.emotion-1 {
+  font-size: 12px;
+  padding-left: 2px;
+}
+
+.emotion-6 {
+  position: absolute;
+  z-index: 100;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  background-color: white;
+  border: solid black 1px;
+  box-shadow: 3px 3px 5px black;
+  padding: 10px;
+  min-width: 100%;
+  right: 0;
+}
+
+.emotion-6 li {
+  padding: 5px;
+  white-space: nowrap;
+}
+
+.emotion-5 {
+  border-width: 0;
+  padding: 0;
+  color: #3d7e9a;
+  font-weight: normal;
+}
+
+.emotion-5:hover {
+  -webkit-text-decoration: underline;
+  text-decoration: underline;
+}
+
+<div
+  className="emotion-8 emotion-9"
+>
+  <button
+    className="emotion-3 emotion-4"
+    onClick={null}
+  >
+    <img
+      alt="test-username"
+      className="emotion-0"
+      src="test-url"
+    />
+    <span
+      className="emotion-1 emotion-2"
+    >
+      ▲
+    </span>
+  </button>
+  <ul
+    className="dropdown-menu emotion-6 emotion-7"
+  >
+    <li>
+      <a
+        href="//profiles/test-username"
+      >
+        View profile
+      </a>
+    </li>
+    <li>
+      <a
+        href="//profiles/test-username/edit"
+      >
+        Edit profile
+      </a>
+    </li>
+    <li>
+      <form
+        action="//users/signout"
+        method="post"
+      >
+        <input
+          name="next"
+          type="hidden"
+          value="/"
+        />
+        <button
+          className="emotion-5"
+          type="submit"
+        >
+          Sign out
+        </button>
+      </form>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`Login component when user is not logged in 1`] = `
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   font-size: 18px;
   font-weight: bold;
   color: black;
   -webkit-text-decoration: none;
   text-decoration: none;
+  line-height: 48px;
+  padding: 0 8px;
 }
 
 .emotion-1:hover {
   -webkit-text-decoration: none;
   text-decoration: none;
+  background-color: #eee;
+}
+
+.emotion-1:focus {
+  outline-offset: -3px;
 }
 
 .emotion-0 {
-  vertical-align: -6px;
+  margin-left: 5px;
 }
 
 <a

--- a/kuma/javascript/src/header/dropdown.test.js
+++ b/kuma/javascript/src/header/dropdown.test.js
@@ -1,6 +1,9 @@
+//@flow
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 import Dropdown from './dropdown.jsx';
+
+jest.useFakeTimers();
 
 test('Dropdown closed and open snapshots', () => {
     const dropdown = create(
@@ -22,6 +25,7 @@ test('Dropdown closed and open snapshots', () => {
     act(() => {
         dropdown.toJSON().children[0].props.onClick();
     });
+
     let openTree = dropdown.toJSON();
     let openString = JSON.stringify(openTree);
 
@@ -32,7 +36,8 @@ test('Dropdown closed and open snapshots', () => {
 
     // Fake a click on the document body to dismiss the menu
     act(() => {
-        document.body.dispatchEvent(new MouseEvent('click'));
+        document.body && document.body.dispatchEvent(new MouseEvent('click'));
+        jest.runAllTimers();
     });
 
     // Expect the menu to be closed, checking deep equality
@@ -42,21 +47,28 @@ test('Dropdown closed and open snapshots', () => {
     act(() => {
         dropdown.toJSON().children[0].props.onClick();
     });
+
     // Verify that it is opened
     expect(JSON.stringify(dropdown.toJSON())).toEqual(openString);
 
     // Fake a keyboard event
     act(() => {
-        document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'A' }));
+        document.body &&
+            document.body.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'A' })
+            );
+        jest.runAllTimers();
     });
     // The menu should still be open
     expect(JSON.stringify(dropdown.toJSON())).toEqual(openString);
 
     // Finally, fake the escape key
     act(() => {
-        document.body.dispatchEvent(
-            new KeyboardEvent('keydown', { key: 'Escape' })
-        );
+        document.body &&
+            document.body.dispatchEvent(
+                new KeyboardEvent('keydown', { key: 'Escape' })
+            );
+        jest.runAllTimers();
     });
     // And expect the menu to have closed
     expect(JSON.stringify(dropdown.toJSON())).toEqual(closedString);

--- a/kuma/javascript/src/header/header.test.js
+++ b/kuma/javascript/src/header/header.test.js
@@ -1,3 +1,4 @@
+//@flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Header from './header.jsx';

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -1,36 +1,112 @@
 //@flow
 import * as React from 'react';
+import { useContext } from 'react';
+
 import { css } from '@emotion/core';
 
+import CurrentUser from '../current-user.jsx';
+import Dropdown from './dropdown.jsx';
 import gettext from '../gettext.js';
 import GithubLogo from './github-logo.svg';
 
 const PATHNAME = window && window.location ? window.location.pathname : '/';
+const LOCALE =
+    window && window.location && window.location.pathname.split('/')[1];
 
 const strings = {
-    signin: gettext('Sign in')
+    signIn: gettext('Sign in'),
+    viewProfile: gettext('View profile'),
+    editProfile: gettext('Edit profile'),
+    signOut: gettext('Sign out')
 };
 
 const styles = {
-    a: css({
+    avatar: css({
+        width: 48,
+        height: 48,
+        borderRadius: '50%'
+    }),
+    signInLink: css({
+        display: 'flex',
+        alignItems: 'center',
         fontSize: 18,
         fontWeight: 'bold',
         color: 'black',
         textDecoration: 'none',
-        ':hover': { textDecoration: 'none' }
+        lineHeight: '48px',
+        padding: '0 8px',
+        ':hover': {
+            textDecoration: 'none',
+            backgroundColor: '#eee'
+        },
+        ':focus': {
+            // Focus outline extends beyond header in Chrome without this
+            outlineOffset: -3
+        }
     }),
-    icon: css({ verticalAlign: -6 })
+    icon: css({ marginLeft: 5 }),
+    signOutButton: css({
+        // Signing out is a POST operation so we use a form and button
+        // but we want the button to look like a regular link.
+        borderWidth: 0,
+        padding: 0,
+        color: '#3d7e9a',
+        fontWeight: 'normal',
+        ':hover': { textDecoration: 'underline' }
+    })
 };
 
 export default function Login(): React.Node {
-    return (
-        <a
-            href={`/users/github/login/?next=${PATHNAME}`}
-            data-service="GitHub"
-            rel="nofollow"
-            css={styles.a}
-        >
-            {strings.signin} <GithubLogo css={styles.icon} />
-        </a>
-    );
+    const userData = useContext(CurrentUser.context);
+
+    // if we don't have the user data yet, don't render anything
+    if (!userData) {
+        return null;
+    }
+
+    if (userData.isAuthenticated && userData.username) {
+        // If we have user data and the user is logged in, show their
+        // profile pic.
+        let label = (
+            <img
+                src={userData.gravatarUrl.small}
+                css={styles.avatar}
+                alt={userData.username}
+            />
+        );
+        return (
+            <Dropdown label={label} right={true}>
+                <li>
+                    <a href={`/${LOCALE}/profiles/${userData.username}`}>
+                        {strings.viewProfile}
+                    </a>
+                </li>
+                <li>
+                    <a href={`/${LOCALE}/profiles/${userData.username}/edit`}>
+                        {strings.editProfile}
+                    </a>
+                </li>
+                <li>
+                    <form action={`/${LOCALE}/users/signout`} method="post">
+                        <input name="next" type="hidden" value={PATHNAME} />
+                        <button css={styles.signOutButton} type="submit">
+                            {strings.signOut}
+                        </button>
+                    </form>
+                </li>
+            </Dropdown>
+        );
+    } else {
+        // Otherwise, show a login prompt
+        return (
+            <a
+                href={`/users/github/login/?next=${PATHNAME}`}
+                data-service="GitHub"
+                rel="nofollow"
+                css={styles.signInLink}
+            >
+                {strings.signIn} <GithubLogo css={styles.icon} />
+            </a>
+        );
+    }
 }

--- a/kuma/javascript/src/header/login.test.js
+++ b/kuma/javascript/src/header/login.test.js
@@ -1,8 +1,63 @@
+//@flow
 import React from 'react';
-import { create } from 'react-test-renderer';
+import { act, create } from 'react-test-renderer';
+import CurrentUser from '../current-user.jsx';
+import Dropdown from './dropdown.jsx';
 import Login from './login.jsx';
 
-test('Login snapshot', () => {
-    const login = create(<Login />);
+test('Login snapshot before user data is fetched', () => {
+    const login = create(
+        <CurrentUser.context.Provider value={null}>
+            <Login />
+        </CurrentUser.context.Provider>
+    ).toJSON();
+    expect(login).toBe(null);
+});
+
+test('Login component when user is not logged in', () => {
+    const login = create(
+        <CurrentUser.context.Provider value={CurrentUser.defaultUserData}>
+            <Login />
+        </CurrentUser.context.Provider>
+    ).toJSON();
+    expect(login.children[0]).toBe('Sign in');
+    expect(login).toMatchSnapshot();
+});
+
+test('Login component when user is logged in', () => {
+    const login = create(
+        <CurrentUser.context.Provider
+            value={{
+                ...CurrentUser.defaultUserData,
+                isAuthenticated: true,
+                username: 'test-username',
+                gravatarUrl: { small: 'test-url', large: 'test-bigurl' }
+            }}
+        >
+            <Login />
+        </CurrentUser.context.Provider>
+    );
+
     expect(login.toJSON()).toMatchSnapshot();
+
+    // Expect a Dropdown element
+    let root = login.root;
+    let dropdown = root.findByType(Dropdown);
+    expect(dropdown).toBeDefined();
+
+    // Whose label prop is an image with the expected src and alt attributes
+    expect(dropdown.props.label.props.src).toEqual('test-url');
+    expect(dropdown.props.label.props.alt).toEqual('test-username');
+
+    // Open up the dropdown menu
+    act(() => {
+        login.toJSON().children[0].props.onClick();
+    });
+
+    expect(login.toJSON()).toMatchSnapshot();
+
+    let string = JSON.stringify(login.toJSON());
+    expect(string).toContain('View profile');
+    expect(string).toContain('Edit profile');
+    expect(string).toContain('Sign out');
 });

--- a/kuma/javascript/src/header/logo.test.js
+++ b/kuma/javascript/src/header/logo.test.js
@@ -1,3 +1,4 @@
+//@flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Logo from './logo.jsx';

--- a/kuma/javascript/src/header/search.test.js
+++ b/kuma/javascript/src/header/search.test.js
@@ -1,3 +1,4 @@
+//@flow
 import React from 'react';
 import { create } from 'react-test-renderer';
 import Search from './search.jsx';

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -1,12 +1,19 @@
 // @flow
 import React from 'react';
 import ReactDOM from 'react-dom';
-import Header from './header/header.jsx';
+
 import ClientSideNav from './client-side-nav.js';
+import CurrentUser from './current-user.jsx';
+import Header from './header/header.jsx';
 
 let container = document.getElementById('react-header');
 if (container) {
-    ReactDOM.render(<Header />, container);
+    ReactDOM.render(
+        <CurrentUser.Provider>
+            <Header />
+        </CurrentUser.Provider>,
+        container
+    );
 }
 
 ClientSideNav.init();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10610,25 +10610,25 @@
       }
     },
     "react": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.1.tgz",
-      "integrity": "sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==",
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
+      "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.1"
+        "scheduler": "^0.13.4"
       }
     },
     "react-dom": {
-      "version": "16.8.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.1.tgz",
-      "integrity": "sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==",
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
+      "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.1"
+        "scheduler": "^0.13.4"
       }
     },
     "react-is": {
@@ -10720,27 +10720,27 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.8.3",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.3.tgz",
-      "integrity": "sha512-rjJGYebduKNZH0k1bUivVrRLX04JfIQ0FKJLPK10TAb06XWhfi4gTobooF9K/DEFNW98iGac3OSxkfIJUN9Mdg==",
+      "version": "16.8.4",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.8.4.tgz",
+      "integrity": "sha512-jQ9Tf/ilIGSr55Cz23AZ/7H3ABEdo9oy2zF9nDHZyhLHDSLKuoILxw2ifpBfuuwQvj4LCoqdru9iZf7gwFH28A==",
       "dev": true,
       "requires": {
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "react-is": "^16.8.3",
-        "scheduler": "^0.13.3"
+        "react-is": "^16.8.4",
+        "scheduler": "^0.13.4"
       },
       "dependencies": {
         "react-is": {
-          "version": "16.8.3",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.3.tgz",
-          "integrity": "sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==",
+          "version": "16.8.4",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.4.tgz",
+          "integrity": "sha512-PVadd+WaUDOAciICm/J1waJaSvgq+4rHE/K70j0PFqKhkTBsPv/82UGQJNXAngz1fOQLLxI6z1sEDmJDQhCTAA==",
           "dev": true
         },
         "scheduler": {
-          "version": "0.13.3",
-          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.3.tgz",
-          "integrity": "sha512-UxN5QRYWtpR1egNWzJcVLk8jlegxAugswQc984lD3kU7NuobsO37/sRfbpTdBjtnD5TBNFA2Q2oLV5+UmPSmEQ==",
+          "version": "0.13.4",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
+          "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
           "dev": true,
           "requires": {
             "loose-envify": "^1.1.0",
@@ -11516,9 +11516,9 @@
       "dev": true
     },
     "scheduler": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.1.tgz",
-      "integrity": "sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==",
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
+      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     "dependencies": {
         "@emotion/core": "^10.0.7",
         "@emotion/styled": "^10.0.7",
-        "react": "^16.8.1",
-        "react-dom": "^16.8.1"
+        "react": "^16.8.4",
+        "react-dom": "^16.8.4"
     },
     "devDependencies": {
         "@babel/core": "^7.2.2",
@@ -63,7 +63,7 @@
         "node-sass": "4.9.4",
         "prettier": "^1.16.4",
         "react-svg-loader": "^2.1.0",
-        "react-test-renderer": "16.8.3",
+        "react-test-renderer": "^16.8.4",
         "sass-true": "4.0.0",
         "stylelint": "9.3.0",
         "svgo": "1.0.5",


### PR DESCRIPTION
This PR introduces a new CurrentUser.Provider React component
that uses fetch() to get user data from the whoami API and then
uses the React Context API to share that user data with any components
that need it. The patch also includes changes to the existing Login
component to display the avatar of logged in users.

The patch also modifies the Login component to display a dropdown menu for
logged in users to allow view profile, edit profile and sign out commands.
This also includes modifications to the Dropdown component to make
it work with non-textual menu labels and to attach the menu to the
right side of the label instead of the left side.

Finally, the patch also bumps the minor version of React and makes
some changes to ensure that we can use Flow on our Jest tests.