### PR TITLE
bug 1518653: Revert PR #5433

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -275,8 +275,8 @@ mysqlclient==1.3.13 \
 # Report performance metrics and exceptions to New Relic
 # Docs: https://docs.newrelic.com/docs/agents/python-agent/
 # Changes: https://docs.newrelic.com/docs/release-notes/agent-release-notes/python-release-notes
-newrelic==4.18.0.118 \
-    --hash=sha256:3cd496022c6906ee3cdbf27c67ec3e03922830bfebbca4549ef6f2e58cf719e2
+newrelic==3.2.1.93 \
+    --hash=sha256:e60204f6d6b41741021d078ad5145414c759ff2482e2136ce22c9957654d9ca7
 
 # Compile .po files into .mo files, used in locale/compile-mo.sh
 polib==1.1.0 \


### PR DESCRIPTION
This reverts PR #5433 (only the python agent though)

Error seen 

```
[2019-05-23 16:43:12,975: ERROR/MainProcess] Unrecoverable error: AttributeError("'str' object has no attribute 'iteritems'",)
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/celery/worker/__init__.py", line 206, in start
    self.blueprint.start(self)
  File "/usr/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/site-packages/celery/bootsteps.py", line 374, in start
    return self.obj.start()
  File "/usr/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 280, in start
    blueprint.start(self)
  File "/usr/local/lib/python2.7/site-packages/celery/bootsteps.py", line 123, in start
    step.start(parent)
  File "/usr/local/lib/python2.7/site-packages/celery/worker/consumer.py", line 884, in start
    c.loop(*c.loop_args())
  File "/usr/local/lib/python2.7/site-packages/celery/worker/loops.py", line 76, in asynloop
    next(loop)
  File "/usr/local/lib/python2.7/site-packages/kombu/async/hub.py", line 340, in create_loop
    cb(*cbargs)
  File "/usr/local/lib/python2.7/site-packages/kombu/transport/redis.py", line 1019, in on_readable
    self._callbacks[queue](message)
  File "/usr/local/lib/python2.7/site-packages/kombu/transport/virtual/__init__.py", line 534, in _callback
    self.qos.append(message, message.delivery_tag)
  File "/usr/local/lib/python2.7/site-packages/kombu/transport/redis.py", line 146, in append
    pipe.zadd(self.unacked_index_key, delivery_tag, time()) \
  File "/usr/local/lib/python2.7/site-packages/newrelic/hooks/datastore_redis.py", line 65, in _nr_wrapper_Redis_method_
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/newrelic/hooks/datastore_redis.py", line 65, in _nr_wrapper_Redis_method_
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/newrelic/hooks/datastore_redis.py", line 65, in _nr_wrapper_Redis_method_
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/newrelic/hooks/datastore_redis.py", line 65, in _nr_wrapper_Redis_method_
    return wrapped(*args, **kwargs)
  File "/usr/local/lib/python2.7/site-packages/redis/client.py", line 2320, in zadd
    for pair in iteritems(mapping):
  File "/usr/local/lib/python2.7/site-packages/redis/_compat.py", line 81, in iteritems
    return x.iteritems()
AttributeError: 'str' object has no attribute 'iteritems'
2019-05-23 16:43:12,986 (15/MainThread) newrelic.core.agent INFO - New Relic Python Agent Shutdown
2019-05-23 16:43:12,986 (18/MainThread) newrelic.core.agent INFO - New Relic Python Agent Shutdown
2019-05-23 16:43:12,986 (12/MainThread) newrelic.core.agent INFO - New Relic Python Agent Shutdown
[2019-05-23 16:43:12,986: INFO/Worker-2] New Relic Python Agent Shutdown
[2019-05-23 16:43:12,986: INFO/Worker-3] New Relic Python Agent Shutdown
[2019-05-23 16:43:12,986: INFO/Worker-1] New Relic Python Agent Shutdown
```