### PR TITLE
bug 1525719: wiki and beta domains (part 2)

### DIFF
--- a/kuma/core/decorators.py
+++ b/kuma/core/decorators.py
@@ -17,6 +17,9 @@ from .urlresolvers import reverse
 from .utils import add_shared_cache_control
 
 
+HOUR = 60 * 60
+
+
 def shared_cache_control(func=None, **kwargs):
     """
     Decorator to set Cache-Control header for shared caches like CDNs.
@@ -42,6 +45,9 @@ def shared_cache_control(func=None, **kwargs):
     if func:
         return _shared_cache_controller(func)
     return _shared_cache_controller
+
+
+beta_shared_cache_control = shared_cache_control(s_maxage=HOUR)
 
 
 def user_access_decorator(redirect_func, redirect_url_func, deny_func=None,

--- a/kuma/landing/urls.py
+++ b/kuma/landing/urls.py
@@ -7,6 +7,9 @@ from kuma.core.decorators import shared_cache_control
 from . import views
 
 
+MONTH = 60 * 60 * 24 * 30
+
+
 lang_urlpatterns = [
     url(r'^$',
         views.home,
@@ -24,12 +27,12 @@ lang_urlpatterns = [
 
 urlpatterns = [
     url(r'^contribute\.json$',
-        views.contribute_json,
+        shared_cache_control(views.contribute_json),
         name='contribute_json'),
     url(r'^robots.txt$',
-        views.robots_txt,
+        shared_cache_control(views.robots_txt),
         name='robots_txt'),
     url(r'^favicon.ico$',
-        shared_cache_control(views.FaviconRedirect.as_view()),
+        shared_cache_control(views.FaviconRedirect.as_view(), s_maxage=MONTH),
         name='favicon_ico'),
 ]

--- a/kuma/landing/urls_beta.py
+++ b/kuma/landing/urls_beta.py
@@ -2,25 +2,26 @@ from __future__ import unicode_literals
 
 from django.conf.urls import url
 
-from kuma.core.decorators import shared_cache_control
+from kuma.core.decorators import beta_shared_cache_control, shared_cache_control
 
 from . import views
 
 
+MONTH = 60 * 60 * 24 * 30
+
+
 lang_urlpatterns = [
-    url(r'^$',
-        views.react_home,
-        name='home'),
+    url(r'^$', views.react_home, name='home'),
 ]
 
 urlpatterns = [
     url(r'^contribute\.json$',
-        views.contribute_json,
+        beta_shared_cache_control(views.contribute_json),
         name='contribute_json'),
     url(r'^robots.txt$',
-        views.robots_txt,
+        beta_shared_cache_control(views.robots_txt),
         name='robots_txt'),
     url(r'^favicon.ico$',
-        shared_cache_control(views.FaviconRedirect.as_view()),
+        shared_cache_control(views.FaviconRedirect.as_view(), s_maxage=MONTH),
         name='favicon_ico'),
 ]

--- a/kuma/landing/views.py
+++ b/kuma/landing/views.py
@@ -7,7 +7,7 @@ from django.views import static
 from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 
-from kuma.core.decorators import shared_cache_control
+from kuma.core.decorators import beta_shared_cache_control, shared_cache_control
 from kuma.feeder.models import Bundle
 from kuma.feeder.sections import SECTION_HACKS
 from kuma.search.models import Filter
@@ -15,7 +15,6 @@ from kuma.search.models import Filter
 from .utils import favicon_url
 
 
-@shared_cache_control
 def contribute_json(request):
     return static.serve(request, 'contribute.json',
                         document_root=settings.ROOT)
@@ -27,7 +26,7 @@ def home(request):
     return render_home(request, 'landing/homepage.html')
 
 
-@shared_cache_control
+@beta_shared_cache_control
 def react_home(request):
     """React-based home page."""
     return render_home(request, 'landing/react_homepage.html')
@@ -118,7 +117,6 @@ Disallow: /
 '''
 
 
-@shared_cache_control
 def robots_txt(request):
     """Serve robots.txt that allows or forbids robots."""
     host = request.get_host()

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1334,6 +1334,7 @@ CSP_DEFAULT_SRC = ("'none'",)
 CSP_CONNECT_SRC = [
     SITE_URL,
     BETA_SITE_URL,
+    WIKI_SITE_URL,
 ]
 CSP_FONT_SRC = [
     SITE_URL,
@@ -1349,7 +1350,8 @@ CSP_IMG_SRC = [
     PROTOCOL + "i2.wp.com",
     "https://secure.gravatar.com",
     "https://www.google-analytics.com",
-    _PROD_ATTACHMENT_SITE_URL
+    _PROD_ATTACHMENT_SITE_URL,
+    WIKI_SITE_URL,
 ]
 if ATTACHMENT_SITE_URL not in (_PROD_ATTACHMENT_SITE_URL, SITE_URL):
     CSP_IMG_SRC.append(ATTACHMENT_SITE_URL)
@@ -1360,11 +1362,13 @@ CSP_SCRIPT_SRC = [
     "static.codepen.io",
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
+    WIKI_SITE_URL,
 ]
 CSP_STYLE_SRC = [
     SITE_URL,
     # TODO fix things so that we don't need this
     "'unsafe-inline'",
+    WIKI_SITE_URL,
 ]
 CSP_REPORT_ONLY = config('CSP_REPORT_ONLY', default=False, cast=bool)
 CSP_REPORT_ENABLE = config('CSP_REPORT_ENABLE', default=False, cast=bool)

--- a/kuma/urls.py
+++ b/kuma/urls.py
@@ -5,10 +5,10 @@ from django.contrib import admin
 from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views.decorators.cache import never_cache
-from django.views.decorators.http import require_safe
 from django.views.generic import RedirectView
 from django.views.static import serve
 
+import kuma.views
 from kuma.attachments import views as attachment_views
 from kuma.core import views as core_views
 from kuma.core.decorators import shared_cache_control
@@ -29,15 +29,7 @@ from kuma.wiki.views.document import as_json as document_as_json
 from kuma.wiki.views.legacy import mindtouch_to_kuma_redirect
 
 
-@shared_cache_control
-@require_safe
-def serve_from_media_root(request, path):
-    """
-    A convenience function which also makes it easy to override the
-    settings within tests.
-    """
-    return serve(request, path, document_root=settings.MEDIA_ROOT)
-
+serve_from_media_root = shared_cache_control(kuma.views.serve_from_media_root)
 
 admin.autodiscover()
 
@@ -132,7 +124,7 @@ urlpatterns += [
     # Services and sundry.
     url('', include('kuma.version.urls')),
 
-    # Serve sitemap files for AWS (these are never hit in SCL3).
+    # Serve sitemap files.
     url(r'^sitemap.xml$',
         serve_from_media_root,
         {'path': 'sitemap.xml'},

--- a/kuma/urls_beta.py
+++ b/kuma/urls_beta.py
@@ -1,16 +1,30 @@
 from django.conf import settings
 from django.conf.urls import include, url
+from django.views.static import serve
+from django.views.generic import RedirectView
 
 from kuma.core import views as core_views
+from kuma.core.decorators import beta_shared_cache_control, shared_cache_control
 from kuma.core.urlresolvers import i18n_patterns
 from kuma.landing.urls_beta import lang_urlpatterns as landing_lang_urlpatterns
+from kuma.views import serve_from_media_root
+
 
 handler403 = core_views.handler403
 handler404 = core_views.handler404
 handler500 = core_views.handler500
 
+DAY = 60 * 60 * 24
+MONTH = DAY * 30
+YEAR = DAY * 365
+
+redirect_to_attachments_domain = shared_cache_control(
+    RedirectView.as_view(url=settings.ATTACHMENT_SITE_URL + '/%(path)s'),
+    s_maxage=YEAR
+)
 
 urlpatterns = [
+    url('', include('kuma.health.urls')),
     url('^api/', include('kuma.api.urls')),
     # The non-locale-based landing URL's
     url('', include('kuma.landing.urls_beta')),
@@ -19,6 +33,22 @@ urlpatterns = [
 urlpatterns += i18n_patterns(url('', include(landing_lang_urlpatterns)))
 # The beta docs URL's (all of which are locale-based)
 urlpatterns += i18n_patterns(url(r'^docs/', include('kuma.wiki.urls_beta')))
+# The version, sitemap, humans, and file-attachment URL's (all non-locale-based)
+urlpatterns += [
+    url('', include('kuma.version.urls')),
+    url(r'^sitemap.xml$', beta_shared_cache_control(serve_from_media_root),
+        {'path': 'sitemap.xml'}, name='sitemap'),
+    url(r'^(?P<path>sitemaps/.+)$',
+        beta_shared_cache_control(serve_from_media_root), name='sitemaps'),
+    url(r'^humans.txt$', beta_shared_cache_control(serve),
+        {'document_root': settings.HUMANSTXT_ROOT, 'path': 'humans.txt'}),
+    # Redirect file attachment URL's to the attachments domain, and
+    # let that domain determine whether or not the file exists.
+    url(r'^(?P<path>files/.+)$', redirect_to_attachments_domain,
+        name='attachments.raw_file'),
+    url(r'^(?P<path>@api/deki/files/.+)$', redirect_to_attachments_domain,
+        name='attachments.mindtouch_file_redirect'),
+]
 
 if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):
     import debug_toolbar

--- a/kuma/urls_beta.py
+++ b/kuma/urls_beta.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.conf.urls import include, url
-from django.views.static import serve
 from django.views.generic import RedirectView
+from django.views.static import serve
 
 from kuma.core import views as core_views
 from kuma.core.decorators import beta_shared_cache_control, shared_cache_control

--- a/kuma/views.py
+++ b/kuma/views.py
@@ -1,0 +1,11 @@
+from django.conf import settings
+from django.views.decorators.http import require_safe
+from django.views.static import serve
+
+
+@require_safe
+def serve_from_media_root(request, path):
+    """
+    A convenience view for serving files from the media root directory.
+    """
+    return serve(request, path, document_root=settings.MEDIA_ROOT)

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -24,7 +24,8 @@ from ratelimit.decorators import ratelimit
 import kuma.wiki.content
 from kuma.api.v1.views import document_api_data
 from kuma.authkeys.decorators import accepts_auth_key
-from kuma.core.decorators import (block_user_agents,
+from kuma.core.decorators import (beta_shared_cache_control,
+                                  block_user_agents,
                                   login_required,
                                   permission_required,
                                   redirect_in_maintenance_mode,
@@ -787,7 +788,7 @@ def document(request, document_slug, document_locale):
 
 
 # This handles the /docs/ URL's within the React-based beta domain.
-@shared_cache_control
+@beta_shared_cache_control
 @csrf_exempt
 @require_http_methods(['GET', 'HEAD'])
 @allow_CORS_GET


### PR DESCRIPTION
This PR addresses the gaps identified with the current implementation of the separation of domains (`beta` and `wiki` domains) listed in https://github.com/mdn/sprints/issues/1205#issuecomment-481456076. In summary, it adds missing endpoints to the `beta` domain and updates some Content Security Policies to account for the `wiki` domain. When adding the missing endpoints to the `beta` domain, some of the changes were made to allow the views that serve those endpoints to be wrapped in different `shared_cache_control` decorators depending on whether they served the `beta` domain or the `wiki` domain.

For testing, I used my usual `.env` file:
```
DEBUG=True
DOMAIN=mdn.localhost
ENABLE_RESTRICTIONS_BY_HOST=True
BETA_HOST=beta.mdn.localhost:8000
WIKI_HOST=wiki.mdn.localhost:8000
ATTACHMENT_HOST=demos:8000
SITE_URL=http://mdn.localhost:8000
STATIC_URL=http://mdn.localhost:8000/static/
ALLOW_ROBOTS_WEB_DOMAINS=mdn.localhost:8000
ALLOW_ROBOTS_DOMAINS=demos:8000
```