### PR TITLE
Bug 1534298, ensure contributeForm exist before adding event listener

### DIFF
--- a/kuma/static/js/components/payments/focus-visible.js
+++ b/kuma/static/js/components/payments/focus-visible.js
@@ -10,40 +10,45 @@
         this.removeEventListener('focusout', removeFocusVisible);
     }
 
-    // When a keyup event is triggered on the contribute form,
-    contributeForm.addEventListener('keyup', function(event) {
-        var currentTarget = event.target;
-        var targetType = currentTarget.type;
+    if (contributeForm) {
+        // When a keyup event is triggered on the contribute form,
+        contributeForm.addEventListener('keyup', function(event) {
+            var currentTarget = event.target;
+            var targetType = currentTarget.type;
 
-        /* The key pressed was the tab key, or the left or right
-           arrow keys(used to cycle through radio buttons), and the
-           target field type is one of `radio` */
-        if (
-            (event.key === 'Tab' ||
-                event.key === 'ArrowLeft' ||
-                event.key === 'ArrowRight') &&
-            targetType === 'radio'
-        ) {
-            // get the parent label element
-            var radioButtonLabel = currentTarget.parentElement;
-            // add the `focus-visible` class
-            radioButtonLabel.classList.add('focus-visible');
-            // listen for when the field loses focus,
-            radioButtonLabel.addEventListener('focusout', removeFocusVisible);
-        }
+            /* The key pressed was the tab key, or the left or right
+               arrow keys(used to cycle through radio buttons), and the
+               target field type is one of `radio` */
+            if (
+                (event.key === 'Tab' ||
+                    event.key === 'ArrowLeft' ||
+                    event.key === 'ArrowRight') &&
+                targetType === 'radio'
+            ) {
+                // get the parent label element
+                var radioButtonLabel = currentTarget.parentElement;
+                // add the `focus-visible` class
+                radioButtonLabel.classList.add('focus-visible');
+                // listen for when the field loses focus,
+                radioButtonLabel.addEventListener(
+                    'focusout',
+                    removeFocusVisible
+                );
+            }
 
-        /* The key pressed was the tab key, and the target field
-           type is one of `text`, `email`, or `number */
-        if (
-            event.key === 'Tab' &&
-            (targetType === 'text' ||
-                targetType === 'email' ||
-                targetType === 'number')
-        ) {
-            // add the `focus-visible` class.
-            currentTarget.classList.add('focus-visible');
-            // listen for when the field loses focus,
-            currentTarget.addEventListener('focusout', removeFocusVisible);
-        }
-    });
+            /* The key pressed was the tab key, and the target field
+               type is one of `text`, `email`, or `number */
+            if (
+                event.key === 'Tab' &&
+                (targetType === 'text' ||
+                    targetType === 'email' ||
+                    targetType === 'number')
+            ) {
+                // add the `focus-visible` class.
+                currentTarget.classList.add('focus-visible');
+                // listen for when the field loses focus,
+                currentTarget.addEventListener('focusout', removeFocusVisible);
+            }
+        });
+    }
 })();


### PR DESCRIPTION
This solves the initial problem but, I ran into another problem. Once I confirmed that I want to cancel my subscription, I am sent to this URL https://developer.mozilla.org/en-US/payments/recurring/management but, here I get a permission denied error.

Going back to https://developer.mozilla.org/en-US/payments/recurring/management via Edit profile > Manage monthly subscription still shows the subscription.

That might simply be because it is still active, but maybe not? If it is because it is still active, we probably want to look at adding a note that indicates that it is in fact cancelled, and perhaps the date on which the subscription will end.

That is out of scope for this bug though, but thought I would mention it.

@jwhitlock @atopal Thoughts?

@davidflanagan r?