### PR TITLE
Fix bug 1527533: Add Prism syntax definition for WebAssembly

### DIFF
--- a/assets/ckeditor4/source/plugins/mdn-syntaxhighlighter/plugin.js
+++ b/assets/ckeditor4/source/plugins/mdn-syntaxhighlighter/plugin.js
@@ -10,7 +10,9 @@ CKEDITOR.config.mdnSyntaxhighlighter_brushes = [
   { name: 'JSON', brush: 'json' },
   { name: 'PHP', brush: 'php' },
   { name: 'Python', brush: 'python' },
+  { name: 'Rust', brush: 'rust' },
   { name: 'SQL', brush: 'sql' },
+  { name: 'WebAssembly', brush: 'wasm' },
   { name: 'XML', brush: 'xml' }
 ];
 

--- a/bower.json
+++ b/bower.json
@@ -15,6 +15,7 @@
             "html5shiv": "bower_components/html5shiv/dist/html5shiv.js",
             "prism": [
                 "bower_components/prism/components/prism-core.js",
+                "bower_components/prism/components/prism-bash.js",
                 "bower_components/prism/components/prism-markup.js",
                 "bower_components/prism/components/prism-css.js",
                 "bower_components/prism/components/prism-clike.js",
@@ -23,6 +24,7 @@
                 "bower_components/prism/components/prism-jsonp.js",
                 "bower_components/prism/components/prism-css-extras.js",
                 "bower_components/prism/components/prism-rust.js",
+                "bower_components/prism/components/prism-wasm.js",
                 "bower_components/prism/plugins/line-highlight/prism-line-highlight.js",
                 "bower_components/prism/plugins/line-numbers/prism-line-numbers.js",
 

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1046,6 +1046,7 @@ PIPELINE_JS = {
         'source_filenames': (
             # Custom Prism build
             "js/libs/prism/prism-core.js",
+            "js/libs/prism/prism-bash.js",
             "js/libs/prism/prism-markup.js",
             "js/libs/prism/prism-css.js",
             "js/libs/prism/prism-clike.js",
@@ -1054,6 +1055,7 @@ PIPELINE_JS = {
             "js/libs/prism/prism-jsonp.js",
             "js/libs/prism/prism-css-extras.js",
             "js/libs/prism/prism-rust.js",
+            "js/libs/prism/prism-wasm.js",
             "js/libs/prism/prism-line-highlight.js",
             "js/libs/prism/prism-line-numbers.js",
 

--- a/kuma/static/js/libs/prism/prism-bash.js
+++ b/kuma/static/js/libs/prism/prism-bash.js
@@ -1,0 +1,84 @@
+(function(Prism) {
+	var insideString = {
+		variable: [
+			// Arithmetic Environment
+			{
+				pattern: /\$?\(\([\s\S]+?\)\)/,
+				inside: {
+					// If there is a $ sign at the beginning highlight $(( and )) as variable
+					variable: [{
+							pattern: /(^\$\(\([\s\S]+)\)\)/,
+							lookbehind: true
+						},
+						/^\$\(\(/
+					],
+					number: /\b0x[\dA-Fa-f]+\b|(?:\b\d+\.?\d*|\B\.\d+)(?:[Ee]-?\d+)?/,
+					// Operators according to https://www.gnu.org/software/bash/manual/bashref.html#Shell-Arithmetic
+					operator: /--?|-=|\+\+?|\+=|!=?|~|\*\*?|\*=|\/=?|%=?|<<=?|>>=?|<=?|>=?|==?|&&?|&=|\^=?|\|\|?|\|=|\?|:/,
+					// If there is no $ sign at the beginning highlight (( and )) as punctuation
+					punctuation: /\(\(?|\)\)?|,|;/
+				}
+			},
+			// Command Substitution
+			{
+				pattern: /\$\([^)]+\)|`[^`]+`/,
+				greedy: true,
+				inside: {
+					variable: /^\$\(|^`|\)$|`$/
+				}
+			},
+			/\$(?:[\w#?*!@]+|\{[^}]+\})/i
+		]
+	};
+
+	Prism.languages.bash = {
+		'shebang': {
+			pattern: /^#!\s*\/bin\/bash|^#!\s*\/bin\/sh/,
+			alias: 'important'
+		},
+		'comment': {
+			pattern: /(^|[^"{\\])#.*/,
+			lookbehind: true
+		},
+		'string': [
+			//Support for Here-Documents https://en.wikipedia.org/wiki/Here_document
+			{
+				pattern: /((?:^|[^<])<<\s*)["']?(\w+?)["']?\s*\r?\n(?:[\s\S])*?\r?\n\2/,
+				lookbehind: true,
+				greedy: true,
+				inside: insideString
+			},
+			{
+				pattern: /(["'])(?:\\[\s\S]|\$\([^)]+\)|`[^`]+`|(?!\1)[^\\])*\1/,
+				greedy: true,
+				inside: insideString
+			}
+		],
+		'variable': insideString.variable,
+		// Originally based on http://ss64.com/bash/
+		'function': {
+			pattern: /(^|[\s;|&])(?:add|alias|apropos|apt|apt-cache|apt-get|aptitude|aspell|automysqlbackup|awk|basename|bash|bc|bconsole|bg|builtin|bzip2|cal|cat|cd|cfdisk|chgrp|chkconfig|chmod|chown|chroot|cksum|clear|cmp|comm|command|cp|cron|crontab|csplit|curl|cut|date|dc|dd|ddrescue|debootstrap|df|diff|diff3|dig|dir|dircolors|dirname|dirs|dmesg|du|egrep|eject|enable|env|ethtool|eval|exec|expand|expect|export|expr|fdformat|fdisk|fg|fgrep|file|find|fmt|fold|format|free|fsck|ftp|fuser|gawk|getopts|git|gparted|grep|groupadd|groupdel|groupmod|groups|grub-mkconfig|gzip|halt|hash|head|help|hg|history|host|hostname|htop|iconv|id|ifconfig|ifdown|ifup|import|install|ip|jobs|join|kill|killall|less|link|ln|locate|logname|logout|logrotate|look|lpc|lpr|lprint|lprintd|lprintq|lprm|ls|lsof|lynx|make|man|mc|mdadm|mkconfig|mkdir|mke2fs|mkfifo|mkfs|mkisofs|mknod|mkswap|mmv|more|most|mount|mtools|mtr|mutt|mv|nano|nc|netstat|nice|nl|nohup|notify-send|npm|nslookup|op|open|parted|passwd|paste|pathchk|ping|pkill|pnpm|popd|pr|printcap|printenv|printf|ps|pushd|pv|pwd|quota|quotacheck|quotactl|ram|rar|rcp|read|readarray|readonly|reboot|remsync|rename|renice|rev|rm|rmdir|rpm|rsync|scp|screen|sdiff|sed|sendmail|seq|service|sftp|shift|shopt|shutdown|sleep|slocate|sort|source|split|ssh|stat|strace|su|sudo|sum|suspend|swapon|sync|tail|tar|tee|test|time|timeout|times|top|touch|tr|traceroute|trap|tsort|tty|type|ulimit|umask|umount|unalias|uname|unexpand|uniq|units|unrar|unshar|unzip|update-grub|uptime|useradd|userdel|usermod|users|uudecode|uuencode|vdir|vi|vim|virsh|vmstat|wait|watch|wc|wget|whereis|which|who|whoami|write|xargs|xdg-open|yarn|yes|zip|zypper)(?=$|[\s;|&])/,
+			lookbehind: true
+		},
+		'keyword': {
+			pattern: /(^|[\s;|&])(?:let|:|\.|if|then|else|elif|fi|for|break|continue|while|in|case|function|select|do|done|until|echo|exit|return|set|declare)(?=$|[\s;|&])/,
+			lookbehind: true
+		},
+		'boolean': {
+			pattern: /(^|[\s;|&])(?:true|false)(?=$|[\s;|&])/,
+			lookbehind: true
+		},
+		'operator': /&&?|\|\|?|==?|!=?|<<<?|>>|<=?|>=?|=~/,
+		'punctuation': /\$?\(\(?|\)\)?|\.\.|[{}[\];]/
+	};
+
+	var inside = insideString.variable[1].inside;
+	inside.string = Prism.languages.bash.string;
+	inside['function'] = Prism.languages.bash['function'];
+	inside.keyword = Prism.languages.bash.keyword;
+	inside['boolean'] = Prism.languages.bash['boolean'];
+	inside.operator = Prism.languages.bash.operator;
+	inside.punctuation = Prism.languages.bash.punctuation;
+
+	Prism.languages.shell = Prism.languages.bash;
+})(Prism);

--- a/kuma/static/js/libs/prism/prism-wasm.js
+++ b/kuma/static/js/libs/prism/prism-wasm.js
@@ -1,0 +1,31 @@
+Prism.languages.wasm = {
+	'comment': [
+		/\(;[\s\S]*?;\)/,
+		{
+			pattern: /;;.*/,
+			greedy: true
+		}
+	],
+	'string': {
+		pattern: /"(?:\\[\s\S]|[^"\\])*"/,
+		greedy: true
+	},
+	'keyword': [
+		{
+			pattern: /\b(?:align|offset)=/,
+			inside: {
+				'operator': /=/
+			}
+		},
+		{
+			pattern: /\b(?:(?:f32|f64|i32|i64)(?:\.(?:abs|add|and|ceil|clz|const|convert_[su]\/i(?:32|64)|copysign|ctz|demote\/f64|div(?:_[su])?|eqz?|extend_[su]\/i32|floor|ge(?:_[su])?|gt(?:_[su])?|le(?:_[su])?|load(?:(?:8|16|32)_[su])?|lt(?:_[su])?|max|min|mul|nearest|neg?|or|popcnt|promote\/f32|reinterpret\/[fi](?:32|64)|rem_[su]|rot[lr]|shl|shr_[su]|store(?:8|16|32)?|sqrt|sub|trunc(?:_[su]\/f(?:32|64))?|wrap\/i64|xor))?|memory\.(?:grow|size))\b/,
+			inside: {
+				'punctuation': /\./
+			}
+		},
+		/\b(?:anyfunc|block|br(?:_if|_table)?|call(?:_indirect)?|data|drop|elem|else|end|export|func|get_(?:global|local)|global|if|import|local|loop|memory|module|mut|nop|offset|param|result|return|select|set_(?:global|local)|start|table|tee_local|then|type|unreachable)\b/
+	],
+	'variable': /\$[\w!#$%&'*+\-./:<=>?@\\^_`|~]+/i,
+	'number': /[+-]?\b(?:\d(?:_?\d)*(?:\.\d(?:_?\d)*)?(?:[eE][+-]?\d(?:_?\d)*)?|0x[\da-fA-F](?:_?[\da-fA-F])*(?:\.[\da-fA-F](?:_?[\da-fA-D])*)?(?:[pP][+-]?\d(?:_?\d)*)?)\b|\binf\b|\bnan(?::0x[\da-fA-F](?:_?[\da-fA-D])*)?\b/,
+	'punctuation': /[()]/
+};

--- a/kuma/static/styles/wiki-wysiwyg.scss
+++ b/kuma/static/styles/wiki-wysiwyg.scss
@@ -82,7 +82,9 @@ $languages: (
     'html': 'HTML',
     'php': 'PHP',
     'python': 'Python',
+    'rust': 'Rust',
     'sql': 'SQL',
+    'wasm': 'WebAssembly',
     'xml': 'XML'
 );
 


### PR DESCRIPTION
Resolves [bug 1527533](https://bugzilla.mozilla.org/show_bug.cgi?id=1527533).

I’ve also added the Prism syntax definition for bash, because it’s exposed in the interface and used on the WebAssembly documentation pages, eg. https://developer.mozilla.org/docs/WebAssembly/Text_format_to_wasm

I’ve also exposed the Rust syntax in the interface because it’s also used on the WebAssembly documentation pages, eg. https://developer.mozilla.org/docs/WebAssembly/Rust_to_wasm