### PR TITLE
bug 1518482: reduce indexed-but-blocked search warnings

### DIFF
--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -75,12 +75,9 @@ Disallow: /*$api
 Disallow: /*$compare
 Disallow: /*$revision
 Disallow: /*$history
-Disallow: /*$edit
 Disallow: /*$children
 Disallow: /*$flag
-Disallow: /*$translate
 Disallow: /*$locales
-Disallow: /*$json
 Disallow: /*$toc
 Disallow: /*$move
 Disallow: /*$quick-review


### PR DESCRIPTION
This PR is a simple first step in reducing the number of indexed-but-blocked warnings in our Google search console (see https://github.com/mdn/sprints/issues/1220). The main problem is that we have many endpoints on MDN that are not intended to be indexed/searched, so we block them in our `robots.txt` file. Google search, however, doesn't yet know that they should not be indexed, and so when they're found as links in our pages (or other pages), tries to crawl and index them.

This PR allows the `$edit`, `$translate`, and `$json` endpoints to be crawled (by removing them from among the disallowed in `robots.txt`) so that Google sees that they should not be indexed (all of these endpoints already either return a robots meta tag of `<meta name="robots" content="noindex, nofollow">`, or in the case of `$json`, a `X-Robots-Tag: noindex` header, so Google will get the signal). We decided to start with these three endpoints since they were among those that generated the most warnings, and also among the least costly to MDN in terms of work to return a response to the crawler.

After Google understands that these endpoints should not be indexed, perhaps we can add them back among the disallowed specified in `robots.txt`.