### PR TITLE
Convert the beta page menus back to hover behavior instead of click

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -98,8 +98,22 @@ Array [
 
 .emotion-9 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-9:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-9:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-9:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-5 {
@@ -115,16 +129,21 @@ Array [
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-5:hover {
-  background-color: #eee;
 }
 
 .emotion-5:focus {
   outline-offset: -3px;
+}
+
+.emotion-5 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-3 {
@@ -134,26 +153,42 @@ Array [
 
 .emotion-7 {
   position: absolute;
+  display: none;
   z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
   background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
   min-width: 100%;
-  display: none;
 }
 
 .emotion-7 li {
-  padding: 5px;
+  padding: 6px 16px;
   white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-7 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-7 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-7 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
 }
 
 .emotion-11 {
@@ -269,19 +304,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          Technologies
+          <a
+            href="/en-US/docs/Web"
+          >
+            Technologies
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a
@@ -348,19 +387,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          References & Guides
+          <a
+            href="/en-US/docs/Learn"
+          >
+            References & Guides
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a
@@ -420,19 +463,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          Feedback
+          <a
+            href="/en-US/docs/MDN/Feedback"
+          >
+            Feedback
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a
@@ -591,8 +638,22 @@ Array [
   </div>,
   .emotion-13 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-13:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-13:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-13:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-9 {
@@ -608,21 +669,66 @@ Array [
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-9:hover {
-  background-color: #eee;
 }
 
 .emotion-9:focus {
   outline-offset: -3px;
 }
 
+.emotion-9 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
 .emotion-7 {
   font-size: 75%;
   padding-left: 2px;
+}
+
+.emotion-11 {
+  position: absolute;
+  display: none;
+  z-index: 100;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  box-sizing: border-box;
+  background-color: white;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
+  min-width: 100%;
+}
+
+.emotion-11 li {
+  padding: 6px 16px;
+  white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-11 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-11 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-11 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
 }
 
 .emotion-16 {
@@ -691,31 +797,6 @@ Array [
   height: 20px;
 }
 
-.emotion-11 {
-  position: absolute;
-  z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  box-sizing: border-box;
-  background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
-  min-width: 100%;
-  right: 0;
-  display: none;
-}
-
-.emotion-11 li {
-  padding: 5px;
-  white-space: nowrap;
-}
-
 <div
     className="emotion-16"
   >
@@ -771,9 +852,8 @@ Array [
       <div
         className="emotion-13 emotion-14"
       >
-        <button
-          className="emotion-9 emotion-10"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-9 emotion-10"
         >
           <svg mock
             className="emotion-6"
@@ -783,9 +863,15 @@ Array [
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-11 emotion-12"
+          onClick={[Function]}
+          style={
+            Object {
+              "right": 0,
+            }
+          }
         >
           <li
             lang="es"

--- a/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
@@ -3,8 +3,22 @@
 exports[`Dropdown closed and open snapshots 1`] = `
 .emotion-6 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-6:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-6:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-6:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-2 {
@@ -20,16 +34,21 @@ exports[`Dropdown closed and open snapshots 1`] = `
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-2:hover {
-  background-color: #eee;
 }
 
 .emotion-2:focus {
   outline-offset: -3px;
+}
+
+.emotion-2 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0 {
@@ -39,34 +58,49 @@ exports[`Dropdown closed and open snapshots 1`] = `
 
 .emotion-4 {
   position: absolute;
+  display: none;
   z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
   background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
   min-width: 100%;
-  display: none;
 }
 
 .emotion-4 li {
-  padding: 5px;
+  padding: 6px 16px;
   white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-4 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-4 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-4 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
 }
 
 <div
   className="emotion-6 emotion-7"
 >
-  <button
-    className="emotion-2 emotion-3"
-    onClick={[Function]}
+  <div
+    className="dropdown-menu-label emotion-2 emotion-3"
   >
     Test
     <span
@@ -74,101 +108,10 @@ exports[`Dropdown closed and open snapshots 1`] = `
     >
       ▼
     </span>
-  </button>
+  </div>
   <ul
     className="dropdown-menu emotion-4 emotion-5"
-  >
-    <li>
-      foo
-    </li>
-    <li>
-      bar
-    </li>
-  </ul>
-</div>
-`;
-
-exports[`Dropdown closed and open snapshots 2`] = `
-.emotion-6 {
-  position: relative;
-  pointer-events: auto;
-  margin-left: -5px;
-}
-
-.emotion-0 {
-  font-size: 75%;
-  padding-left: 2px;
-}
-
-.emotion-2 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  white-space: nowrap;
-  padding: 0 5px;
-  border: none;
-  background-color: #83d0f2;
-}
-
-.emotion-2:hover {
-  background-color: #eee;
-}
-
-.emotion-2:focus {
-  outline-offset: -3px;
-}
-
-.emotion-2:hover {
-  background-color: #83d0f2;
-}
-
-.emotion-4 {
-  position: absolute;
-  z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  box-sizing: border-box;
-  background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
-  min-width: 100%;
-}
-
-.emotion-4 li {
-  padding: 5px;
-  white-space: nowrap;
-}
-
-<div
-  className="emotion-6 emotion-7"
->
-  <button
-    className="emotion-2 emotion-3"
-    onClick={null}
-  >
-    Test
-    <span
-      className="emotion-0 emotion-1"
-    >
-      ▲
-    </span>
-  </button>
-  <ul
-    className="dropdown-menu emotion-4 emotion-5"
+    onClick={[Function]}
   >
     <li>
       foo

--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -98,8 +98,22 @@ Array [
 
 .emotion-9 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-9:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-9:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-9:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-5 {
@@ -115,16 +129,21 @@ Array [
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-5:hover {
-  background-color: #eee;
 }
 
 .emotion-5:focus {
   outline-offset: -3px;
+}
+
+.emotion-5 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-3 {
@@ -134,26 +153,42 @@ Array [
 
 .emotion-7 {
   position: absolute;
+  display: none;
   z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
   background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
   min-width: 100%;
-  display: none;
 }
 
 .emotion-7 li {
-  padding: 5px;
+  padding: 6px 16px;
   white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-7 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-7 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-7 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
 }
 
 .emotion-11 {
@@ -269,19 +304,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          Technologies
+          <a
+            href="/en-US/docs/Web"
+          >
+            Technologies
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a
@@ -348,19 +387,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          References & Guides
+          <a
+            href="/en-US/docs/Learn"
+          >
+            References & Guides
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a
@@ -420,19 +463,23 @@ Array [
       <div
         className="emotion-9 emotion-10"
       >
-        <button
-          className="emotion-5 emotion-6"
-          onClick={[Function]}
+        <div
+          className="dropdown-menu-label emotion-5 emotion-6"
         >
-          Feedback
+          <a
+            href="/en-US/docs/MDN/Feedback"
+          >
+            Feedback
+          </a>
           <span
             className="emotion-3 emotion-4"
           >
             ▼
           </span>
-        </button>
+        </div>
         <ul
           className="dropdown-menu emotion-7 emotion-8"
+          onClick={[Function]}
         >
           <li>
             <a

--- a/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
@@ -3,8 +3,22 @@
 exports[`LanguageMenu snapshot 1`] = `
 .emotion-7 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-7:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-7:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-7:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-3 {
@@ -20,16 +34,21 @@ exports[`LanguageMenu snapshot 1`] = `
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-3:hover {
-  background-color: #eee;
 }
 
 .emotion-3:focus {
   outline-offset: -3px;
+}
+
+.emotion-3 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0 {
@@ -43,35 +62,49 @@ exports[`LanguageMenu snapshot 1`] = `
 
 .emotion-5 {
   position: absolute;
+  display: none;
   z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
   background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
   min-width: 100%;
-  right: 0;
-  display: none;
 }
 
 .emotion-5 li {
-  padding: 5px;
+  padding: 6px 16px;
   white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-5 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-5 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-5 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
 }
 
 <div
   className="emotion-7 emotion-8"
 >
-  <button
-    className="emotion-3 emotion-4"
-    onClick={[Function]}
+  <div
+    className="dropdown-menu-label emotion-3 emotion-4"
   >
     <svg mock
       className="emotion-0"
@@ -81,9 +114,15 @@ exports[`LanguageMenu snapshot 1`] = `
     >
       ▼
     </span>
-  </button>
+  </div>
   <ul
     className="dropdown-menu emotion-5 emotion-6"
+    onClick={[Function]}
+    style={
+      Object {
+        "right": 0,
+      }
+    }
   >
     <li
       lang="es"

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -22,8 +22,22 @@ exports[`Login component when user is logged in 1`] = `
 
 .emotion-6 {
   position: relative;
-  pointer-events: auto;
   margin-left: -5px;
+}
+
+.emotion-6:hover .dropdown-menu-label {
+  color: #3d7e9a;
+}
+
+.emotion-6:hover .dropdown-menu-label a {
+  color: #3d7e9a;
+}
+
+.emotion-6:hover .dropdown-menu {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 .emotion-1 {
@@ -39,16 +53,21 @@ exports[`Login component when user is logged in 1`] = `
   -ms-flex-align: center;
   align-items: center;
   white-space: nowrap;
-  padding: 0 5px;
+  font-size: 15px;
+  font-weight: bold;
+  color: #333;
+  padding: 0 5px 5px 5px;
   border: none;
-}
-
-.emotion-1:hover {
-  background-color: #eee;
 }
 
 .emotion-1:focus {
   outline-offset: -3px;
+}
+
+.emotion-1 a {
+  color: #333;
+  -webkit-text-decoration: none;
+  text-decoration: none;
 }
 
 .emotion-0 {
@@ -59,196 +78,48 @@ exports[`Login component when user is logged in 1`] = `
 
 .emotion-4 {
   position: absolute;
-  z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: column;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  box-sizing: border-box;
-  background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
-  min-width: 100%;
-  right: 0;
   display: none;
-}
-
-.emotion-4 li {
-  padding: 5px;
-  white-space: nowrap;
-}
-
-.emotion-3 {
-  border-width: 0;
-  padding: 0;
-  color: #3d7e9a;
-  font-size: 1em;
-  font-weight: normal;
-}
-
-.emotion-3:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-<div
-  className="emotion-8 emotion-9"
->
-  <div
-    className="emotion-6 emotion-7"
-  >
-    <button
-      className="emotion-1 emotion-2"
-      onClick={[Function]}
-    >
-      <img
-        alt="test-username"
-        className="emotion-0"
-        src="/static/img/avatar.png"
-        srcSet="test-bigurl 200w test-url 50w"
-      />
-    </button>
-    <ul
-      className="dropdown-menu emotion-4 emotion-5"
-    >
-      <li>
-        <a
-          href="/en-US/profiles/test-username"
-        >
-          View profile
-        </a>
-      </li>
-      <li>
-        <a
-          href="/en-US/profiles/test-username/edit"
-        >
-          Edit profile
-        </a>
-      </li>
-      <li>
-        <form
-          action="/en-US/users/signout"
-          method="post"
-        >
-          <input
-            name="next"
-            type="hidden"
-            value="[fake absolute url]"
-          />
-          <button
-            className="emotion-3"
-            type="submit"
-          >
-            Sign out
-          </button>
-        </form>
-      </li>
-    </ul>
-  </div>
-</div>
-`;
-
-exports[`Login component when user is logged in 2`] = `
-.emotion-8 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  margin-left: 24px;
-}
-
-.emotion-8 button {
-  font-size: 1em;
-}
-
-.emotion-6 {
-  position: relative;
-  pointer-events: auto;
-  margin-left: -5px;
-}
-
-.emotion-0 {
-  width: 40px;
-  height: 40px;
-  border-radius: 50%;
-}
-
-.emotion-3 {
-  border-width: 0;
-  padding: 0;
-  color: #3d7e9a;
-  font-size: 1em;
-  font-weight: normal;
-}
-
-.emotion-3:hover {
-  -webkit-text-decoration: underline;
-  text-decoration: underline;
-}
-
-.emotion-1 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-direction: row;
-  -ms-flex-direction: row;
-  flex-direction: row;
-  -webkit-align-items: center;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-  white-space: nowrap;
-  padding: 0 5px;
-  border: none;
-  background-color: #83d0f2;
-}
-
-.emotion-1:hover {
-  background-color: #eee;
-}
-
-.emotion-1:focus {
-  outline-offset: -3px;
-}
-
-.emotion-1:hover {
-  background-color: #83d0f2;
-}
-
-.emotion-4 {
-  position: absolute;
   z-index: 100;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
   box-sizing: border-box;
   background-color: white;
-  border: solid #83d0f2 1.5px;
-  box-shadow: 3px 3px 5px rgba(0,0,0,0.25);
-  padding: 10px;
+  box-shadow: 0 2px 8px 0 rgba(12,12,13,0.1);
+  border: solid 1px #d8dfe2;
+  border-radius: 4px;
+  padding: 4px 0;
   min-width: 100%;
-  right: 0;
 }
 
 .emotion-4 li {
-  padding: 5px;
+  padding: 6px 16px;
   white-space: nowrap;
+  color: #3d7e9a;
+  font-size: 15px;
+  font-weight: bold;
+}
+
+.emotion-4 li:hover {
+  color: #fff;
+  background-color: #3d7e9a;
+}
+
+.emotion-4 li:hover a {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: #fff;
+}
+
+.emotion-4 li:hover button {
+  color: #fff;
+  background-color: #3d7e9a !important;
+}
+
+.emotion-3 {
+  border-width: 0;
+  padding: 0;
+  color: #3d7e9a;
 }
 
 <div
@@ -257,9 +128,8 @@ exports[`Login component when user is logged in 2`] = `
   <div
     className="emotion-6 emotion-7"
   >
-    <button
-      className="emotion-1 emotion-2"
-      onClick={null}
+    <div
+      className="dropdown-menu-label emotion-1 emotion-2"
     >
       <img
         alt="test-username"
@@ -267,9 +137,15 @@ exports[`Login component when user is logged in 2`] = `
         src="/static/img/avatar.png"
         srcSet="test-bigurl 200w test-url 50w"
       />
-    </button>
+    </div>
     <ul
       className="dropdown-menu emotion-4 emotion-5"
+      onClick={[Function]}
+      style={
+        Object {
+          "right": 0,
+        }
+      }
     >
       <li>
         <a

--- a/kuma/javascript/src/header/dropdown.test.js
+++ b/kuma/javascript/src/header/dropdown.test.js
@@ -1,6 +1,6 @@
 //@flow
 import React from 'react';
-import { act, create } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import Dropdown from './dropdown.jsx';
 
 jest.useFakeTimers();
@@ -23,57 +23,4 @@ test('Dropdown closed and open snapshots', () => {
     expect(closedString).toContain('foo');
     expect(closedString).toContain('bar');
     expect(closedTree).toMatchSnapshot();
-
-    // Fake a click on the menu label
-    act(() => {
-        dropdown.toJSON().children[0].props.onClick();
-    });
-
-    let openTree = dropdown.toJSON();
-    let openString = JSON.stringify(openTree);
-
-    // Now expect the menu to be open, and snapshot it in that state
-    expect(openString).toContain('▲');
-    expect(closedString).toContain('foo');
-    expect(closedString).toContain('bar');
-    expect(openTree).toMatchSnapshot();
-
-    // Fake a click on the document body to dismiss the menu
-    act(() => {
-        document.body && document.body.dispatchEvent(new MouseEvent('click'));
-        jest.runAllTimers();
-    });
-
-    // Expect the menu to be closed, checking deep equality
-    expect(JSON.stringify(dropdown.toJSON())).toEqual(closedString);
-
-    // Open the menu again
-    act(() => {
-        dropdown.toJSON().children[0].props.onClick();
-    });
-
-    // Verify that it is opened
-    expect(JSON.stringify(dropdown.toJSON())).toEqual(openString);
-
-    // Fake a keyboard event
-    act(() => {
-        document.body &&
-            document.body.dispatchEvent(
-                new KeyboardEvent('keydown', { key: 'A' })
-            );
-        jest.runAllTimers();
-    });
-    // The menu should still be open
-    expect(JSON.stringify(dropdown.toJSON())).toEqual(openString);
-
-    // Finally, fake the escape key
-    act(() => {
-        document.body &&
-            document.body.dispatchEvent(
-                new KeyboardEvent('keydown', { key: 'Escape' })
-            );
-        jest.runAllTimers();
-    });
-    // And expect the menu to have closed
-    expect(JSON.stringify(dropdown.toJSON())).toEqual(closedString);
 });

--- a/kuma/javascript/src/header/header.jsx
+++ b/kuma/javascript/src/header/header.jsx
@@ -91,6 +91,7 @@ const styles = {
 const menus = [
     {
         label: 'Technologies',
+        url: 'Web',
         items: [
             { url: 'Web/HTML', label: 'HTML' },
             { url: 'Web/CSS', label: 'CSS' },
@@ -107,6 +108,7 @@ const menus = [
     },
     {
         label: 'References & Guides',
+        url: 'Learn',
         items: [
             { url: 'Learn', label: 'Learn web development' },
             { url: 'Web/Tutorials', label: 'Tutorials' },
@@ -119,6 +121,7 @@ const menus = [
     },
     {
         label: 'Feedback',
+        url: 'MDN/Feedback',
         items: [
             {
                 url: 'https://support.mozilla.org/',
@@ -180,7 +183,13 @@ export default function Header(): React.Node {
                 <Row css={styles.menus}>
                     {menus.map((m, index) => (
                         <React.Fragment key={index}>
-                            <Dropdown label={gettext(m.label)}>
+                            <Dropdown
+                                label={
+                                    <a href={fixurl(m.url)}>
+                                        {gettext(m.label)}
+                                    </a>
+                                }
+                            >
                                 {m.items.map((item, index) => (
                                     <li key={index}>
                                         {item.external ? (

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -44,10 +44,7 @@ const styles = {
         // but we want the button to look like a regular link.
         borderWidth: 0,
         padding: 0,
-        color: '#3d7e9a',
-        fontSize: '1em',
-        fontWeight: 'normal',
-        ':hover': { textDecoration: 'underline' }
+        color: '#3d7e9a'
     }),
     editLink: css({ lineHeight: 1 }),
     editIcon: css({ width: '1.33em' })

--- a/kuma/javascript/src/header/login.test.js
+++ b/kuma/javascript/src/header/login.test.js
@@ -1,6 +1,6 @@
 //@flow
 import React from 'react';
-import { act, create } from 'react-test-renderer';
+import { create } from 'react-test-renderer';
 import DocumentProvider from '../document-provider.jsx';
 import { fakeDocumentData } from '../document-provider.test.js';
 import Dropdown from './dropdown.jsx';
@@ -57,13 +57,6 @@ test('Login component when user is logged in', () => {
     expect(dropdown.props.label.props.srcSet).toContain('test-url');
     expect(dropdown.props.label.props.srcSet).toContain('test-bigurl');
     expect(dropdown.props.label.props.alt).toEqual('test-username');
-
-    // Open up the dropdown menu
-    act(() => {
-        login.toJSON().children[0].children[0].props.onClick();
-    });
-
-    expect(login.toJSON()).toMatchSnapshot();
 
     let string = JSON.stringify(login.toJSON());
     expect(string).toContain('View profile');


### PR DESCRIPTION
This PR updates the design of our menus and converts them back to
the original hover behavior, with a smaller target area so that they
don't pop up as easily. And it restores the links that were previously
available when clicking directly on the menu labels.

The hover behavior works with simulated touch events in chrome dev tools
but not in firefox dev tools. I'd like to just deploy this as is and then
we can more easily test with a real touch device.

Because this new menu does not respond to click events, I've had to delete
some test cases that were testing clicks on the menu.