### PR TITLE
soft page transitions

### DIFF
--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -65,7 +65,7 @@ export default function DocumentProvider(
         const body = document.body;
         // This is the function that does client side navigation
         function navigate(url, localeAndSlug) {
-            body.style.opacity = '0.15';
+            document.querySelector('#page-layout').classList.add('opaque');
             fetch(`/api/v1/doc${localeAndSlug}`, { redirect: 'follow' })
                 .then(response => {
                     if (response.ok) {
@@ -99,7 +99,7 @@ export default function DocumentProvider(
                         }
                         window.scrollTo(0, 0);
                         setDocumentData(json);
-                        body.style.opacity = '1';
+                        document.querySelector('#page-layout').classList.remove('opaque');
                     }
                 })
                 .catch(() => {

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -295,7 +295,18 @@ export default function Page() {
     return (
         <>
             <Header />
-            <div css={styles.pageLayout}>
+            <style>{`
+                #page-layout {
+                    opacity: 1;
+                    transition: opacity .2s ease-in-out;
+                }
+                #page-layout.opaque {
+                    opacity: 0.0;
+                    transition: opacity .2s ease-in-out;
+                }
+                `}
+            </style>
+            <div css={styles.pageLayout} id="page-layout">
                 <Titlebar />
                 <TOC />
                 <Article />


### PR DESCRIPTION
Tease me all you like but this demonstrates, what I think, a nice upgrade to how we navigate between pages. 

What I disliked was that the whole top nav was fading from opacity:1 to opacity:0.1. And it felt a bit jarring that it isn't fading smoothly. 

I tried to make 3 videos to demonstrate. I use the network dev tools to slow down the api XHR fetches. 

Original:

![version0](https://user-images.githubusercontent.com/26739/56923574-de614280-6a98-11e9-8bc8-0a8cc027f0fa.gif)

Better:

![version2](https://user-images.githubusercontent.com/26739/56923620-05b80f80-6a99-11e9-8a0b-477917347924.gif)

Smoother (this PR):

![version3](https://user-images.githubusercontent.com/26739/56923649-18324900-6a99-11e9-8e6c-b2bb5bd6edaa.gif)


**THE CODE IS TERRIBLE.**

The idea was just to make a change and hope that @davidflanagan or @schalkneethling can do it correctly. I just forced in some CSS into the DOM and I bet there are more correct ways to do it. 

**Most importantly, do you like it enough to make it worth tidying up?**