### PR TITLE
bug 1544482: reduce indexing default chunk size

### DIFF
--- a/kuma/search/management/commands/reindex.py
+++ b/kuma/search/management/commands/reindex.py
@@ -11,11 +11,11 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument(
             '-c', '--chunk',
-            help='Chunk size when reindexing (default 1000). Lower is better'
+            help='Chunk size when reindexing (default 250). Lower is better'
                  'for slow computers with little memory',
             type=int,
             dest='chunk_size',
-            default=1000)
+            default=250)
         parser.add_argument(
             '-p', '--percent',
             help='the percentage of the db to index (1 to 100) (default 100)',

--- a/kuma/search/models.py
+++ b/kuma/search/models.py
@@ -66,7 +66,7 @@ class Index(models.Model):
         return '%s-%s' % (settings.ES_INDEX_PREFIX, self.name)
 
     def populate(self):
-        return WikiDocumentType.reindex_all(index=self, chunk_size=500)
+        return WikiDocumentType.reindex_all(index=self, chunk_size=250)
 
     def record_outdated(self, instance):
         if self.successor:


### PR DESCRIPTION
This PR reduces the default chunk size used when indexing for search, as well as makes it consistent whether indexing via the Django Admin console or via the `./manage.py reindex` management command. The default was 500 when using the Django Admin console, and 1000 when using the `./manage.py reindex` management command. Now, they are both 250.

The reason for this is that using a chunk size of 500 caused out-of-memory issues with the `celery-worker` pods on stage, even when the Kubernetes memory limit of the `celery-worker` pods was increased to match that of the pods on prod (`4Gi`).

A re-index on stage was successfully completed on stage with a chunk-size of 250.