### PR TITLE
bug 1548380 - Invalidate CloudFront on publish

### DIFF
--- a/kuma/api/management/commands/publish.py
+++ b/kuma/api/management/commands/publish.py
@@ -38,11 +38,25 @@ class Command(BaseCommand):
             default=1000,
             help='Partition the work into tasks, with each task handling this '
                  'many documents (default=1000)')
+        parser.add_argument(
+            '--skip-cache-invaldation',
+            help=(
+                'No cache invalidation after publishing. By default True '
+                'if --all flag is used.'
+            ),
+            action='store_true')
 
     def handle(self, *args, **options):
+        skip_cache_invalidation = (
+            options['all'] or options['skip_cache_invalidation']
+        )
         Logger = namedtuple('Logger', 'info, error')
         log = Logger(info=self.stdout.write, error=self.stderr.write)
         if options['all'] or options['locale']:
+            if options['locale'] and options['all']:
+                raise CommandError(
+                    'Specifying --locale with --all is the same as --all'
+                )
             filters = {}
             if options['locale'] and not options['all']:
                 locale = options['locale']
@@ -62,7 +76,11 @@ class Command(BaseCommand):
             tasks = []
             for i, chunk in enumerate(chunked(doc_pks, chunk_size)):
                 message = 'Published chunk #{} of {}'.format(i + 1, num_tasks)
-                tasks.append(publish.si(chunk, completion_message=message))
+                tasks.append(publish.si(
+                    chunk,
+                    completion_message=message,
+                    skip_cache_invalidation=skip_cache_invalidation
+                ))
             if num_tasks == 1:
                 msg = ('Launching a single task handling '
                        'all {} documents.'.format(num_docs))
@@ -91,4 +109,8 @@ class Command(BaseCommand):
                     log.error(msg.format(locale, slug))
                 else:
                     doc_pks.append(doc_pk)
-            publish(doc_pks, log=log)
+            publish(
+                doc_pks,
+                log=log,
+                skip_cache_invalidation=skip_cache_invalidation
+            )

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -53,6 +53,12 @@ def get_s3_key(doc=None, locale=None, slug=None, for_redirect=False):
     return key.lstrip('/')
 
 
+def get_cdn_key(locale, slug):
+    """Given a document (or locale and slug), return the "key" as this
+    is called in the CDN."""
+    return '/' + get_s3_key(locale=locale, slug=slug)
+
+
 def get_content_based_redirect(document):
     """
     Returns None if the document is not a content-based redirect, otherwise a

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1911,7 +1911,7 @@ MDN_CLOUDFRONT_DISTRIBUTIONS = {
         'id': config('MDN_CLOUDFRONT_API_DISTRIBUTIONID', default=None),
         # TODO We should have a (Django) system check that checks that this
         # transform callable works. For example, it *has* to start with a '/'.
-        'transform': lambda locale, slug: '/api/v1/doc/' + locale + '/' + slug
+        'transform_function': 'kuma.api.v1.views.get_cdn_key'
     },
     # TODO We should have an entry here for the existing website.
     # At the time of writing we conservatively set the TTL to 5 min.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1524,6 +1524,9 @@ CELERY_ROUTES = {
     'kuma.api.tasks.unpublish': {
         'queue': 'mdn_api'
     },
+    'kuma.api.tasks.cdn_cache_invalidate': {
+        'queue': 'mdn_api'
+    },
 }
 
 # Wiki rebuild settings
@@ -1893,3 +1896,26 @@ SSR_TIMEOUT = float(config('SSR_TIMEOUT', default='1'))
 
 # Setting for configuring the AWS S3 bucket name used for the document API.
 MDN_API_S3_BUCKET_NAME = config('MDN_API_S3_BUCKET_NAME', default=None)
+
+# When we potentially have multiple CDN distributions that do different
+# things.
+# Inside kuma, when a document is considered "changed", we trigger
+# worker tasks that do things such as publishing/unpublishing to S3.
+# Quite agnostic from *how* that works, this list of distributions,
+# if they have an 'id', gets called for each (locale, slug) to
+# turn that into CloudFront "paths".
+# Note that the 'id' is optional because its ultimate value might
+# or not might not be in the environment.
+MDN_CLOUDFRONT_DISTRIBUTIONS = {
+    'api': {
+        'id': config('MDN_CLOUDFRONT_API_DISTRIBUTIONID', default=None),
+        # TODO We should have a (Django) system check that checks that this
+        # transform callable works. For example, it *has* to start with a '/'.
+        'transform': lambda locale, slug: '/api/v1/doc/' + locale + '/' + slug
+    },
+    # TODO We should have an entry here for the existing website.
+    # At the time of writing we conservatively set the TTL to 5 min.
+    # If this CloudFront invalidation really works, we can bump that 5 min
+    # to ~60min and put configuration here for it too.
+
+}

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -71,3 +71,7 @@ PIPELINE['COMPILERS'] = ('pipeline.compilers.sass.SASSCompiler',)
 # a 10x speedup on Docker on MacOS.
 WHITENOISE_AUTOREFRESH = True
 WHITENOISE_USE_FINDERS = True
+
+# This makes sure we our tests never actually use the real settings for
+# this.
+MDN_CLOUDFRONT_DISTRIBUTIONS = {}


### PR DESCRIPTION
Here's how I tested this locally...

I have my dev environment hooked up to my personal AWS S3 account. And the S3 bucket I've set up has a CloudFront distribution in front of it. Any edits to the wiki in my MySQL appears here, as an example: `curl -v https://d1jm0vr30jmdki.cloudfront.net/api/v1/doc/en-US/Learn/CSS`

So I wrote this script:

```python
import time
import datetime
import requests


def run(url):
    for _ in range(1000):
        r = requests.get(url)
        r.raise_for_status()
        print(datetime.datetime.now(), repr(r.json()['title']), r.headers.get('x-cache'), r.headers.get('cache-control'))
        time.sleep(3)

if __name__ == '__main__':
    import sys
    args = sys.argv[1:]
    url = args[0]
    run(url)
```

Started that in a terminal and went into my browser on `http://mdn.localhost:8000/en-US/docs/Web/CSS$edit` 
There, I edited the title and pressed "Publish". Then I went back to the terminal that keeps hitting the CDN and waited till its output changed. 

Hint: it did. and it was fast. :)