### PR TITLE
Include the post-message-handler.js module in React-based pages.

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -959,6 +959,7 @@ PIPELINE_JS = {
         'source_filenames': (
             'js/libs/jquery/jquery.js',
             'js/libs/jquery-ajax-prefilter.js',
+            'js/utils/post-message-handler.js',
             # 'js/libs/icons.js',
             # 'js/components.js',
             'js/analytics.js',


### PR DESCRIPTION
Interactive examples embedded in our pages post two different sets
of perf metrics to us, and for some reason we handle these messages
in two different places. One handler is in includes/perf.html and
this was already running in React-based pages. The other handler is
in js/utils/post-message-handler.js and it had been removed from
React-based pages. This PR puts it back.

In addition to this PR, we also need to land
https://github.com/mdn/bob/pull/244 in order for the interactive
examples data reporting mechanism to work with our beta site.