### PR TITLE
Use React effect hooks to fix up article section headings.

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -708,6 +708,12 @@ Array [
   max-width: 42rem;
 }
 
+.emotion-22 a.sectionLink {
+  font-size: 24px;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .emotion-21 {
   margin-top: 32px;
   font-size: 0.88889rem;

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -1,0 +1,140 @@
+// @flow
+import * as React from 'react';
+import { useEffect, useRef } from 'react';
+import { css } from '@emotion/core';
+
+import ClockIcon from './icons/clock.svg';
+import ContributorsIcon from './icons/contributors.svg';
+import { getLocale, gettext } from './l10n.js';
+
+import type { DocumentData } from './document-provider.jsx';
+type DocumentProps = {
+    document: DocumentData
+};
+
+// A media query that identifies screens narrower than a tablet
+const NARROW = '@media (max-width: 749px)';
+
+const styles = {
+    article: css({
+        gridArea: 'main',
+        boxSizing: 'border-box',
+        width: '100%',
+        overflowX: 'scroll',
+        // Less padding on the left because the sidebar also has
+        // padding on the right
+        padding: '30px 24px 30px 12px',
+        [NARROW]: {
+            // Except on small screens the sidebar is below, so we
+            // need the same (but overall smaller) padding on both sides.
+            padding: '15px 12px'
+        },
+        '& p': {
+            maxWidth: '42rem'
+        },
+        '& a.sectionLink': {
+            fontSize: 24,
+            textDecoration: 'none'
+        }
+    }),
+    metadata: css({
+        marginTop: 32,
+        fontSize: '0.88889rem',
+        color: '#696969',
+        '& div': {
+            margin: '4px 0'
+        }
+    }),
+    contributorsIcon: css({
+        width: 14,
+        height: 14,
+        marginRight: 5,
+        verticalAlign: 'middle',
+        fill: '#696969'
+    }),
+    clockIcon: css({
+        width: 16,
+        height: 16,
+        marginRight: 5,
+        verticalAlign: 'middle',
+        fill: '#696969'
+    })
+};
+
+// This is an effect function that runs every time the article is rendered.
+// This is the React version of the code in kuma/static/js/highlight.js
+// which is used on the wiki domain
+function highlightSections(article) {
+    let sections = article.querySelectorAll('#wikiArticle h3, #wikiArticle h5');
+    for (let section of sections) {
+        section.classList.add('highlight-spanned');
+        section.innerHTML = `<span class="highlight-span">${
+            section.innerHTML
+        }</span>`;
+    }
+}
+
+// This is an effect function that runs every time the article is rendered.
+// This is the React version of the pre-React code in
+// kuma/static/js/components/local-anchor.js
+function addAnchors(article) {
+    for (let heading of article.querySelectorAll('h2[id], h3[id]')) {
+        let anchor = document.createElement('a');
+        anchor.href = `#${heading.id}`;
+        anchor.classList.add('sectionLink');
+        anchor.textContent = ' \uD83D\uDD17'; // Unicode link emoji
+        heading.insertAdjacentElement('beforeend', anchor);
+    }
+}
+
+export default function Article({ document }: DocumentProps) {
+    const article = useRef(null);
+    useEffect(() => article.current && highlightSections(article.current));
+    useEffect(() => article.current && addAnchors(article.current));
+
+    return (
+        /*
+         * The "text-content" class and "wikiArticle" id are required
+         * because our stylesheets expect them and formatting isn't quite
+         * right without them.
+         */
+        <div ref={article} className="text-content" css={styles.article}>
+            <article
+                id="wikiArticle"
+                dangerouslySetInnerHTML={{ __html: document.bodyHTML }}
+            />
+            <ArticleMetadata document={document} />
+        </div>
+    );
+}
+
+function ArticleMetadata({ document }: DocumentProps) {
+    const locale = getLocale();
+    return (
+        <div css={styles.metadata}>
+            <div>
+                <ContributorsIcon css={styles.contributorsIcon} />{' '}
+                <strong>{gettext('Contributors to this page:')}</strong>{' '}
+                {document.contributors.map((c, i) => (
+                    <span key={c}>
+                        {i > 0 && ', '}
+                        <a href={`/${locale}/profiles/${c}`} rel="nofollow">
+                            {c}
+                        </a>
+                    </span>
+                ))}
+            </div>
+            <div>
+                <ClockIcon css={styles.clockIcon} />{' '}
+                <strong>{gettext('Last updated by:')}</strong>{' '}
+                {document.lastModifiedBy}{' '}
+                <time dateTime={document.lastModified}>
+                    {new Date(document.lastModified)
+                        .toISOString()
+                        .slice(0, -5)
+                        .replace('T', ' ')}
+                </time>
+            </div>
+        </div>
+    );
+}

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -3,11 +3,10 @@ import * as React from 'react';
 import { useContext, useEffect } from 'react';
 import { css } from '@emotion/core';
 
-import ClockIcon from './icons/clock.svg';
-import ContributorsIcon from './icons/contributors.svg';
+import Article from './article.jsx';
 import DocumentProvider from './document-provider.jsx';
 import GAProvider from './ga-provider.jsx';
-import { getLocale, gettext } from './l10n.js';
+import { gettext } from './l10n.js';
 import LanguageMenu from './header/language-menu.jsx';
 import { Row } from './layout.jsx';
 import Header from './header/header.jsx';
@@ -91,23 +90,6 @@ const styles = {
         fontSize: 18,
         margin: '0 8px'
     }),
-    article: css({
-        gridArea: 'main',
-        boxSizing: 'border-box',
-        width: '100%',
-        overflowX: 'scroll',
-        // Less padding on the left because the sidebar also has
-        // padding on the right
-        padding: '30px 24px 30px 12px',
-        [NARROW]: {
-            // Except on small screens the sidebar is below, so we
-            // need the same (but overall smaller) padding on both sides.
-            padding: '15px 12px'
-        },
-        '& p': {
-            maxWidth: '42rem'
-        }
-    }),
     sidebar: css({
         gridArea: 'side',
         boxSizing: 'border-box',
@@ -124,28 +106,6 @@ const styles = {
     }),
     related: css({
         fontSize: 20
-    }),
-    metadata: css({
-        marginTop: 32,
-        fontSize: '0.88889rem',
-        color: '#696969',
-        '& div': {
-            margin: '4px 0'
-        }
-    }),
-    contributorsIcon: css({
-        width: 14,
-        height: 14,
-        marginRight: 5,
-        verticalAlign: 'middle',
-        fill: '#696969'
-    }),
-    clockIcon: css({
-        width: 16,
-        height: 16,
-        marginRight: 5,
-        verticalAlign: 'middle',
-        fill: '#696969'
     })
 };
 
@@ -197,54 +157,6 @@ function Breadcrumbs({ document }: DocumentProps) {
                 </ol>
             </nav>
             <LanguageMenu />
-        </div>
-    );
-}
-
-function Article({ document }: DocumentProps) {
-    return (
-        /*
-         * The "text-content" class and "wikiArticle" id are required
-         * because our stylesheets expect them and formatting isn't quite
-         * right without them.
-         */
-        <div className="text-content" css={styles.article}>
-            <article
-                id="wikiArticle"
-                dangerouslySetInnerHTML={{ __html: document.bodyHTML }}
-            />
-            <ArticleMetadata document={document} />
-        </div>
-    );
-}
-
-function ArticleMetadata({ document }: DocumentProps) {
-    const locale = getLocale();
-    return (
-        <div css={styles.metadata}>
-            <div>
-                <ContributorsIcon css={styles.contributorsIcon} />{' '}
-                <strong>{gettext('Contributors to this page:')}</strong>{' '}
-                {document.contributors.map((c, i) => (
-                    <span key={c}>
-                        {i > 0 && ', '}
-                        <a href={`/${locale}/profiles/${c}`} rel="nofollow">
-                            {c}
-                        </a>
-                    </span>
-                ))}
-            </div>
-            <div>
-                <ClockIcon css={styles.clockIcon} />{' '}
-                <strong>{gettext('Last updated by:')}</strong>{' '}
-                {document.lastModifiedBy}{' '}
-                <time dateTime={document.lastModified}>
-                    {new Date(document.lastModified)
-                        .toISOString()
-                        .slice(0, -5)
-                        .replace('T', ' ')}
-                </time>
-            </div>
         </div>
     );
 }

