### PR TITLE
fixes bug 1546503 - custom celery and gunicorn workers in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '2.1'
 services:
   worker: &worker
     image: mdnwebdocs/kuma_base
-    command: ./manage.py celery worker --loglevel=INFO --events --beat --autoreload --concurrency=4 -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
+    command: ./manage.py celery worker --loglevel=INFO --events --beat --autoreload --concurrency=${CELERY_WORKERS:-4}  -Q mdn_purgeable,mdn_search,mdn_emails,mdn_wiki,mdn_api,celery
     user: ${UID:-1000}
     volumes:
       - ./:/app:z
@@ -50,7 +50,7 @@ services:
   # Web is based on worker b/c you cannot clear the "ports" with docker-compose.
   web:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 --worker-class=meinheld.gmeinheld.MeinheldWorker kuma.wsgi:application
+    command: gunicorn -w ${GUNICORN_WORKERS:-4} --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 --worker-class=meinheld.gmeinheld.MeinheldWorker kuma.wsgi:application
     depends_on:
       - mysql
       - elasticsearch
@@ -63,7 +63,7 @@ services:
   # API is used by KumaScript for content and metadata
   api:
     <<: *worker
-    command: gunicorn -w 4 --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
+    command: gunicorn -w ${GUNICORN_WORKERS:-4} --bind 0.0.0.0:8000 --access-logfile=- --timeout=120 kuma.wsgi:application
     depends_on:
       - mysql
       - elasticsearch

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -236,6 +236,20 @@ around 4 seconds to page load time.
 
 .. _Environment variables: http://12factor.net/config
 
+Customizing number of workers
+=============================
+
+The ``docker-compose.yml`` in git comes with a default setting of
+4 ``celery`` workers and 4 ``gunicorn`` workers. That's pretty resource
+intensive since they prefork. To change the number of ``gunicorn``
+and ``celery`` workers, consider setting this in your ``.env`` file::
+
+    CELERY_WORKERS=2
+    GUNICORN_WORKERS=3
+
+In that example, it will only start 2 ``celery`` workers and 3 ``gunicorn``
+workers just for your environment.
+
 .. _advanced_config_docker:
 
 Customizing the Docker environment


### PR DESCRIPTION
Here's how I test this:

```
▶ cat .env | rg _WORKERS
CELERY_WORKERS=2
GUNICORN_WORKERS=3
```

Then I see this output:

```
web_1            | [2019-04-23 20:25:18 +0000] [1] [INFO] Starting gunicorn 19.7.1
web_1            | [2019-04-23 20:25:18 +0000] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
web_1            | [2019-04-23 20:25:18 +0000] [1] [INFO] Using worker: meinheld.gmeinheld.MeinheldWorker
web_1            | [2019-04-23 20:25:18 +0000] [9] [INFO] Booting worker with pid: 9
web_1            | [2019-04-23 20:25:18 +0000] [10] [INFO] Booting worker with pid: 10
web_1            | [2019-04-23 20:25:18 +0000] [11] [INFO] Booting worker with pid: 11
```

Note, this means the same number of workers both for `web` and for `api`. 