### PR TITLE
bug 1525719: React l10n deux 1525719

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,12 +105,13 @@ localeextract:
 # (including new ones) in Pontoon.
 locale-populate-react:
 	@ mkdir -p locale/compendia
-	for localename in `find locale -mindepth 1 -maxdepth 1 -type d | cut -d/ -f2 | grep -v templates | grep -v compendia`; do \
+	for localename in `find locale -mindepth 1 -maxdepth 1 -type d | cut -d/ -f2 | grep -v templates | grep -v compendia | grep -v .git`; do \
 		rm -f locale/compendia/$$localename.compendium; \
 		msgcat --use-first -o locale/compendia/$$localename.compendium locale/$$localename/LC_MESSAGES/django.po locale/$$localename/LC_MESSAGES/javascript.po; \
 		rm -f locale/$$localename/LC_MESSAGES/react.po; \
 		msgmerge --compendium locale/compendia/$$localename.compendium -o locale/$$localename/LC_MESSAGES/react.po /dev/null locale/templates/LC_MESSAGES/react.pot; \
 	done
+	rm -rf locale/compendia
 
 localecompile:
 	cd locale; ../scripts/compile-mo.sh .

--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,23 @@ localeextract:
 	python manage.py extract
 	python manage.py merge
 
+# The "react" domain contains all the strings from the "javascript" domain,
+# plus some strings duplicated from the "django" domain. While the React
+# pages are in beta, borrow translations from the other two domains.
+# This works by combining (msgcat) the django and javascript domains into a
+# temporary compendium, and then using that as a source of translations
+# (msgmerge). These react.po files are generated but not committed or
+# sent to Pontoon, so new strings are not yet translated.
+#
+# When we're ready to move the new pages out of beta, the copied strings can
+# be committed:
+#
+# 1. Run "make locale-populate-react" one last time
+# 2. Check in /{locale}/react.po files into mdn-l10n, remove from .gitignore
+# 3. Remove this command locale-populate-react
+#
+# We can then treat the "react" domain like others, and translate strings
+# (including new ones) in Pontoon.
 locale-populate-react:
 	@ mkdir -p locale/compendia
 	for localename in `find locale -mindepth 1 -maxdepth 1 -type d | cut -d/ -f2 | grep -v templates | grep -v compendia`; do \

--- a/docker/images/kuma/Dockerfile
+++ b/docker/images/kuma/Dockerfile
@@ -9,6 +9,6 @@ COPY --chown=kuma:kuma . /app
 
 # Temporarily enable candidate languages so assets are built for all
 # environments, but still defaults to disabled in production.
+# Also generate react.po translation files for beta.
 RUN ENABLE_CANDIDATE_LANGUAGES=True \
-    make locale-populate-react localecompile build-static \
-    && rm -rf build locale/compendia
+    make locale-populate-react localecompile build-static

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -133,7 +133,7 @@
   </footer>
 
   <!-- site js -->
-  <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
+  <script src="{{ react_i18n(request.LANGUAGE_CODE) }}"></script>
   {% javascript 'react-main' %}
   <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();


### PR DESCRIPTION
This addresses the comments on PR #5302:

* Add a comment documenting the why and how of ``make locale-populate-react``, and how to remove it when it is no longer needed.
* Delete the temporary folder ``/locale/compendia`` in ``make locale-populate-react``, so it doesn't need to be deleted when building the kuma docker image.

It also switches ``wiki/react_document.html`` to use ``react_i18n`` instead of ``statici18n``, so that it will load the variant ``static/jsi18n/{locale}/react.js``.