### PR TITLE
bug 1525719: fix headless test when run against prod

### DIFF
--- a/tests/headless/__init__.py
+++ b/tests/headless/__init__.py
@@ -8,11 +8,11 @@ pytest.register_assert_rewrite('utils.urls')
 # Untrusted attachments and samples domains that are indexed
 INDEXED_ATTACHMENT_DOMAINS = set((
     'mdn.mozillademos.org',          # Main attachments domain
+    'demos.mdn.mozit.cloud',         # Alternate attachments domain (testing)
     'demos-origin.mdn.mozit.cloud',  # Attachments origin
 ))
 
 # Kuma web domains that are indexed
 INDEXED_WEB_DOMAINS = set((
     'developer.mozilla.org',    # Main website, CDN origin
-    'cdn.mdn.mozilla.net',      # Assets CDN
 ))


### PR DESCRIPTION
These are some minor tweaks that came out of the testing for the new `beta` and `wiki` domains.
- the addition of `demos.mdn.mozit.cloud` to `INDEXED_ATTACHMENT_DOMAINS` (used by the headless tests) fixes a test failure when running the headless tests against https://developer.mozilla.org or https://wiki.developer.mozilla.org
- the removal of `cdn.mdn.mozilla.net` (the domain name that used to point to our former static-asset CDN, now long unused) is simply clean-up (it has no effect on the tests)

This is not urgent. I just didn't want to forget about it.