### PR TITLE
Bug 1488884: Fix sidebar links without bottom margin

### DIFF
--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -12,33 +12,29 @@
     overflow: hidden;
     @include set-font-size($smaller-font-size);
 
+    li > em,
+    li > s,
     a {
         display: inline-block;
         max-width: 100%;
         position: relative;
         overflow: hidden;
         text-overflow: ellipsis;
-        margin-bottom: 10px;
+    }
 
-        /* 404 link */
-        &.new {
-            color: $error;
-        }
+    /* 404 link */
+    a.new {
+        color: $error;
     }
 
     li {
         line-height: 1.2;
-        padding-bottom: $grid-spacing / 2;
-
-        > em {
-            margin-bottom: 10px;
-            display: inline-block;
-        }
+        padding-bottom: $grid-spacing;
     }
 
     li li {
         @include bidi(((padding-left, $grid-spacing, padding-right, 0),));
-        padding-bottom: 0;
+        padding-bottom: $grid-spacing / 2;
 
         &:first-child {
             padding-top: $grid-spacing / 2;


### PR DESCRIPTION
See [bug 1488884](https://bugzilla.mozilla.org/show_bug.cgi?id=1488884) and #4957 for details.

Previously links like `‑ms‑filter` wouldn’t have a bottom margin when it’s the current page, this PR fixes that.

review?(@schalkneethling)

Screenshots:
------------

<details>
<summary><strong>Before</strong></summary>

![Kuma PR‑5353 (Before)](https://user-images.githubusercontent.com/3889017/56367410-7d628080-61f5-11e9-9e7e-7942129e3ea8.png)

</details>
<details>
<summary><strong>After</strong></summary>

![Kuma PR‑5353 (After)](https://user-images.githubusercontent.com/3889017/56367435-88b5ac00-61f5-11e9-89f4-a37b4c127c27.png)

</details>