### PR TITLE
bug 1532736: increase rate limit on document views

### DIFF
--- a/kuma/wiki/views/document.py
+++ b/kuma/wiki/views/document.py
@@ -604,7 +604,7 @@ def _document_raw(doc_html):
 @allow_CORS_GET
 @process_document_path
 @newrelic.agent.function_trace()
-@ratelimit(key='user_or_ip', rate='800/m', block=True)
+@ratelimit(key='user_or_ip', rate='1200/m', block=True)
 def document(request, document_slug, document_locale):
     """
     View a wiki document.
@@ -794,7 +794,7 @@ def document(request, document_slug, document_locale):
 @allow_CORS_GET
 @process_document_path
 @newrelic.agent.function_trace()
-@ratelimit(key='user_or_ip', rate='400/m', block=True)
+@ratelimit(key='user_or_ip', rate='1200/m', block=True)
 def react_document(request, document_slug, document_locale):
     """
     View a wiki document.


### PR DESCRIPTION
This PR simply increases the rate-limiting threshold for both the React and Non-React document views in order to avoid rate-limiting the Google bots. See https://github.com/mdn/sprints/issues/1629 for more context.