### PR TITLE
bug 1534804: Avoid prepending anchors on edit page

### DIFF
--- a/kuma/static/js/components/local-anchor.js
+++ b/kuma/static/js/components/local-anchor.js
@@ -8,6 +8,12 @@
 
     function prependLocalAnchors() {
         var mainDocument = document.getElementById('document-main');
+
+        // if no `mainDocument`, skip because we're on an edit page
+        if (!mainDocument) {
+            return;
+        }
+
         // collect all headings with an `id` attribute
         var headings = Array.from(document.querySelectorAll('h2[id]')).concat(
             Array.from(document.querySelectorAll('h3[id]'))


### PR DESCRIPTION
On the edit page, there is no element with ID ``document-main``, so an error is raised when adding the click event listener. When the lookup fails, skip the work to add anchors for linking.