### PR TITLE
urllib3 1.24.3

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -58,9 +58,9 @@ pyasn1==0.1.9 \
 # Code: https://github.com/urllib3/urllib3
 # Changes: https://github.com/urllib3/urllib3/blob/master/CHANGES.rst
 # Docs: https://urllib3.readthedocs.io/en/latest/
-urllib3==1.24.2 \
-    --hash=sha256:4c291ca23bbb55c76518905869ef34bdd5f0e46af7afe6861e8375643ffee1a0 \
-    --hash=sha256:9a247273df709c4fedb38c711e44292304f73f39ab01beda9f6b9fc375669ac3
+urllib3==1.24.3 \
+    --hash=sha256:2393a695cd12afedd0dcb26fe5d50d0cf248e5a66f75dbd89a3d4eb333a61af4 \
+    --hash=sha256:a637e5fae88995b256e3409dc4d52c2e2e0ba32c42a6365fee8bbd2238de3cfb
 
 
 # bleach


### PR DESCRIPTION
requires.io is complaining about urllib3 but I'm pretty sure `requests` wouldn't let us use urllib3 1.25.x.

Annoyingly, there's no [CHANGELOG](https://github.com/urllib3/urllib3/blob/master/CHANGES.rst) for 1.24.3 and the [release tag](https://github.com/urllib3/urllib3/compare/1.24.3...master) mentions a lot of changes. 

First, let's see if Travis likes it and then we can wonder how to test this manually. 