### PR TITLE
bug 1411271 - be less optimistic about github profile completion

### DIFF
--- a/kuma/users/providers/github/views.py
+++ b/kuma/users/providers/github/views.py
@@ -21,8 +21,10 @@ class KumaGitHubOAuth2Adapter(GitHubOAuth2Adapter):
     def complete_login(self, request, app, token, **kwargs):
         params = {'access_token': token.token}
         profile_data = requests.get(self.profile_url, params=params)
+        profile_data.raise_for_status()
         extra_data = profile_data.json()
         email_data = requests.get(self.email_url, params=params)
+        email_data.raise_for_status()
         extra_data['email_addresses'] = email_data.json()
         return self.get_provider().sociallogin_from_response(request,
                                                              extra_data)

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -128,8 +128,7 @@ class SocialTestMixin(object):
             process='login',
             token_status_code=200,
             profile_status_code=200,
-            email_status_code=200,
-        ):
+            email_status_code=200):
         """
         Mock a login to GitHub and return the response.
 

--- a/kuma/users/tests/__init__.py
+++ b/kuma/users/tests/__init__.py
@@ -125,7 +125,11 @@ class SocialTestMixin(object):
 
     def github_login(
             self, token_data=None, profile_data=None, email_data=None,
-            process='login'):
+            process='login',
+            token_status_code=200,
+            profile_status_code=200,
+            email_status_code=200,
+        ):
         """
         Mock a login to GitHub and return the response.
 
@@ -134,6 +138,9 @@ class SocialTestMixin(object):
         profile_data - GitHub profile data, or None for default
         email_data - GitHub email data, or None for default
         process - 'login', 'connect', or 'redirect'
+        token_status_code - HTTP code for posting token (default 200)
+        profile_status_code - HTTP code for getting profile (default 200)
+        email_status_code - HTTP code for getting email addresses (default 200)
         """
         login_url = reverse('github_login')
         callback_url = reverse('github_callback')
@@ -157,15 +164,20 @@ class SocialTestMixin(object):
             mock_requests.post(
                 GitHubOAuth2Adapter.access_token_url,
                 json=token_data or self.github_token_data,
-                headers={'content-type': 'application/json'})
+                headers={'content-type': 'application/json'},
+                status_code=token_status_code)
             # The authenticated user's profile data
             mock_requests.get(
                 GitHubOAuth2Adapter.profile_url,
-                json=profile_data or self.github_profile_data)
+                json=profile_data or self.github_profile_data,
+                status_code=profile_status_code)
             # The user's emails, which could be an empty list
             if email_data is None:
                 email_data = self.github_email_data
-            mock_requests.get(GitHubOAuth2Adapter.emails_url, json=email_data)
+            mock_requests.get(
+                GitHubOAuth2Adapter.emails_url,
+                json=email_data,
+                status_code=email_status_code)
 
             # Simulate the callback from Github
             data = {'code': 'github_code', 'state': state}

--- a/kuma/users/tests/test_views.py
+++ b/kuma/users/tests/test_views.py
@@ -1099,6 +1099,27 @@ class KumaGitHubTests(UserTestCase, SocialTestMixin):
         resp = self.github_login()
         self.assertRedirects(resp, self.signup_url)
 
+    def test_login_500_on_token(self):
+        resp = self.github_login(token_status_code=500)
+        # No redirect!
+        assert resp.status_code == 200
+        doc = pq(resp.content)
+        assert 'Account Sign In Failure' in doc.find('h1').text()
+
+    def test_login_500_on_getting_profile(self):
+        resp = self.github_login(profile_status_code=500)
+        # No redirect!
+        assert resp.status_code == 200
+        doc = pq(resp.content)
+        assert 'Account Sign In Failure' in doc.find('h1').text()
+
+    def test_login_500_on_getting_email_addresses(self):
+        resp = self.github_login(email_status_code=500)
+        # No redirect!
+        assert resp.status_code == 200
+        doc = pq(resp.content)
+        assert 'Account Sign In Failure' in doc.find('h1').text()
+
     @override_config(RECAPTCHA_PRIVATE_KEY='private_key',
                      RECAPTCHA_PUBLIC_KEY='public_key')
     def test_signin_captcha(self):


### PR DESCRIPTION
With this change, what happens now (if the communication with Github's API fails) is that you get this:

<img width="1616" alt="Screen Shot 2019-05-16 at 2 00 31 PM" src="https://user-images.githubusercontent.com/26739/57880014-bd645580-77eb-11e9-9f5a-da73b108b1f3.png">

It's not great. For example, it doesn't say that it was "OUR" fault and not the users'. For example, a 500 error from GitHub should first of all [just be reattempted](https://bugzilla.mozilla.org/show_bug.cgi?id=1552277) so the human doesn't have to try again. 

Also, that template doesn't have a good call to action that informs her to try again. 

I suppose we can revisit that later. 

Either way, this is much better than triggering cryptic internal server errors. It gives the user a much better chance to not think "Oh crap! This isn't working. I better do something else."