### PR TITLE
Add Edit and History buttons to the titlebar for logged-in users.

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -607,11 +607,18 @@ Array [
   -webkit-flex-direction: row;
   -ms-flex-direction: row;
   flex-direction: row;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
   width: 100%;
   max-width: 1352px;
 }
 
 .emotion-0 {
+  -webkit-flex: 1 1;
+  -ms-flex: 1 1;
+  flex: 1 1;
   font-family: x-locale-heading-primary,zillaslab,"Palatino","Palatino Linotype",x-locale-heading-secondary,serif;
   font-size: 45px;
   font-weight: bold;

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -5,12 +5,15 @@ import { css } from '@emotion/core';
 
 import Article from './article.jsx';
 import DocumentProvider from './document-provider.jsx';
+import EditIcon from './icons/pencil.svg';
 import GAProvider from './ga-provider.jsx';
 import { gettext } from './l10n.js';
+import HistoryIcon from './icons/clock.svg';
 import LanguageMenu from './header/language-menu.jsx';
 import Header from './header/header.jsx';
 import TaskCompletionSurvey from './task-completion-survey.jsx';
 import { navigateRenderComplete } from './perf.js';
+import UserProvider from './user-provider.jsx';
 
 import type { DocumentData } from './document-provider.jsx';
 type DocumentProps = {
@@ -44,10 +47,12 @@ const styles = {
     titlebar: css({
         display: 'flex',
         flexDirection: 'row',
+        alignItems: 'center',
         width: '100%',
         maxWidth: 1352
     }),
     title: css({
+        flex: '1 1',
         fontFamily:
             'x-locale-heading-primary, zillaslab, "Palatino", "Palatino Linotype", x-locale-heading-secondary, serif',
         fontSize: 45,
@@ -56,6 +61,31 @@ const styles = {
             // Reduce the H1 size on narrow screens
             fontSize: 28
         }
+    }),
+
+    editAndHistoryButtons: css({
+        display: 'flex',
+        flexDirection: 'row',
+        flex: '0 0'
+    }),
+    editButton: css({
+        height: 32,
+        border: 'solid 2px #3d7e9a',
+        color: '#3d7e9a', // for the text
+        fill: '#3d7e9a', // for the icon
+        backgroundColor: '#fff',
+        whiteSpace: 'nowrap',
+        fontSize: 15,
+        fontWeight: 'bold',
+        padding: '0 18px'
+    }),
+    historyButton: css({
+        width: 32,
+        height: 32,
+        border: 'solid 2px #333',
+        backgroundColor: '#fff',
+        padding: 5,
+        marginLeft: 8
     }),
 
     // Breadcrumbs styles
@@ -129,11 +159,51 @@ const styles = {
     })
 };
 
-function Titlebar({ document }: DocumentProps) {
+function EditAndHistoryButtons({ document }: DocumentProps) {
+    let editURL = document.editURL;
+    return (
+        <div css={styles.editAndHistoryButtons}>
+            <button
+                css={styles.editButton}
+                onClick={() => {
+                    window.location = editURL;
+                }}
+            >
+                <EditIcon width={13} height={13} /> {gettext('Edit')}
+            </button>
+            <button
+                css={styles.historyButton}
+                aria-label={gettext('History')}
+                onClick={() => {
+                    window.location = editURL.replace('$edit', '$history');
+                }}
+            >
+                <HistoryIcon width={18} height={18} />
+            </button>
+        </div>
+    );
+}
+
+export function Titlebar({ document }: DocumentProps) {
+    const userData = useContext(UserProvider.context);
+
+    // If we have user data, and the user is logged in, and they
+    // are a contributor (or, if we don't know whether they are
+    // a contributor because the backend does not support that yet)
+    // then we want to show Edit and History buttons on the
+    // right side of the titlebar.
+    let showEditAndHistory =
+        userData &&
+        userData.isAuthenticated &&
+        (userData.isContributor === undefined || userData.isContributor);
+
     return (
         <div css={styles.titlebarContainer}>
             <div css={styles.titlebar}>
                 <h1 css={styles.title}>{document.title}</h1>
+                {showEditAndHistory && (
+                    <EditAndHistoryButtons document={document} />
+                )}
             </div>
         </div>
     );

--- a/kuma/javascript/src/page.test.js
+++ b/kuma/javascript/src/page.test.js
@@ -4,6 +4,8 @@ import { create } from 'react-test-renderer';
 import DocumentProvider from './document-provider.jsx';
 import { fakeDocumentData } from './document-provider.test.js';
 import Page from './page.jsx';
+import { Titlebar } from './page.jsx';
+import UserProvider from './user-provider.jsx';
 
 test('Page snapshot', () => {
     const page = create(
@@ -12,4 +14,64 @@ test('Page snapshot', () => {
         </DocumentProvider>
     );
     expect(page.toJSON()).toMatchSnapshot();
+});
+
+test('Titlebar shows edit and history buttons', () => {
+    let titlebar;
+    let buttons;
+
+    // No user data; expect no buttons
+    titlebar = create(
+        <DocumentProvider initialDocumentData={fakeDocumentData}>
+            <UserProvider.context.Provider value={null}>
+                <Titlebar document={fakeDocumentData} />
+            </UserProvider.context.Provider>
+        </DocumentProvider>
+    );
+    buttons = titlebar.root.findAll(instance => instance.type === 'button');
+    expect(buttons.length).toBe(0);
+
+    // User not logged in, expect no buttons
+    titlebar = create(
+        <UserProvider.context.Provider value={UserProvider.defaultUserData}>
+            <Titlebar document={fakeDocumentData} />
+        </UserProvider.context.Provider>
+    );
+    buttons = titlebar.root.findAll(instance => instance.type === 'button');
+    expect(buttons.length).toBe(0);
+
+    // User logged in and contributor, expect two buttons
+    titlebar = create(
+        <UserProvider.context.Provider
+            value={{
+                ...UserProvider.defaultUserData,
+                isAuthenticated: true,
+                isContributor: true
+            }}
+        >
+            <Titlebar
+                document={{
+                    ...fakeDocumentData,
+                    editURL: 'foobar$edit'
+                }}
+            />
+        </UserProvider.context.Provider>
+    );
+    buttons = titlebar.root.findAll(instance => instance.type === 'button');
+    expect(buttons.length).toBe(2);
+
+    // Make the mock window.location property writeable
+    // NOTE: This is a little brittle since it assumes that page.jsx
+    // is setting window.location and not window.location.href, for example.
+    Object.defineProperty(window, 'location', {
+        writable: true,
+        value: null
+    });
+
+    // Clicking first button sets window.location.href to editURL
+    // Clicking the second button sets it to the history URL instead
+    buttons[0].props.onClick();
+    expect(window.location).toBe('foobar$edit');
+    buttons[1].props.onClick();
+    expect(window.location).toBe('foobar$history');
 });

--- a/kuma/javascript/src/user-provider.jsx
+++ b/kuma/javascript/src/user-provider.jsx
@@ -9,6 +9,7 @@ export type UserData = {
     username: ?string,
     isAuthenticated: boolean,
     isBetaTester: boolean,
+    isContributor?: boolean, // This is not implemented on backend yet
     isStaff: boolean,
     isSuperuser: boolean,
     timezone: ?string,


### PR DESCRIPTION
Clicking these buttons takes the user to the wiki site. Currently
all logged-in users will see the buttons, but this PR includes some
code that makes a distinction between contributors and logged in
users who are not contributors. Once we've made that distinction
on the backend and in the whoami API, the frontend will show the
buttons to contributors onlyi.