### PR TITLE
bug 1467529 - django-decorator-include 1.4.1

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -83,9 +83,9 @@ django_csp==3.4 \
 # Code: https://github.com/twidi/django-decorator-include
 # Changes: https://github.com/twidi/django-decorator-include/blob/develop/CHANGELOG.rst#changelog
 # Docs: https://github.com/twidi/django-decorator-include#django-decorator-include
-django-decorator-include==1.3 \
-    --hash=sha256:2dcbbb028723f242f2280d7c475cce59b69db967722ed80ccc9dc7729ca2e802 \
-    --hash=sha256:fd172a88de1dd38e19ddb0d91525ab7240139a3b11687bf1ea2eb775549fd073
+django-decorator-include==1.4.1 \
+    --hash=sha256:5514ab61381613959b40321dc97daca3e0449b04b65dac8373534a030f1238fc \
+    --hash=sha256:715d00054bcbebd5f65575a7bd97d4823c1a459ed283a8c499f5a8b25cc75099
 
 # Add CreationDateTimeField, management commands
 # Code: https://github.com/django-extensions/django-extensions


### PR DESCRIPTION
tl;dr; this [won't get rid of the django2 upgrade warnings](https://bugzilla.mozilla.org/show_bug.cgi?id=1467529#c10) but it's never bad to do small upgrades incrementally. 