### PR TITLE
bug 1551968 - Exclude noindex documents from sitemaps

### DIFF
--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -320,9 +320,6 @@ def build_locale_sitemap(locale):
     queryset = Document.objects.filter(
         locale=locale,
         is_redirect=False,
-        # TODO(peterbe) Needs to consolidate with
-        # https://github.com/mozilla/kuma/pull/5377
-        deleted=False,
     ).exclude(
         html=''
     )

--- a/kuma/wiki/tasks.py
+++ b/kuma/wiki/tasks.py
@@ -12,6 +12,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.sitemaps import GenericSitemap
 from django.core.mail import mail_admins, send_mail
 from django.db import transaction
+from django.db.models import Q
 from django.template.loader import render_to_string
 from django.utils.encoding import smart_str
 from lxml import etree
@@ -22,6 +23,7 @@ from kuma.core.utils import chunked
 from kuma.search.models import Index
 from kuma.users.models import User
 
+from .constants import EXPERIMENT_TITLE_PREFIX, LEGACY_MINDTOUCH_NAMESPACES
 from .events import first_edit_email
 from .exceptions import PageMoveError
 from .models import (Document, DocumentDeletionLog,
@@ -311,19 +313,62 @@ def build_locale_sitemap(locale):
     ]
     make = [('sitemap_other.xml', other_urls)]
 
-    # Add the document URL's within this locale.
-    queryset = Document.objects.filter_for_list(locale=locale)
-    if queryset.exists():
-        sitemap = WikiSitemap({
-            'queryset': queryset,
-            'date_field': 'modified',
-        })
-        for page in range(1, sitemap.paginator.num_pages + 1):
-            urls = sitemap.get_urls(page=page)
-            if page == 1:
-                name = 'sitemap.xml'
-            else:
-                name = 'sitemap_%s.xml' % page
+    # We *could* use the `Document.objects.filter_for_list()` manager
+    # but it has a list of `.only()` columns which isn't right,
+    # it has a list of hardcoded slug prefixes, and it forces an order by
+    # on 'slug' which is slow and not needed in this context.
+    queryset = Document.objects.filter(
+        locale=locale,
+        is_redirect=False,
+        # TODO(peterbe) Needs to consolidate with
+        # https://github.com/mozilla/kuma/pull/5377
+        deleted=False,
+    ).exclude(
+        html=''
+    )
+    # Be explicit about exactly only the columns we need.
+    queryset = queryset.only('id', 'locale', 'slug', 'modified')
+
+    # The logic for rendering a page will do various checks on each
+    # document to evaluate if it should be excluded from robots.
+    # Ie. in a jinja template it does...
+    #  `{% if reasons... %}noindex, nofollow{% endif %}`
+    # Some of those evaluations are complex and depend on the request.
+    # That's too complex here but we can at least do some low-hanging
+    # fruit filtering.
+    queryset = queryset.exclude(
+        current_revision__isnull=True,
+    )
+    q = Q(slug__startswith=EXPERIMENT_TITLE_PREFIX)
+    for legacy_mindtouch_namespace in LEGACY_MINDTOUCH_NAMESPACES:
+        q |= Q(slug__startswith='{}:'.format(legacy_mindtouch_namespace))
+    queryset = queryset.exclude(q)
+
+    # We have to make the queryset ordered. Otherwise the GenericSitemap
+    # generator might throw this perfectly valid warning:
+    #
+    #    UnorderedObjectListWarning:
+    #     Pagination may yield inconsistent results with an unordered
+    #     object_list: <class 'kuma.wiki.models.Document'> QuerySet.
+    #
+    # Any order is fine. Use something definitely indexed. It's needed for
+    # paginator used by GenericSitemap.
+    queryset = queryset.order_by('id')
+
+    # To avoid an extra query to see if the queryset is empty, let's just
+    # start iterator and create the sitemap on the first found page.
+    # Note, how we check if 'urls' became truthy before adding it.
+    sitemap = WikiSitemap({
+        'queryset': queryset,
+        'date_field': 'modified',
+    })
+    for page in range(1, sitemap.paginator.num_pages + 1):
+        urls = sitemap.get_urls(page=page)
+        if page == 1:
+            name = 'sitemap.xml'
+        else:
+            name = 'sitemap_%s.xml' % page
+        if urls:
             make.append((name, urls))
 
     # Make the sitemap files.

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -173,13 +173,7 @@ def test_sitemaps_excluded_documents(tmpdir, settings, wiki_user):
     # Exclude the inter-linking sitemaps
     all_locs = [loc for loc in all_locs if not loc.endswith('.xml')]
 
