### PR TITLE
bug 957802: Restore coverage uploads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,8 +80,6 @@ script:
     - tox -v
 after_failure:
     - dmesg | tail
-after_success:
-    - codecov
 notifications:
     irc:
         channels:

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 # These requirements are for development and include the default requirements
 -r default.txt
+-r travis.txt
 
 # Extract messages from Django templates
 # Code: https://github.com/python-babel/django-babel
@@ -52,12 +53,6 @@ pytest-cov==2.4.0 \
 pytest-django==3.1.2 \
     --hash=sha256:038ccc5a9daa1b1b0eb739ab7dce54e495811eca5ea3af4815a2a3ac45152309 \
     --hash=sha256:00995c2999b884a38ae9cd30a8c00ed32b3d38c1041250ea84caf18085589662
-
-# Run tests in a virtual environment
-# Keep in sync w/ travis.txt
-tox==2.3.1 \
-    --hash=sha256:1823c93ca378092c10bbde428213d3f5066b30adb09e5c001087a83e3e0a402a \
-    --hash=sha256:bf7fcc140863820700d3ccd65b33820ba747b61c5fe4e2b91bb8c64cb21a47ee
 
 # Wait until a database (or other) service is able to accept connections.
 # Code: https://github.com/pmac/urlwait

--- a/requirements/travis.txt
+++ b/requirements/travis.txt
@@ -1,7 +1,19 @@
 # this is a standalone requirements file used in .travis.yml to install
 # Travis CI specific requirements
-codecov==1.6.3
-# Keep in sync w/ dev.txt
-tox==2.3.1
-# Keep in sync w/ constraints.txt
-coverage==4.3.4
+
+-r default_and_test.txt
+
+# Run tests in a virtual environment
+# Code: https://github.com/tox-dev/tox
+# Changes: https://tox.readthedocs.io/en/latest/changelog.html
+# Docs: https://tox.readthedocs.io/en/latest/
+tox==2.3.1 \
+    --hash=sha256:1823c93ca378092c10bbde428213d3f5066b30adb09e5c001087a83e3e0a402a \
+    --hash=sha256:bf7fcc140863820700d3ccd65b33820ba747b61c5fe4e2b91bb8c64cb21a47ee
+
+# Upload coverage reports to codecov.io
+# Code: https://github.com/codecov/codecov-python
+# Changes: https://github.com/codecov/codecov-python/blob/master/CHANGELOG.md
+codecov==2.0.15 \
+    --hash=sha256:8ed8b7c6791010d359baed66f84f061bba5bd41174bf324c31311e8737602788 \
+    --hash=sha256:ae00d68e18d8a20e9c3288ba3875ae03db3a8e892115bf9b83ef20507732bed4

--- a/tox.ini
+++ b/tox.ini
@@ -9,10 +9,16 @@ deps =
 commands =
     make localecompile build-static clean
     pytest --cov=kuma kuma
+    codecov -e TOXENV
 passenv =
     DATABASE_URL
     DJANGO_SETTINGS_MODULE
     PIPELINE_*
+    TOXENV
+    CI
+    TRAVIS
+    TRAVIS_*
+    CODECOV_*
 
 [testenv:pytest3]
 basepython = python3.6


### PR DESCRIPTION
* Move the ``tox`` install to ``travis.txt``, and load from ``dev.txt``
* Install ``codecov`` inside the TravisCI job, and use their [suggested integration](https://github.com/codecov/codecov-python#using-tox)