### PR TITLE
make scrape_document accept multiple urls

### DIFF
--- a/docs/data.rst
+++ b/docs/data.rst
@@ -77,6 +77,8 @@ following, using the desired URL::
 
     ./manage.py scrape_document https://developer.mozilla.org/en-US/docs/Web/CSS/display
 
+You can also pass in multiple URLs instead of doing one URL at a time.
+
 Scraping a document includes:
 
 - The parent documents (such as ``Web`` and ``Web/CSS`` for ``Web/CSS/display``)


### PR DESCRIPTION
I use this tool surprisingly often and it's so annoying to have to start it with one URL at a time. 

Also, in a perfect world, I'd rename the management command to be called `scrape_documents` instead but I didn't want "rock the boat" too much. 