### PR TITLE
bug 1525719: Extract strings from React, use existing translations

### DIFF
--- a/docker/images/kuma/Dockerfile
+++ b/docker/images/kuma/Dockerfile
@@ -10,4 +10,5 @@ COPY --chown=kuma:kuma . /app
 # Temporarily enable candidate languages so assets are built for all
 # environments, but still defaults to disabled in production.
 RUN ENABLE_CANDIDATE_LANGUAGES=True \
-    make localecompile build-static && rm -rf build
+    make locale-populate-react localecompile build-static \
+    && rm -rf build locale/compendia

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -151,7 +151,7 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+    <script src="{{ react_i18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'react-main' %}
     <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import datetime
 import json
+import os.path
 
 import jinja2
 from django.conf import settings
@@ -17,6 +18,7 @@ from django_jinja import library
 from pytz import timezone, utc
 from soapbox.models import Message
 from statici18n.templatetags.statici18n import statici18n
+from statici18n.utils import get_filename
 from urlobject import URLObject
 
 from ..urlresolvers import reverse, split_path
@@ -188,3 +190,16 @@ def get_locale_localized(locale):
     language = settings.LOCALES[locale].english
 
     return _(language)
+
+
+@library.global_function
+def react_i18n(locale):
+    """
+    Return the path to the internationalization file for React code.
+
+    This is similar to statici18n, but uses 'react' domain instead of
+    STATICI18N_DOMAIN.
+    """
+    filename = get_filename(locale, 'react')
+    filepath = os.path.join(settings.STATICI18N_OUTPUT_DIR, filename)
+    return static(filepath)

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -679,6 +679,8 @@ PUENTE = {
             ('kuma/static/js/components/**.js', 'javascript'),
             ('assets/ckeditor4/source/plugins/mdn-**/*.js',
              'javascript'),
+            ('kuma/javascript/src/**.js', 'javascript'),
+            ('kuma/javascript/src/**.jsx', 'javascript'),
         ],
     },
     'PROJECT': 'MDN',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -679,6 +679,8 @@ PUENTE = {
             ('kuma/static/js/components/**.js', 'javascript'),
             ('assets/ckeditor4/source/plugins/mdn-**/*.js',
              'javascript'),
+        ],
+        'react': [
             ('kuma/javascript/src/**.js', 'javascript'),
             ('kuma/javascript/src/**.jsx', 'javascript'),
         ],
@@ -686,6 +688,11 @@ PUENTE = {
     'PROJECT': 'MDN',
     'MSGID_BUGS_ADDRESS': ADMIN_EMAILS[0],
 }
+
+# Combine JavaScript strings into React domain
+PUENTE['DOMAIN_METHODS']['react'] = (
+    PUENTE['DOMAIN_METHODS']['javascript'] +
+    PUENTE['DOMAIN_METHODS']['react'])
 
 STATICI18N_ROOT = 'build/locale'
 STATICI18N_DOMAIN = 'javascript'

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -660,7 +660,7 @@ TEMPLATES = [
 ]
 
 PUENTE = {
-    'VERSION': '2019.01',
+    'VERSION': '2019.02',
     'BASE_DIR': BASE_DIR,
     'TEXT_DOMAIN': 'django',
     # Tells the extract script what files to look for l10n in and what function


### PR DESCRIPTION
This builds on PR #5279, creating a new translations domain ``react`` that includes all of the ``javascript`` strings, as well as the React strings that are very likely to appear in ``django``. 

This requires the changes in https://github.com/mozilla-l10n/mdn-l10n/commit/bfc4155109fcb1a264454d51d3f01ef3a7d29279, which include an updated ``.gitignore``. This was merged to master with the latest push to production.

``make localerefresh`` now calls the new target ``make locale-populate-react``, which collects existing translations into [compendium](https://www.gnu.org/software/gettext/manual/html_node/Compendium.html#Compendium) files, which are used to populate ``react.po`` from existing translations, without sending them to Pontoon.

``make build-static`` now calls the new target ``make compile-react-i18n``, which works the same as ``make compilejsi18n``, but for the new ``react`` domain. A new Jinja2 command ``react_i18n`` returns the URL of these ``react``-domain JS files.

To get things started, run this in the web container:

```
make locale-populate-react localecompile compile-react-i18n collectstatic
# make localerefresh # Alternatively, run everything
```

You can then see the translated strings in the React app, such as the [French Learn page](http://localhost:8000/fr/ducks/Apprendre):

![react-fr](https://user-images.githubusercontent.com/286017/54375145-7e305180-464e-11e9-8175-686e3b998f87.png)




