### PR TITLE
use .env in CI

### DIFF
--- a/.env.travis
+++ b/.env.travis
@@ -1,7 +1,5 @@
-from .testing import *  # noqa
-
-ES_LIVE_INDEX = False
-ES_DEFAULT_NUM_REPLICAS = 0
+ES_LIVE_INDEX=False
+ES_DEFAULT_NUM_REPLICAS=0
 # See the following URL on why we set num_shards to 1 for tests:
 # http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/relevance-is-broken.html
-ES_DEFAULT_NUM_SHARDS = 1
+ES_DEFAULT_NUM_SHARDS=1

--- a/.env.travis
+++ b/.env.travis
@@ -2,6 +2,10 @@
 # If there's anything special that should only be set in Travis, this
 # is the file to update.
 
+# Always safe thing to do
+PYTHONUNBUFFERED=1
+PYTHONDONTWRITEBYTECODE=1
+
 ES_LIVE_INDEX=False
 ES_DEFAULT_NUM_REPLICAS=0
 # See the following URL on why we set num_shards to 1 for tests:

--- a/.env.travis
+++ b/.env.travis
@@ -1,3 +1,7 @@
+# This file is exclusive for use inside TravisCI
+# If there's anything special that should only be set in Travis, this
+# is the file to update.
+
 ES_LIVE_INDEX=False
 ES_DEFAULT_NUM_REPLICAS=0
 # See the following URL on why we set num_shards to 1 for tests:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 env:
     global:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma
-        - DJANGO_SETTINGS_MODULE=kuma.settings
+        - DJANGO_SETTINGS_MODULE=kuma.settings.testing
         - DOCKER_COMPOSE_VERSION=1.23.2
         - ES_VERSION=6.7.1
         - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.1.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,39 +35,39 @@ matrix:
             CREATE_DB=kuma
             INSTALL_ELASTICSEARCH=1
             INSTALL_NPM_TOOLS=1
-        - python: "2.7"
-          env:
-            TOXENV=flake8
-        - python: "2.7"
-          env:
-            TOXENV=docs
-        - python: "2.7"
-          env:
-            TOXENV=locales
-            CREATE_DB=kuma
-            INSTALL_NPM_TOOLS=1
-        - python: "2.7"
-          env:
-            TOXENV=docker
-            INSTALL_DOCKER_COMPOSE=1
-            UID=0
-        - python: "2.7"
-          env:
-            TOXENV=assetlint
-            INSTALL_NPM_TOOLS=1
-        - python: "3.6"
-          env:
-            TOXENV=pytest3
-            CREATE_DB=kuma
-            INSTALL_ELASTICSEARCH=1
-            INSTALL_NPM_TOOLS=1
-    allow_failures:
-        - python: "3.6"
-          env:
-            TOXENV=pytest3
-            CREATE_DB=kuma
-            INSTALL_ELASTICSEARCH=1
-            INSTALL_NPM_TOOLS=1
+    #     - python: "2.7"
+    #       env:
+    #         TOXENV=flake8
+    #     - python: "2.7"
+    #       env:
+    #         TOXENV=docs
+    #     - python: "2.7"
+    #       env:
+    #         TOXENV=locales
+    #         CREATE_DB=kuma
+    #         INSTALL_NPM_TOOLS=1
+    #     - python: "2.7"
+    #       env:
+    #         TOXENV=docker
+    #         INSTALL_DOCKER_COMPOSE=1
+    #         UID=0
+    #     - python: "2.7"
+    #       env:
+    #         TOXENV=assetlint
+    #         INSTALL_NPM_TOOLS=1
+    #     - python: "3.6"
+    #       env:
+    #         TOXENV=pytest3
+    #         CREATE_DB=kuma
+    #         INSTALL_ELASTICSEARCH=1
+    #         INSTALL_NPM_TOOLS=1
+    # allow_failures:
+    #     - python: "3.6"
+    #       env:
+    #         TOXENV=pytest3
+    #         CREATE_DB=kuma
+    #         INSTALL_ELASTICSEARCH=1
+    #         INSTALL_NPM_TOOLS=1
 install:
     - nvm install 10
     - nvm use 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ services:
 env:
     global:
         - DATABASE_URL=mysql://root:@127.0.0.1:3306/kuma
