### PR TITLE
bug 1548130 - index faster

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -216,6 +216,7 @@ def get_seo_description(content, locale=None, strip_markup=True):
     if content:
         # Try constraining the search for summary to an explicit "Summary"
         # section, if any.
+        # This line is ~20x times slower than doing the PyQuery analysis.
         summary_section = (parse(content).extractSection('Summary')
                            .serialize())
         if summary_section:

--- a/kuma/wiki/search.py
+++ b/kuma/wiki/search.py
@@ -80,7 +80,7 @@ class WikiDocumentType(document.Document):
             'locale': obj.locale,
             'modified': obj.modified,
             'content': strip_tags(obj.rendered_html or ''),
-            'tags': list(obj.tags.names()),
+            'tags': [o.name for o in obj.tags.all()],
             'kumascript_macros': cls.case_insensitive_keywords(
                 obj.extract.macro_names()),
             'css_classnames': cls.case_insensitive_keywords(

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -401,7 +401,7 @@ def index_documents(ids, index_pk, reraise=False):
 
     objects = Document.objects.filter(id__in=ids)
     documents = []
-    for obj in objects:
+    for obj in objects.select_related('parent').prefetch_related('tags'):
         try:
             documents.append(cls.from_django(obj))
         except Exception:


### PR DESCRIPTION
The sad truth is that when doing this change locally, it doesn't actually make a huge difference. 
Instead of incurring 1-2 SQL queries per document, it's now 0 SQL queries (warmed up by the prefetch_related). 

The real heavy cost lies in the lines `obj.get_summary_text()` and `obj.extract.macro_names()`.