### PR TITLE
Bug 1525719: move user and waffle-related ga() calls to client side

### DIFF
--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -5,20 +5,23 @@
     (function(win) {
         'use strict';
 
-        {{ waffle.wafflejs() }}
-
+        {#- This is stuff not needed by the React-based site #}
         {%- if not beta %}
-        // This needs to be set before ckeditor.js loads
-        {%- if settings.CKEDITOR_DEV %}
-          {%- set ckeditor_basepath = static('js/libs/ckeditor4/source/ckeditor/') %}
-        {%- else %}
-          {%- set ckeditor_basepath = static('js/libs/ckeditor4/build/ckeditor/') %}
-        {%- endif %}
-        window.CKEDITOR_BASEPATH = '{{ ckeditor_basepath }}';
+            {#- With React, waffle flags are returned by the /whoami API. #}
+            {{ waffle.wafflejs() }}
 
-        // Site configuration
-        win.mdn.ckeditor = {};
+            // This needs to be set before ckeditor.js loads
+            {%- if settings.CKEDITOR_DEV %}
+              {%- set ckeditor_basepath = static('js/libs/ckeditor4/source/ckeditor/') %}
+            {%- else %}
+              {%- set ckeditor_basepath = static('js/libs/ckeditor4/build/ckeditor/') %}
+            {%- endif %}
+            window.CKEDITOR_BASEPATH = '{{ ckeditor_basepath }}';
+
+            // Site configuration
+            win.mdn.ckeditor = {};
         {%- endif %}
+
         win.mdn.features = {};
         win.mdn.siteUrl = '{{ settings.SITE_URL }}';
         win.mdn.wikiSiteUrl = '{{ settings.WIKI_SITE_URL }}';

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -100,10 +100,19 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
     job.fetch_on_miss = ensure_contributors
     contributors = [c['username'] for c in job.get(doc.pk)]
 
+    # The original english slug for this document, for google analytics
+    if doc.locale == 'en-US':
+        en_slug = doc.slug
+    elif doc.parent_id and doc.parent.locale == 'en-US':
+        en_slug = doc.parent.slug
+    else:
+        en_slug = ''
+
     return {
         'documentData': {
             'locale': doc.locale,
             'slug': doc.slug,
+            'enSlug': en_slug,
             'id': doc.id,
             'title': doc.title,
             'summary': doc.get_summary_html(),

--- a/kuma/javascript/src/app.jsx
+++ b/kuma/javascript/src/app.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 
 import DocumentProvider from './document-provider.jsx';
+import GAProvider from './ga-provider.jsx';
 import LocaleProvider from './locale-provider.jsx';
 import Page from './page.jsx';
 import UserProvider from './user-provider.jsx';
@@ -14,12 +15,14 @@ type Props = { documentData: DocumentData, requestData: RequestData };
 
 export default function App(props: Props) {
     return (
-        <LocaleProvider locale={props.requestData.locale}>
-            <DocumentProvider initialDocumentData={props.documentData}>
-                <UserProvider>
-                    <Page />
-                </UserProvider>
-            </DocumentProvider>
-        </LocaleProvider>
+        <GAProvider>
+            <LocaleProvider locale={props.requestData.locale}>
+                <DocumentProvider initialDocumentData={props.documentData}>
+                    <UserProvider>
+                        <Page />
+                    </UserProvider>
+                </DocumentProvider>
+            </LocaleProvider>
+        </GAProvider>
     );
 }

--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -8,6 +8,7 @@ import LocaleProvider from './locale-provider.jsx';
 export type DocumentData = {
     locale: string,
     slug: string,
+    enSlug: string, // For non-english documents, the original english slug
     id: number,
     title: string,
     summary: string,
@@ -93,18 +94,15 @@ export default function DocumentProvider(
                         body.style.opacity = '1';
 
                         // Tell Google Analytics about this navigation.
-                        // We use 'dimension3' to mean client-side navigate
-                        ga('set', 'dimension3', 'Yes');
+                        // We use 'dimension19' to mean client-side navigate
+                        ga('set', 'dimension19', 'Yes');
 
-                        // TODO: get page_revision in document data
-                        // and send it as dimension 12, if that is something
-                        // that Kadir still wants to analyze
-
-                        // TODO: get en_slug and send that as dimension17
-                        // even when the document language is not en. Right
-                        // now dimension17 is only being set for english
-                        // documents
-                        if (documentData.locale === 'en-US') {
+                        // If the document data includes enSlug, or if the
+                        // document is in english, then pass the slug to
+                        // google analytics as dimension 17.
+                        if (documentData.enSlug) {
+                            ga('set', 'dimension17', documentData.enSlug);
+                        } else if (documentData.locale === 'en-US') {
                             ga('set', 'dimension17', documentData.slug);
                         }
 

--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useContext, useEffect, useState } from 'react';
 
+import GAProvider from './ga-provider.jsx';
 import LocaleProvider from './locale-provider.jsx';
 
 export type DocumentData = {
@@ -40,6 +41,7 @@ export default function DocumentProvider(
 ): React.Node {
     const locale = useContext(LocaleProvider.context);
     const [documentData, setDocumentData] = useState(props.initialDocumentData);
+    const ga = useContext(GAProvider.context);
 
     // A one-time effect that runs only on mount, to set up
     // an event handler for client-side navigation
@@ -89,6 +91,24 @@ export default function DocumentProvider(
                         window.scrollTo(0, 0);
                         setDocumentData(documentData);
                         body.style.opacity = '1';
+
+                        // Tell Google Analytics about this navigation.
+                        // We use 'dimension3' to mean client-side navigate
+                        ga('set', 'dimension3', 'Yes');
+
+                        // TODO: get page_revision in document data
+                        // and send it as dimension 12, if that is something
+                        // that Kadir still wants to analyze
+
+                        // TODO: get en_slug and send that as dimension17
+                        // even when the document language is not en. Right
+                        // now dimension17 is only being set for english
+                        // documents
+                        if (documentData.locale === 'en-US') {
+                            ga('set', 'dimension17', documentData.slug);
+                        }
+
+                        ga('send', 'pageload');
                     }
                 })
                 .catch(() => {

--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -106,7 +106,7 @@ export default function DocumentProvider(
                             ga('set', 'dimension17', documentData.slug);
                         }
 
-                        ga('send', 'pageload');
+                        ga('send', 'pageview');
                     }
                 })
                 .catch(() => {

--- a/kuma/javascript/src/document-provider.test.js
+++ b/kuma/javascript/src/document-provider.test.js
@@ -7,6 +7,7 @@ import DocumentProvider from './document-provider.jsx';
 export const fakeDocumentData = {
     locale: 'en-US',
     slug: 'test',
+    enSlug: 'test',
     id: 42,
     title: '[fake document title]',
     summary: '[fake document summary]',

--- a/kuma/javascript/src/document-provider.test.js
+++ b/kuma/javascript/src/document-provider.test.js
@@ -7,7 +7,7 @@ import DocumentProvider from './document-provider.jsx';
 export const fakeDocumentData = {
     locale: 'en-US',
     slug: 'test',
-    enSlug: 'test',
+    enSlug: 'fake/en/slug',
     id: 42,
     title: '[fake document title]',
     summary: '[fake document summary]',

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -1,0 +1,45 @@
+// @flow
+import * as React from 'react';
+
+type GAOptions = { [string]: any };
+type GAFunction = (
+    string,
+    string | GAOptions,
+    ...Array<string | number | GAOptions>
+) => void;
+
+const noop: GAFunction = () => {};
+
+const context = React.createContext<GAFunction>(noop);
+
+/**
+ * If we're running in the browser (not being server-side rendered)
+ * and if the HTML document includes the Google Analytics snippet that
+ * defines the ga() function, then this provider component makes that
+ * ga() function available to any component via:
+ *
+ *    let ga = useContext(GAProvider.context)
+ *
+ * If we're not in a browser or if google analytics is not enabled,
+ * then we provide a dummy function that ignores its arguments and
+ * does nothing.  The idea is that components can always safely call
+ * the function provided by this component.
+ */
+export default function GAProvider(props: {
+    children: React.Node
+}): React.Node {
+    let ga: GAFunction;
+
+    // If there is a window object that defines a ga() function, then
+    // that ga function is the value we will provide. Otherwise we just
+    // provide a dummy function that does nothing.
+    if (typeof window === 'object' && typeof window.ga === 'function') {
+        ga = window.ga;
+    } else {
+        ga = noop;
+    }
+
+    return <context.Provider value={ga}>{props.children}</context.Provider>;
+}
+
+GAProvider.context = context;

--- a/kuma/javascript/src/ga-provider.test.js
+++ b/kuma/javascript/src/ga-provider.test.js
@@ -1,0 +1,47 @@
+//@flow
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import GAProvider from './ga-provider.jsx';
+
+describe('GAProvider', () => {
+    beforeEach(() => {
+        delete window.ga;
+    });
+
+    test('Provides the window.ga() function', () => {
+        const Consumer = GAProvider.context.Consumer;
+        const contextConsumer = jest.fn();
+        const dummyGAFunc = () => {};
+        window.ga = dummyGAFunc;
+
+        create(
+            <GAProvider>
+                <Consumer>{contextConsumer}</Consumer>
+            </GAProvider>
+        );
+
+        // We expect GAProvider to set window.ga as its value and we
+        // expect the Consumer to get that value from the provider and
+        // pass it to the contextConsumer function.
+        expect(contextConsumer.mock.calls.length).toBe(1);
+        expect(contextConsumer.mock.calls[0][0]).toEqual(dummyGAFunc);
+    });
+
+    test('Provides a dummy if no window.ga function', () => {
+        const Consumer = GAProvider.context.Consumer;
+        const contextConsumer = jest.fn();
+
+        create(
+            <GAProvider>
+                <Consumer>{contextConsumer}</Consumer>
+            </GAProvider>
+        );
+
+        // If there is no window.ga() function defined, we expect
+        // GAProvider to provide a dummy function anyway.
+        expect(window.ga).toBe(undefined);
+        expect(contextConsumer.mock.calls.length).toBe(1);
+        expect(typeof contextConsumer.mock.calls[0][0]).toBe('function');
+    });
+});

--- a/kuma/javascript/src/locale-provider.test.js
+++ b/kuma/javascript/src/locale-provider.test.js
@@ -1,0 +1,23 @@
+//@flow
+import React from 'react';
+import { create } from 'react-test-renderer';
+
+import LocaleProvider from './locale-provider.jsx';
+
+describe('LocaleProvider', () => {
+    test('provides the specified locale', () => {
+        const Consumer = LocaleProvider.context.Consumer;
+        const contextConsumer = jest.fn();
+
+        create(
+            <LocaleProvider locale="foo-bar">
+                <Consumer>{contextConsumer}</Consumer>
+            </LocaleProvider>
+        );
+
+        // We expect the Consumer to get the locale value from the provider
+        // and pass it to the contextConsumer function.
+        expect(contextConsumer.mock.calls.length).toBe(1);
+        expect(contextConsumer.mock.calls[0][0]).toEqual('foo-bar');
+    });
+});

--- a/kuma/javascript/src/user-provider.jsx
+++ b/kuma/javascript/src/user-provider.jsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import { useContext, useEffect, useState } from 'react';
 
+import DocumentProvider from './document-provider.jsx';
 import GAProvider from './ga-provider.jsx';
 
 export type UserData = {
@@ -43,6 +44,7 @@ export default function UserProvider(props: {
     children: React.Node
 }): React.Node {
     const [userData, setUserData] = useState<?UserData>(null);
+    const documentData = useContext(DocumentProvider.context);
     const ga = useContext(GAProvider.context);
 
     useEffect(() => {
@@ -69,7 +71,7 @@ export default function UserProvider(props: {
 
                 // Once the user data has loaded, set some Google
                 // Analytics variables and then send the initial
-                // pageload event to GA.
+                // pageview event to GA.
                 if (userData.isAuthenticated) {
                     ga('set', 'dimension1', 'Yes');
                     if (userData.isBetaTester) {
@@ -82,6 +84,11 @@ export default function UserProvider(props: {
 
                 if (userData.waffle.flags.section_edit) {
                     ga('set', 'dimension9', 'Yes');
+                }
+
+                if (documentData && documentData.enSlug) {
+                    // dimension17 == 'English Slug'
+                    ga('set', 'dimension17', documentData.enSlug);
                 }
 
                 // We only fetch user data once, right after the initial page

--- a/kuma/javascript/src/user-provider.jsx
+++ b/kuma/javascript/src/user-provider.jsx
@@ -1,6 +1,8 @@
 // @flow
 import * as React from 'react';
-import { useState, useEffect } from 'react';
+import { useContext, useEffect, useState } from 'react';
+
+import GAProvider from './ga-provider.jsx';
 
 export type UserData = {
     username: ?string,
@@ -12,6 +14,11 @@ export type UserData = {
     gravatarUrl: {
         small: ?string,
         large: ?string
+    },
+    waffle: {
+        flags: { [flag_name: string]: boolean },
+        switches: { [switch_name: string]: boolean },
+        samples: { [sample_name: string]: boolean }
     }
 };
 
@@ -22,7 +29,12 @@ const defaultUserData: UserData = {
     isStaff: false,
     isSuperuser: false,
     timezone: null,
-    gravatarUrl: { small: null, large: null }
+    gravatarUrl: { small: null, large: null },
+    waffle: {
+        flags: {},
+        switches: {},
+        samples: {}
+    }
 };
 
 const context = React.createContext<?UserData>(defaultUserData);
@@ -31,18 +43,68 @@ export default function UserProvider(props: {
     children: React.Node
 }): React.Node {
     const [userData, setUserData] = useState<?UserData>(null);
+    const ga = useContext(GAProvider.context);
+
     useEffect(() => {
         fetch('/api/v1/whoami')
             .then(response => response.json())
             .then(data => {
-                setUserData({
+                let userData = {
                     username: data.username,
                     isAuthenticated: data.is_authenticated,
                     isBetaTester: data.is_beta_tester,
                     isStaff: data.is_staff,
                     isSuperuser: data.is_super_user,
                     timezone: data.timezone,
-                    gravatarUrl: data.gravatar_url
+                    gravatarUrl: data.gravatar_url,
+                    // NOTE: if we ever decide that waffle data should
+                    // be re-fetched on client-side navigation, we'll
+                    // have to create a separate context for it.
+                    waffle: data.waffle
+                };
+
+                // Set the userData as a state variable that we provide
+                // to anyone that calls `useContext(UserProvider.context)`
+                setUserData(userData);
+
+                // Once the user data has loaded, set some Google
+                // Analytics variables and then send the initial
+                // pageload event to GA.
+                if (userData.isAuthenticated) {
+                    ga('set', 'dimension1', 'Yes');
+                    if (userData.isBetaTester) {
+                        ga('set', 'dimension2', 'Yes');
+                    }
+                    if (userData.isStaff) {
+                        ga('set', 'dimension18', 'Yes');
+                    }
+                }
+
+                if (userData.waffle.flags.section_edit) {
+                    ga('set', 'dimension9', 'Yes');
+                }
+
+                // We only fetch user data once, right after the initial page
+                // load, so when that user data arrives it is time to send
+                // the initial 'pageview' event for the initial load. See
+                // document-provider.jsx for code that sends 'pageview'
+                // events for client-side navigation.
+                ga('send', {
+                    hitType: 'pageview',
+                    hitCallback: () => {
+                        // If the user came to the site by following a
+                        // link that has a 'utm' tracker in it, then
+                        // after we report that data to google
+                        // analytics, we use replaceState to clean up
+                        // the location bar
+                        if (window.location.search.includes('utm_')) {
+                            window.history.replaceState(
+                                {},
+                                '',
+                                window.location.pathname
+                            );
+                        }
+                    }
                 });
             });
     }, []); // empty array means we only fetch on mount, not on every render

--- a/kuma/javascript/src/user-provider.test.js
+++ b/kuma/javascript/src/user-provider.test.js
@@ -3,6 +3,8 @@
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
+import DocumentProvider from './document-provider.jsx';
+import { fakeDocumentData } from './document-provider.test.js';
 import GAProvider from './ga-provider.jsx';
 import UserProvider from './user-provider.jsx';
 
@@ -80,9 +82,11 @@ describe('UserProvider', () => {
         act(() => {
             create(
                 <GAProvider>
-                    <P>
-                        <C>{contextConsumer}</C>
-                    </P>
+                    <DocumentProvider initialDocumentData={fakeDocumentData}>
+                        <P>
+                            <C>{contextConsumer}</C>
+                        </P>
+                    </DocumentProvider>
                 </GAProvider>
             );
         });
@@ -103,12 +107,17 @@ describe('UserProvider', () => {
         process.nextTick(() => {
             expect(contextConsumer).toHaveBeenCalledTimes(2);
             expect(contextConsumer.mock.calls[1][0]).toEqual(userData);
-            expect(gaMock).toHaveBeenCalledTimes(4);
+            expect(gaMock).toHaveBeenCalledTimes(5);
             expect(gaMock.mock.calls[0]).toEqual(['set', 'dimension1', 'Yes']);
             expect(gaMock.mock.calls[1]).toEqual(['set', 'dimension18', 'Yes']);
             expect(gaMock.mock.calls[2]).toEqual(['set', 'dimension9', 'Yes']);
-            expect(gaMock.mock.calls[3][0]).toEqual('send');
-            expect(gaMock.mock.calls[3][1].hitType).toEqual('pageview');
+            expect(gaMock.mock.calls[3]).toEqual([
+                'set',
+                'dimension17',
+                'fake/en/slug'
+            ]);
+            expect(gaMock.mock.calls[4][0]).toEqual('send');
+            expect(gaMock.mock.calls[4][1].hitType).toEqual('pageview');
             done();
         });
     });

--- a/kuma/javascript/src/user-provider.test.js
+++ b/kuma/javascript/src/user-provider.test.js
@@ -1,7 +1,9 @@
 //@flow
+/* eslint-disable camelcase */
 import React from 'react';
 import { act, create } from 'react-test-renderer';
 
+import GAProvider from './ga-provider.jsx';
 import UserProvider from './user-provider.jsx';
 
 describe('UserProvider', () => {
@@ -36,14 +38,23 @@ describe('UserProvider', () => {
     // https://github.com/facebook/react/issues/14769 and hopefully a
     // version of act() that can take async methods will fix the
     // issue.
-    test('Provider fetches user data', done => {
+    test('Provider fetches user data and waffle flags', done => {
         const P = UserProvider;
         const C = UserProvider.context.Consumer;
         const contextConsumer = jest.fn();
+
+        const waffleFlags = {
+            flags: { section_edit: true },
+            switches: { bar: false },
+            samples: {}
+        };
+
         const userData = {
             ...UserProvider.defaultUserData,
             username: 'testing',
-            isStaff: true
+            isAuthenticated: true,
+            isStaff: true,
+            waffle: waffleFlags
         };
 
         // In this test we want to verify that UserProvider is
@@ -52,42 +63,52 @@ describe('UserProvider', () => {
             return Promise.resolve({
                 json: () =>
                     Promise.resolve({
-                        // We expect the server to send JSON data
-                        // using snake_case
-                        /* eslint-disable camelcase */
                         username: 'testing',
-                        is_authenticated: false,
+                        is_authenticated: true,
                         is_beta_tester: false,
                         is_staff: true,
                         is_super_user: false,
                         timezone: null,
-                        gravatar_url: { small: null, large: null }
-                        /* eslint-enable camelcase */
+                        gravatar_url: { small: null, large: null },
+                        waffle: waffleFlags
                     })
             });
         });
 
+        let gaMock = (window.ga = jest.fn());
+
         act(() => {
             create(
-                <P>
-                    <C>{contextConsumer}</C>
-                </P>
+                <GAProvider>
+                    <P>
+                        <C>{contextConsumer}</C>
+                    </P>
+                </GAProvider>
             );
         });
 
         // To start, we expect the contextConsumer function to be called
         // with the default null value. And we expect our fetch() mock to
         // be called when the component is first mounted, too.
+        // At this point we don't expect any GA calls
         expect(contextConsumer).toHaveBeenCalledTimes(1);
         expect(contextConsumer).toHaveBeenCalledWith(null);
         expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(global.fetch).toHaveBeenCalledWith('/api/v1/whoami');
+        expect(gaMock).toHaveBeenCalledTimes(0);
 
         // After the fetch succeeds, we expect contextConsumer to be
-        // called again with the fetched userdata
+        // called again with the fetched userdata. And we expect some
+        // data to have been sent to the ga() function
         process.nextTick(() => {
             expect(contextConsumer).toHaveBeenCalledTimes(2);
             expect(contextConsumer.mock.calls[1][0]).toEqual(userData);
+            expect(gaMock).toHaveBeenCalledTimes(4);
+            expect(gaMock.mock.calls[0]).toEqual(['set', 'dimension1', 'Yes']);
+            expect(gaMock.mock.calls[1]).toEqual(['set', 'dimension18', 'Yes']);
+            expect(gaMock.mock.calls[2]).toEqual(['set', 'dimension9', 'Yes']);
+            expect(gaMock.mock.calls[3][0]).toEqual('send');
+            expect(gaMock.mock.calls[3][1].hitType).toEqual('pageview');
             done();
         });
     });

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -31,7 +31,37 @@
   {#- If the stylesheet exists, include it. Otherwise, does nothing. #}
   {% stylesheet 'locale-%s' % LANG %}
 
-  {% include "includes/google_analytics.html" %}
+{#- This is the react-specific version of includes/google_analytics.html #}
+{#- The user and waffle-related stuff has been moved to the client side. #}
+<script>
+    // Mozilla DNT Helper
+    {% include "js/libs/mozilla.dnthelper.min.js" %}
+    {%- if config.GOOGLE_ANALYTICS_ACCOUNT != '0' %}
+    {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
+    // only load GA if DNT is not enabled
+    if (Mozilla && !Mozilla.dntEnabled()) {
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
+        ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
+        ga('set', 'anonymizeIp', true);
+
+        {#- TODO: delete or move to the client side #}
+        {%- if analytics_page_revision %}
+            // dimension12 == 'Page Revision'
+            ga('set', 'dimension12', '{{ analytics_page_revision }}');
+        {%- endif %}
+
+        {#- TODO: delete or move to the client side #}
+        {%- if analytics_en_slug %}
+            // dimension17 == 'English Slug'
+            ga('set', 'dimension17', '{{analytics_en_slug}}');
+        {%- endif %}
+    }
+    {%- endif %}
+</script>
+
 
   {% include "wiki/includes/perf.html" %}
 

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -46,18 +46,6 @@
         })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
         ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
-
-        {#- TODO: delete or move to the client side #}
-        {%- if analytics_page_revision %}
-            // dimension12 == 'Page Revision'
-            ga('set', 'dimension12', '{{ analytics_page_revision }}');
-        {%- endif %}
-
-        {#- TODO: delete or move to the client side #}
-        {%- if analytics_en_slug %}
-            // dimension17 == 'English Slug'
-            ga('set', 'dimension17', '{{analytics_en_slug}}');
-        {%- endif %}
     }
     {%- endif %}
 </script>


### PR DESCRIPTION
We currently hardcode a bunch of ga() analytics calls into the
HTML rendered by our Jinja templates, even when the data in question
depends on the current user or the current waffle flags. This means
that the HTML we generate can't be cached for re-use.

This PR modifies the react_document.html template so that our
React-based beta pages are cacheable and do not reference the
current user or current waffle flags. Instead, user and waffle
related ga() calls are now made on the client side in user-provider.jsx
when that data is obtained from the /whoami API.

This PR also adds ga('send', 'pageload') calls for client-side navigation.