### PR TITLE
bug 1552016 - SmartIntTestCase is slow

### DIFF
--- a/kuma/core/tests/test_utils.py
+++ b/kuma/core/tests/test_utils.py
@@ -2,7 +2,6 @@
 from __future__ import unicode_literals
 
 import pytest
-from django.test import TestCase
 from django.urls import get_urlconf, set_urlconf
 from django.utils.encoding import force_bytes
 
@@ -14,23 +13,23 @@ from kuma.core.utils import (
 )
 
 
-class SmartIntTestCase(TestCase):
-    def test_sanity(self):
-        assert 10 == smart_int('10')
-        assert 10 == smart_int('10.5')
+def test_smart_int():
+    # Sanity check
+    assert 10 == smart_int('10')
+    assert 10 == smart_int('10.5')
 
-    def test_int(self):
-        assert 10 == smart_int(10)
+    # Test int
+    assert 10 == smart_int(10)
 
-    def test_invalid_string(self):
-        assert 0 == smart_int('invalid')
+    # Invalid string
+    assert 0 == smart_int('invalid')
 
-    def test_empty_string(self):
-        assert 0 == smart_int('')
+    # Empty string
+    assert 0 == smart_int('')
 
-    def test_wrong_type(self):
-        assert 0 == smart_int(None)
-        assert 10 == smart_int([], 10)
+    # Wrong type
+    assert 0 == smart_int(None)
+    assert 10 == smart_int([], 10)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
**Before:**

  See https://bugzilla.mozilla.org/show_bug.cgi?id=1552016#c0

**After:**

```
root@e7ae587582f5:/app# pytest kuma/core/tests/test_utils.py --durations=10
================================================================================================ test session starts ================================================================================================
platform linux2 -- Python 2.7.16, pytest-3.1.3, py-1.4.33, pluggy-0.4.0
Django settings: kuma.settings.testing (from ini file)
rootdir: /app, inifile: pytest.ini
plugins: django-3.1.2, cov-2.4.0
collected 13 items

kuma/core/tests/test_utils.py .............

============================================================================================= slowest 10 test durations =============================================================================================
0.01s setup    kuma/core/tests/test_utils.py::test_smart_int
0.01s teardown kuma/core/tests/test_utils.py::test_safer_pyquery
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf_when_exception[None-kuma.urls]
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf[None-None]
0.00s setup    kuma/core/tests/test_utils.py::test_order_params[http://example.com?foo=bar&bar=baz-http://example.com?bar=baz&foo=bar]
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf_when_exception[kuma.urls-kuma.urls_beta]
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf_when_exception[kuma.urls-None]
0.00s setup    kuma/core/tests/test_utils.py::test_order_params[https://example.com-https://example.com]
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf[None-kuma.urls]
0.00s setup    kuma/core/tests/test_utils.py::test_override_urlconf[kuma.urls-kuma.urls_beta]
```

Yay! 0.01s instead of 8.58s.