### PR TITLE
bug 1553303: exclude kuma Dockerfile from renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,8 @@
     "assets/ckeditor4/source/plugins/descriptionlist/package.json",
     "kuma/static/js/libs/jquery-ui-1.10.3.custom/development-bundle/package.json",
     "kumascript/package.json",
-    "tests/performance/Dockerfile"
+    "tests/performance/Dockerfile",
+    "docker/images/kuma/Dockerfile"
   ],
   "masterIssue": true,
   "dockerfile": {


### PR DESCRIPTION
This PR adjusts the `renovate` configuration to exclude the Dockerfile for kuma (`docker/images/kuma/Dockerfile`). The base image in that file, `mdnwebdocs/kuma_base:latest` should never be pinned, since it is never acquired from the registry but rather always from a local build performed immediately previous (see our Jenkins and Travis flows).