### PR TITLE
bug 1525719: reorganize doc API data

### DIFF
--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -86,29 +86,31 @@ def test_doc_api(client, api_settings, trans_doc, cleared_cacheback_cache,
     assert_no_cache_header(response)
 
     data = response.json()
-    assert data['locale'] == trans_doc.locale
-    assert data['slug'] == trans_doc.slug
-    assert data['id'] == trans_doc.id
-    assert data['title'] == trans_doc.title
-    assert data['language'] == trans_doc.language
-    assert data['absoluteURL'] == trans_doc.get_absolute_url()
+    assert data['documentData']
     assert data['redirectURL'] is None
-    assert data['editURL'] == absolutify(trans_doc.get_edit_url(),
-                                         for_wiki_site=True)
-    assert data['bodyHTML'] == trans_doc.get_body_html()
-    assert data['quickLinksHTML'] == trans_doc.get_quick_links_html()
-    assert data['tocHTML'] == trans_doc.get_toc_html()
-    assert data['translations'] == [{
+    doc_data = data['documentData']
+    assert doc_data['locale'] == trans_doc.locale
+    assert doc_data['slug'] == trans_doc.slug
+    assert doc_data['id'] == trans_doc.id
+    assert doc_data['title'] == trans_doc.title
+    assert doc_data['language'] == trans_doc.language
+    assert doc_data['absoluteURL'] == trans_doc.get_absolute_url()
+    assert doc_data['editURL'] == absolutify(trans_doc.get_edit_url(),
+                                             for_wiki_site=True)
+    assert doc_data['bodyHTML'] == trans_doc.get_body_html()
+    assert doc_data['quickLinksHTML'] == trans_doc.get_quick_links_html()
+    assert doc_data['tocHTML'] == trans_doc.get_toc_html()
+    assert doc_data['translations'] == [{
         'locale': 'en-US',
         'language': 'English (US)',
         'localizedLanguage': u'Anglais am\u00e9ricain',
         'title': 'Root Document',
         'url': '/en-US/docs/Root'
     }]
-    assert data['contributors'] == (
+    assert doc_data['contributors'] == (
         ['wiki_user'] if ensure_contributors else [])
-    assert data['lastModified'] == '2017-04-14T12:20:00'
-    assert data['lastModifiedBy'] == 'wiki_user'
+    assert doc_data['lastModified'] == '2017-04-14T12:20:00'
+    assert doc_data['lastModifiedBy'] == 'wiki_user'
 
     # Clear the cache for a clean slate when calling document_api_data().
     DocumentContributorsJob().delete(trans_doc.pk)
@@ -138,23 +140,25 @@ def test_doc_api_for_redirect_to_doc(client, api_settings, root_doc,
     assert_no_cache_header(response)
 
     data = response.json()
-    assert data['locale'] == root_doc.locale
-    assert data['slug'] == root_doc.slug
-    assert data['id'] == root_doc.id
-    assert data['title'] == root_doc.title
-    assert data['language'] == root_doc.language
-    assert data['absoluteURL'] == root_doc.get_absolute_url()
+    assert data['documentData']
     assert data['redirectURL'] is None
-    assert data['editURL'] == absolutify(root_doc.get_edit_url(),
-                                         for_wiki_site=True)
-    assert data['bodyHTML'] == root_doc.get_body_html()
-    assert data['quickLinksHTML'] == root_doc.get_quick_links_html()
-    assert data['tocHTML'] == root_doc.get_toc_html()
-    assert data['translations'] == []
-    assert data['contributors'] == (
+    doc_data = data['documentData']
+    assert doc_data['locale'] == root_doc.locale
+    assert doc_data['slug'] == root_doc.slug
+    assert doc_data['id'] == root_doc.id
+    assert doc_data['title'] == root_doc.title
+    assert doc_data['language'] == root_doc.language
+    assert doc_data['absoluteURL'] == root_doc.get_absolute_url()
+    assert doc_data['editURL'] == absolutify(root_doc.get_edit_url(),
+                                             for_wiki_site=True)
+    assert doc_data['bodyHTML'] == root_doc.get_body_html()
+    assert doc_data['quickLinksHTML'] == root_doc.get_quick_links_html()
+    assert doc_data['tocHTML'] == root_doc.get_toc_html()
+    assert doc_data['translations'] == []
+    assert doc_data['contributors'] == (
         ['wiki_user'] if ensure_contributors else [])
-    assert data['lastModified'] == '2017-04-14T12:15:00'
-    assert data['lastModifiedBy'] == 'wiki_user'
+    assert doc_data['lastModified'] == '2017-04-14T12:15:00'
+    assert doc_data['lastModifiedBy'] == 'wiki_user'
 
     # Clear the cache for a clean slate when calling document_api_data().
     DocumentContributorsJob().delete(root_doc.pk)
@@ -185,21 +189,8 @@ def test_doc_api_for_redirect_to_non_doc(client, api_settings, redirect_to_home,
     assert_no_cache_header(response)
 
     data = response.json()
-    assert data['locale'] is None
-    assert data['slug'] is None
-    assert data['id'] is None
-    assert data['title'] is None
-    assert data['language'] is None
-    assert data['absoluteURL'] is None
+    assert data['documentData'] is None
     assert data['redirectURL'] == expected_redirect_url
-    assert data['editURL'] is None
-    assert data['bodyHTML'] is None
-    assert data['quickLinksHTML'] is None
-    assert data['tocHTML'] is None
-    assert data['translations'] is None
-    assert data['contributors'] is None
-    assert data['lastModified'] is None
-    assert data['lastModifiedBy'] is None
 
     # Also ensure that we get exactly the same data by calling
     # the document_api_data() function directly

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -86,50 +86,55 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
     """
     Returns the JSON data for the document for the document API.
     """
-    if doc:
-        job = DocumentContributorsJob()
-        # If "ensure_contributors" is True, we need the contributors since the
-        # result will likely be cached, so we'll set "fetch_on_miss" and wait
-        # for the result if it's not already available or stale.
-        job.fetch_on_miss = ensure_contributors
-        contributors = [c['username'] for c in job.get(doc.pk)]
-    else:
-        contributors = None
+    if redirect_url:
+        return {
+            'documentData': None,
+            'redirectURL': redirect_url,
+        }
+
+    job = DocumentContributorsJob()
+    # If "ensure_contributors" is True, we need the contributors since the
+    # result will likely be cached, so we'll set "fetch_on_miss" and wait
+    # for the result if it's not already available or stale.
+    job.fetch_on_miss = ensure_contributors
+    contributors = [c['username'] for c in job.get(doc.pk)]
 
     return {
-        'locale': doc and doc.locale,
-        'slug': doc and doc.slug,
-        'id': doc and doc.id,
-        'title': doc and doc.title,
-        'summary': doc and doc.get_summary_html(),
-        'language': doc and doc.language,
-        'absoluteURL': doc and doc.get_absolute_url(),
-        'redirectURL': redirect_url,
-        'editURL': doc and absolutify(doc.get_edit_url(), for_wiki_site=True),
-        'bodyHTML': doc and doc.get_body_html(),
-        'quickLinksHTML': doc and doc.get_quick_links_html(),
-        'tocHTML': doc and doc.get_toc_html(),
-        'parents': doc and [
-            {
-                'url': d.get_absolute_url(),
-                'title': d.title
-            } for d in doc.parents
-        ],
-        'translations': doc and [
-            {
-                'language': t.language,
-                'localizedLanguage': _(settings.LOCALES[t.locale].english),
-                'locale': t.locale,
-                'url': t.get_absolute_url(),
-                'title': t.title
-            } for t in doc.get_other_translations(
-                fields=('locale', 'slug', 'title'))
-        ],
-        'contributors': contributors,
-        'lastModified': (doc and doc.current_revision and
-                         doc.current_revision.created.isoformat()),
-        'lastModifiedBy': (doc and doc.current_revision and
-                           str(doc.current_revision.creator))
+        'documentData': {
+            'locale': doc.locale,
+            'slug': doc.slug,
+            'id': doc.id,
+            'title': doc.title,
+            'summary': doc.get_summary_html(),
+            'language': doc.language,
+            'absoluteURL': doc.get_absolute_url(),
+            'editURL': absolutify(doc.get_edit_url(), for_wiki_site=True),
+            'bodyHTML': doc.get_body_html(),
+            'quickLinksHTML': doc.get_quick_links_html(),
+            'tocHTML': doc.get_toc_html(),
+            'parents': [
+                {
+                    'url': d.get_absolute_url(),
+                    'title': d.title
+                } for d in doc.parents
+            ],
+            'translations': [
+                {
+                    'language': t.language,
+                    'localizedLanguage': _(settings.LOCALES[t.locale].english),
+                    'locale': t.locale,
+                    'url': t.get_absolute_url(),
+                    'title': t.title
+                } for t in doc.get_other_translations(
+                    fields=('locale', 'slug', 'title'))
+            ],
+            'contributors': contributors,
+            'lastModified': (doc.current_revision and
+                             doc.current_revision.created.isoformat()),
+            'lastModifiedBy': (doc.current_revision and
+                               str(doc.current_revision.creator))
+        },
+        'redirectURL': None,
     }
 
 

--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -9,7 +9,6 @@ export type DocumentData = {
     title: string,
     summary: string,
     absoluteURL: string,
-    redirectURL: string,
     editURL: string,
     bodyHTML: string,
     quickLinksHTML: string,
@@ -87,12 +86,12 @@ export default function DocumentProvider(
                         // full page load of that document.
                         window.location = json.redirectURL;
                     } else {
-                        let receivedLocaleAndSlug = `/${json.locale}/${
-                            json.slug
-                        }`;
+                        let documentData = json.documentData;
+                        const { locale, slug, absoluteURL } = documentData;
+                        let receivedLocaleAndSlug = `/${locale}/${slug}`;
                         if (receivedLocaleAndSlug !== localeAndSlug) {
                             // This was a redirect.
-                            let receivedURL = json.absoluteURL;
+                            const receivedURL = absoluteURL;
                             history.replaceState(
                                 { receivedURL, receivedLocaleAndSlug },
                                 '',
@@ -100,14 +99,15 @@ export default function DocumentProvider(
                             );
                         }
 
-                        // If the returned JSON does not include requestLocale
-                        // then add it based on the request we just made.
-                        if (!json.requestLocale) {
-                            json.requestLocale = localeAndSlug.split('/')[1];
-                        }
+                        // The returned JSON never includes the "requestLocale"
+                        // (it is only included in the "initialDocumentData"),
+                        // so insert it into the "documentData" here.
+                        documentData.requestLocale = localeAndSlug.split(
+                            '/'
+                        )[1];
 
                         window.scrollTo(0, 0);
-                        setDocumentData(json);
+                        setDocumentData(documentData);
                         body.style.opacity = '1';
                     }
                 })

--- a/kuma/javascript/src/document-provider.test.js
+++ b/kuma/javascript/src/document-provider.test.js
@@ -12,7 +12,6 @@ export const fakeDocumentData = {
     title: '[fake document title]',
     summary: '[fake document summary]',
     absoluteURL: '[fake absolute url]',
-    redirectURL: '',
     editURL: '[fake edit url]',
     bodyHTML: '[fake body HTML]',
     quickLinksHTML: '[fake quicklinks HTML]',

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -67,20 +67,17 @@ export default function Login(): React.Node {
     if (!documentData) {
         return null;
     }
-    const { editURL, requestLocale } = documentData;
+    const { absoluteURL, editURL, requestLocale } = documentData;
     const userData = useContext(UserProvider.context);
 
-    const PATHNAME = documentData.absoluteURL;
+    const PATHNAME = absoluteURL;
 
     // This is available as window.mdn.wikiSiteUrl. But we can't access
     // that during server-side rendering, so we either need to add that mdn
     // data to the document data, or we need to derive it from existing
     // document data somehow
     // TODO: pass this URL in some more reasonable way
-    const WIKI_SITE_URL = documentData.editURL.substring(
-        0,
-        documentData.editURL.indexOf(documentData.absoluteURL)
-    );
+    const WIKI_SITE_URL = editURL.substring(0, editURL.indexOf(absoluteURL));
 
     // if we don't have the user data yet, don't render anything
     if (!userData) {

--- a/kuma/javascript/src/header/search.jsx
+++ b/kuma/javascript/src/header/search.jsx
@@ -43,17 +43,14 @@ export default function Search() {
     if (!documentData) {
         return null;
     }
-    const { requestLocale } = documentData;
+    const { absoluteURL, editURL, requestLocale } = documentData;
 
     // This is available as window.mdn.wikiSiteUrl. But we can't access
     // that during server-side rendering, so we either need to add that mdn
     // data to the document data, or we need to derive it from existing
     // document data somehow
     // TODO: pass this URL in some more reasonable way
-    const WIKI_SITE_URL = documentData.editURL.substring(
-        0,
-        documentData.editURL.indexOf(documentData.absoluteURL)
-    );
+    const WIKI_SITE_URL = editURL.substring(0, editURL.indexOf(absoluteURL));
 
     return (
         <form

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -93,7 +93,7 @@
 
   {#{% include "includes/a11y-nav.html" %}#}
 
-  {{ render_react_app(document_api_data)|safe }}
+  {{ render_react_app(document_data)|safe }}
 
   {% if settings.NEWSLETTER and settings.NEWSLETTER_ARTICLE %}
   <div class="center">

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -873,25 +873,16 @@ def react_document(request, document_slug, document_locale):
                    set(trans.locale for trans in other_translations))
 
     # Get the JSON data for this document
-    document_data = document_api_data(doc, ensure_contributors=True)
+    doc_api_data = document_api_data(doc, ensure_contributors=True)
+    document_data = doc_api_data['documentData']
 
     # And add another property to specify the requested locale
     # (which may not be the same as the locale of the document)
-    #
-    # TODO(djf):
-    # As Peter points out, it isn't really right to mix request
-    # variables with document variables like this. Also, Ryan and I
-    # have discussed handlig redirects with a different datastructure
-    # than the document data, so I suggest that we change the dict
-    # returned by document_api_data to look like this:
-    #   { 'documentData': dict or None, 'redirectURL': string or None }
-    # and then we can add requestLocale to that dict without mixing
-    # up the two kinds of data.
     document_data['requestLocale'] = document_locale
 
     # Bundle it all up and, finally, return.
     context = {
-        'document_api_data': document_data,
+        'document_data': document_data,
 
         # TODO: anything we're actually using in the template ought
         # to be bundled up into the json object above instead.


### PR DESCRIPTION
This PR re-organizes the document API JSON structure according to https://github.com/mozilla/kuma/pull/5371#discussion_r280120646. @davidflanagan, I think I've updated all of the appropriate places in the React files. I noticed that `docker-compose exec web npm run test` doesn't pass, but it doesn't seem to be related to my changes since the same failures occur when I run it with `master`.