### PR TITLE
bug 1540177: Sync CoC with Mozilla template

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,20 @@
-Code of conduct
-===============
+# Mozilla Community Participation Guidelines
 
-This repository is governed by Mozilla's code of conduct and etiquette guidelines. For more details please see the [Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/) and [Developer Etiquette Guidelines](https://bugzilla.mozilla.org/page.cgi?id=etiquette.html).
+This repository is governed by Mozilla's code of conduct and etiquette guidelines.
+For more details, please read the
+[Mozilla Community Participation Guidelines](https://www.mozilla.org/about/governance/policies/participation/).
+
+## How to Report
+
+For more information on how to report violations of the CPG, please read our
+[How to Report](https://www.mozilla.org/en-US/about/governance/policies/participation/reporting/)
+page.
+
+## Project Specific Etiquette
+
+See the [Contributing Guide][cg] for code standards, and the
+[Bugzilla Developer Etiquette Guidelines](bdeg) for general tips for being a
+helpful participant in an open source project.
+
+[cg]: https://github.com/mozilla/kuma/blob/master/CONTRIBUTING.md
+[bdeg]: https://bugzilla.mozilla.org/page.cgi?id=etiquette.html


### PR DESCRIPTION
Update the text of the Code of Conduct to match the new Mozilla
template, with changes:

* Make [markdownlint](https://github.com/DavidAnson/markdownlint) happy (validated on https://dlaa.me/markdownlint/) (https://github.com/mozilla/repo-templates/issues/6)
* Remove redundant quotes around a link (https://github.com/mozilla/repo-templates/issues/5)
* Add links to Bugzilla Etiquette and Contributing docs