### PR TITLE
Bug 1533828, add credit card maintenance info

### DIFF
--- a/kuma/payments/jinja2/payments/email/thank_you/email.html
+++ b/kuma/payments/jinja2/payments/email/thank_you/email.html
@@ -124,10 +124,14 @@
                                                             <td align="left" style="font-family:Geneva,Tahoma,Verdana,sans-serif;font-size:14px;line-height:22px;color:#555555;padding-top:16px">
                                                               <h3>{{_('Managing your payments')}}</h3>
                                                               <p>
-                                                                {% trans url=support_mail_link, email=support_mail %}
-                                                                If you would like to manage your monthly payment,
-                                                                such as changing your card account details or the
-                                                                amount you pay, please contact <a href="{{ url }}">{{ email }}</a>.
+                                                                {% trans url='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Manage%20monthly%20payment",
+                                                                         manage_subscription_url=url('recurring_payment_management')|absolutify,
+                                                                         email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
+                                                                    If you would like to manage your monthly payment, such as changing
+                                                                    your card account details or the amount you pay, please cancel your
+                                                                    subscription on the <a href="{{ manage_subscription_url }}">manage monthly
+                                                                    subscriptions page</a> and sign up again using the new card details. If
+                                                                    you have any questions please contact <a href="{{ url }}">{{ email }}.</a>
                                                                 {% endtrans %}
                                                               </p>
                                                             </td>

--- a/kuma/payments/jinja2/payments/email/thank_you/plain.ltxt
+++ b/kuma/payments/jinja2/payments/email/thank_you/plain.ltxt
@@ -14,7 +14,7 @@ We are committed to providing the best source of information about web standards
 
 {{_('Managing your payments')}}
 {% trans %}
-If you would like to manage your monthly payment, such as changing your card account details or the amount you pay, please contact {{ support_mail }}.
+If you would like to manage your monthly payment, such as changing your card account details or the amount you pay, please cancel your subscription on {{ recurring_payment_management }} and sign up again using the new card details. If you have any questions please contact {{ support_mail }}.
 {% endtrans %}
 
 {{_('Cancelling your payments')}}

--- a/kuma/payments/jinja2/payments/payments.html
+++ b/kuma/payments/jinja2/payments/payments.html
@@ -199,14 +199,14 @@
             <ol id="contribute-monthly-faqs" class="faqs clear">
                 {%- call faq_entry(11, _("How do I manage my monthly payment?")) %}
                     <p>
-                        {% trans url='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL,
+                        {% trans url='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Manage%20monthly%20payment",
                                  manage_subscription_url=url('recurring_payment_management'),
                                  email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
-                            If you would like to manage your monthly payment,
-                            such as changing your card account details or the amount you pay,
-                            please contact <a href="{{ url }}">{{ email }}</a>. You can cancel
-                            your subscription on the
-                            <a href="{{ manage_subscription_url }}">manage monthly subscriptions</a> page.
+                            If you would like to manage your monthly payment, such as changing
+                            your card account details or the amount you pay, please cancel your
+                            subscription on the <a href="{{ manage_subscription_url }}">manage monthly
+                            subscriptions page</a> and sign up again using the new card details. If
+                            you have any questions please contact <a href="{{ url }}">{{ email }}.</a>
                         {% endtrans %}
                     </p>
                 {% endcall %}

--- a/kuma/payments/jinja2/payments/thank_you.html
+++ b/kuma/payments/jinja2/payments/thank_you.html
@@ -85,23 +85,27 @@
                         <div class="sub-section">
                             <h3>{{_('Managing your payments')}}</h3>
                             <p>
-                                {% trans url="mailto:" + settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Manage%20monthly%20payment",
+                                {% trans url='mailto:%s' % settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Manage%20monthly%20payment",
+                                         manage_subscription_url=url('recurring_payment_management'),
                                          email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
-                                    If you would like to manage your monthly payment,
-                                    such as changing your card account details or the
-                                    amount you pay, please contact
-                                    <a href="{{ url }}">{{ email }}</a>.
+                                    If you would like to manage your monthly payment, such as changing
+                                    your card account details or the amount you pay, please cancel your
+                                    subscription on the <a href="{{ manage_subscription_url }}">manage monthly
+                                    subscriptions page</a> and sign up again using the new card details. If
+                                    you have any questions please contact <a href="{{ url }}">{{ email }}.</a>
                                 {% endtrans %}
                             </p>
                         </div>
                         <div class="sub-section">
                             <h3>{{_('Refunds and canceling your payments')}}</h3>
                             <p>
-                                {% trans url="mailto:" + settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Cancel%20monthly%20payment",
-                                    email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
+                                {% trans url="mailto:%s" % settings.CONTRIBUTION_SUPPORT_EMAIL + "?Subject=Manage%20monthly%20payment",
+                                         manage_subscription_url=url('recurring_payment_management'),
+                                         email=settings.CONTRIBUTION_SUPPORT_EMAIL %}
                                     If you would like to cancel your monthly payment or apply for a refund, you are free to do so at any point.
-                                    Please contact <a href="{{ url }}">{{ email }}</a> to cancel. If you choose to cancel, we will not charge your payment
-                                    card for subsequent months.
+                                    Please contact <a href="{{ url }}">{{ email }}</a> for a refund. If you choose to cancel, you can do so on
+                                    the <a href="{{ manage_subscription_url }}">manage monthly subscriptions</a> page. We will not charge your
+                                    payment card for subsequent months.
                                 {% endtrans %}
                             </p>
                         </div>

--- a/kuma/payments/tasks.py
+++ b/kuma/payments/tasks.py
@@ -9,6 +9,8 @@ from django.utils import translation
 
 from kuma.core.decorators import skip_in_maintenance_mode
 from kuma.core.email_utils import render_email
+from kuma.core.urlresolvers import reverse
+from kuma.wiki.templatetags.jinja_helpers import absolutify
 
 
 log = logging.getLogger('kuma.payments.tasks')
@@ -24,6 +26,7 @@ def payments_thank_you_email(username, user_email, recurring=False):
         'support_mail_link': 'mailto:' + settings.CONTRIBUTION_SUPPORT_EMAIL + '?Subject=Recurring%20payment%20support',
         'support_mail': settings.CONTRIBUTION_SUPPORT_EMAIL,
         'recurring_payment': recurring,
+        'recurring_payment_management': absolutify(reverse('recurring_payment_management')),
     }
 
     # TODO: Remove when we ship translations, get legal approval


### PR DESCRIPTION
Tested locally and the links work as expected. Not sure how to test the emails though, but it looks like this should be good to go.

![Screenshot 2019-03-27 at 12 21 42](https://user-images.githubusercontent.com/10350960/55068826-5e0b8400-508b-11e9-86c1-6382eac8cc93.png)

@jwhitlock r?