-        - DJANGO_SETTINGS_MODULE=kuma.settings.travis
+        - DJANGO_SETTINGS_MODULE=kuma.settings
         - DOCKER_COMPOSE_VERSION=1.23.2
         - ES_VERSION=6.7.1
         - ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.1.tar.gz
@@ -77,7 +77,8 @@ install:
     # Wait for ElasticSearch to be ready
     - if [[ "$INSTALL_ELASTICSEARCH" == "1" ]]; then wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200; fi;
 script:
-    - tox -v
+    # - tox -v
+    - tox -e pytest  # TEMPORARY
 after_failure:
     - dmesg | tail
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,6 @@ webpack:
 compilejsi18n:
 	@ echo "## Generating JavaScript translation catalogs ##"
 	@ mkdir -p build/locale
-	@ echo "What's up with DJANGO_SETTINGS_MODULE??????"
-	@ echo "${DJANGO_SETTINGS_MODULE}"
 	@ python manage.py compilejsi18n
 
 compile-react-i18n:

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ compilejsi18n:
 	@ echo "## Generating JavaScript translation catalogs ##"
 	@ mkdir -p build/locale
 	@ echo "What's up with DJANGO_SETTINGS_MODULE??????"
-	@ echo "$DJANGO_SETTINGS_MODULE"
+	@ echo "${DJANGO_SETTINGS_MODULE}"
 	@ python manage.py compilejsi18n
 
 compile-react-i18n:

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ webpack:
 compilejsi18n:
 	@ echo "## Generating JavaScript translation catalogs ##"
 	@ mkdir -p build/locale
+	@ echo "What's up with DJANGO_SETTINGS_MODULE??????"
+	@ echo "$DJANGO_SETTINGS_MODULE"
 	@ python manage.py compilejsi18n
 
 compile-react-i18n:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,34 +14,33 @@ services:
     environment:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
-      - ALLOW_ALL_IFRAMES=${ALLOW_ALL_IFRAMES:-False}
+      # - ALLOW_ALL_IFRAMES=${ALLOW_ALL_IFRAMES:-False}
       - ALLOWED_HOSTS=*
       - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
+      # - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
+      # - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - BROKER_URL=redis://redis:6379/0
-      - CELERY_ALWAYS_EAGER=False
+      # - CELERY_ALWAYS_EAGER=False
       - CELERY_RESULT_BACKEND=redis://redis:6379/1
       - CSRF_COOKIE_SECURE=False
       - DATABASE_URL=mysql://${DATABASE_USER:-root}:${DATABASE_PASSWORD:-kuma}@mysql:3306/developer_mozilla_org
-      - DEBUG=${DEBUG:-True}
-      - DOMAIN=${DOMAIN:-localhost}
+      # - DEBUG=${DEBUG:-True}
+      # - DOMAIN=${DOMAIN:-localhost}
       - ENABLE_RESTRICTIONS_BY_HOST=${ENABLE_RESTRICTIONS_BY_HOST:-False}
       - ES_URLS=elasticsearch:9200
-      - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
+      # - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}
       - REDIS_CACHE_SERVER=redis://redis:6379/3
       - PROTOCOL=http://
       - SESSION_COOKIE_SECURE=False