--- a/kuma/static/js/components/local-anchor.js
+++ b/kuma/static/js/components/local-anchor.js
@@ -1,6 +1,9 @@
 /**
  * Find all level two and three headings, and append a link
  * element that links directly to the heading
+ *
+ * See also the React version of this code in the addAnchors() function
+ * of kuma/javascript/src/article.jsx
  */
 
 (function() {

--- a/kuma/static/js/highlight.js
+++ b/kuma/static/js/highlight.js
@@ -1,3 +1,5 @@
+// The React version of this code is in the highlightSections() function
+// of kuma/javascript/src/article.jsx
 (function($) {
     'use strict';
 
@@ -5,12 +7,13 @@
     function highlight(targets) {
         var $targets = $(targets);
         $targets.each(function() {
-            $(this).addClass('highlight-spanned').wrapInner('<span class="highlight-span"></span>');
+            $(this)
+                .addClass('highlight-spanned')
+                .wrapInner('<span class="highlight-span"></span>');
         });
     }
 
     var $articleSubHeads;
     $articleSubHeads = $('#wikiArticle h3, #wikiArticle h5');
     highlight($articleSubHeads);
-
 })(jQuery);


### PR DESCRIPTION
Kuma runs two JavaScript modules on page load to add styles and
anchors to certain section heading within the main article content.
This PR adds those features to the React version of the site. It
moves the Article component from page.jsx into its own article.jsx
file, and then adds two useEffect() hooks to run code over the
article HTML content each time the article is re-rendered.