### PR TITLE
Bug 1523662, Google results container wbr in displayed URL

### DIFF
--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -68,7 +68,6 @@
     */
     $('.document .document-head h1, .quick-links a code, .crumbs span[property=name]').each(function() {
         var $wrapper = $(this);
-        var text = $wrapper.text();
         // don't do anything if there are any child elements, they would be removed
         if ($wrapper.children().length > 0) {
             return;
@@ -80,19 +79,11 @@
          * IF followed by [ . : ( OR capital letter
          * IF followed by 3 letters or [ @ . : (
          */
-        var split = text.split(/([a-z]{3})(?=[[.:(A-Z][@.:(A-Z]{0,}[a-zA-Z]{3})/g);
-        // empty wrapper
-        $wrapper.empty();
-        // put split string back into wrapper
-        $.each(split, function(key, value) {
-            // skip first match and even values (as it matches the 3 charcters before the split)
-            if(key > 0 && key % 2 === 0) {
-                // add <wbr>
-                $wrapper.append('<wbr>');
-            }
-            // add text back, make sure it goes back as text, not code to run
-            $wrapper.append(doc.createTextNode(value));
-        });
+        $wrapper.text(
+            $wrapper.text().replace(
+                /([a-z]{3})(?=[[.:(A-Z][@.:(A-Z]{0,}[a-zA-Z]{3})/g,'$1\u200b'
+            )
+        );
     });
 
     /*

--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -9,6 +9,12 @@
 .document-title {
     h1 {
         @include set-font-size($mobile-document-title-font-size);
+        /* Needed to make Chrome honor the zero-width spaces */
+        word-break: break-word;
+
+        @media #{$mq-mobile-and-up} {
+            @include set-font-size($h1-font-size);
+        }
     }
 
     em {
@@ -27,13 +33,6 @@
     }
 }
 
-@media #{$mq-mobile-and-up} {
-    .document-title {
-        h1 {
-            @include set-font-size($h1-font-size);
-        }
-    }
-}
 
 @media #{$mq-mobile-and-up} {
     @supports (display: flex) {

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -1,6 +1,8 @@
 /*
 wiki article bread crumbs
 ********************************************************************** */
+$crumb-vertical-spacing-tablet: $grid-spacing / 2;
+$crumb-vertical-spacing-desktop: $grid-spacing / 4;
 
 .crumbs {
     border: 1px solid #d7d7d7;
@@ -8,6 +10,17 @@ wiki article bread crumbs
     margin: $grid-spacing 0;
     padding: $grid-spacing 0;
     @include set-font-size($smaller-font-size);
+
+    @media #{$mq-tablet-and-up} {
+        border-top-width: 0;
+        margin-top: 0;
+        padding-bottom: $grid-spacing - $crumb-vertical-spacing-tablet;
+        padding-top: 0;
+    }
+
+    @media #{$mq-small-desktop-and-up} {
+        padding-bottom: $grid-spacing - $crumb-vertical-spacing-desktop;
+    }
 
     li {
         display: inline;
@@ -29,45 +42,29 @@ wiki article bread crumbs
         /* borders increase hit area for mobile without messing with position of arrow */
         border-top: 15px solid transparent;
         border-bottom: 15px solid transparent;
-        line-height: 1;
+        line-height: 1.5;
+        /* Needed to make Chrome honor the zero-width spaces */
+        word-break: break-word;
+
+        @media #{$mq-tablet-and-up} {
+            border-top: none;
+            border-bottom: $crumb-vertical-spacing-tablet solid transparent;
+        }
+
+        @media #{$mq-small-desktop-and-up} {
+            border-bottom: $crumb-vertical-spacing-desktop solid transparent;
+        }
 
         &:after {
-            margin: 10px 5px 3px;
+            margin: 10px 5px 5px;
             vertical-align: bottom;
             @include set-bidi-icon($path-to-svg-arrow-icons + 'chevron-right.svg', $path-to-svg-arrow-icons + 'chevron-left.svg', auto, auto, 8px, 10px);
+            height: 11px;
         }
     }
 
     li:last-child span:after {
         display: none;
-    }
-}
-
-@media #{$mq-tablet-and-up} {
-    $crumb-vertical-spacing: $grid-spacing / 2;
-
-    .crumbs {
-        border-top-width: 0;
-        margin-top: 0;
-        padding-bottom: $grid-spacing - $crumb-vertical-spacing;
-        padding-top: 0;
-
-        span {
-            border-top: none;
-            border-bottom: $crumb-vertical-spacing solid transparent;
-        }
-    }
-}
-
-@media #{$mq-small-desktop-and-up} {
-    $crumb-vertical-spacing: 5px;
-
-    .crumbs {
-        padding-bottom: $grid-spacing - $crumb-vertical-spacing;
-
-        span {
-            border-bottom: $crumb-vertical-spacing solid transparent;
-        }
     }
 }
 


### PR DESCRIPTION
Having read over the report in https://bugzilla.mozilla.org/show_bug.cgi?id=1523662 it seems the problem is that `JavaScript` is split into two words by the RegExp i.e. `Java<wbr />Script`

When Google then for some pages uses the text of the breadcrumbs as the text for the linking URL the raw HTML is displayed, including the `<wbr />` tag. As per @atopal's suggestion, and tweaking the RegExp, this no longer happens.

@davidflanagan r?