### PR TITLE
Bug 1525719: handle request locale more cleanly in beta pages

### DIFF
--- a/kuma/javascript/src/app.jsx
+++ b/kuma/javascript/src/app.jsx
@@ -2,17 +2,24 @@
 import * as React from 'react';
 
 import DocumentProvider from './document-provider.jsx';
+import LocaleProvider from './locale-provider.jsx';
 import Page from './page.jsx';
 import UserProvider from './user-provider.jsx';
 
 import type DocumentData from './document-provider.jsx';
+type RequestData = {
+    locale: string
+};
+type Props = { documentData: DocumentData, requestData: RequestData };
 
-export default function App(props: { initialDocumentData: DocumentData }) {
+export default function App(props: Props) {
     return (
-        <DocumentProvider initialDocumentData={props.initialDocumentData}>
-            <UserProvider>
-                <Page />
-            </UserProvider>
-        </DocumentProvider>
+        <LocaleProvider locale={props.requestData.locale}>
+            <DocumentProvider initialDocumentData={props.documentData}>
+                <UserProvider>
+                    <Page />
+                </UserProvider>
+            </DocumentProvider>
+        </LocaleProvider>
     );
 }

--- a/kuma/javascript/src/document-provider.test.js
+++ b/kuma/javascript/src/document-provider.test.js
@@ -5,7 +5,6 @@ import { create } from 'react-test-renderer';
 import DocumentProvider from './document-provider.jsx';
 
 export const fakeDocumentData = {
-    requestLocale: 'en-US',
     locale: 'en-US',
     slug: 'test',
     id: 42,

--- a/kuma/javascript/src/header/header.jsx
+++ b/kuma/javascript/src/header/header.jsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/core';
 
 import DocumentProvider from '../document-provider.jsx';
 import LanguageMenu from './language-menu.jsx';
+import LocaleProvider from '../locale-provider.jsx';
 import Login from './login.jsx';
 import Logo from '../icons/logo.svg';
 import Dropdown from './dropdown.jsx';
@@ -147,24 +148,24 @@ const menus = [
 
 export default function Header(): React.Node {
     const documentData = useContext(DocumentProvider.context);
+    const locale = useContext(LocaleProvider.context);
     if (!documentData) {
         return null;
     }
-    const { requestLocale, slug } = documentData;
 
     function fixurl(url) {
         // The "Report a content issue" menu item has a link that requires
         // the document slug, so we work that in here.
-        url = url.replace('{{SLUG}}', encodeURIComponent(slug));
+        url = url.replace('{{SLUG}}', encodeURIComponent(documentData.slug));
         if (!url.startsWith('https://')) {
-            url = `/${requestLocale}/docs/${url}`;
+            url = `/${locale}/docs/${url}`;
         }
         return url;
     }
 
     return (
         <div css={styles.header}>
-            <a css={styles.logoContainer} href={`/${requestLocale}/`}>
+            <a css={styles.logoContainer} href={`/${locale}/`}>
                 <Logo css={styles.logo} alt="MDN Web Docs Logo" />
             </a>
             <Row css={styles.menus}>

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -9,6 +9,7 @@ import Dropdown from './dropdown.jsx';
 import EditIcon from '../icons/pencil.svg';
 import gettext from '../gettext.js';
 import GithubLogo from '../icons/github.svg';
+import LocaleProvider from '../locale-provider.jsx';
 import { Row, Strut } from '../layout.jsx';
 import UserProvider from '../user-provider.jsx';
 
@@ -63,11 +64,12 @@ const styles = {
 };
 
 export default function Login(): React.Node {
+    const locale = useContext(LocaleProvider.context);
     const documentData = useContext(DocumentProvider.context);
     if (!documentData) {
         return null;
     }
-    const { absoluteURL, editURL, requestLocale } = documentData;
+    const { absoluteURL, editURL } = documentData;
     const userData = useContext(UserProvider.context);
 
     const PATHNAME = absoluteURL;
@@ -99,7 +101,7 @@ export default function Login(): React.Node {
                 <Dropdown label={label} right={true}>
                     <li>
                         <a
-                            href={`${WIKI_SITE_URL}/${requestLocale}/profiles/${
+                            href={`${WIKI_SITE_URL}/${locale}/profiles/${
                                 userData.username
                             }`}
                         >
@@ -108,7 +110,7 @@ export default function Login(): React.Node {
                     </li>
                     <li>
                         <a
-                            href={`${WIKI_SITE_URL}/${requestLocale}/profiles/${
+                            href={`${WIKI_SITE_URL}/${locale}/profiles/${
                                 userData.username
                             }/edit`}
                         >
@@ -117,7 +119,7 @@ export default function Login(): React.Node {
                     </li>
                     <li>
                         <form
-                            action={`${WIKI_SITE_URL}/${requestLocale}/users/signout`}
+                            action={`${WIKI_SITE_URL}/${locale}/users/signout`}
                             method="post"
                         >
                             <input name="next" type="hidden" value={PATHNAME} />

--- a/kuma/javascript/src/header/search.jsx
+++ b/kuma/javascript/src/header/search.jsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/core';
 
 import DocumentProvider from '../document-provider.jsx';
 import gettext from '../gettext.js';
+import LocaleProvider from '../locale-provider.jsx';
 import SearchIcon from '../icons/search.svg';
 
 const strings = {
@@ -39,11 +40,12 @@ const styles = {
 };
 
 export default function Search() {
+    const locale = useContext(LocaleProvider.context);
     const documentData = useContext(DocumentProvider.context);
     if (!documentData) {
         return null;
     }
-    const { absoluteURL, editURL, requestLocale } = documentData;
+    const { absoluteURL, editURL } = documentData;
 
     // This is available as window.mdn.wikiSiteUrl. But we can't access
     // that during server-side rendering, so we either need to add that mdn
@@ -56,7 +58,7 @@ export default function Search() {
         <form
             css={styles.container}
             id="nav-main-search"
-            action={`${WIKI_SITE_URL}/${requestLocale}/search`}
+            action={`${WIKI_SITE_URL}/${locale}/search`}
             method="get"
             role="search"
         >

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -9,14 +9,16 @@ if (container) {
     // The HTML page that loads this code is expected to have an inline
     // script that sets this window._document_data property to an object
     // with all the data needed to hydrate or render the UI.
-    let data = window._document_data;
+    let data = window._react_data;
 
     // Remove the global reference to this data object so that it can
     // be garbage collected once it is no longer in use.
-    window._document_data = null; // eslint-disable-line camelcase
+    window._react_data = null; // eslint-disable-line camelcase
 
     // This is the React UI for a page of documentation
-    let app = <App initialDocumentData={data} />;
+    let app = (
+        <App documentData={data.documentData} requestData={data.requestData} />
+    );
 
     if (container.firstElementChild) {
         // If the container element is not empty, then it was presumably

--- a/kuma/javascript/src/locale-provider.jsx
+++ b/kuma/javascript/src/locale-provider.jsx
@@ -1,0 +1,26 @@
+// @flow
+import * as React from 'react';
+
+const context = React.createContext<string>('en-US');
+
+// This component is a context provider that makes the current locale
+// available to any components that need it. This is the locale that
+// appears in the browser location bar. We need a provider for it,
+// however because when we're rendering on the server, we can't just
+// look at window.location.pathname to extract the locale. Note also
+// that when documents are not translated, we return the english
+// version and this means that the locale in the URL (which is the
+// value provided by this component) may differ from the locale of the
+// document that is displayed.
+export default function LocaleProvider(props: {
+    locale: string,
+    children: React.Node
+}): React.Node {
+    return (
+        <context.Provider value={props.locale}>
+            {props.children}
+        </context.Provider>
+    );
+}
+
+LocaleProvider.context = context;

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -7,6 +7,7 @@ import ClockIcon from './icons/clock.svg';
 import ContributorsIcon from './icons/contributors.svg';
 import DocumentProvider from './document-provider.jsx';
 import gettext from './gettext.js';
+import LocaleProvider from './locale-provider.jsx';
 import { Row } from './layout.jsx';
 import Header from './header/header.jsx';
 
@@ -254,6 +255,7 @@ function Article() {
 }
 
 function ArticleMetadata() {
+    const locale = useContext(LocaleProvider.context);
     const documentData = useContext(DocumentProvider.context);
     return (
         documentData && (
@@ -264,12 +266,7 @@ function ArticleMetadata() {
                     {documentData.contributors.map((c, i) => (
                         <span key={c}>
                             {i > 0 && ', '}
-                            <a
-                                href={`/${
-                                    documentData.requestLocale
-                                }/profiles/${c}`}
-                                rel="nofollow"
-                            >
+                            <a href={`/${locale}/profiles/${c}`} rel="nofollow">
                                 {c}
                             </a>
                         </span>

--- a/kuma/javascript/src/ssr.jsx
+++ b/kuma/javascript/src/ssr.jsx
@@ -8,5 +8,7 @@ import App from './app.jsx';
  * a JSON object of document data. It is used by ../ssr-server.js
  */
 export default function ssr(data) {
-    return renderToString(<App initialDocumentData={data} />);
+    return renderToString(
+        <App documentData={data.documentData} requestData={data.requestData} />
+    );
 }

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -93,7 +93,7 @@
 
   {#{% include "includes/a11y-nav.html" %}#}
 
-  {{ render_react_app(document_data)|safe }}
+  {{ render_react_app(document_data, request_data)|safe }}
 
   {% if settings.NEWSLETTER and settings.NEWSLETTER_ARTICLE %}
   <div class="center">

--- a/kuma/wiki/tests/test_ssr.py
+++ b/kuma/wiki/tests/test_ssr.py
@@ -31,11 +31,18 @@ def test_server_side_render(mock_dumps, mock_requests, settings):
     toc = 'table of contents'
     links = 'sidebar'
     contributors = ['a', 'b']
-    data = {
+    document_data = {
         'bodyHTML': body,
         'tocHTML': toc,
         'quickLinksHTML': links,
         'contributors': contributors
+    }
+    request_data = {
+        'locale': 'en-US'
+    }
+    data = {
+        'documentData': document_data,
+        'requestData': request_data
     }
 
     # This will be the output sent by the mock Node server
@@ -45,14 +52,14 @@ def test_server_side_render(mock_dumps, mock_requests, settings):
     mock_requests.post(settings.SSR_URL, text=mock_html)
 
     # Run the template tag
-    output = ssr.render_react_app(data)
+    output = ssr.render_react_app(document_data, request_data)
 
     # Make sure the output is as expected
     # The HTML attributes in the data should not be repeated in the output
-    data.update(bodyHTML='', tocHTML='', quickLinksHTML='')
+    document_data.update(bodyHTML='', tocHTML='', quickLinksHTML='')
     assert output == (
         u'<div id="react-container">{}</div>\n'
-        u'<script>window._document_data = {};</script>\n'
+        u'<script>window._react_data = {};</script>\n'
     ).format(mock_html, json.dumps(data))
 
 
@@ -60,11 +67,18 @@ def test_server_side_render(mock_dumps, mock_requests, settings):
 def test_client_side_render(mock_dumps):
     """For client-side rendering expect a script json data and an empty div."""
     mock_dumps.side_effect = sorted_json_dumps
-    data = {'x': 'one', 'y': 2, 'z': ['a', 'b']}
-    output = ssr.render_react_app(data, ssr=False)
+    document_data = {'x': 'one', 'y': 2, 'z': ['a', 'b']}
+    request_data = {
+        'locale': 'en-US'
+    }
+    data = {
+        'documentData': document_data,
+        'requestData': request_data
+    }
+    output = ssr.render_react_app(document_data, request_data, ssr=False)
     assert output == (
         u'<div id="react-container"></div>\n'
-        u'<script>window._document_data = {};</script>\n'
+        u'<script>window._react_data = {};</script>\n'
     ).format(json.dumps(data))
 
 
@@ -77,5 +91,13 @@ def test_failed_server_side_render(mock_dumps, failure_class,
     """If SSR fails, we should do client-side rendering instead."""
     mock_dumps.side_effect = sorted_json_dumps
     mock_requests.post(settings.SSR_URL, exc=failure_class('message'))
-    data = {'x': 'one', 'y': 2, 'z': ['a', 'b']}
-    assert ssr.render_react_app(data) == ssr.render_react_app(data, ssr=False)
+    document_data = {'x': 'one', 'y': 2, 'z': ['a', 'b']}
+    request_data = {
+        'locale': 'en-US'
+    }
+    data = {
+        'documentData': document_data,
+        'requestData': request_data
+    }
+    assert (ssr.render_react_app(document_data, request_data) ==
+            ssr.render_react_app(document_data, request_data, ssr=False))

--- a/kuma/wiki/tests/test_ssr.py
+++ b/kuma/wiki/tests/test_ssr.py
@@ -95,9 +95,5 @@ def test_failed_server_side_render(mock_dumps, failure_class,
     request_data = {
         'locale': 'en-US'
     }
-    data = {
-        'documentData': document_data,
-        'requestData': request_data
-    }
     assert (ssr.render_react_app(document_data, request_data) ==
             ssr.render_react_app(document_data, request_data, ssr=False))

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -877,13 +877,18 @@ def react_document(request, document_slug, document_locale):
     doc_api_data = document_api_data(doc, ensure_contributors=True)
     document_data = doc_api_data['documentData']
 
-    # And add another property to specify the requested locale
-    # (which may not be the same as the locale of the document)
-    document_data['requestLocale'] = document_locale
+    # Create another object of request-related data to pass to jinja
+    request_data = {
+        # Despite its name, the document_locale argument is the locale
+        # of the request, and is not always (in the case of missing
+        # translations) the same as the locale of the document.
+        'locale': document_locale
+    }
 
     # Bundle it all up and, finally, return.
     context = {
         'document_data': document_data,
+        'request_data': request_data,
 
         # TODO: anything we're actually using in the template ought
         # to be bundled up into the json object above instead.


### PR DESCRIPTION
This patch creates a cleaner separation between document data and
request-related data in our code that does server-side rendering
and no longer mixes requestLocale into the document data object.

On the client-side locale is now handled with a LocaleProvider
component and corresponding context object.