### PR TITLE
bug 1551701: revert back to Redis 2.x

### DIFF
--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -315,9 +315,9 @@ raven==6.9.0 \
     --hash=sha256:95f44f3ea2c1b176d5450df4becdb96c15bf2632888f9ab193e9dd22300ce46a
 
 # Modern caching server, to replace memcached in AWS
-redis==3.2.1 \
-    --hash=sha256:6946b5dca72e86103edc8033019cc3814c031232d339d5f4533b02ea85685175 \
-    --hash=sha256:8ca418d2ddca1b1a850afa1680a7d2fd1f3322739271de4b704e0d4668449273
+redis==2.10.6 \
+    --hash=sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb \
+    --hash=sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f
 
 # Mock HTTP requests for tests
 requests-mock==0.7.0 \


### PR DESCRIPTION
This PR partially reverts https://github.com/mozilla/kuma/pull/5411, moving the Python Redis client package back to version 2. It turns out that the upgrade to Redis version 3 is incompatible with Celery version 3 (see https://github.com/mozilla/kuma/pull/5411#issuecomment-495771668), and breaks our Celery workers.