### PR TITLE
bug 1553333: fix ES port-binding failure in Jenkins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -102,8 +102,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=false
       - ES_JAVA_OPTS=-Xms512m -Xmx512m
-    ports:
-      - "9200:9200"
     volumes:
       - esdata:/usr/share/elasticsearch/data
 


### PR DESCRIPTION
Sometimes, when running `docker-compose -f docker-compose.yml -f docker-compose.test.yml run test` within Jenkins, the host system's bind to port 9200 fails when spinning-up the `elasticsearch` service:
```
+ docker-compose -f docker-compose.yml -f docker-compose.test.yml run test
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_elasticsearch_1 ... 
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_mysql_1         ... 
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_redis_1         ... 
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_elasticsearch_1 ... error
ERROR: for kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_elasticsearch_1  
Cannot start service elasticsearch: driver failed programming external connectivity on endpoint kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_elasticsearch_1 (ab17e49d1c083d1d03ac65474381a2c19a5d4f3c1d0bd950dc126dfcfe1a6946):
Bind for 0.0.0.0:9200 failed: port is already allocated
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_mysql_1         ... done
Creating kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_redis_1         ... done
ERROR: for elasticsearch 
Cannot start service elasticsearch: driver failed programming external connectivity on endpoint kuma_master-dag2lj3obypfho7nheyqt4rqhoc6v2dswzq2pndatnegq7lwo6na_elasticsearch_1 (ab17e49d1c083d1d03ac65474381a2c19a5d4f3c1d0bd950dc126dfcfe1a6946): 
Bind for 0.0.0.0:9200 failed: port is already allocated
Encountered errors while bringing up the project.
script returned exit code 1
```

This PR moves the host bind port for `elasticsearch` from `9200` to `9201`, which should keep it away from any commonly used ports while still keeping it available outside of docker.

I pushed the branch in my fork into a branch of the same name in the `kuma` repo just so Jenkins would pick it up and run the tests. It started and ran fine:
```
+ docker-compose -f docker-compose.yml -f docker-compose.test.yml run test
Creating elasticsearch-port-error-1553333_mysql_1 ... 
Creating elasticsearch-port-error-1553333_elasticsearch_1 ... 
Creating elasticsearch-port-error-1553333_redis_1         ...
============================= test session starts ==============================
platform linux2 -- Python 2.7.16, pytest-3.1.3, py-1.4.33, pluggy-0.4.0
Django settings: kuma.settings.testing (from ini file)
rootdir: /app, inifile: pytest.ini
plugins: cov-2.4.0, django-3.1.2
collected 1898 items
kuma/api/tests/test_signal_handlers.py ....
kuma/api/tests/test_tasks.py ............
kuma/api/v1/tests/test_views.py ...........................
...
```
but of course the real indicator of success will be when we've not seen any port-binding failures in Jenkins for a week or two.