### PR TITLE
fixes bug 1544078 - rendered_html shouldn't update if rendered_errors

### DIFF
--- a/kuma/wiki/tests/test_views_document.py
+++ b/kuma/wiki/tests/test_views_document.py
@@ -851,3 +851,31 @@ def test_hreflang(client, root_doc, locales, expected_results):
         assert html.attr('lang') == expected_result
         assert html.find('head > link[hreflang="{}"][href$="{}"]'.format(
             expected_result, url))
+
+
+def test_render_document_with_cache_control(
+    mock_kumascript_get,
+    constance_config,
+    wiki_user,
+    client
+):
+    """If you're logged in and view the document with Shift-Refresh
+    it should re-render it.
+    """
+
+    assert 0
+
+
+def test_render_document_with_cache_control_with_kumascript_errors(
+    mock_kumascript_get,
+    constance_config,
+    wiki_user,
+    client
+):
+    """If you're logged in and view the document with Shift-Refresh
+    it should re-render it. However, what if we're so unlucky that
+    an error happens. Whatever should happen is that we should have to
+    see the raw content.
+    """
+
+    assert 0


### PR DESCRIPTION
**INCOMPLETE!** This doesn't have tests yet. Or rather, all old tests passed just passed despite this rather critical change. 

Steps to reproduce are here: https://bugzilla.mozilla.org/show_bug.cgi?id=1544078#c6
However, a better thing to do is to 
1. Click the "Edit" button, type in a change, but before you hit "Publish"
2. Go to http://localhost:8000/admin/constance/config/ and set the `KUMASCRIPT_TIMEOUT` to 0.1
3. Go back to edit and now press "Publish"
What you should see is the old page *without* your change. But you shouldn't see `{{SomeMacro(...)}}` and stuff like that. 

As of this change; what you get now is this:
<img width="1511" alt="Screen Shot 2019-04-19 at 4 13 23 PM" src="https://user-images.githubusercontent.com/26739/56442272-21affa00-62be-11e9-894f-35a1d015c823.png">
And the search snippets don't show `{{SomeMacro(...)}}` stuff. 

What's not clear to me is how are these pages re-attempted?? Is there a cron job that does that (aka. django celery).

By the way, are we sure it's safe to fully display that error (when you click the "More information about this error"). What if that reveals something sensitive that we don't want to expose about our infra?!

Lastly, note that this change does NOT attempt to change how the document is **viewed**. I didn't want to rock the boat too much. Also, at the moment, I haven't had any feedback on [this needinfo](https://bugzilla.mozilla.org/show_bug.cgi?id=1544078#c7). 

