### PR TITLE
bug 1401272: Enable MySQL Strict Mode

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -86,6 +86,7 @@ if 'mysql' in DEFAULT_DATABASE['ENGINE']:
             'init_command': 'SET '
                             'innodb_strict_mode=1,'
                             'storage_engine=INNODB,'
+                            "sql_mode='STRICT_TRANS_TABLES',"
                             'character_set_connection=utf8,'
                             'collation_connection=utf8_general_ci',
         },


### PR DESCRIPTION
This will eliminate warning w001 from [django-mysql](http://django-mysql.readthedocs.org/en/latest/checks.html#django-mysql-w001-strict-mode), and the default in MySQL 5.7.