-      - SITE_URL=${SITE_URL:-http://localhost:8000}
-      - STATIC_URL=${STATIC_URL:-http://localhost:8000/static/}
+      # - SITE_URL=${SITE_URL:-http://localhost:8000}
+      # - STATIC_URL=${STATIC_URL:-http://localhost:8000/static/}
       - WAFFLE_COOKIE_SECURE=False
       # Other environment overrides
       - PYTHONDONTWRITEBYTECODE=1
       - PYTHONUNBUFFERED=True
-      - PYTHONWARNINGS=${PYTHONWARNINGS:-default}
-      - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
-      - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
+      # - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
+      # - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
       # For the server side rendering server and the code that connects to it.
       - SSR_PORT=8000
       - SSR_URL=http://ssr:8000/ssr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,15 @@ services:
       - elasticsearch
       - redis
       - kumascript
+    env_file:
+      - .env
     environment:
       # Django settings overrides:
       - ACCOUNT_DEFAULT_HTTP_PROTOCOL=http
       # - ALLOW_ALL_IFRAMES=${ALLOW_ALL_IFRAMES:-False}
       - ALLOWED_HOSTS=*
-      - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
+      # - ATTACHMENT_HOST=${ATTACHMENT_HOST:-localhost:8000}
+      - ATTACHMENT_HOST=localhost:8000
       # - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
       # - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
       - BROKER_URL=redis://redis:6379/0
@@ -26,7 +29,7 @@ services:
       - DATABASE_URL=mysql://${DATABASE_USER:-root}:${DATABASE_PASSWORD:-kuma}@mysql:3306/developer_mozilla_org
       # - DEBUG=${DEBUG:-True}
       # - DOMAIN=${DOMAIN:-localhost}
-      - ENABLE_RESTRICTIONS_BY_HOST=${ENABLE_RESTRICTIONS_BY_HOST:-False}
+      - ENABLE_RESTRICTIONS_BY_HOST=False
       - ES_URLS=elasticsearch:9200
       # - INTERACTIVE_EXAMPLES_BASE=${INTERACTIVE_EXAMPLES_BASE:-https://interactive-examples.mdn.mozilla.net}
       - KUMASCRIPT_URL_TEMPLATE=http://kumascript:9080/docs/{path}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -440,9 +440,6 @@ SECRET_KEY = config('SECRET_KEY',
                     default='#%tc(zja8j01!r#h_y)=hy!^k)9az74k+-ib&ij&+**s3-e^_z')
 
 
-print("SECRET_KEY SET TO:", SECRET_KEY)#TEMPORARY
-
-
 _CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
     'django.template.context_processors.debug',

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -440,6 +440,9 @@ SECRET_KEY = config('SECRET_KEY',
                     default='#%tc(zja8j01!r#h_y)=hy!^k)9az74k+-ib&ij&+**s3-e^_z')
 
 
+print("SECRET_KEY SET TO:", SECRET_KEY)#TEMPORARY
+
+
 _CONTEXT_PROCESSORS = (
     'django.contrib.auth.context_processors.auth',
     'django.template.context_processors.debug',

--- a/scripts/travis-install
+++ b/scripts/travis-install
@@ -53,3 +53,6 @@ then
     chmod +x $DOCKER_COMPOSE_FILE
     sudo cp $DOCKER_COMPOSE_FILE /usr/local/bin/docker-compose
 fi
+
+# Make the .env.travis file available
+cp .env.travis .env

--- a/tox.ini
+++ b/tox.ini
@@ -8,8 +8,7 @@ deps =
     -rrequirements/dev.txt
 commands =
     make localecompile build-static clean
-    ; pytest --cov=kuma kuma
-    pytest --cov=kuma kuma -x  ; TEMPORARY
+    pytest --cov=kuma kuma -x
     codecov -e TOXENV
 passenv =
     DATABASE_URL

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,8 @@ deps =
     -rrequirements/dev.txt
 commands =
     make localecompile build-static clean
-    pytest --cov=kuma kuma
+    ; pytest --cov=kuma kuma
+    pytest --cov=kuma kuma -x  ; TEMPORARY
     codecov -e TOXENV
 passenv =
     DATABASE_URL


### PR DESCRIPTION
Work in progress to reduce the environment variables in `docker-compose.yml` to an absolute minimum. Everything should either be defaults in `settings/common.py` or personal overrides in `.env`.