### PR TITLE
Make the language menu work for React-based pages

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -36,13 +36,13 @@ if (container) {
     }
 
     // Finally, here is some other miscellaneous code that we need to run.
-    // The idea is that this is code need to make the non-React parts of
+    // The idea is that this is code needed to make the non-React parts of
     // the UX work correctly. If we end up with more than a couple of things
-    // here we should refactor them into a separate module
+    // here, we should refactor them into a separate module
 
     // An event handler to make the language selector menu
     // in the footer work correctly.
-    // See also kuma/static/js/main.js where similar code appears ot
+    // See also kuma/static/js/main.js where similar code appears to
     // make the menu work on the wiki domain
     for (let menu of document.querySelectorAll('select.autosubmit')) {
         menu.addEventListener('change', function() {

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -34,4 +34,19 @@ if (container) {
         // server side rendering.
         ReactDOM.render(app, container);
     }
+
+    // Finally, here is some other miscellaneous code that we need to run.
+    // The idea is that this is code need to make the non-React parts of
+    // the UX work correctly. If we end up with more than a couple of things
+    // here we should refactor them into a separate module
+
+    // An event handler to make the language selector menu
+    // in the footer work correctly.
+    // See also kuma/static/js/main.js where similar code appears ot
+    // make the menu work on the wiki domain
+    for (let menu of document.querySelectorAll('select.autosubmit')) {
+        menu.addEventListener('change', function() {
+            this.form.submit();
+        });
+    }
 }


### PR DESCRIPTION
The main.js file is not included into our React-based pages, so
the language menu in the footer does not autosubmit like it is
supposed to. This PR adds the required event handler to make it
work again. For now, at least, this code is just tacked on at
the end of index.jsx so it can be transpiled and bundled with
webpack.