### PR TITLE
Move the TOC (the old black "jump bar") into the sidebar

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -925,7 +925,7 @@ Array [
       </div>
     </div>
   </div>,
-  .emotion-6 {
+  .emotion-8 {
   display: grid;
   box-sizing: border-box;
   max-width: 1400px;
@@ -935,7 +935,7 @@ Array [
 }
 
 @media (max-width:749px) {
-  .emotion-6 {
+  .emotion-8 {
     grid-template-columns: 1fr;
     grid-template-areas: "main" "side";
   }
@@ -991,7 +991,7 @@ Array [
   fill: #696969;
 }
 
-.emotion-5 {
+.emotion-7 {
   grid-area: side;
   box-sizing: border-box;
   width: 100%;
@@ -1000,17 +1000,33 @@ Array [
 }
 
 @media (max-width:749px) {
-  .emotion-5 {
+  .emotion-7 {
     padding: 15px 12px;
   }
 }
 
+.emotion-5 {
+  background-color: #f8f8f8;
+  border: solid 1px #dce3e5;
+  border-top: solid 4px #83d0f2;
+  border-radius: 4px;
+  padding: 10px;
+  margin-bottom: 24px;
+}
+
+.emotion-5 ul {
+  list-style: none;
+  padding-left: 10px;
+}
+
 .emotion-4 {
+  font-family: x-locale-heading-primary,zillaslab,"Palatino","Palatino Linotype",x-locale-heading-secondary,serif;
   font-size: 20px;
+  margin-bottom: 4px;
 }
 
 <div
-    className="emotion-6"
+    className="emotion-8"
   >
     <div
       className="text-content emotion-3"
@@ -1073,20 +1089,40 @@ Array [
       </div>
     </div>
     <div
-      className="quick-links emotion-5"
+      className="emotion-7"
     >
       <div
-        className="quick-links-head emotion-4"
+        className="emotion-5"
       >
-        Related Topics
+        <div
+          className="emotion-4"
+        >
+          On this Page
+        </div>
+        <ul
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "[fake TOC HTML]",
+            }
+          }
+        />
       </div>
       <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "[fake quicklinks HTML]",
+        className="quick-links"
+      >
+        <div
+          className="quick-links-head emotion-4"
+        >
+          Related Topics
+        </div>
+        <div
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "[fake quicklinks HTML]",
+            }
           }
-        }
-      />
+        />
+      </div>
     </div>
   </div>,
 ]

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -154,8 +154,23 @@ const styles = {
             padding: '15px 12px'
         }
     }),
-    related: css({
-        fontSize: 20
+    toc: css({
+        backgroundColor: '#f8f8f8',
+        border: 'solid 1px #dce3e5',
+        borderTop: 'solid 4px #83d0f2',
+        borderRadius: 4,
+        padding: 10,
+        marginBottom: 24,
+        '& ul': {
+            listStyle: 'none',
+            paddingLeft: 10
+        }
+    }),
+    sidebarHeading: css({
+        fontFamily:
+            'x-locale-heading-primary, zillaslab, "Palatino", "Palatino Linotype", x-locale-heading-secondary, serif',
+        fontSize: 20,
+        marginBottom: 4
     })
 };
 
@@ -210,16 +225,40 @@ export function Titlebar({ document }: DocumentProps) {
 }
 
 function Sidebar({ document }: DocumentProps) {
+    // TODO(djf): We may want to omit the "On this Page" section from
+    // the sidebar for pages with slugs like /Web/*/*/*: those are
+    // mostly HTML and CSS reference pages with repetitive TOCs. The
+    // TOC would afford quick access to the BCD table, but might not
+    // be useful for much else. For Learn/ slugs, however, the TOC is
+    // likely to be much more informative. I think a decision is still
+    // needed here.  For now, we show the TOC on all pages, but this
+    // may need to change to be based on the document.slug.
+    let showTOC = true;
+
     return (
-        <div className="quick-links" css={styles.sidebar}>
-            <div css={styles.related} className="quick-links-head">
-                {gettext('Related Topics')}
+        <div css={styles.sidebar}>
+            {showTOC && (
+                <div css={styles.toc}>
+                    <div css={styles.sidebarHeading}>
+                        {gettext('On this Page')}
+                    </div>
+                    <ul
+                        dangerouslySetInnerHTML={{
+                            __html: document.tocHTML
+                        }}
+                    />
+                </div>
+            )}
+            <div className="quick-links">
+                <div css={styles.sidebarHeading} className="quick-links-head">
+                    {gettext('Related Topics')}
+                </div>
+                <div
+                    dangerouslySetInnerHTML={{
+                        __html: document.quickLinksHTML
+                    }}
+                />
             </div>
-            <div
-                dangerouslySetInnerHTML={{
-                    __html: document.quickLinksHTML
-                }}
-            />
         </div>
     );
 }


### PR DESCRIPTION
This PR moves the table of contents for the page into the sidebar.
These are the links to internal sections that used to be in the
"jump bar". This is based on preliminary designs that Nick has
shown me and he's given approval to land it in this state.

It is still to be decided whether we want to show the TOC on all
pages or only on the Learn/ pages.