### PR TITLE
Bug 1555004: stop including the react.js strings file into beta pages

### DIFF
--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -152,7 +152,7 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    <!-- strings used by javascript modules. Hopefully we can remove soon -->
+    {# Strings used by javascript modules. Hopefully we can remove soon. #}
     <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'react-main' %}
     <script>

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -152,7 +152,8 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    <script src="{{ react_i18n(request.LANGUAGE_CODE) }}"></script>
+    <!-- strings used by javascript modules. Hopefully we can remove soon -->
+    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'react-main' %}
     <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();

--- a/kuma/core/templatetags/jinja_helpers.py
+++ b/kuma/core/templatetags/jinja_helpers.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 import datetime
 import json
-import os.path
 
 import jinja2
 from django.conf import settings
@@ -18,7 +17,6 @@ from django_jinja import library
 from pytz import timezone, utc
 from soapbox.models import Message
 from statici18n.templatetags.statici18n import statici18n
-from statici18n.utils import get_filename
 from urlobject import URLObject
 
 from ..urlresolvers import reverse, split_path
@@ -204,16 +202,3 @@ def get_locale_localized(locale):
     language = settings.LOCALES[locale].english
 
     return _(language)
-
-
-@library.global_function
-def react_i18n(locale):
-    """
-    Return the path to the internationalization file for React code.
-
-    This is similar to statici18n, but uses 'react' domain instead of
-    STATICI18N_DOMAIN.
-    """
-    filename = get_filename(locale, 'react')
-    filepath = os.path.join(settings.STATICI18N_OUTPUT_DIR, filename)
-    return static(filepath)

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -144,7 +144,7 @@
     </div>
   </footer>
 
-  <!-- strings used by javascript modules. Hopefully we can remove soon -->
+  {# strings used by javascript modules. Hopefully we can remove soon #}
   <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
   <!-- site js -->
   {% javascript 'react-main' %}

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -144,9 +144,9 @@
     </div>
   </footer>
 
+  <!-- strings used by javascript modules. Hopefully we can remove soon -->
+  <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
   <!-- site js -->
-  <script src="{{ react_i18n(request.LANGUAGE_CODE) }}"></script>
-
   {% javascript 'react-main' %}
   <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();


### PR DESCRIPTION
For reasons I do not understand we've all-of-a-sudden started getting
500 errors from the server because the react.js strings files aren't
properly in the django staticfiles manifest. Rather than figure out
the source cause, this PR just removes the react.js include from the
templates that use it, because with the new React localization system
we don't actually use it anymore, and it should have been removed
a couple of weeks ago.

This is basically a partial revert of commit
bf5fad61ac58f22f5f3b7fcb712cd2f8f0e2dab9 which is what set up
that react.js file in the first place. React localization is now
handled during SSR with the react.json file. So this PR reverts
react.js back to the original javascript.js which provides localization
for any strings used by non-React JavaScript modules.  (When we remove
those non-React JavaScript modules, or at least all of them that use
strings, we'll be able to remove this javascript.js strings file
as well.