### PR TITLE
bug 1542759 - upgrade Jinja2 used for docs

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -3,7 +3,7 @@
 
 # These should stay synced with other requirements files
 Babel==2.2.0
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==0.23
 pytz==2018.5
 six==1.11.0


### PR DESCRIPTION
No-risk since the docs environment isn't executed on our servers. 
But I just wanted to get rid of this warning: https://github.com/mozilla/kuma/network/alert/requirements/docs.txt/Jinja2/open