### PR TITLE
bug 1525719: add CSRF_TRUSTED_ORIGINS

### DIFF
--- a/docker-compose.ssl.yml
+++ b/docker-compose.ssl.yml
@@ -3,7 +3,7 @@ services:
   worker: &worker
     environment:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=https
-      - ALLOWED_HOSTS=developer.127.0.0.1.nip.io,demos.developer.127.0.0.1.nip.io,api,localhost,web
+      - ALLOWED_HOSTS=developer.127.0.0.1.nip.io,beta.developer.127.0.0.1.nip.io,wiki.developer.127.0.0.1.nip.io,demos.developer.127.0.0.1.nip.io,api,localhost,web
       - ATTACHMENT_HOST=demos.developer.127.0.0.1.nip.io
       - CSRF_COOKIE_SECURE=True
       - DOMAIN=developer.127.0.0.1.nip.io
@@ -13,6 +13,7 @@ services:
       - SITE_ID=2
       - SITE_URL=https://developer.127.0.0.1.nip.io
       - STATIC_URL=https://developer.127.0.0.1.nip.io/static/
+      - WAFFLE_COOKIE_SECURE=True
   api:
     <<: *worker
   web:
@@ -34,4 +35,3 @@ services:
   kumascript:
     environment:
       - LIVE_SAMPLES_URL=https://demos.developer.127.0.0.1.nip.io
-

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1734,6 +1734,14 @@ LOGGING = {
 
 CSRF_COOKIE_DOMAIN = DOMAIN
 CSRF_COOKIE_SECURE = config('CSRF_COOKIE_SECURE', default=True, cast=bool)
+# We need to explcitly set the trusted origins, because when CSRF_COOKIE_DOMAIN
+# is explicitly set, as we do above, Django's CsrfViewMiddleware will reject
+# the request unless the domain of the incoming referer header matches not just
+# the CSRF_COOKIE_DOMAIN alone, but the CSRF_COOKIE_DOMAIN with the server port
+# appended as well, and we don't want that behavior (a server port of 8000 is
+# added both in secure local development as well as in K8s stage/production, so
+# that will guarantee a mismatch with the referer).
+CSRF_TRUSTED_ORIGINS = [WIKI_HOST, DOMAIN]
 X_FRAME_OPTIONS = 'DENY'
 
 


### PR DESCRIPTION
### Description
This fixes the permission-denied errors that MDN editors were getting when https://github.com/mozilla/kuma/pull/5325 (along with other updates) was pushed to production earlier today (it was rolled back). These errors are still happening on the stage instance.

This was a subtle error to track down. It turns out that because https://github.com/mozilla/kuma/pull/5325 introduces a non-default value for the `CSRF_COOKIE_DOMAIN`, Django's `CsrfViewMiddleware` will in our case start rejecting all unsafe (e.g., POST) requests because the domain check of the `Referer` header starts to fail. When the default value (`None`) of `CSRF_COOKIE_DOMAIN` is used, the domain check of the `Referer` header consists in comparing its domain against the value of the `HOST` header. However, when a non-default value for the `CSRF_COOKIE_DOMAIN` is used, the domain of the `Referer` header is compared against `CSRF_COOKIE_DOMAIN` with the server port (`request.get_port()`) appended, which always fails because `8000` is appended (due to the way we have our pods set-up in our Kubernetes cluster) but the domain of the `Referer` never includes a port (e.g., the domain of the `Referer` header would be `developer.mozilla.org` but it would have to match `developer.mozilla.org:8000`).

The fix is to use the `CSRF_TRUSTED_ORIGINS` setting to explicitly set the trusted domains that the domain of the `Referer` header is compared with, which in our case, would be `DOMAIN` (e.g., `developer.mozilla.org`) and `WIKI_HOST` (e.g., `wiki.developer.mozilla.org`). The `BETA_HOST` is NOT included since that domain is meant to be read-only.

### Testing

For testing locally, I first checked out Kuma master (without this fix) and brought up Docker using my `.env` file configured like this:
```sh
DEBUG=True
COMPOSE_FILE=docker-compose.yml:docker-compose.ssl.yml
...
```

and then went to https://developer.127.0.0.1.nip.io/en-US/docs/Web/HTML, edited it, and then published my edit. I get a `403`.

Next, I repeated the steps with this branch, and was successful.

### Next step

If this is approved, I think the next step is to push this to stage and fully test all operations that require CSRF tokens

