### PR TITLE
bug 1544084: revert atomic edits

### DIFF
--- a/kuma/wiki/views/edit.py
+++ b/kuma/wiki/views/edit.py
@@ -4,7 +4,6 @@ import newrelic.agent
 from csp.decorators import csp_update
 from django.conf import settings
 from django.core.exceptions import PermissionDenied
-from django.db import transaction
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.safestring import mark_safe
@@ -86,7 +85,6 @@ def _edit_document_collision(request, orig_rev, curr_rev, is_async_submit,
 @process_document_path
 @check_readonly
 @prevent_indexing
-@transaction.atomic
 def edit(request, document_slug, document_locale):
     """
     Create a new revision of a wiki document, or edit document metadata.


### PR DESCRIPTION
It appears that https://github.com/mozilla/kuma/pull/5348 has broken editing (see https://github.com/mdn/sprints/issues/1366). I'm not sure why, since I can't reproduce it locally or even on stage, so this PR reverts the change that wrapped the edit view in an atomic transaction, in order to restore functionality for the writers while this is investigated further.