### PR TITLE
Add a loading progress indicator at the top of the screen.

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -2,10 +2,39 @@
 
 exports[`Page snapshot 1`] = `
 Array [
-  .emotion-0 {
+  @keyframes animation-0 {
+  from {
+    -webkit-transform: translate(-90%,0);
+    -ms-transform: translate(-90%,0);
+    transform: translate(-90%,0);
+  }
+
+  to {
+    -webkit-transform: translate(0,0);
+    -ms-transform: translate(0,0);
+    transform: translate(0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 1.0;
+  }
+
+  to {
+    opacity: 0.5;
+  }
+}
+
+.emotion-0 {
+  position: fixed;
+  display: none;
   height: 5px;
   width: 100%;
   background-image: linear-gradient(-271deg,#206584,#83d0f2);
+  display: block;
+  -webkit-animation: animation-0 0.5s,animation-1 1s infinite alternate;
+  animation: animation-0 0.5s,animation-1 1s infinite alternate;
 }
 
 <div

--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -2,10 +2,39 @@
 
 exports[`Header snapshot 1`] = `
 Array [
-  .emotion-0 {
+  @keyframes animation-0 {
+  from {
+    -webkit-transform: translate(-90%,0);
+    -ms-transform: translate(-90%,0);
+    transform: translate(-90%,0);
+  }
+
+  to {
+    -webkit-transform: translate(0,0);
+    -ms-transform: translate(0,0);
+    transform: translate(0,0);
+  }
+}
+
+@keyframes animation-1 {
+  from {
+    opacity: 1.0;
+  }
+
+  to {
+    opacity: 0.5;
+  }
+}
+
+.emotion-0 {
+  position: fixed;
+  display: none;
   height: 5px;
   width: 100%;
   background-image: linear-gradient(-271deg,#206584,#83d0f2);
+  display: block;
+  -webkit-animation: animation-0 0.5s,animation-1 1s infinite alternate;
+  animation: animation-0 0.5s,animation-1 1s infinite alternate;
 }
 
 <div

--- a/kuma/javascript/src/header/header.jsx
+++ b/kuma/javascript/src/header/header.jsx
@@ -1,7 +1,7 @@
 //@flow
 import * as React from 'react';
 import { useContext } from 'react';
-import { css } from '@emotion/core';
+import { css, keyframes } from '@emotion/core';
 
 import DocumentProvider from '../document-provider.jsx';
 import { getLocale, gettext } from '../l10n.js';
@@ -15,11 +15,27 @@ const DESKTOP = '@media (min-width: 1024px)';
 const TABLET = '@media (min-width: 750px) and (max-width: 1023px)';
 const PHONE = '@media (max-width: 749px)';
 
+const slidein = keyframes`
+  from { transform: translate(-90%, 0); }
+  to { transform: translate(0, 0); }
+`;
+
+const throb = keyframes`
+  from { opacity: 1.0; }
+  to { opacity: 0.5; }
+`;
+
 const styles = {
     loadingBar: css({
+        position: 'fixed',
+        display: 'none',
         height: 5,
         width: '100%',
         backgroundImage: 'linear-gradient(-271deg, #206584, #83d0f2)'
+    }),
+    loadingAnimation: css({
+        display: 'block',
+        animation: `${slidein} 0.5s, ${throb} 1s infinite alternate`
     }),
     header: css({
         display: 'grid',
@@ -152,6 +168,7 @@ const menus = [
 
 export default function Header(): React.Node {
     const documentData = useContext(DocumentProvider.context);
+    const loading = useContext(DocumentProvider.loadingContext);
     const locale = getLocale();
     if (!documentData) {
         return null;
@@ -169,7 +186,9 @@ export default function Header(): React.Node {
 
     return (
         <>
-            <div css={styles.loadingBar} />
+            <div
+                css={[styles.loadingBar, loading && styles.loadingAnimation]}
+            />
             <div css={styles.header}>
                 <a css={styles.logoContainer} href={`/${locale}/`}>
                     <Logo css={styles.logo} alt="MDN Web Docs Logo" />

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -202,7 +202,7 @@ export default function Page() {
      * Register an effect that runs every time we see a new document URL.
      * The effect sends a Google Analytics timing event to record how long
      * it took from the start of the navigation until the new document is
-     * rendered.
+     * rendered. And then it turns off the loading indicator for the page
      *
      * Effects don't run during server-side-rendering, but that is fine
      * because we only want to send the GA event for client-side navigation.
@@ -211,6 +211,13 @@ export default function Page() {
      */
     useEffect(() => {
         navigateRenderComplete(ga);
+
+        // Client side navigation is typically so fast that the loading
+        // animation might not even be noticed, so we artificially prolong
+        // the effect with setTimeout()
+        setTimeout(() => {
+            DocumentProvider.setLoading(false);
+        }, 200);
     }, [document && document.absoluteURL]);
 
     return (


### PR DESCRIPTION
This PR repurposes the blue bar at the top of each MDN page
and animates it while the page is loading. Once the page has
loaded, the blue bar is hidden. This PR removes the old hack
where we faded the document while loading.