### PR TITLE
fixes 1544482 - elasticsearch 6.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma
         - DJANGO_SETTINGS_MODULE=kuma.settings.travis
         - DOCKER_COMPOSE_VERSION=1.23.2
-        - ES_VERSION=5.6.10
-        - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.10.tar.gz
+        - ES_VERSION=6.7.1
+        - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.1.tar.gz
         - PIPELINE_CLEANCSS_BINARY=$TRAVIS_BUILD_DIR/node_modules/.bin/cleancss
         - PIPELINE_CLEANCSS_ARGUMENTS="-O1 --skip-rebase"
         - PIPELINE_CSS_COMPRESSOR=kuma.core.pipeline.cleancss.CleanCSSCompressor

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,11 +97,13 @@ services:
       - mysqlvolume:/var/lib/mysql
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.10
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.7.1
     environment:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
+    ports:
+      - "9200:9200"
     volumes:
       - esdata:/usr/share/elasticsearch/data
 

--- a/docs/elasticsearch.rst
+++ b/docs/elasticsearch.rst
@@ -16,8 +16,8 @@ is released).
 
 Kuma's goal is to update to the last minor version of the previous major
 release, so we expect to update every 12 to 18 months. Kuma is running on
-ElasticSearch 5.6.10 in development and production, which is planned to be
-supported until March 2019.
+ElasticSearch 6.7.1 in development and production, which is planned to be
+supported until September 2020.
 
 The Kuma search tests use the configured Elasticsearch, and can be run inside
 the ``web`` Docker container to confirm the engine works::

--- a/docs/rendering.rst
+++ b/docs/rendering.rst
@@ -898,7 +898,7 @@ KumaScript macros, CSS class names, and HTML attributes, to allow
 .. _`internal search`: https://developer.mozilla.org/en-US/search
 .. _strip_tags: https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.html.strip_tags
 .. _`security advisory`: https://www.djangoproject.com/weblog/2014/mar/22/strip-tags-advisory/
-.. _`HTML Strip Char Filter`: https://www.elastic.co/guide/en/elasticsearch/reference/5.6/analysis-htmlstrip-charfilter.html
+.. _`HTML Strip Char Filter`: https://www.elastic.co/guide/en/elasticsearch/reference/6.7/analysis-htmlstrip-charfilter.html
 .. _`advanced search queries`: https://developer.mozilla.org/en-US/docs/MDN/Contribute/Tools/Search
 
 

--- a/kuma/search/management/commands/reindex.py
+++ b/kuma/search/management/commands/reindex.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '-c', '--chunk',
-            help='Chunk size when reindexing (default 100). Lower is better'
+            help='Chunk size when reindexing (default 1000). Lower is better'
                  'for slow computers with little memory',
             type=int,
             dest='chunk_size',

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -128,22 +128,12 @@ def fake_view(request, selected_filters=None):
 def test_base_search(db):
     '''WikiDocumentType.search() searches all documents by default.'''
     search = WikiDocumentType.search()
-    expected = {
-        'query': {
-            'match_all': {}
-        }
-    }
-    assert search.to_dict() == expected
+    assert search.to_dict() == {}
 
 
 def test_base_search_mocked_es(mock_search):
     '''Mocked WikiDocumentType.search() returns same search query.'''
-    expected = {
-        'query': {
-            'match_all': {}
-        }
-    }
-    assert mock_search.to_dict() == expected
+    assert mock_search.to_dict() == {}
 
 
 def test_language_filter_backend_fr(rf, mock_search):
@@ -202,7 +192,7 @@ def test_language_filter_backend_all(rf, mock_search):
     request = rf.get('/en-US/search?q=article&locale=*')
     request.LANGUAGE_CODE = 'en-US'
     search = backend.filter_queryset(request, mock_search, None)
-    assert search.to_dict() == {'query': {'match_all': {}}}
+    assert search.to_dict() == {}
 
 
 def test_search_query_backend(rf, mock_search):
@@ -243,7 +233,7 @@ def test_search_query_backend_empty(rf, mock_search):
     request = rf.get('/en-US/search?q=')
     request.user = AnonymousUser()
     search = backend.filter_queryset(request, mock_search, fake_view(request))
-    assert search.to_dict() == {'query': {'match_all': {}}}
+    assert search.to_dict() == {}
 
 
 def test_search_query_backend_as_admin(rf, mock_search, admin_user):
@@ -252,8 +242,7 @@ def test_search_query_backend_as_admin(rf, mock_search, admin_user):
     request = rf.get('/en-US/search?q=')
     request.user = admin_user
     search = backend.filter_queryset(request, mock_search, fake_view(request))
