### PR TITLE
bug 1525719: fix provider_login_url for beta

### DIFF
--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -2,8 +2,9 @@ from __future__ import unicode_literals
 
 import pytest
 from django.test import TestCase
+from django.urls import get_urlconf, set_urlconf
 
-from kuma.core.utils import order_params, smart_int
+from kuma.core.utils import order_params, override_urlconf, smart_int
 
 
 class SmartIntTestCase(TestCase):
@@ -33,3 +34,37 @@ class SmartIntTestCase(TestCase):
      ))
 def test_order_params(original, expected):
     assert order_params(original) == expected
+
+
+@pytest.mark.parametrize(
+    'current,override',
+    ((None, None),
+     (None, 'kuma.urls'),
+     ('kuma.urls', None),
+     ('kuma.urls', 'kuma.urls_beta'))
+)
+def test_override_urlconf(current, override):
+    set_urlconf(current)
+    assert get_urlconf() == current
+    with override_urlconf(override):
+        assert get_urlconf() == override
+    assert get_urlconf() == current
+
+
+@pytest.mark.parametrize(
+    'current,override',
+    ((None, None),
+     (None, 'kuma.urls'),
+     ('kuma.urls', None),
+     ('kuma.urls', 'kuma.urls_beta'))
+)
+def test_override_urlconf_when_exception(current, override):
+    set_urlconf(current)
+    assert get_urlconf() == current
+    try:
+        with override_urlconf(override):
+            assert get_urlconf() == override
+            raise Exception('something went wrong')
+    except Exception as err:
+        assert str(err) == 'something went wrong'
+    assert get_urlconf() == current

--- a/kuma/core/utils.py
+++ b/kuma/core/utils.py
@@ -4,6 +4,7 @@ import datetime
 import hashlib
 import logging
 import os
+from contextlib import contextmanager
 from itertools import islice
 
 from babel import dates, localedata
@@ -12,6 +13,7 @@ from django.conf import settings
 from django.core.paginator import EmptyPage, InvalidPage, Paginator
 from django.http import QueryDict
 from django.shortcuts import _get_queryset
+from django.urls import get_urlconf, set_urlconf
 from django.utils.cache import patch_cache_control
 from django.utils.encoding import force_text, smart_bytes
 from django.utils.http import urlencode
@@ -442,3 +444,17 @@ def order_params(original_url):
     new_qs = urlencode(qs)
     new_url = urlunsplit((bits.scheme, bits.netloc, bits.path, new_qs, bits.fragment))
     return new_url
+
+
+@contextmanager
+def override_urlconf(new_urlconf):
+    """
+    Context manager for temporarily overriding the urlconf for the current
+    thread.
+    """
+    original_urlconf = get_urlconf()
+    set_urlconf(new_urlconf)
+    try:
+        yield
+    finally:
+        set_urlconf(original_urlconf)

--- a/kuma/payments/jinja2/payments/includes/payments-banner.html
+++ b/kuma/payments/jinja2/payments/includes/payments-banner.html
@@ -85,7 +85,11 @@
                         {% endwith %}
 
                         {% if not user.is_authenticated %}
+                            {% if beta %}
+                            {% set github_url = provider_login_url('github', process='login') | absolutify(for_wiki_site=True) %}
+                            {% else %}
                             {% set github_url = provider_login_url('github', process='login') %}
+                            {% endif %}
                             <div id="login-popover" class="hidden align-center login-prompt">
                                 <p>{{_('We’ve noticed you’re not logged in to MDN. To complete your monthly payment, we’ll need you to log in first.')}}</p>
                                 <a href="{{ github_url }}" id="github_redirect_payment" class="payment-form-button js-login-link" data-service="GitHub" rel="nofollow" data-next="{{ github_next_url }}">

--- a/kuma/users/templatetags/jinja_helpers.py
+++ b/kuma/users/templatetags/jinja_helpers.py
@@ -11,6 +11,7 @@ from jinja2 import contextfunction, escape, Markup
 
 from kuma.core.templatetags.jinja_helpers import datetimeformat
 from kuma.core.urlresolvers import reverse
+from kuma.core.utils import override_urlconf
 
 from ..jobs import UserGravatarURLJob
 
@@ -120,7 +121,9 @@ def provider_login_url(context, provider_id, **params):
         if not params['next']:
             del params['next']
     # get the login url and append params as url parameters
-    return Markup(provider.get_login_url(request, **params))
+    with override_urlconf('kuma.urls'):
+        result = Markup(provider.get_login_url(request, **params))
+    return result
 
 
 @library.global_function


### PR DESCRIPTION
This is a potential fix for the ISE (e.g., see the error in Sentry for stage: `Reverse for 'github_login' not found. 'github_login' is not a valid view function or pattern name.`) for both the `beta` homepage as well as any `beta` doc page on stage (e.g., `https://beta.developer.allizom.org/en-US` and `https://beta.developer.allizom.org/en-US/docs/Web/CSS`).

I was unable to get the contribution banner to display for `beta.mdn.localhost:8000` for local testing (it did display for `mdn.localhost:8000`), so I'm unable to confirm if this will fix the issue, but I wanted to submit the PR for review as early as possible.

### Testing set-up
For testing, I'd recommend doing the following:
* update your `/etc/hosts` file to look something like this:
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
255.255.255.255	broadcasthost
::1             localhost
```
* and update your `.env` file to look like this:
```
DOMAIN=mdn.localhost
ENABLE_RESTRICTIONS_BY_HOST=True
BETA_HOST=beta.mdn.localhost:8000
WIKI_HOST=wiki.mdn.localhost:8000
ATTACHMENT_HOST=demos:8000
SITE_URL=http://mdn.localhost:8000
STATIC_URL=http://mdn.localhost:8000/static/
ALLOW_ROBOTS_WEB_DOMAINS=mdn.localhost:8000
ALLOW_ROBOTS_DOMAINS=demos:8000
DEBUG=True
STRIPE_PUBLIC_KEY=<test-public-key>
STRIPE_SECRET_KEY=<test-secret-key>
STRIPE_PRODUCT_ID=prod_test
MDN_CONTRIBUTION=True
CSP_ENABLE_MIDDLEWARE=True
```