### PR TITLE
fixes bug 1114650 - stay logged in much longer

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1192,6 +1192,11 @@ for override in pipeline_overrides:
 SESSION_COOKIE_DOMAIN = DOMAIN
 SESSION_COOKIE_SECURE = config('SESSION_COOKIE_SECURE', default=True, cast=bool)
 SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_AGE = config(
+    'SESSION_COOKIE_AGE',
+    default=60 * 60 * 24 * 365,
+    cast=int
+)
 
 WAFFLE_SECURE = config('WAFFLE_COOKIE_SECURE', default=True, cast=bool)
 # This is a setting unique to Kuma which specifies the domain


### PR DESCRIPTION
Easy change. Less easy in terms of security discussion. 

The way I see it, 2 weeks is far too short and it's annoying to be thrown out. 
Our site doesn't really have anything critical. At best you can edit wiki documents but the money $tuff that we get involved in is shifted onto Stripe anyway. There's no sharing of critical PII. 
In other words, I feel like we can allow for a much longer lasting session cookie. Rogueness can lead to destroying stuff but it can't really lead to revealing sensitive stuff. 

My ideal functionality is a bit like GitHub and Amazon.com. You're more or less always logged in if you've logged in once but if you haven't manually logged in recently, and you click on something "more sensitive" then it triggers a fresh check that I still know my password. 

I'm only speculating but I wonder if we could, when you click `https://developer.mozilla.org/en-US/profiles/${username}/edit`, check that current user's session cookie age as it's known in the MySQL database. If it's older than say 1 day, then redirect the user to GitHub to sign in again, just like you'd do if someone goes straight to `https://developer.mozilla.org/en-US/profiles/${username}/edit` (from a bookmark or manually typing the URL) on a browser with no cookies. 