### PR TITLE
bug 1340194: Stop setting random passwords for account recovery

### DIFF
--- a/kuma/users/models.py
+++ b/kuma/users/models.py
@@ -1,5 +1,4 @@
 import datetime
-import uuid
 
 from constance import config
 from django.conf import settings
@@ -221,16 +220,7 @@ class User(AbstractUser):
         return user.is_staff or user.is_superuser or user.pk == self.pk
 
     def get_recovery_url(self):
-        """
-        Creates a recovery URL for the user.
-
-        The recovery URL uses the password reset workflow, which requires the
-        user has a password on their account.  Users without a password get a
-        randomly generated password.
-        """
-        if not self.has_usable_password():
-            self.set_password(uuid.uuid4().hex)
-            self.save()
+        """Creates a recovery URL for the user."""
         uidb64 = urlsafe_base64_encode(force_bytes(self.pk))
         token = default_token_generator.make_token(self)
         link = reverse('users.recover',

--- a/kuma/users/tests/test_models.py
+++ b/kuma/users/tests/test_models.py
@@ -109,7 +109,20 @@ class TestUser(UserTestCase):
         user.save()
         url = user.get_recovery_url()
         assert url
-        assert user.has_usable_password()
+        assert not user.has_usable_password()
+
+        # The same URL is returned on second call
+        user.refresh_from_db()
+        url2 = user.get_recovery_url()
+        assert url == url2
+
+    def test_get_recovery_url_blank_password(self):
+        user = self.user_model.objects.get(username='testuser')
+        user.password = ''
+        user.save()
+        url = user.get_recovery_url()
+        assert url
+        assert not user.has_usable_password()
 
         # The same URL is returned on second call
         user.refresh_from_db()

--- a/kuma/users/tests/test_tasks.py
+++ b/kuma/users/tests/test_tasks.py
@@ -22,7 +22,7 @@ class SendRecoveryEmailTests(TestCase):
         testuser.save()
         send_recovery_email(testuser.pk, email='actual@example.com')
         testuser.refresh_from_db()
-        assert testuser.has_usable_password()
+        assert not testuser.has_usable_password()
         recovery_url = testuser.get_recovery_url()
         assert len(mail.outbox) == 1
         recovery_email = mail.outbox[0]

--- a/kuma/users/views.py
+++ b/kuma/users/views.py
@@ -1,7 +1,6 @@
 import collections
 import json
 import operator
-import uuid
 from datetime import datetime, timedelta
 
 from allauth.account.adapter import get_adapter
@@ -13,7 +12,7 @@ from allauth.socialaccount.views import SignupView as BaseSignupView
 from constance import config
 from django import forms
 from django.conf import settings
-from django.contrib.auth import authenticate, get_user_model, login
+from django.contrib.auth import get_user_model, login
 from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.models import Group
 from django.contrib.auth.tokens import default_token_generator
@@ -640,13 +639,7 @@ def recover(request, uidb64=None, token=None):
     except (TypeError, ValueError, OverflowError, UserModel.DoesNotExist):
         user = None
     if user and default_token_generator.check_token(user, token):
-        temp_pwd = uuid.uuid4().hex
-        user.set_password(temp_pwd)
-        user.save()
-        user = authenticate(username=user.username, password=temp_pwd)
-        user.set_unusable_password()
-        user.save()
-        login(request, user)
+        login(request, user, 'kuma.users.auth_backends.KumaAuthBackend')
         return redirect('users.recover_done')
     return render(request, 'users/recover_failed.html')
 


### PR DESCRIPTION
The account recovery code, used to allow legacy Persona users to link existing MDN profiles to GitHub, often sets a password for the user.

When generating a recovery URL, a random password was set on the user. This may be because Django's ``PasswordResetForm`` checks that the user has a usable password, and maybe there was other code that required that. I checked with Django 1.11 and current code, and it is OK to send a recovery email to a user with a blank or unusable password, so I'm removing that code and adding test code that the URL can be generated. Django made a similar choice, and [allows password reset when the existing password is unusable in Django 2.1](https://docs.djangoproject.com/en/2.1/topics/auth/passwords/#django.contrib.auth.hashers.is_password_usable).

When logging a user in via a recovery URL, the view set a random password on the user, so that it could be used to log them in with authenticate, and then set it to an unusable password. In [Django 1.10](https://docs.djangoproject.com/en/1.11/releases/1.10/#django-contrib-auth),
login gained an optional ``backend`` parameter, which could be used to login a user without credentials. The code to add a temporary random password has been removed.

You can test this by adding a Persona login, removing your GitHub login, ensuring you have an unusable password, and starting signup to get the account recovery link. Or, you can call ``get_recovery_url`` on your ``User``, and paste it into a browser.

There may be several users in production that started but did not finish account recovery (for example, they no longer have access to their Persona email). These users have passwords in production, set to random strings. They can be set to unusable passwords with something like:

```
for user in User.objects.exclude(password__startswith='!'):
   user.set_unusable_password()
   user.save()
```

This will invalidate any active recovery URLs, so you can wait for 4 days (``settings.PASSWORD_RESET_TIMOUT_DAYS`` +1), or trust that they will generate a new one.

We'll then be back in a situation where there is no valid reason to have a usable password, even a randomly-generated one, in production.