### PR TITLE
bug 1525719: fix functional tests for prod

### DIFF
--- a/tests/functional/test_feedback.py
+++ b/tests/functional/test_feedback.py
@@ -5,7 +5,7 @@ import pytest
 from pages.article import ArticlePage
 from utils.urls import assert_valid_url
 
-ARTICLE_NAME = 'Send feedback (about|on) MDN'
+ARTICLE_NAME = 'Send feedback about MDN Web Docs'
 
 
 @pytest.mark.smoke


### PR DESCRIPTION
Again, this is a minor tweak that came out of the testing for the new beta and wiki domains. In this case, the https://developer.mozilla.org/en-US/docs/MDN/Feedback document's title differed between stage and prod. The stage document was out of date, so I scraped the document from prod into stage to make them the same, and then standardized the test on the prod title.

This is not urgent. I just didn't want to forget about it.