### PR TITLE
bug 1467529 - django.urls import of django.core.urlresolvers

### DIFF
--- a/kuma/core/middleware.py
+++ b/kuma/core/middleware.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 from django.conf import settings
 from django.contrib.sessions.middleware import SessionMiddleware
 from django.core.exceptions import MiddlewareNotUsed
-from django.core.urlresolvers import get_script_prefix, resolve, Resolver404
 from django.http import (HttpResponseForbidden,
                          HttpResponsePermanentRedirect,
                          HttpResponseRedirect)
+from django.urls import get_script_prefix, resolve, Resolver404
 from django.utils.encoding import smart_str
 from django.utils.six.moves.urllib.parse import urlsplit, urlunsplit
 from waffle.middleware import WaffleMiddleware

--- a/kuma/core/tests/test_locale_middleware.py
+++ b/kuma/core/tests/test_locale_middleware.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import pytest
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from . import assert_shared_cache_header
 

--- a/kuma/health/tests/test_views.py
+++ b/kuma/health/tests/test_views.py
@@ -4,8 +4,8 @@ import json
 
 import mock
 import pytest
-from django.core.urlresolvers import reverse
 from django.db import DatabaseError
+from django.urls import reverse
 from elasticsearch.exceptions import (ConnectionError as ES_ConnectionError,
                                       NotFoundError)
 from requests.exceptions import ConnectionError as Requests_ConnectionError

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -2,13 +2,12 @@ from decorator_include import decorator_include
 from django.conf import settings
 from django.conf.urls import include, url
 from django.contrib import admin
-from django.core.urlresolvers import reverse_lazy
 from django.shortcuts import render
+from django.urls import reverse_lazy
 from django.views.decorators.cache import never_cache
 from django.views.decorators.http import require_safe
 from django.views.generic import RedirectView
 from django.views.static import serve
-
 
 from kuma.attachments import views as attachment_views
 from kuma.core import views as core_views

--- a/kuma/wiki/tests/test_events.py
+++ b/kuma/wiki/tests/test_events.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import mock
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from kuma.core.utils import order_params
 

--- a/kuma/wiki/utils.py
+++ b/kuma/wiki/utils.py
@@ -6,7 +6,7 @@ from apiclient.discovery import build
 from constance import config
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from django.core.urlresolvers import resolve, Resolver404
+from django.urls import resolve, Resolver404
 from django.utils import translation
 from httplib2 import Http
 from oauth2client.service_account import ServiceAccountCredentials


### PR DESCRIPTION
The way I tested it was with:

```
$ PYTHONWARNINGS=all pytest kuma --capture=no -vv | tee warnings.log
```

The warnings output is so large but it's easy to search through that `warnings.log` file. 
The only warnings about django.core.urlresolvers, now, comes from [`django-decorator-include`](https://bugzilla.mozilla.org/show_bug.cgi?id=1467529#c8) which'll be for another day. 