### PR TITLE
fixes bug 1546114 - control PYTHONWARNINGS in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=True
+      - PYTHONWARNINGS=${PYTHONWARNINGS:-default}
       - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
       - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -478,3 +478,16 @@ will still be available at http://localhost:8000/en-US/, but GitHub logins will
 not work.
 
 .. _`Django Admin for Sites`: http://localhost:8000/admin/sites/site/
+
+Enabling ``PYTHONWARNINGS``
+===========================
+
+By default, ``PYTHONWARNINGS`` is not set, leaving it to be ``default``
+(which is like regular ``python`` on the command line). To change its
+value you can edit your ``.env`` file. For example::
+
+    # Unmask all possible Python warnings
+    PYTHONWARNINGS=all
+
+The ``docker-compose.yml`` will read this and start ``gunicorn`` and the
+``celery`` worker with this setting.


### PR DESCRIPTION
I was tempted to add it to [`.env-dist.dev`](https://github.com/mozilla/kuma/blob/master/.env-dist.dev) but there are so many other juicy tips and tricks that is not already in there. 