### PR TITLE
Bug 1525719: measure and report client-side navigation timing.

### DIFF
--- a/kuma/javascript/src/document-provider.jsx
+++ b/kuma/javascript/src/document-provider.jsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useState } from 'react';
 
 import GAProvider from './ga-provider.jsx';
 import { getLocale } from './l10n.js';
+import { navigateStart, navigateFetchComplete } from './perf.js';
 
 export type DocumentData = {
     locale: string,
@@ -68,6 +69,7 @@ export default function DocumentProvider(
 
         // This is the function that does client side navigation
         function navigate(url, slug) {
+            navigateStart();
             body.style.opacity = '0.15';
             // The fallback is for the case when we request a non-English
             // document that doesn't exist. In that case, before we abandon
@@ -95,6 +97,9 @@ export default function DocumentProvider(
                         // full page load of that document.
                         window.location = json.redirectURL;
                     } else {
+                        // Make a note of how long it took to fetch data.
+                        navigateFetchComplete();
+
                         let documentData = json.documentData;
                         // If the slug of the received document is different
                         // than the slug we requested, then we were redirected

--- a/kuma/javascript/src/ga-provider.jsx
+++ b/kuma/javascript/src/ga-provider.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import { useContext, useEffect, useState } from 'react';
 
-type GAFunction = (...any) => void;
+export type GAFunction = (...any) => void;
 
 const noop: GAFunction = () => {};
 

--- a/kuma/javascript/src/perf.js
+++ b/kuma/javascript/src/perf.js
@@ -1,0 +1,60 @@
+// @flow
+// eslint-disable no-console
+import type { GAFunction } from './ga-provider.jsx';
+
+const START = 'client-side-navigate-start';
+const FETCH = 'client-side-navigate-fetch';
+const RENDER = 'client-side-navigate-render';
+
+let navigating = false;
+
+export function navigateStart() {
+    navigating = true;
+    try {
+        performance.clearMarks(START);
+        performance.clearMeasures(FETCH);
+        performance.clearMeasures(RENDER);
+        performance.mark(START);
+    } catch (e) {
+        console.error(e);
+    }
+}
+
+export function navigateFetchComplete() {
+    if (navigating) {
+        try {
+            performance.measure(FETCH, START);
+        } catch (e) {
+            console.error(e);
+        }
+    }
+}
+
+export function navigateRenderComplete(ga: GAFunction) {
+    if (navigating) {
+        navigating = false;
+
+        try {
+            performance.measure(RENDER, START);
+
+            let fetchTime = performance.getEntriesByName(FETCH)[0].duration;
+            let renderTime = performance.getEntriesByName(RENDER)[0].duration;
+
+            ga('send', {
+                hitType: 'timing',
+                timingCategory: 'Client side navigation',
+                timingVar: 'fetch',
+                timingValue: Math.round(fetchTime)
+            });
+
+            ga('send', {
+                hitType: 'timing',
+                timingCategory: 'Client side navigation',
+                timingVar: 'render',
+                timingValue: Math.round(renderTime)
+            });
+        } catch (e) {
+            console.error(e);
+        }
+    }
+}


### PR DESCRIPTION
This PR uses performance.mark() and performance.measure() to record
the fetch and the fetch+render times for each client-side navigation
and reports those times to Google Analytics with a 'timing' hitType
and a timingCategory of 'Client side navigation'.