### PR TITLE
Bug 970278: Add noindex, nofollow tag to deprecated MindTouch pages

### DIFF
--- a/kuma/wiki/constants.py
+++ b/kuma/wiki/constants.py
@@ -201,6 +201,19 @@ ALLOWED_PROTOCOLS = [
 
 DIFF_WRAP_COLUMN = 65
 EXPERIMENT_TITLE_PREFIX = 'Experiment:'
+LEGACY_MINDTOUCH_NAMESPACES = (
+    'Help',
+    'Help_talk',
+    'Project',
+    'Project_talk',
+    'Special',
+    'Talk',
+    'Template',
+    'Template_talk',
+    'User',
+    'User_talk'
+)
+
 DOCUMENTS_PER_PAGE = 100
 _ks_urlbits = urlparse(settings.KUMASCRIPT_URL_TEMPLATE)
 KUMASCRIPT_BASE_URL = urlunparse((_ks_urlbits.scheme, _ks_urlbits.netloc,

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -39,7 +39,7 @@
 {% endif %}
 
 {% block robots_value %}
-  {%- if document.is_experiment or fallback_reason or not document_html -%}
+  {%- if document.is_experiment or document.has_legacy_namespace or fallback_reason or not document_html -%}
     noindex, nofollow
   {%- else -%}
     {{ super() }}

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -30,6 +30,7 @@ from kuma.spam.models import AkismetSubmission, SpamAttempt
 
 from . import kumascript
 from .constants import (DEKI_FILE_URL, EXPERIMENT_TITLE_PREFIX, KUMA_FILE_URL,
+                        LEGACY_MINDTOUCH_NAMESPACES,
                         REDIRECT_CONTENT, REDIRECT_HTML)
 from .content import (clean_content, Extractor, get_content_sections,
                       get_seo_description, H2TOCFilter, H3TOCFilter,
@@ -1430,6 +1431,11 @@ Full traceback:
     @property
     def is_experiment(self):
         return self.slug.startswith(EXPERIMENT_TITLE_PREFIX)
+
+    @property
+    def has_legacy_namespace(self):
+        namespace, separator, _ = self.slug.partition(':')
+        return namespace in LEGACY_MINDTOUCH_NAMESPACES if separator else False
 
     def get_hreflang(self, other_locales=None):
         """

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -40,6 +40,30 @@ def test_document_is_experiment():
     assert doc.is_experiment
 
 
+@pytest.mark.parametrize('slug,legacy', [
+    # See LEGACY_MINDTOUCH_NAMESPACES in ../constants.py
+    ('Help:Login', True),
+    ('Help_talk:Login', True),
+    ('Project:MDN', True),
+    ('Project_talk:MDN', True),
+    ('Special:easter_egg', True),
+    ('Talk:Web:CSS', True),
+    ('Template:domxref', True),
+    ('Template_talk:domxref', True),
+    ('User:jezdez', True),
+    ('User_talk:jezdez', True),
+    # Experiments aren't legacy yet
+    ('Experiment:Blue', False),
+    # Slugs without colons don't have namespaces
+    ('CSS', False),
+    # Slugs with colons might not be legacy
+    (':hover', False)
+])
+def test_document_has_legacy_namespace(slug, legacy):
+    """Excluded slugs should not update the search index."""
+    assert Document(slug=slug).has_legacy_namespace == legacy
+
+
 def test_document_delete_removes_tag_relationsip(root_doc):
     """Deleting a tagged document also deletes the tag relationship."""
     root_doc.tags.add('grape')

--- a/kuma/wiki/views/legacy.py
+++ b/kuma/wiki/views/legacy.py
@@ -5,23 +5,11 @@ from django.shortcuts import redirect
 
 from kuma.core.decorators import shared_cache_control
 
+from ..constants import LEGACY_MINDTOUCH_NAMESPACES
 from ..models import Document, Revision
 
 
 # Legacy MindTouch redirects.
-
-MINDTOUCH_NAMESPACES = (
-    'Help',
-    'Help_talk',
-    'Project',
-    'Project_talk',
-    'Special',
-    'Talk',
-    'Template',
-    'Template_talk',
-    'User',
-)
-
 
 def mindtouch_namespace_to_kuma_url(locale, namespace, slug):
     """
@@ -87,7 +75,7 @@ def mindtouch_to_kuma_url(locale, path):
         # The namespaces (Talk:, User:, etc.) get their own
         # special-case handling.
         # TODO: Test invalid namespace
-        if namespace in MINDTOUCH_NAMESPACES:
+        if namespace in LEGACY_MINDTOUCH_NAMESPACES:
             return mindtouch_namespace_to_kuma_url(locale, namespace, slug)
 
     # Last attempt: we try the request locale as the document locale,

--- a/tests/headless/test_endpoints.py
+++ b/tests/headless/test_endpoints.py
@@ -51,6 +51,21 @@ def test_document(base_url, is_indexed):
 
 @pytest.mark.headless
 @pytest.mark.nondestructive
+def test_user_document(base_url):
+    url = base_url + '/en-US/docs/User:anonymous:uitest'
+    resp = requests.get(url)
+    assert resp.status_code == 200
+    assert resp.headers['Content-Type'] == 'text/html; charset=utf-8'
+    meta = META_ROBOTS_RE.search(resp.content)
+    assert meta
+    content = meta.group('content')
+    # Pages with legacy MindTouch namespaces like 'User:' never get
+    # indexed, regardless of what the base url is
+    assert content == 'noindex, nofollow'
+
+
+@pytest.mark.headless
+@pytest.mark.nondestructive
 def test_document_based_redirection(base_url):
     """Ensure that content-based redirects properly redirect."""
     url = base_url + '/en-US/docs/MDN/Promote'


### PR DESCRIPTION
We've got various pages with slugs that begin with User:, Talk:,
User_talk:, and Template_talk: in our wiki that we really don't
want to support any more. We're not quite ready to delete them
but we at least don't want them to be turn up in search results.
This PR gives these pages a <meta name="robots" content="noindex,nofollow">
tag to prevent crawlers from indexing or crawling them.

Note that (per bug 1443179) we, in general, do not want to use
nofollow on pages. But in this case, since we're almost ready to
delete these pages, I don't think we want to rely on any links
they contain.