### PR TITLE
bug 1475871: Fix the "Other" email field in signup, add tests

### DIFF
--- a/kuma/users/jinja2/socialaccount/signup.html
+++ b/kuma/users/jinja2/socialaccount/signup.html
@@ -133,9 +133,10 @@
                   <ul class="choices">
                   {% set matching_uids = matching_accounts.values_list('uid', flat=True) %}
                   {% for email_choice in form.email %}
-                    {% set id_for_label="%s_%s" % (email_choice.name, loop.index0) %}
-                    <li class="{{ 'exists' if email_choice.choice_value in matching_uids }}">
-                      {% if email_choice.choice_value == form.other_email_value %}
+                    {% set id_for_label="%s_%s" % (form.email.name, loop.index0) %}
+                    {% set choice_value=email_choice.data.value %}
+                    <li {{-' class="exists"'|safe if choice_value in matching_uids }}>
+                      {% if choice_value == form.other_email_value %}
                         {{ email_choice.tag() }}
                         <label for="{{ id_for_label }}" class="inner other-label">{{ _('Other:') }}</label>
                         {{ form.other_email }}
@@ -144,8 +145,8 @@
                       <label for="{{ id_for_label }}">
                         {{ email_choice.tag() }}
                         {{ email_choice.choice_label }}
-                        {%- if email_choice.choice_value in email_addresses %}
-                          {%- if email_addresses[email_choice.choice_value].get('verified', False) %}
+                        {%- if choice_value in email_addresses %}
+                          {%- if email_addresses[choice_value].get('verified', False) %}
                             <strong>{{ _('Verified') }}</strong>
                           {%- else %}
                             {{ _('Unverified') }}

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -178,21 +178,67 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
 
     def test_signup(self):
         """
-        After a new user signs up with Persona, their username, an
-        indication that Persona was used to log in, and a logout link
-        appear in the auth tools section of the page.
+        After a new user logs in with GitHub, they signup to pick a username
+        and email to use on MDN. One signup is complete, the sign-in
+        link is replaced by the profile and logout links.
         """
         response = self.github_login()
         assert response.status_code == 200
         assert 'Sign In Failure' not in response.content.decode('utf-8')
 
+        # Test the signup form and our very custom email selector
+        signup_url = reverse('socialaccount_signup')
+        response = self.client.get(signup_url)
+        parsed = pq(response.content)
+        expected_emails = [
+            {
+                # BUG: The class should be omitted if empty
+                'li_attrib': {'class': ''},
+                # BUG: The label 'for' should match the radio 'id'
+                'label_attrib': {'for': '_0'},
+                'radio_attrib': {'required': '',
+                                 'type': 'radio',
+                                 'name': 'email',
+                                 'value': 'octocat-private@example.com',
+                                 'id': 'email_0'},
+            }, {
+                'li_attrib': {'class': ''},
+                'label_attrib': {'for': '_1'},
+                'radio_attrib': {'checked': 'checked',
+                                 'required': '',
+                                 'type': 'radio',
+                                 'name': 'email',
+                                 'value': 'octocat@example.com',
+                                 'id': 'email_1'},
+            }, {
+                # BUG: This should include an email input for "other"
+                'li_attrib': {'class': ''},
+                'label_attrib': {'for': '_2'},
+                'radio_attrib': {'required': '',
+                                 'type': 'radio',
+                                 'name': 'email',
+                                 'value': '_other',
+                                 'id': 'email_2'},
+            },
+        ]
+        email_lis = parsed.find('ul.choices li')
+        assert len(email_lis) == len(expected_emails)
+        for expected, email_li in zip(expected_emails, email_lis):
+            actual = {'li_attrib': email_li.attrib}
+            email_label = email_li.find('label')
+            actual['label_attrib'] = email_label.attrib
+            # BUG: The label should include Verified or Unverified
+            email_radio = email_label.cssselect('input[type=radio]')[0]
+            actual['radio_attrib'] = email_radio.attrib
+            assert actual == expected
+
+        # POST user choices to complete signup
         username = self.github_profile_data['login']
         email = self.github_email_data[0]['email']
         data = {'website': '',
                 'username': username,
                 'email': email,
                 'terms': True}
-        signup_url = reverse('socialaccount_signup')
         response = self.client.post(signup_url, data=data)
         assert response.status_code == 302
         assert_no_cache_header(response)

--- a/kuma/users/tests/test_templates.py
+++ b/kuma/users/tests/test_templates.py
@@ -179,7 +179,7 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
     def test_signup(self):
         """
         After a new user logs in with GitHub, they signup to pick a username
-        and email to use on MDN. One signup is complete, the sign-in
+        and email to use on MDN. Once signup is complete, the sign-in
         link is replaced by the profile and logout links.
         """
         response = self.github_login()
@@ -241,7 +241,7 @@ class AllauthGitHubTestCase(UserTestCase, SocialTestMixin):
                 actual['verified'] = 'Unknown'
                 if 'Verified' in text:
                     actual['verified'] = True
-                elif 'Unverified' in text:
+                elif 'Unverified' in text:  # pragma: no cover
                     actual['verified'] = False
                 email_radio = email_label.cssselect('input[type=radio]')[0]
             actual['radio_attrib'] = email_radio.attrib

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1266,7 +1266,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         # test setup is so painful for login tests.
         parsed = pq(response.content)
         li_exists = parsed.find('ul.choices li.exists')
-        assert len(li_exists) == 0
+        assert not li_exists
 
         # Create a legacy Persona account with the given email address
         octocat3 = user(username='octocat3', is_active=True,
@@ -1281,7 +1281,7 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         # user that signup may fail and they should use account recovery.
         li_exists = parsed.find('ul.choices li.exists')
         assert len(li_exists) == 1
-        email_input = li_exists[0].cssselect('input[type=radio]')
+        email_input = li_exists('input[type=radio]')
         assert len(email_input) == 1
         assert email_input[0].attrib['value'] == testemail
 


### PR DESCRIPTION
The signup page is displayed after a new user logs in with GitHub for the first time. It includes an email selector that is highly custom, like it came from 2012:

* The email includes **Verified** or Unverified, to show GitHub's verification status. We trust emails that GitHub say are verified, and send a verification email otherwise
* The last selection is "Other", and includes an ``email`` ``<input>`` that is displayed on the same line
* If an existing user has a matching email, then we display with a strikeout, to indicate that while GitHub returned it, picking that email will cause the form to fail

These special features have been broken for a while. My suspicion is that it broke during the Django 1.11 update, since we're using undocumented APIs to build the custom form. I'm not sure there is a "right" way to build this form in Django, so I focused on making it work roughly the same way, and adding tests to verify that the generated HTML works as expected.

For local testing, I already have local GitHub auth working. I added a legacy Persona account and deleted my GitHub link:

```
me = User.objects.get(username='jwhitlock')
me.socialaccount_set.all().delete()
me.socialaccount_set.create(provider='persona', uid=me.email)
```

I then get a sign-up page that looks a bit like this (emails changed to protect the guilty, including myself):

<img width="702" alt="mdn signup bug 1475871 before fix 2" src="https://user-images.githubusercontent.com/286017/55644352-4b83ff80-579b-11e9-9c03-a80b988d0128.png">

**After the fix, it looks like this:**

<img width="691" alt="mdn signup bug 1475871" src="https://user-images.githubusercontent.com/286017/55643978-2347d100-579a-11e9-963e-bcd8e7bc2016.png">
