### PR TITLE
bug 1357416: Normalize slugs to NFC

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import unicodedata
 from difflib import ndiff
 
 import waffle
@@ -375,6 +376,11 @@ class DocumentForm(forms.ModelForm):
         elif self.parent_slug:
             # Prepend parent slug if given from view
             slug = self.parent_slug + '/' + slug
+
+        # Convert to NFC, required for URLs (bug 1357416)
+        # http://www.unicode.org/faq/normalization.html
+        slug = unicodedata.normalize('NFC', slug)
+
         # check both for disallowed characters and match for the allowed
         if (INVALID_DOC_SLUG_CHARS_RE.search(slug) or
                 not DOCUMENT_PATH_RE.search(slug)):
@@ -546,6 +552,10 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
         # Get the cleaned slug
         slug = self.cleaned_data['slug']
+
+        # Convert to NFC, required for URLs (bug 1357416)
+        # http://www.unicode.org/faq/normalization.html
+        slug = unicodedata.normalize('NFC', slug)
 
         # first check if the given slug doesn't contain slashes and other
         # characters not allowed in a revision slug component (without parent)

--- a/kuma/wiki/tests/test_forms.py
+++ b/kuma/wiki/tests/test_forms.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import json
+import unicodedata
 
 import pytest
 import requests_mock
@@ -17,7 +18,7 @@ from kuma.spam.constants import (CHECK_URL, SPAM_ADMIN_FLAG, SPAM_CHECKS_FLAG,
 from kuma.users.tests import UserTestCase
 
 from ..constants import SPAM_TRAINING_SWITCH
-from ..forms import AkismetHistoricalData, RevisionForm, TreeMoveForm
+from ..forms import AkismetHistoricalData, DocumentForm, RevisionForm, TreeMoveForm
 from ..models import DocumentSpamAttempt, Revision, RevisionIP
 from ..tests import document, normalize_html, revision
 
@@ -214,6 +215,67 @@ def test_multiword_tags(root_doc, rf):
     rev_form = RevisionForm(data=data, instance=rev, request=request)
     assert rev_form.is_valid()
     assert rev_form.cleaned_data['tags'] == '"MDN Meta"'
+
+
+def test_revision_form_normalize_unicode(root_doc, rf):
+    """Revision slugs are normalized to NFC, required for URLs."""
+
+    raw_slug = u'Εφαρμογές'  # "Applications" in Greek (el)
+
+    # In NFD, 'έ' is represented by two "decomposed" codepoints
+    #  03B5 (GREEK SMALL LETTER EPSILON)
+    #  0301 (COMBINING ACUTE ACCENT)
+
+    nfd_slug = unicodedata.normalize('NFD', raw_slug)
+    # In NFC, 'έ' is represented by a "composed" codepoint
+    #  03AD (GREEK SMALL LETTER EPSILON WITH TONOS)
+    nfc_slug = unicodedata.normalize('NFC', raw_slug)
+
+    assert nfd_slug != nfc_slug
+
+    rev = root_doc.current_revision
+    request = rf.get('/')
+    request.user = rev.creator
+    data = {
+        'content': 'Content',
+        'toc_depth': 1,
+        'slug': nfd_slug
+    }
+    rev_form = RevisionForm(data=data, instance=rev, request=request)
+    assert rev_form.is_valid()
+    assert rev_form.cleaned_data['slug'] == nfc_slug
+
+
+def test_document_form_normalize_unicode(root_doc, rf):
+    """Document slugs are normalized to NFC, required for URLs."""
+
+    raw_slug = u'ফায়ারফক্স'  # "Firefox" in Bengali (bn-BD)
+
+    # This slug is the same in NFC and NFD. The second character has these
+    # codepoints:
+    # 09af BENGALI LETTER YA (য)
+    # 09bc BENGALI SIGN NUKTA
+    # 09be BENGALI VOWEL SIGN AA (non-breaking spacing mark)
+    nfc_slug = u'\u09ab\u09be\u09af\u09bc\u09be\u09b0\u09ab\u0995\u09cd\u09b8'
+    assert nfc_slug == unicodedata.normalize('NFC', raw_slug)
+
+    # An alternate representation of the second character is:
+    # 09df BENGALI LETTER YYA (য়)
+    # 09be BENGALI VOWEL SIGN AA (non-breaking spacing mark)
+    alt_slug = u'\u09ab\u09be\u09df\u09be\u09b0\u09ab\u0995\u09cd\u09b8'
+    assert alt_slug != nfc_slug
+
+    rev = root_doc.current_revision
+    request = rf.get('/')
+    request.user = rev.creator
+    data = {
+        'slug': alt_slug,
+        'title': root_doc.title,
+        'locale': root_doc.locale
+    }
+    doc_form = DocumentForm(data=data, instance=root_doc)
+    assert doc_form.is_valid()
+    assert doc_form.cleaned_data['slug'] == nfc_slug
 
 
 def test_case_sensitive_tags(root_doc, rf):


### PR DESCRIPTION
This adds a NFC normalization step to the ``RevisionForm`` and ``DocumentForm``, used when editing, translating, and moving pages, so that slugs are automatically normalized before saving.

Some unicode text is displayed the same, but is composed of a different sequence of unicode codepoints. For example, the Greek small case epsilon with a tonos (έ) can be represented by a [single codepoint](https://codepoints.net/U+03AD), or by an [epsilon](https://codepoints.net/U+03b5) (ε) followed by a [combining acute accent](https://codepoints.net/U+0301) (``´``). This can mean that
two unicode strings appear the same but are different because of the code points.

Unicode defines [normalization forms](http://www.unicode.org/faq/normalization.html) that define the canonical representation of these strings. One form, Normalization Form D (NFD, or "decomposed"), uses the canonical decomposition, where έ is represented by two codepoints, and there is a defined order for multiple combining codepoints. Normalization Form C (NFC, or "composed") uses NFD followed by a canonical composition, where έ is represented by one codepoint. There are two others, NFKD and NFKC, but you don't need to know those, or [all the details of Annex #15](https://www.unicode.org/reports/tr15/#Norm_Forms), for this PR.

The W3C specifies [NFC for content](https://www.w3.org/International/questions/qa-html-css-normalization), and it appears browsers perform NFC on URLs. It is possible to enter a non-NFC slug in editing, translating, and moving pages, and because the browser performs NFC, these pages become unreachable. This is most likely to occur in the Bengali (bn-BD) domain.

I've [manually updated slugs with non-NFC forms](https://bugzilla.mozilla.org/show_bug.cgi?id=1357416#c3). There were 16 of them left. This prevents new ones from being created.