### PR TITLE
bug 1357416: Normalize slugs to NFKC

### DIFF
--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import unicodedata
 from difflib import ndiff
 
 import waffle
@@ -375,6 +376,11 @@ class DocumentForm(forms.ModelForm):
         elif self.parent_slug:
             # Prepend parent slug if given from view
             slug = self.parent_slug + '/' + slug
+
+        # Convert to NFKC, required for URLs (bug 1357416)
+        # http://www.unicode.org/faq/normalization.html
+        slug = unicodedata.normalize('NFKC', slug)
+
         # check both for disallowed characters and match for the allowed
         if (INVALID_DOC_SLUG_CHARS_RE.search(slug) or
                 not DOCUMENT_PATH_RE.search(slug)):
@@ -546,6 +552,10 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
         # Get the cleaned slug
         slug = self.cleaned_data['slug']
+
+        # Convert to NFKC, required for URLs (bug 1357416)
+        # http://www.unicode.org/faq/normalization.html
+        slug = unicodedata.normalize('NFKC', slug)
 
         # first check if the given slug doesn't contain slashes and other
         # characters not allowed in a revision slug component (without parent)


### PR DESCRIPTION
This replaces PR #5342, which used NFC. After further research, NFKC appeared to be a better choice, and if we're making the change anyway let's use the better normalization for slugs.

This adds a NFKC normalization step to the ``RevisionForm`` and ``DocumentForm``, used when editing, translating, and moving pages, so that slugs are automatically normalized before saving.

Some unicode text is displayed the same, but is composed of a different sequence of unicode codepoints. For example, the Greek small case epsilon with a tonos (έ) can be represented by a single codepoint, or by an epsilon (ε) followed by a combining acute accent. This can mean that two unicode strings appear the same but are different because of the code points. Further, some codepoints appear to be formatted versions of other codepoints, such as the roman numeral 4 (Ⅳ) versus capital letters I and V (IV), and can be confusing as identifiers.

Unicode defines [normalization forms](http://www.unicode.org/reports/tr15/) that define transformations to normalized forms of these strings:

* NFD (Normalization Form D): έ is decomposed to two codepoints, and others to multiple codepoints with a defined order.
* NFC (Normalization Form C): NFD is applied, and then some codepoints are composed back into single codepoints. έ is a single codepoint in NFC.
* NFKD (Normalization Form KD): NFD, with further transformations to generate compatible but not canonical strings. For example, superscript codepoints like "2⁵" are converted to "25", the single ellipsis codepoint "…" is converted to three periods "..."., and the roman numeral codepoint "Ⅳ" is converted to the two letters "IV".
* NFKC (Normalization Form KC): NFKD is applied, and then composition can reduce the number of codepoints in the string. An NFKC string is also NFC, but not all NFC strings are NFKC.

RFC 3987 suggests [NFC or NFKC for normalizing IRIs](https://tools.ietf.org/html/rfc3987#section-5.3.2.2), with a [recommendation of NFKC for non-ASCII IRIs](https://tools.ietf.org/html/rfc3987#section-7.5). Django uses [NFKC for slugifying strings](https://github.com/django/django/blob/277017aea4cf72a1797102e6d129165181d04e17/django/utils/text.py#L385-L398). The [Unicode Normalization FAQ](http://www.unicode.org/reports/tr15/) recommends NFC for content, and NFKC for identifiers.

It appears that browsers or some other part of our tech stack performs NFC on URLs, so that non-NFC slugs result in pages that are unreachable. This is most likely to occur in the Bengali (bn-BD) domain. We've also seen issues with ellipsis and some alternates for spaces and parenthesis,
that seem to be most common in Japanese (ja), that are mitigated with NFKC.

Future work may include automatically redirecting to the NFKC equivalent, to avoid having to manually create redirects, and normalizing content like titles and the document content with NFC.