### PR TITLE
bug 1519582: bleach revision content on save

### DIFF
--- a/kuma/scrape/tests/test_source_revision.py
+++ b/kuma/scrape/tests/test_source_revision.py
@@ -146,7 +146,7 @@ def test_gather_with_prereqs(tagged_doc, client):
     expected_data = {
         'id': tagged_doc.current_revision_id,
         'comment': 'Frist Post!',
-        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...</p>',
         'created': datetime(2016, 12, 15, 17, 23),
         'creator': {'username': 'creator'},
         'document': tagged_doc,
@@ -190,7 +190,7 @@ def test_gather_second_pass(tagged_doc, client):
     expected_data = {
         'id': tagged_doc.current_revision_id,
         'comment': 'Frist Post!',
-        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...</p>',
         'created': datetime(2016, 12, 15, 17, 23),
         'creator': {'username': 'creator'},
         'document': tagged_doc,
@@ -234,7 +234,7 @@ def test_gather_document_slug_wins(tagged_doc, client):
     expected_data = {
         'id': tagged_doc.current_revision_id,
         'comment': 'Frist Post!',
-        'content': '<p>The HTML element <code>&lt;input&gt;</code>...',
+        'content': '<p>The HTML element <code>&lt;input&gt;</code>...</p>',
         'created': datetime(2016, 12, 15, 17, 23),
         'creator': {'username': 'creator'},
         'document': tagged_doc,

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1428,7 +1428,7 @@ CELERY_ROUTES = {
     'kuma.users.tasks.send_welcome_email': {
         'queue': 'mdn_emails'
     },
-    'kuma.users.tasks.email_render_document_progress': {
+    'kuma.users.tasks.email_document_progress': {
         'queue': 'mdn_emails'
     },
     'kuma.payments.tasks.contribute_thank_you_email': {
@@ -1456,6 +1456,9 @@ CELERY_ROUTES = {
         'queue': 'mdn_wiki'
     },
     'kuma.wiki.tasks.render_document_chunk': {
+        'queue': 'mdn_wiki'
+    },
+    'kuma.wiki.tasks.clean_document_chunk': {
         'queue': 'mdn_wiki'
     },
     'kuma.wiki.tasks.render_stale_documents': {

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -522,12 +522,10 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
                 self.initial['slug'] = self.instance.document.slug
 
             content = self.instance.content
-            parsed_content = kuma.wiki.content.parse(content)
-            parsed_content.injectSectionIDs()
             if self.section_id:
+                parsed_content = kuma.wiki.content.parse(content)
                 parsed_content.extractSection(self.section_id)
-            parsed_content.filterEditorSafety()
-            content = parsed_content.serialize()
+                content = parsed_content.serialize()
             self.initial['content'] = content
 
             self.initial['review_tags'] = list(self.instance

--- a/kuma/wiki/management/commands/clean_document.py
+++ b/kuma/wiki/management/commands/clean_document.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+"""
+Manually schedule the cleaning of one or more documents
+"""
+from __future__ import division
+from __future__ import unicode_literals
+
+from math import ceil
+
+from celery import chain
+from django.contrib.auth.models import Group
+from django.core.management.base import BaseCommand, CommandError
+
+from kuma.core.utils import chunked
+from kuma.users.models import User
+from kuma.wiki.models import Document
+from kuma.wiki.tasks import (clean_document_chunk, email_document_progress)
+
+
+class Command(BaseCommand):
+    args = '<document_path document_path ...>'
+    help = 'Clean the current revision of one or more wiki documents'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'paths',
+            help='Path to document(s), like /en-US/docs/Web',
+            nargs='*',  # overridden by --all or --locale
+            metavar='path')
+        parser.add_argument(
+            '--all',
+            help='Clean ALL documents (rather than by path)',
+            action='store_true')
+        parser.add_argument(
+            '--locale',
+            help='Clean ALL documents in this locale (rather than by path)')
+
+    def handle(self, *args, **options):
+        user = get_or_create_known_user('mdnwebdocs-bot')
+        if options['all'] or options['locale']:
+            filters = {}
+            if options['locale'] and not options['all']:
+                locale = options['locale'].decode('utf8')
+                self.stdout.write(
+                    'Cleaning all documents in locale {}'.format(locale))
+                filters.update(locale=locale)
+            else:
+                self.stdout.write('Cleaning all documents')
+            docs = Document.objects.filter(**filters)
+            docs = docs.order_by('-modified')
+            docs = docs.values_list('id', flat=True)
+            self.stdout.write('...found {} documents.'.format(len(docs)))
+            chain_clean_docs(docs, user.pk)
+        else:
+            # Accept page paths from command line, but be liberal
+            # in what we accept, eg: /en-US/docs/CSS (full path);
+            # /en-US/CSS (no /docs); or even en-US/CSS (no leading slash)
+            paths = options['paths']
+            if not paths:
+                raise CommandError('Need at least one document path to clean')
+            for path in paths:
+                if path.startswith('/'):
+                    path = path[1:]
+                locale, sep, slug = path.partition('/')
+                head, sep, tail = slug.partition('/')
+                if head == 'docs':
+                    slug = tail
+                try:
+                    doc = Document.objects.get(locale=locale, slug=slug)
+                    self.stdout.write('Cleaning {!r}'.format(doc))
+                    rev = doc.clean_current_revision(user)
+                except Exception as e:
+                    self.stderr.write('...error: {}'.format(str(e)))
+                else:
+                    if rev is None:
+                        self.stdout.write("...skipped (it's already clean)")
+                    else:
+                        self.stdout.write('...created {!r}'.format(rev))
+
+
+def get_or_create_known_user(username):
+    user = User.objects.get_or_create(username=username)[0]
+    known_authors = Group.objects.get_or_create(name="Known Authors")[0]
+    user.groups.add(known_authors)
+    return user
+
+
+def chain_clean_docs(doc_pks, user_pk):
+    tasks = []
+    count = 0
+    total = len(doc_pks)
+    n = int(ceil(total / 5))
+    chunks = chunked(doc_pks, n)
+
+    for chunk in chunks:
+        count += len(chunk)
+        tasks.append(clean_document_chunk.si(chunk, user_pk))
+        percent_complete = int(ceil((count / total) * 100))
+        tasks.append(
+            email_document_progress.si('clean_document', percent_complete,
+                                       total))
+
+    chain(*tasks).apply_async()

--- a/kuma/wiki/management/commands/render_document.py
+++ b/kuma/wiki/management/commands/render_document.py
@@ -14,7 +14,7 @@ from django.db.models import Q
 
 from kuma.core.utils import chunked
 from kuma.wiki.models import Document, DocumentRenderingInProgress
-from kuma.wiki.tasks import (email_render_document_progress, render_document,
+from kuma.wiki.tasks import (email_document_progress, render_document,
                              render_document_chunk)
 from kuma.wiki.templatetags.jinja_helpers import absolutify
 
@@ -118,7 +118,8 @@ class Command(BaseCommand):
                                          force))
             percent_complete = int(ceil((count / total) * 100))
             tasks.append(
-                email_render_document_progress.si(percent_complete, total))
+                email_document_progress.si('render_document', percent_complete,
+                                           total))
 
         # Make it so.
         chain(*tasks).apply_async()

--- a/kuma/wiki/tests/__init__.py
+++ b/kuma/wiki/tests/__init__.py
@@ -143,7 +143,7 @@ def normalize_html(html):
     return (kuma.wiki.content
             .parse(html)
             .filter(WhitespaceRemovalFilter)
-            .serialize(alphabetical_attributes=True))
+            .serialize())
 
 
 def create_document_editor_group():

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -559,9 +559,11 @@ class RevisionTests(UserTestCase):
         assert fake_tidied == rev.get_tidied_content()
 
     def test_get_tidied_content_tidies_in_process_by_default(self):
-        content = '<h1>  Test get_tidied_content.  </h1>'
+        content = '<h1>  Test get_tidied_content  </h1>'
         rev = revision(is_approved=True, save=True, content=content)
-        tidied_content, errors = tidy_content(content)
+        tidied_content, errors = tidy_content(
+            '<h1 id="Test_get_tidied_content">  Test get_tidied_content  </h1>'
+        )
         assert tidied_content == rev.get_tidied_content()
 
     def test_get_tidied_content_returns_none_on_allow_none(self):

--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -34,10 +34,10 @@ from ..views.utils import calculate_etag
 AuthKey = namedtuple('AuthKey', 'key header')
 
 EMPTY_IFRAME = '<iframe></iframe>'
-SECTION1 = '<h3 id="S1">Section 1</h3><p>This is a page. Deal with it.</p>'
-SECTION2 = '<h3 id="S2">Section 2</h3><p>This is a page. Deal with it.</p>'
-SECTION3 = '<h3 id="S3">Section 3</h3><p>This is a page. Deal with it.</p>'
-SECTION4 = '<h3 id="S4">Section 4</h3><p>This is a page. Deal with it.</p>'
+SECTION1 = '<h3 id="S1">S1</h3><p>This is a page. Deal with it.</p>'
+SECTION2 = '<h3 id="S2">S2</h3><p>This is a page. Deal with it.</p>'
+SECTION3 = '<h3 id="S3">S3</h3><p>This is a page. Deal with it.</p>'
+SECTION4 = '<h3 id="S4">S4</h3><p>This is a page. Deal with it.</p>'
 SECTIONS = SECTION1 + SECTION2 + SECTION3 + SECTION4
 SECTION_CASE_TO_DETAILS = {
     'no-section': (None, SECTIONS),

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -154,7 +154,11 @@ def _filter_doc_html(request, doc, doc_html, rendering_params):
     # ?raw view is often used for editors - apply safety filtering.
     # TODO: Should this stuff happen in render() itself?
     if rendering_params['raw']:
-        # HACK: Raw rendered content has not had section IDs injected
+        # TODO: There will be no need to call "injectSectionIDs" or
+        #       "filterEditorSafety" when the code that calls "clean_content"
+        #       on Revision.save is deployed to production, AND the current
+        #       revisions of all docs have had their content cleaned with
+        #       "clean_content".
         tool.injectSectionIDs()
         tool.filterEditorSafety()
 
@@ -465,6 +469,10 @@ def as_json(request, document_slug=None, document_locale=None):
         return HttpResponseBadRequest()
 
     document = get_object_or_404(Document, **kwargs)
+    # TODO: There will be no need for the following line of code when the
+    #       code that calls "clean_content" on Revision.save is deployed to
+    #       production, AND the current revisions of all docs have had their
+    #       content cleaned with "clean_content".
     (kuma.wiki.content.parse(document.html)
                       .injectSectionIDs()
                       .serialize())

--- a/kuma/wiki/views/translate.py
+++ b/kuma/wiki/views/translate.py
@@ -130,6 +130,10 @@ def translate(request, document_slug, document_locale):
     if not doc:
         content = based_on_rev.content
     if content:
+        # TODO: There will be no need to "filterEditorSafety" when the code
+        #       that calls "clean_content" on Revision.save is deployed to
+        #       production, AND the current revisions of all docs have had
+        #       their content cleaned with "clean_content".
         initial.update(content=kuma.wiki.content.parse(content)
                                                 .filterEditorSafety()
                                                 .serialize())


### PR DESCRIPTION
The intent of this PR is to bring more unity to the rendering of documents among the various endpoints of Kuma (see https://kuma.readthedocs.io/en/latest/rendering.html#future-changes). It takes the step of cleaning the content that's saved with a revision of any document, where the cleaning does the following:
- bleaches the content
- adds section ID's
- filters the sources of `iframe` elements
- alphabetically orders the attributes of elements

That change is small. Most of the other changes in this PR are related to updating the tests as well as adding a few new tests in light of the change to the revision content.

I've also added `TODO` comments within the code to note areas that could be simplified after/if this code is deployed and all existing documents have been updated with a cleaned current revision. So this PR is the first step in the following process:

1. Review/merge/deploy this PR
1. Create a formal or informal management command that creates a new, cleaned current revision for each document
1. Create/review/deploy another PR to clean-up the code as noted in the `TODO` comments