-    assert search.to_dict() == {'explain': True,
-                                'query': {'match_all': {}}}
+    assert search.to_dict() == {'explain': True}
 
 
 @pytest.mark.parametrize('param',
@@ -301,7 +290,7 @@ def test_keyword_query_ignores_unknown_index(rf, mock_search):
     backend = KeywordQueryBackend()
     request = rf.get('/en-US/search?topic=test')
     search = backend.filter_queryset(request, mock_search, fake_view(request))
-    assert search.to_dict() == {'query': {'match_all': {}}}
+    assert search.to_dict() == {}
 
 
 def test_tag_group_filter_backend(rf, mock_search):
@@ -311,7 +300,6 @@ def test_tag_group_filter_backend(rf, mock_search):
     view = fake_view(request, selected_filters=['tagged'])
     search = backend.filter_queryset(request, mock_search, view)
     expected = {
-        'query': {'match_all': {}},
         'post_filter': {'term': {'tags': 'tagged'}},
         'aggs': {
             'addons': {'filter': {'terms': {'tags': ['Add-ons',
@@ -329,7 +317,6 @@ def test_tag_group_filter_backend_multiple_tags_or_operator(rf, mock_search):
     view = fake_view(request, selected_filters=['addons'])
     search = backend.filter_queryset(request, mock_search, view)
     expected = {
-        'query': {'match_all': {}},
         'post_filter': {'bool': {'should': [
             {'term': {'tags': 'Add-ons'}},
             {'term': {'tags': 'Extensions'}}]}},
@@ -349,7 +336,6 @@ def test_tag_group_filter_backend_multiple_tags_and_operator(rf, mock_search):
     view = fake_view(request, selected_filters=['brown-dogs'])
     search = backend.filter_queryset(request, mock_search, view)
     expected = {
-        'query': {'match_all': {}},
         'post_filter': {'bool': {'must': [
             {'term': {'tags': 'Brown'}},
             {'term': {'tags': 'Dog'}}]}},
@@ -369,7 +355,6 @@ def test_tag_group_filter_backend_multiple_groups(rf, mock_search):
     view = fake_view(request, selected_filters=['addons', 'css'])
     search = backend.filter_queryset(request, mock_search, view)
     expected = {
-        'query': {'match_all': {}},
         'post_filter': {'bool': {'should': [
             {'term': {'tags': 'CSS'}},
             {'term': {'tags': 'Add-ons'}},
@@ -391,7 +376,6 @@ def test_tag_group_filter_backend_no_groups(rf, mock_search):
     view = fake_view(request, selected_filters=[])
     search = backend.filter_queryset(request, mock_search, view)
     expected = {
-        'query': {'match_all': {}},
         'aggs': {
             'addons': {'filter': {'terms': {'tags': ['Add-ons',
                                                      'Extensions']}}},
@@ -407,7 +391,6 @@ def test_highlight_filter_backend(rf, mock_search):
     request = rf.get('/en-US/search?highlight=1')
     search = backend.filter_queryset(request, mock_search, fake_view(request))
     expected = {
-        'query': {'match_all': {}},
         'highlight': {'fields': {'content': {}, 'summary': {}},
                       'order': 'score',
                       'post_tags': ['</mark>'],
@@ -420,7 +403,7 @@ def test_highlight_filter_backend_no_highlight(rf, mock_search):
     backend = HighlightFilterBackend()
     request = rf.get('/en-US/search')
     search = backend.filter_queryset(request, mock_search, fake_view(request))
-    assert search.to_dict() == {'query': {'match_all': {}}}
+    assert search.to_dict() == {}
 
 
 class FilterTexts(ElasticTestCase):

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -25,7 +25,7 @@ from .constants import EXPERIMENT_TITLE_PREFIX
 log = logging.getLogger('kuma.wiki.search')
 
 
-class WikiDocumentType(document.DocType):
+class WikiDocumentType(document.Document):
     excerpt_fields = ['summary', 'content']
     exclude_slugs = ['Talk:', 'User:', 'User_talk:', 'Template_talk:',
                      'Project_talk:', EXPERIMENT_TITLE_PREFIX]
@@ -70,7 +70,7 @@ class WikiDocumentType(document.DocType):
 
     @classmethod
     def from_django(cls, obj):
-        is_root_document = (obj.slug.count('/') == 1)
+        is_root_document = obj.slug.count('/') == 1
         doc = {
             'id': obj.id,
             'boost': 4.0 if is_root_document else 1.0,

--- a/kuma/wiki/tests/test_kumascript.py
+++ b/kuma/wiki/tests/test_kumascript.py
@@ -124,7 +124,6 @@ def test_macro_page_count(db, mock_es_client):
 
     es_json = {
         'size': 0,
-        'query': {'match_all': {}},
         'aggs': {'usage': {'terms': {
             'field': 'kumascript_macros',
             'size': 2000}

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -216,9 +216,19 @@ futures==3.0.5 \
 # Code: https://github.com/elastic/elasticsearch-py
 # Changes: https://elasticsearch-py.readthedocs.io/en/master/Changelog.html
 # Docs: https://elasticsearch-py.readthedocs.io/en/master/
-elasticsearch==5.5.0 \
-    --hash=sha256:a9d1dabc18c2b593b1be5c85b697af2bbfb094a7d9cca21c48ac323257e3e7a0 \
-    --hash=sha256:d03379ef519dde70b3b842deb0df576520a7a4735abe1d5ec3f32f8e66899be2
+elasticsearch==6.3.1 \
+    --hash=sha256:7546cc08e3899716e12fe67d12d7cfe9a64647014d1134b014c3c392b63cad42 \
+    --hash=sha256:aada5cfdc4a543c47098eb3aca6663848ef5d04b4324935ced441debc11ec98b
+
+# elasticsearch-dsl
+#
+# Required by elasticsearch-dsl but only needed because we're on Python 2.7
+# Code: https://github.com/phihag/ipaddress
+ipaddress==1.0.22 \
+    --hash=sha256:64b28eec5e78e7510698f6d4da08800a5c575caa4a286c93d651c5d3ff7b6794 \
+    --hash=sha256:b146c751ea45cad6188dd6cf2d9b757f6f4f8d6ffb96a023e6f2e26eea02a72c
+
+
 # Extensions to datetime module
 # Code: https://github.com/dateutil/dateutil/
 # Changes: https://dateutil.readthedocs.io/en/stable/changelog.html

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -227,9 +227,9 @@ dj-email-url==0.0.4 \
 # Code: https://github.com/elastic/elasticsearch-dsl-py
 # Changes: https://elasticsearch-dsl.readthedocs.io/en/latest/Changelog.html
 # Docs: https://elasticsearch-dsl.readthedocs.io/en/latest/
-elasticsearch-dsl==6.3.1 \
-    --hash=sha256:5f43196a3fd91b2eac90f7345e99f92c66004d85a1fd803cdecf756430827231 \
-    --hash=sha256:5f80b3b4a6e61db5d273bc57c32a80b2ddbc555afcc122c62c20440c355008be
+elasticsearch-dsl==6.4.0 \
+    --hash=sha256:26416f4dd46ceca43d62ef74970d9de4bdd6f4b0f163316f0b432c9e61a08bec \
+    --hash=sha256:f60aea7fd756ac1fbe7ce114bbf4949aefbf495dfe8896640e787c67344f12f6
 
 # Parse external RSS / Atom feeds
 feedparser==5.2.1 \

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -227,9 +227,9 @@ dj-email-url==0.0.4 \
 # Code: https://github.com/elastic/elasticsearch-dsl-py
 # Changes: https://elasticsearch-dsl.readthedocs.io/en/latest/Changelog.html
 # Docs: https://elasticsearch-dsl.readthedocs.io/en/latest/
-elasticsearch-dsl==5.4.0 \
-    --hash=sha256:197246ddd556b4b7d2738dfa9e4831068c9b5cb21706f6aca035136d42849109 \
-    --hash=sha256:cbef6467085d7debc870bc450d996c7ba5b8822eb86a6033bba09134ffb01ba8
+elasticsearch-dsl==6.3.1 \
+    --hash=sha256:5f43196a3fd91b2eac90f7345e99f92c66004d85a1fd803cdecf756430827231 \
+    --hash=sha256:5f80b3b4a6e61db5d273bc57c32a80b2ddbc555afcc122c62c20440c355008be
 
 # Parse external RSS / Atom feeds
 feedparser==5.2.1 \


### PR DESCRIPTION
I can search and I can reindex. 

There might be some stuff in `kuma/wiki/search.py` that is obsolete not with the upgrade of `elasticsearch_dsl`. For example, in other projects where I use ES 6.x and `elasticsearch_dsl` I don't specify a mapping in the sub-class `Meta` but instead you specify settings and an index name. However, kuma is odd in that you created and define indexes using the Django Admin. I didn't want to rock the boat too much at this point. In particular, I'm not fully grasped up on why we bother doing indexes through the Django Admin. I've never done it like that before and it all feels, to me, right now, like overkill. 