-    # The all_locs will have one for each locale but we definitely shouldn't
-    # have any of the slugs that we know shouldn't be included
-    assert not [loc for loc in all_locs if legacy_slug in loc]
-    assert not [loc for loc in all_locs if experiment_slug in loc]
-    assert not [loc for loc in all_locs if no_revision_slug in loc]
-    assert not [loc for loc in all_locs if no_html_slug in loc]
-    # Just for sanity, we now check exactly which slugs we expect in entirety.
+    # Now check exactly which slugs we expect in entirety.
     # Note that this automatically asserts that all the legacy docs
     # created above don't get returned.
     assert set([urlparse(loc).path for loc in all_locs]) == set([

--- a/kuma/wiki/tests/test_tasks.py
+++ b/kuma/wiki/tests/test_tasks.py
@@ -1,7 +1,6 @@
 from __future__ import with_statement
 
 import os
-import random
 import re
 from datetime import datetime
 
@@ -105,22 +104,21 @@ def test_sitemaps_excluded_documents(tmpdir, settings, wiki_user):
         created=datetime(2017, 4, 24, 13, 49)
     )
 
-    # Make one that has a legacy slug
-    legacy_slug = '{}:something'.format(
-        random.choice(LEGACY_MINDTOUCH_NAMESPACES)
-    )
-    legacy_doc = Document.objects.create(
-        locale='en-US',
-        slug=legacy_slug,
-        title='A Legacy Document'
-    )
-    Revision.objects.create(
-        document=legacy_doc,
-        creator=wiki_user,
-        content='<p>Legacy...</p>',
-        title='Legacy Document',
-        created=datetime(2017, 4, 24, 13, 49)
-    )
+    # Make one document for every mindtouch legacy namespace.
+    for namespace in LEGACY_MINDTOUCH_NAMESPACES:
+        legacy_slug = '{}:something'.format(namespace)
+        legacy_doc = Document.objects.create(
+            locale='en-US',
+            slug=legacy_slug,
+            title='A Legacy Document'
+        )
+        Revision.objects.create(
+            document=legacy_doc,
+            creator=wiki_user,
+            content='<p>Legacy...</p>',
+            title='Legacy Document',
+            created=datetime(2017, 4, 24, 13, 49)
+        )
 
     # Add an "experiment" document
     experiment_slug = EXPERIMENT_TITLE_PREFIX + 'myexperiment'
@@ -182,6 +180,8 @@ def test_sitemaps_excluded_documents(tmpdir, settings, wiki_user):
     assert not [loc for loc in all_locs if no_revision_slug in loc]
     assert not [loc for loc in all_locs if no_html_slug in loc]
     # Just for sanity, we now check exactly which slugs we expect in entirety.
+    # Note that this automatically asserts that all the legacy docs
+    # created above don't get returned.
     assert set([urlparse(loc).path for loc in all_locs]) == set([
         '/en-US/', '/en-US/docs/top', '/sv-SE/'
     ])


### PR DESCRIPTION
Regarding [this comment](https://bugzilla.mozilla.org/show_bug.cgi?id=1551968#c1) I put in some lines like this:

```python
queries_before = len(connection.queries)

...

queries_after = len(connection.queries)
print("#QUERIES:", queries_after - queries_before)
```

inside the `build_locale_sitemap` function. Now, when I run `docker-compose exec web ./manage.py make_sitemaps` the print output looks something like this:

```
...
('#QUERIES:', 3)
('#QUERIES:', 3)
('#QUERIES:', 3)
('#QUERIES:', 2)
('#QUERIES:', 3)
('#QUERIES:', 3)
('#QUERIES:', 3)
('#QUERIES:', 2)
...
```

(it's one for every `settings.LANGUAGES`)

*Before*, with the `master` branch the same instrumentation looked like this:

```
('#QUERIES:', 26)
('#QUERIES:', 17)
('#QUERIES:', 23)
('#QUERIES:', 17)
('#QUERIES:', 36)
('#QUERIES:', 1)
('#QUERIES:', 18)
('#QUERIES:', 36)
('#QUERIES:', 25)
('#QUERIES:', 1)
('#QUERIES:', 14)
('#QUERIES:', 36)
('#QUERIES:', 6)
('#QUERIES:', 1)
('#QUERIES:', 1)
('#QUERIES:', 17)
('#QUERIES:', 21)
```

And **note**, this is using my dev mysql. In Prod we'd get linearly many more queries that matches how many matched documents we have per locale. This PR makes that stable instead. It's a marginally more expensive SQL query but that's many times faster than doing *many* SQL queries. 