### PR TITLE
bug 1475383 - Remove Facebook link and icon from footer

### DIFF
--- a/jinja2/includes/footer/moz-footer.html
+++ b/jinja2/includes/footer/moz-footer.html
@@ -11,11 +11,6 @@
         </a>
     </li>
     <li class="footer-social">
-        <a href="https://www.facebook.com/mozilla">
-            {{ include_svg('includes/icons/social/facebook.svg', _('Facebook')) }}
-        </a>
-    </li>
-    <li class="footer-social">
         <a href="https://www.instagram.com/mozillagram/">
             {{ include_svg('includes/icons/social/instagram.svg', _('Instagram')) }}
         </a>


### PR DESCRIPTION
The `.svg` file is still used on the user profile page. Can you think of any other references to it?

<img width="943" alt="Screen Shot 2019-05-28 at 2 06 11 PM" src="https://user-images.githubusercontent.com/26739/58501250-f092d700-8151-11e9-8b0a-897ec016ba78.png">
