### PR TITLE
bug 1532736: Change rate limit on homepage, docs

### DIFF
--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -6,7 +6,6 @@ from django.shortcuts import redirect, render
 from django.views import static
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
-from ratelimit.decorators import ratelimit
 
 from kuma.core.decorators import shared_cache_control
 from kuma.feeder.models import Bundle
@@ -23,7 +22,6 @@ def contribute_json(request):
 
 
 @shared_cache_control
-@ratelimit(key='user_or_ip', rate='400/m', block=True)
 def home(request):
     """Home page."""
     updates = list(Bundle.objects.recent_entries(SECTION_HACKS.updates)[:5])

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -594,7 +594,7 @@ def _document_raw(doc_html):
 @allow_CORS_GET
 @process_document_path
 @newrelic.agent.function_trace()
-@ratelimit(key='user_or_ip', rate='400/m', block=True)
+@ratelimit(key='user_or_ip', rate='800/m', block=True)
 def document(request, document_slug, document_locale):
     """
     View a wiki document.


### PR DESCRIPTION
Adjust rate limits added in response to a Dec 3, 2017 downtime event (PR #4591, [bug 1423738](https://bugzilla.mozilla.org/show_bug.cgi?id=1423738)).

Drop the rate limit on the homepage, which should get cached quickly by CloudFront.

Double the rate limit on documents, to begin probing what limit still allows the system to respond without downtime.

Approving. merging, and deploying should be coordinated with @limed, who will be most directly impacted by downtime alerts.
