### PR TITLE
bug 1462440: increase timeout for headless tests

### DIFF
--- a/Jenkinsfiles/integration-tests.groovy
+++ b/Jenkinsfiles/integration-tests.groovy
@@ -46,8 +46,8 @@ def functional_test(browser, base_dir) {
 def headless_test(base_dir) {
     return {
         node {
-            // Setup the pytest command (timeout at 7 min for stalled nodes).
-            def cmd = "timeout --preserve-status 7m" +
+            // Setup the pytest command (timeout at 8 min for stalled nodes).
+            def cmd = "timeout --preserve-status 8m" +
                       " py.test tests/headless" +
                       " --base-url='${config.job.base_url}'" +
                       " --junit-xml=/app/test_results/headless.xml" +


### PR DESCRIPTION
This PR increases the timeout for the headless tests from 7 min to 8 min, since we've noticed that the headless tests seem to take at least 6.5 minutes to run and this gives them a little more breathing room.