### PR TITLE
bug 1525719: cleanup react_document view

### DIFF
--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -95,6 +95,7 @@ def test_doc_api(client, api_settings, trans_doc, cleared_cacheback_cache,
     assert doc_data['id'] == trans_doc.id
     assert doc_data['title'] == trans_doc.title
     assert doc_data['language'] == trans_doc.language
+    assert doc_data['hrefLang'] == 'fr'
     assert doc_data['absoluteURL'] == trans_doc.get_absolute_url()
     assert doc_data['editURL'] == absolutify(trans_doc.get_edit_url(),
                                              for_wiki_site=True)
@@ -104,6 +105,7 @@ def test_doc_api(client, api_settings, trans_doc, cleared_cacheback_cache,
     assert doc_data['translations'] == [{
         'locale': 'en-US',
         'language': 'English (US)',
+        'hrefLang': 'en',
         'localizedLanguage': u'Anglais am\u00e9ricain',
         'title': 'Root Document',
         'url': '/en-US/docs/Root'
@@ -149,6 +151,7 @@ def test_doc_api_for_redirect_to_doc(client, api_settings, root_doc,
     assert doc_data['id'] == root_doc.id
     assert doc_data['title'] == root_doc.title
     assert doc_data['language'] == root_doc.language
+    assert doc_data['hrefLang'] == 'en'
     assert doc_data['absoluteURL'] == root_doc.get_absolute_url()
     assert doc_data['editURL'] == absolutify(root_doc.get_edit_url(),
                                              for_wiki_site=True)

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -108,6 +108,10 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
     else:
         en_slug = ''
 
+    other_translations = doc.get_other_translations(
+        fields=('locale', 'slug', 'title'))
+    all_locales = set([doc.locale]) | set(t.locale for t in other_translations)
+
     return {
         'documentData': {
             'locale': doc.locale,
@@ -117,6 +121,7 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
             'title': doc.title,
             'summary': doc.get_summary_html(),
             'language': doc.language,
+            'hrefLang': doc.get_hreflang(all_locales),
             'absoluteURL': doc.get_absolute_url(),
             'editURL': absolutify(doc.get_edit_url(), for_wiki_site=True),
             'bodyHTML': doc.get_body_html(),
@@ -131,12 +136,12 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
             'translations': [
                 {
                     'language': t.language,
+                    'hrefLang': t.get_hreflang(all_locales),
                     'localizedLanguage': _(settings.LOCALES[t.locale].english),
                     'locale': t.locale,
                     'url': t.get_absolute_url(),
                     'title': t.title
-                } for t in doc.get_other_translations(
-                    fields=('locale', 'slug', 'title'))
+                } for t in other_translations
             ],
             'contributors': contributors,
             'lastModified': (doc.current_revision and

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -110,7 +110,8 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
 
     other_translations = doc.get_other_translations(
         fields=('locale', 'slug', 'title'))
-    all_locales = set([doc.locale]) | set(t.locale for t in other_translations)
+    available_locales = (
+        set([doc.locale]) | set(t.locale for t in other_translations))
 
     return {
         'documentData': {
@@ -121,7 +122,7 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
             'title': doc.title,
             'summary': doc.get_summary_html(),
             'language': doc.language,
-            'hrefLang': doc.get_hreflang(all_locales),
+            'hrefLang': doc.get_hreflang(available_locales),
             'absoluteURL': doc.get_absolute_url(),
             'editURL': absolutify(doc.get_edit_url(), for_wiki_site=True),
             'bodyHTML': doc.get_body_html(),
@@ -136,7 +137,7 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
             'translations': [
                 {
                     'language': t.language,
-                    'hrefLang': t.get_hreflang(all_locales),
+                    'hrefLang': t.get_hreflang(available_locales),
                     'localizedLanguage': _(settings.LOCALES[t.locale].english),
                     'locale': t.locale,
                     'url': t.get_absolute_url(),

--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -12,6 +12,8 @@ export type DocumentData = {
     id: number,
     title: string,
     summary: string,
+    language: string,
+    hrefLang: string,
     absoluteURL: string,
     editURL: string,
     bodyHTML: string,
@@ -21,6 +23,7 @@ export type DocumentData = {
     translations: Array<{
         locale: string,
         language: string,
+        hrefLang: string,
         localizedLanguage: string,
         url: string,
         title: string

--- a/kuma/javascript/src/document-provider.test.js
+++ b/kuma/javascript/src/document-provider.test.js
@@ -11,6 +11,8 @@ export const fakeDocumentData = {
     id: 42,
     title: '[fake document title]',
     summary: '[fake document summary]',
+    language: 'English (US)',
+    hrefLang: 'en',
     absoluteURL: '[fake absolute url]',
     editURL: '[fake edit url]',
     bodyHTML: '[fake body HTML]',
@@ -30,6 +32,7 @@ export const fakeDocumentData = {
         {
             locale: 'es',
             language: 'Español',
+            hrefLang: 'es',
             localizedLanguage: 'Spanish',
             url: '[fake spanish url]',
             title: '[fake spanish translation]'

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -1,15 +1,14 @@
 {% set beta = settings.ENABLE_RESTRICTIONS_BY_HOST and is_beta(request) %}
 {% set untrusted = settings.ENABLE_RESTRICTIONS_BY_HOST and is_untrusted(request) %}
-{% set doc_abs_url = document.get_absolute_url() %}
-{% set canonical = doc_abs_url | absolutify %}
+{% set canonical = document_data['absoluteURL'] | absolutify %}
 
 <!DOCTYPE html>
-<html lang="{{ document.get_hreflang(all_locales) }}" dir="{{ DIR }}">
+<html lang="{{ document_data['hrefLang'] }}" dir="{{ DIR }}">
 <head prefix="og: http://ogp.me/ns#">
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=Edge">
   <script>(function(d) { d.className = d.className.replace(/\bno-js/, ''); })(document.documentElement);</script>
-  <title>{{ page_title(document.title + seo_parent_title) }}</title>
+  <title>{{ page_title(document_data['title'] + seo_parent_title) }}</title>
 
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="robots" content=
@@ -85,18 +84,16 @@
   <link rel="canonical" href="{{ canonical }}" >
 
   {# Google requires the current page to be referenced as an alternate too for SEO purposes see bug 1449210 #}
-  <link rel="alternate" hreflang="{{ document.get_hreflang(all_locales) }}" href="{{ document.get_absolute_url() | absolutify }}" title="{{ document.title }}">
-  {% if other_translations %}
-    {% for translation in other_translations %}
-      <link rel="alternate" hreflang="{{ translation.get_hreflang(all_locales) }}" href="{{ translation.get_absolute_url() | absolutify }}" title="{{ translation.title }}">
-    {% endfor %}
-  {% endif %}
+  <link rel="alternate" hreflang="{{ document_data['hrefLang'] }}" href="{{ canonical }}" title="{{ document_data['title'] }}">
+  {% for translation in document_data['translations'] %}
+    <link rel="alternate" hreflang="{{ translation['hrefLang'] }}" href="{{ translation['url'] | absolutify }}" title="{{ translation['title'] }}">
+  {% endfor %}
 
   <!-- document-specific social tags -->
-  <meta property="og:title" content="{{ document.title }}">
+  <meta property="og:title" content="{{ document_data['title'] }}">
   <meta property="og:url" content="{{ canonical }}">
   <meta name="twitter:url" content="{{ canonical }}">
-  <meta name="twitter:title" content="{{ document.title }}">
+  <meta name="twitter:title" content="{{ document_data['title'] }}">
   {% if seo_summary %}
   <meta property="og:description" content="{{ seo_summary }}">
   <meta name="description" content="{{ seo_summary }}">

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -799,12 +799,10 @@ def react_document(request, document_slug, document_locale):
     """
     View a wiki document.
     """
-    fallback_reason = None
     slug_dict = split_slug(document_slug)
 
     # Is there a document at this slug, in this locale?
-    doc, fallback_reason = _get_doc_and_fallback_reason(document_locale,
-                                                        document_slug)
+    doc, _ = _get_doc_and_fallback_reason(document_locale, document_slug)
 
     if doc is None:
         # We can throw a 404 immediately if the request type is HEAD.
@@ -813,7 +811,7 @@ def react_document(request, document_slug, document_locale):
             raise Http404
 
         # Check if we should fall back to default locale.
-        fallback_doc, fallback_reason, redirect_url = _default_locale_fallback(
+        fallback_doc, _, redirect_url = _default_locale_fallback(
             request, document_slug, document_locale)
         if fallback_doc is not None:
             doc = fallback_doc
@@ -849,8 +847,7 @@ def react_document(request, document_slug, document_locale):
     seo_summary = doc.get_summary_text()
 
     # Get the additional title information, if necessary.
-    seo_parent_title = _get_seo_parent_title(
-        doc, slug_dict, document_locale)
+    seo_parent_title = _get_seo_parent_title(doc, slug_dict, document_locale)
 
     # Get the JSON data for this document
     doc_api_data = document_api_data(doc, ensure_contributors=True)
@@ -871,7 +868,6 @@ def react_document(request, document_slug, document_locale):
 
         # TODO: anything we're actually using in the template ought
         # to be bundled up into the json object above instead.
-        'fallback_reason': fallback_reason,
         'seo_summary': seo_summary,
         'seo_parent_title': seo_parent_title,
     }

--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -852,27 +852,6 @@ def react_document(request, document_slug, document_locale):
     seo_parent_title = _get_seo_parent_title(
         doc, slug_dict, document_locale)
 
-    # Record the English slug in Google Analytics,
-    # to associate translations
-    if doc.locale == 'en-US':
-        en_slug = doc.slug
-    elif doc.parent_id and doc.parent.locale == 'en-US':
-        en_slug = doc.parent.slug
-    else:
-        en_slug = ''
-
-    share_text = ugettext(
-        'I learned about %(title)s on MDN.') % {"title": doc.title}
-
-    contributors = doc.contributors
-    contributors_count = len(contributors)
-    has_contributors = contributors_count > 0
-    other_translations = doc.get_other_translations(
-        fields=['title', 'locale', 'slug', 'parent']
-    )
-    all_locales = (set([doc.locale]) |
-                   set(trans.locale for trans in other_translations))
-
     # Get the JSON data for this document
     doc_api_data = document_api_data(doc, ensure_contributors=True)
     document_data = doc_api_data['documentData']
@@ -892,20 +871,9 @@ def react_document(request, document_slug, document_locale):
 
         # TODO: anything we're actually using in the template ought
         # to be bundled up into the json object above instead.
-        'document': doc,
-        'contributors': contributors,
-        'contributors_count': contributors_count,
-        'contributors_limit': 6,
-        'has_contributors': has_contributors,
         'fallback_reason': fallback_reason,
         'seo_summary': seo_summary,
         'seo_parent_title': seo_parent_title,
-        'share_text': share_text,
-        'search_url': get_search_url_from_referer(request) or '',
-        'analytics_page_revision': doc.current_revision_id,
-        'analytics_en_slug': en_slug,
-        'other_translations': other_translations,
-        'all_locales': all_locales,
     }
     response = render(request, 'wiki/react_document.html', context)
 


### PR DESCRIPTION
I was double-checking how we handle contributors in the React-based views, and realized that there was some redundancy in the `react_document` view, as well as a number of no-longer-used context variables. This PR simplifies that view based on current usage. There is more here that we'll simplify later as we move more of the Jinja template code to the React side.