### PR TITLE
fixes bug 1548082 - hide ES_URLS creds in admin display

### DIFF
--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-from six.moves.urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils import translation
+from six.moves.urllib.parse import urlparse
 
 from .i18n import get_language_mapping
 

--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from six.moves.urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils import translation
@@ -8,7 +9,28 @@ from .i18n import get_language_mapping
 
 def global_settings(request):
     """Adds settings to the context."""
-    return {'settings': settings}
+
+    def clean_safe_url(url):
+        if '://' not in url:
+            # E.g. 'elasticsearch:9200'
+            url = 'http://' + url
+        parsed = urlparse(url)
+        if '@' in parsed.netloc:
+            parsed = parsed._replace(
+                netloc='username:secret@' + parsed.netloc.split('@')[-1]
+            )
+        return parsed.geturl()
+
+    return {
+        'settings': settings,
+
+        # Because the 'settings.ES_URLS' might contain the username:password
+        # it's never appropriate to display in templates. So clean them up.
+        # But return it as a lambda so it only executes if really needed.
+        'safe_es_urls': lambda: [
+            clean_safe_url(x) for x in settings.ES_URLS
+        ]
+    }
 
 
 def i18n(request):

--- a/kuma/search/tests/test_views_admin.py
+++ b/kuma/search/tests/test_views_admin.py
@@ -1,0 +1,30 @@
+import pytest
+
+from kuma.core.urlresolvers import reverse
+
+
+@pytest.mark.django_db
+def test_view_indexes(client, settings, wiki_user):
+    """Test that looking at the list of Indexes doesn't reveal the
+    username:password from any 'settings.ES_URLS'.
+    """
+    wiki_user.is_staff = True
+    wiki_user.is_superuser = True
+    wiki_user.set_password('secret')
+    wiki_user.save()
+    client.login(username=wiki_user.username, password='secret')
+
+    settings.ES_URLS = [
+        'localhost:9200',
+        'https://uuuuser:passsw@remote.example.com:9200/prefix'
+    ]
+
+    url = reverse('admin:search_index_changelist')
+    response = client.get(url)
+    assert response.status_code == 200
+    assert settings.ES_URLS[0] in response.content
+    assert settings.ES_URLS[1] not in response.content
+    assert settings.ES_URLS[1].replace(
+        'uuuuser:passsw',
+        'username:secret'
+    ) in response.content

--- a/kuma/search/tests/test_views_admin.py
+++ b/kuma/search/tests/test_views_admin.py
@@ -4,23 +4,17 @@ from kuma.core.urlresolvers import reverse
 
 
 @pytest.mark.django_db
-def test_view_indexes(client, settings, wiki_user):
+def test_view_indexes(admin_client, settings):
     """Test that looking at the list of Indexes doesn't reveal the
     username:password from any 'settings.ES_URLS'.
     """
-    wiki_user.is_staff = True
-    wiki_user.is_superuser = True
-    wiki_user.set_password('secret')
-    wiki_user.save()
-    client.login(username=wiki_user.username, password='secret')
-
     settings.ES_URLS = [
         'localhost:9200',
         'https://uuuuser:passsw@remote.example.com:9200/prefix'
     ]
 
     url = reverse('admin:search_index_changelist')
-    response = client.get(url)
+    response = admin_client.get(url)
     assert response.status_code == 200
     assert settings.ES_URLS[0] in response.content
     assert settings.ES_URLS[1] not in response.content

--- a/templates/admin/search/index/change_list.html
+++ b/templates/admin/search/index/change_list.html
@@ -3,9 +3,11 @@
 
 {% block content_title %}
   {{ block.super }}
+
   {% if settings.ES_URLS %}
   <div class="g-d-c grp-rte">
-    <p>{% blocktrans with backend=settings.ES_URLS|join:", " %}Elasticsearch server: {{ backend }}{% endblocktrans %}</p>
+    {# 'safe_es_urls' comes from a context processors #}
+    <p>{% blocktrans with backend=safe_es_urls|join:", " %}Elasticsearch server: {{ backend }}{% endblocktrans %}</p>
   </div>
   {% endif %}
 {% endblock %}

--- a/templates/admin/search/index/change_list.html
+++ b/templates/admin/search/index/change_list.html
@@ -6,7 +6,7 @@
 
   {% if settings.ES_URLS %}
   <div class="g-d-c grp-rte">
-    {# 'safe_es_urls' comes from a context processors #}
+    {# 'safe_es_urls' comes from a context processor #}
     <p>{% blocktrans with backend=safe_es_urls|join:", " %}Elasticsearch server: {{ backend }}{% endblocktrans %}</p>
   </div>
   {% endif %}


### PR DESCRIPTION
Any URL in `settings.ES_URLS`, *with credentials in the URL*, get scrubbed before being displayed like `https://username:password@....` (where the '...' is the same as before). 