### PR TITLE
fixes bug 1544084 - Sending first edit email potentially premature

### DIFF
--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 
-import mock
 import pytest
 import requests_mock
 from django.conf import settings

--- a/kuma/conftest.py
+++ b/kuma/conftest.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+import mock
 import pytest
 import requests_mock
 from django.conf import settings

--- a/kuma/core/tests/__init__.py
+++ b/kuma/core/tests/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
-from functools import wraps
 import os
+from functools import wraps
 
 import mock
 from django.conf import settings

--- a/kuma/wiki/forms.py
+++ b/kuma/wiki/forms.py
@@ -7,6 +7,7 @@ import waffle
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.db import transaction
 from django.forms.widgets import CheckboxSelectMultiple
 from django.template.loader import render_to_string
 from django.utils import translation
@@ -829,7 +830,9 @@ class RevisionForm(AkismetCheckFormMixin, forms.ModelForm):
 
             # send first edit emails
             if is_first_edit:
-                send_first_edit_email.delay(new_rev.pk)
+                transaction.on_commit(
+                    lambda: send_first_edit_email.delay(new_rev.pk)
+                )
 
             # schedule a document rendering
             document.schedule_rendering('max-age=0')

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -14,7 +14,6 @@ from django.core.mail import mail_admins, send_mail
 from django.db import transaction
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
-from djcelery_transactions import task as transaction_task
 from lxml import etree
 
 from kuma.core.decorators import skip_in_maintenance_mode
@@ -269,7 +268,7 @@ def delete_old_revision_ips(days=30):
     RevisionIP.objects.delete_old(days=days)
 
 
-@transaction_task
+@task
 @skip_in_maintenance_mode
 def send_first_edit_email(revision_pk):
     """ Make an 'edited' notification email for first-time editors """

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -18,7 +18,8 @@ from django.utils.six.moves.urllib.parse import parse_qs, urlparse
 from pyquery import PyQuery as pq
 
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header)
+                             assert_shared_cache_header,
+                             call_on_commit_immediately)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import urlparams
 from kuma.users.models import User
@@ -675,6 +676,7 @@ class NewRevisionTests(UserTestCase, WikiTestCase):
                        'form#wiki-page-edit textarea[name="content"]')) == 1
 
     @override_settings(TIDINGS_CONFIRM_ANONYMOUS_WATCHES=False)
+    @call_on_commit_immediately
     def test_new_revision_POST_document_with_current(self):
         """HTTP POST to new revision URL creates the revision on a document.
 

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,8 +17,9 @@ from waffle.testutils import override_flag, override_switch
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, get_user,
-                             call_on_commit_immediately)
+                             assert_shared_cache_header,
+                             call_on_commit_immediately,
+                             get_user)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html
 from kuma.spam.constants import (

--- a/kuma/wiki/tests/test_views.py
+++ b/kuma/wiki/tests/test_views.py
@@ -17,7 +17,8 @@ from waffle.testutils import override_flag, override_switch
 
 from kuma.core.templatetags.jinja_helpers import add_utm
 from kuma.core.tests import (assert_no_cache_header,
-                             assert_shared_cache_header, get_user)
+                             assert_shared_cache_header, get_user,
+                             call_on_commit_immediately)
 from kuma.core.urlresolvers import reverse
 from kuma.core.utils import to_html
 from kuma.spam.constants import (
@@ -1833,6 +1834,7 @@ class DocumentEditingTests(UserTestCase, WikiTestCase):
         assert rev_ip.referrer == 'http://localhost/'
 
     @pytest.mark.edit_emails
+    @call_on_commit_immediately
     def test_email_for_first_edits(self):
         self.client.login(username='testuser', password='testpass')
         data = new_document_data()

--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -4,6 +4,7 @@ import newrelic.agent
 from csp.decorators import csp_update
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
@@ -85,6 +86,7 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 @process_document_path
 @check_readonly
 @prevent_indexing
+@transaction.atomic
 def edit(request, document_slug, document_locale):
     """
     Create a new revision of a wiki document, or edit document metadata.


### PR DESCRIPTION
The way I tested manually was messy but insightful. 

The code that calls `send_first_edit_email` used to look like this:

```python
if is_first_edit:
    send_first_edit_email.delay(new_rev.pk)
```

What I did was temporarily edit it to look like this:

```python
# if is_first_edit:
if 1:
    print("Trigger to send email...")
    send_first_edit_email.delay(new_rev.pk)

import time, time
time.sleep(10)
if random.random() > 0.5:
    raise Exception("oh no!")
else:
    print("i'm done sleeping")
```

Then, after editing a wiki page I watched the console (by the way, I changed my email to console printing rather than files inside the docker container). The was the out:

```
<timestamp1>: Trigger to send email...
<timestamp2>: **the whole email string output**
<timestamp3>: i'm done sleeping
```
...or...
```
<timestamp1>: Trigger to send email...
<timestamp2>: **the whole email string output**
<timestamp3>: Traceback (most recent call last):
 ...
Exception: oh no!
```

Point being, the email got sent even before all the other things happened. And had an error occurred the email would still have been sent :(