### PR TITLE
Bug 1525719: modify localization code to not violate CSP

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -17,7 +17,7 @@ if (container) {
     window._react_data = null; // eslint-disable-line camelcase
 
     // Store the string catalog so that l10n.gettext() can do translations
-    localize(data.requestData.locale, data.localizationData);
+    localize(data.requestData.locale, data.stringCatalog, data.pluralFunction);
 
     // This is the React UI for a page of documentation
     let app = <App documentData={data.documentData} />;

--- a/kuma/javascript/src/l10n.test.js
+++ b/kuma/javascript/src/l10n.test.js
@@ -3,20 +3,18 @@
 import { localize, getLocale, gettext, ngettext, interpolate } from './l10n.js';
 
 describe('getLocale', () => {
-    let emptyData = { catalog: {}, plural: null };
-
     it('default value', () => {
         expect(getLocale()).toBe('en-US');
     });
     it('value can be set with localize()', () => {
-        localize('en-pt', emptyData);
+        localize('en-pt', {}, null);
         expect(getLocale()).toBe('en-pt');
-        localize('en-uk', emptyData);
+        localize('en-uk', {}, null);
         expect(getLocale()).toBe('en-uk');
-        localize('', emptyData);
+        localize('', {});
         expect(getLocale()).toBe('en-US');
         // $FlowFixMe$: purposely testing bad data
-        localize(null, emptyData);
+        localize(null, {});
         expect(getLocale()).toBe('en-US');
     });
 });
@@ -35,13 +33,7 @@ describe('gettext', () => {
         expect(gettext('foo!')).toBe('foo!');
         expect(gettext('__bar&&##')).toBe('__bar&&##');
 
-        // $FlowFixMe$: purposely testing bad data
         localize('test', {});
-        expect(gettext('')).toBe('');
-        expect(gettext('foo!')).toBe('foo!');
-        expect(gettext('__bar&&##')).toBe('__bar&&##');
-
-        localize('test', { catalog: {}, plural: null });
         expect(gettext('')).toBe('');
         expect(gettext('foo!')).toBe('foo!');
         expect(gettext('__bar&&##')).toBe('__bar&&##');
@@ -49,18 +41,16 @@ describe('gettext', () => {
 
     it('works with a django-style string catalog', () => {
         localize('test', {
-            catalog: {
-                '': 'translated empty string',
-                'foo!': 'bar!',
-                '__bar&&##': 'gibberish',
-                singular: ['one', 'many'],
-                // This should not happen, but I want to test that we
-                // handle it if data is bad.
-                // $FlowFixMe$ (purposeful type error we're supressing)
-                'null string': null
-            },
-            plural: null
+            '': 'translated empty string',
+            'foo!': 'bar!',
+            '__bar&&##': 'gibberish',
+            singular: ['one', 'many'],
+            // This should not happen, but I want to test that we
+            // handle it if data is bad.
+            // $FlowFixMe$ (purposeful type error we're supressing)
+            'null string': null
         });
+
         expect(gettext('')).toBe('translated empty string');
         expect(gettext('foo!')).toBe('bar!');
         expect(gettext('__bar&&##')).toBe('gibberish');
@@ -87,26 +77,21 @@ describe('ngettext', () => {
         expect(ngettext('s', 'p', 2)).toBe('p');
         expect(ngettext('s', 'p', 3)).toBe('p');
 
-        // $FlowFixMe$: purposely testing bad data
         localize('test', {});
         expect(ngettext('s', 'p', 1)).toBe('s');
         expect(ngettext('s', 'p', 2)).toBe('p');
         expect(ngettext('s', 'p', 3)).toBe('p');
 
-        localize('test', {
-            catalog: { t: 'translation' },
-            plural: '(n >=1 && n <= 4) ? n-1 : 4'
-        });
+        localize('test', { t: 'translation' }, n =>
+            n >= 1 && n <= 4 ? n - 1 : 4
+        );
         expect(ngettext('s', 'p', 1)).toBe('s');
         expect(ngettext('s', 'p', 2)).toBe('p');
         expect(ngettext('s', 'p', 3)).toBe('p');
     });
 
     it('Uses english pluralization rules by default', () => {
-        localize('test', {
-            catalog: { s: ['singular', 'plural'] },
-            plural: null
-        });
+        localize('test', { s: ['singular', 'plural'] }, null);
         expect(ngettext('s', 'p', 0)).toBe('plural');
         expect(ngettext('s', 'p', 1)).toBe('singular');
         expect(ngettext('s', 'p', 2)).toBe('plural');
@@ -116,10 +101,9 @@ describe('ngettext', () => {
     });
 
     it('Supports custom pluralization rules', () => {
-        localize('test', {
-            catalog: { s: ['one', 'two', 'three', 'four', 'many'] },
-            plural: '(n >=1 && n <= 4) ? n-1 : 4'
-        });
+        localize('test', { s: ['one', 'two', 'three', 'four', 'many'] }, n =>
+            n >= 1 && n <= 4 ? n - 1 : 4
+        );
         expect(ngettext('s', 'p', 1)).toBe('one');
         expect(ngettext('s', 'p', 2)).toBe('two');
         expect(ngettext('s', 'p', 3)).toBe('three');
@@ -130,10 +114,7 @@ describe('ngettext', () => {
     });
 
     it('Returns singular if no plural forms available', () => {
-        localize('test', {
-            catalog: { s: 't' },
-            plural: '(n >=1 && n <= 4) ? n-1 : 4'
-        });
+        localize('test', { s: 't' }, n => (n >= 1 && n <= 4 ? n - 1 : 4));
         expect(ngettext('s', 'p', 1)).toBe('t');
         expect(ngettext('s', 'p', 2)).toBe('t');
         expect(ngettext('s', 'p', 3)).toBe('t');

--- a/kuma/javascript/src/ssr.jsx
+++ b/kuma/javascript/src/ssr.jsx
@@ -9,8 +9,20 @@ import { localize } from './l10n.js';
  * a JSON object of document data. It is used by ../ssr-server.js
  */
 export default function ssr(data) {
-    // Store the string catalog so that l10n.gettext() can do translations
-    localize(data.requestData.locale, data.localizationData);
+    // Before we can render the App, we need to call localize() so that
+    // gettext() and ngettext() will work property during rendering.
+    let pluralFunction = null;
+    if (data.pluralExpression) {
+        // Creating a function like this in client-side JS will usually
+        // violate CSP. But we're running in Node here, so it is okay.
+        pluralFunction = new Function(
+            'n',
+            `let v=(${
+                data.pluralExpression
+            });return(v===true)?1:((v===false)?0:v);`
+        );
+    }
+    localize(data.requestData.locale, data.stringCatalog, pluralFunction);
 
     return renderToString(<App documentData={data.documentData} />);
 }

--- a/kuma/javascript/src/task-completion-survey.test.js
+++ b/kuma/javascript/src/task-completion-survey.test.js
@@ -34,7 +34,7 @@ describe('TaskCompletionSurvey', () => {
         mockUserData.waffle.flags[WAFFLE_FLAG] = true;
         localStorage.clear();
 
-        localize(mockLocale, { catalog: {}, plural: null });
+        localize(mockLocale, {}, null);
 
         const tcs = create(
             <GAProvider.context.Provider value={mockGA2}>


### PR DESCRIPTION
In a recent patch I introduced a new l10n.js module for localization
of our React code. It used the Function() constructor to build a
plural function from the plural expression string that Django supplied.
Unfortunately, this violates the CSP policy that we would like to start
using.

So this PR modifies the backend to embed a valid plural function into
the window._react_data object that it includes in each HTML page. And
it also modifies ssr.jsx to use the Function() constructor to create
the plural function (in Node, so it does not violate CSP) when needed.

Because this patch decouples the plural expression from the string
catalog, it also removes the generic localizationData object and
uses the stringCatalog object directly.