### PR TITLE
Invalidate cloudfront on publish/render

### DIFF
--- a/kuma/api/management/commands/publish.py
+++ b/kuma/api/management/commands/publish.py
@@ -38,11 +38,25 @@ class Command(BaseCommand):
             default=1000,
             help='Partition the work into tasks, with each task handling this '
                  'many documents (default=1000)')
+        parser.add_argument(
+            '--skip-cache-invaldation',
+            help=(
+                'No cache invalidation after publishing. By default True '
+                'if --all flag is used.'
+            ),
+            action='store_true')
 
     def handle(self, *args, **options):
+        skip_cache_invalidation = (
+            options['all'] or options['skip_cache_invalidation']
+        )
         Logger = namedtuple('Logger', 'info, error')
         log = Logger(info=self.stdout.write, error=self.stderr.write)
         if options['all'] or options['locale']:
+            if options['locale'] and options['all']:
+                raise CommandError(
+                    'Specifying --locale with --all is the same as --all'
+                )
             filters = {}
             if options['locale'] and not options['all']:
                 locale = options['locale']
@@ -62,7 +76,11 @@ class Command(BaseCommand):
             tasks = []
             for i, chunk in enumerate(chunked(doc_pks, chunk_size)):
                 message = 'Published chunk #{} of {}'.format(i + 1, num_tasks)
-                tasks.append(publish.si(chunk, completion_message=message))
+                tasks.append(publish.si(
+                    chunk,
+                    completion_message=message,
+                    skip_cache_invalidation=skip_cache_invalidation
+                ))
             if num_tasks == 1:
                 msg = ('Launching a single task handling '
                        'all {} documents.'.format(num_docs))
@@ -91,4 +109,8 @@ class Command(BaseCommand):
                     log.error(msg.format(locale, slug))
                 else:
                     doc_pks.append(doc_pk)
-            publish(doc_pks, log=log)
+            publish(
+                doc_pks,
+                log=log,
+                skip_cache_invalidation=skip_cache_invalidation
+            )

--- a/kuma/api/signal_handlers.py
+++ b/kuma/api/signal_handlers.py
@@ -21,13 +21,13 @@ def on_restore_done(sender, instance, **kwargs):
 
 @receiver(render_done, sender=Document,
           dispatch_uid='api.document.render_done.publish')
-def on_render_done(sender, instance, **kwargs):
+def on_render_done(sender, instance, invalidate_cdn_cache, **kwargs):
     """
     A signal handler to publish the document to the document API after it
     has been rendered.
     """
     if not instance.deleted:
-        publish.delay([instance.pk])
+        publish.delay([instance.pk], invalidate_cdn_cache=invalidate_cdn_cache)
 
 
 @receiver(post_delete, sender=Document,

--- a/kuma/api/tests/test_signal_handlers.py
+++ b/kuma/api/tests/test_signal_handlers.py
@@ -12,11 +12,14 @@ def test_restore_signal(publish_mock, root_doc):
     publish_mock.delay.assert_called_once_with([root_doc.pk])
 
 
+@pytest.mark.parametrize('invalidate_cdn_cache', (True, False))
 @mock.patch('kuma.api.signal_handlers.publish')
-def test_render_signal(publish_mock, root_doc):
+def test_render_signal(publish_mock, root_doc, invalidate_cdn_cache):
     """The document is published on the render_done signal."""
-    render_done.send(sender=Document, instance=root_doc)
-    publish_mock.delay.assert_called_once_with([root_doc.pk])
+    render_done.send(sender=Document, instance=root_doc,
+                     invalidate_cdn_cache=invalidate_cdn_cache)
+    publish_mock.delay.assert_called_once_with(
+        [root_doc.pk], invalidate_cdn_cache=invalidate_cdn_cache)
 
 
 @pytest.mark.parametrize('case', ('normal', 'redirect'))

--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -20,11 +20,15 @@ reverse = partial(core_reverse, urlconf='kuma.urls_beta')
 def test_get_s3_key(root_doc):
     locale, slug = root_doc.locale, root_doc.slug
     expected_key = 'api/v1/doc/{}/{}'.format(locale, slug)
-    assert (get_s3_key(root_doc) == get_s3_key(locale=locale, slug=slug) ==
-            expected_key)
-    assert (get_s3_key(root_doc, for_redirect=True) ==
-            get_s3_key(locale=locale, slug=slug, for_redirect=True) ==
-            '/' + expected_key)
+    assert (
+        get_s3_key(root_doc) == get_s3_key(locale=locale, slug=slug) ==
+        expected_key
+    )
+    assert (
+        get_s3_key(root_doc, prefix_with_forward_slash=True) ==
+        get_s3_key(locale=locale, slug=slug, prefix_with_forward_slash=True) ==
+        '/' + expected_key
+    )
 
 
 @pytest.mark.parametrize('case', ('normal',
@@ -39,7 +43,7 @@ def test_get_content_based_redirect(root_doc, redirect_doc, redirect_to_self,
         expected = None
     elif case == 'redirect':
         doc = redirect_doc
-        expected = (get_s3_key(root_doc, for_redirect=True), True)
+        expected = (get_s3_key(root_doc, prefix_with_forward_slash=True), True)
     elif case == 'redirect-to-self':
         doc = redirect_to_self
         expected = None

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -56,6 +56,12 @@ def get_s3_key(doc=None, locale=None, slug=None, for_redirect=False):
     return key.lstrip('/')
 
 
+def get_cdn_key(locale, slug):
+    """Given a document (or locale and slug), return the "key" as this
+    is called in the CDN."""
+    return '/' + get_s3_key(locale=locale, slug=slug)
+
+
 def get_content_based_redirect(document):
     """
     Returns None if the document is not a content-based redirect, otherwise a

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -46,20 +46,20 @@ def doc(request, locale, slug):
     return JsonResponse(document_api_data(document))
 
 
-def get_s3_key(doc=None, locale=None, slug=None, for_redirect=False):
+def get_s3_key(doc=None, locale=None, slug=None,
+               prefix_with_forward_slash=False):
     if doc:
         locale, slug = doc.locale, doc.slug
     key = reverse('api.v1.doc', args=(locale, slug), urlconf='kuma.urls_beta')
-    if for_redirect:
+    if prefix_with_forward_slash:
         # Redirects within an S3 bucket must be prefixed with "/".
         return key
     return key.lstrip('/')
 
 
 def get_cdn_key(locale, slug):
-    """Given a document (or locale and slug), return the "key" as this
-    is called in the CDN."""
-    return '/' + get_s3_key(locale=locale, slug=slug)
+    """Given a document's locale and slug, return the "key" for the CDN."""
+    return get_s3_key(locale=locale, slug=slug, prefix_with_forward_slash=True)
 
 
 def get_content_based_redirect(document):
@@ -76,7 +76,10 @@ def get_content_based_redirect(document):
         redirect_document = document.get_redirect_document(id_only=False)
         if redirect_document:
             # This is a redirect to another document.
-            return (get_s3_key(redirect_document, for_redirect=True), True)
+            return (
+                get_s3_key(redirect_document, prefix_with_forward_slash=True),
+                True
+            )
         # This is a redirect to non-document page. For now, if it's the home
         # page, return a relative path (so we stay on the read-only domain),
         # otherwise return the full URL for the wiki site.

--- a/kuma/search/tests/test_filters.py
+++ b/kuma/search/tests/test_filters.py
@@ -429,7 +429,8 @@ class FilterTexts(ElasticTestCase):
         doc = Document.objects.get(pk=1)
         doc.rendered_html = '<html><body class="eval">foo()</body></html>'
         doc.save()
-        render_done.send(sender=Document, instance=doc)
+        render_done.send(
+            sender=Document, instance=doc, invalidate_cdn_cache=False)
         self.refresh()
 
         class View(SearchView):

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1876,7 +1876,7 @@ MDN_API_S3_BUCKET_NAME = config('MDN_API_S3_BUCKET_NAME', default=None)
 # or not might not be in the environment.
 MDN_CLOUDFRONT_DISTRIBUTIONS = {
     'api': {
-        'id': config('MDN_CLOUDFRONT_API_DISTRIBUTIONID', default=None),
+        'id': config('MDN_API_CLOUDFRONT_DISTRIBUTIONID', default=None),
         # TODO We should have a (Django) system check that checks that this
         # transform callable works. For example, it *has* to start with a '/'.
         'transform_function': 'kuma.api.v1.views.get_cdn_key'

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1879,7 +1879,7 @@ MDN_CLOUDFRONT_DISTRIBUTIONS = {
         'id': config('MDN_CLOUDFRONT_API_DISTRIBUTIONID', default=None),
         # TODO We should have a (Django) system check that checks that this
         # transform callable works. For example, it *has* to start with a '/'.
-        'transform': lambda locale, slug: '/api/v1/doc/' + locale + '/' + slug
+        'transform_function': 'kuma.api.v1.views.get_cdn_key'
     },
     # TODO We should have an entry here for the existing website.
     # At the time of writing we conservatively set the TTL to 5 min.

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1495,7 +1495,7 @@ CELERY_TASK_ROUTES = {
     'kuma.api.tasks.unpublish': {
         'queue': 'mdn_api'
     },
-    'kuma.api.tasks.cdn_cache_invalidate': {
+    'kuma.api.tasks.request_cdn_cache_invalidation': {
         'queue': 'mdn_api'
     },
 }

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -71,3 +71,7 @@ PIPELINE['COMPILERS'] = ('pipeline.compilers.sass.SASSCompiler',)
 # a 10x speedup on Docker on MacOS.
 WHITENOISE_AUTOREFRESH = True
 WHITENOISE_USE_FINDERS = True
+
+# This makes sure we our tests never actually use the real settings for
+# this.
+MDN_CLOUDFRONT_DISTRIBUTIONS = {}

--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -551,7 +551,8 @@ class Document(NotificationsMixin, models.Model):
             # Attempt an immediate rendering.
             self.render(cache_control, base_url)
 
-    def render(self, cache_control=None, base_url=None, timeout=None):
+    def render(self, cache_control=None, base_url=None, timeout=None,
+               invalidate_cdn_cache=True):
         """
         Render content using kumascript and any other services necessary.
         """
@@ -610,7 +611,8 @@ class Document(NotificationsMixin, models.Model):
 
         self.save()
 
-        render_done.send(sender=self.__class__, instance=self)
+        render_done.send(sender=self.__class__, instance=self,
+                         invalidate_cdn_cache=invalidate_cdn_cache)
 
     def get_summary(self, strip_markup=True, use_rendered=True):
         """

--- a/kuma/wiki/signals.py
+++ b/kuma/wiki/signals.py
@@ -1,4 +1,5 @@
 import django.dispatch
 
-render_done = django.dispatch.Signal(providing_args=["instance"])
+render_done = django.dispatch.Signal(
+    providing_args=["instance", "invalidate_cdn_cache"])
 restore_done = django.dispatch.Signal(providing_args=["instance"])

--- a/kuma/wiki/tests/test_models.py
+++ b/kuma/wiki/tests/test_models.py
@@ -282,6 +282,22 @@ def test_document_get_redirect_document(root_doc):
     assert old_doc.get_redirect_document() == root_doc
 
 
+@pytest.mark.parametrize('invalidate_cdn_cache', (True, False))
+@mock.patch('kuma.wiki.models.render_done')
+def test_document_render_invalidate_cdn_cache(mock_render_done, root_doc,
+                                              invalidate_cdn_cache):
+    """
+    The "invalidate_cdn_cache" argument to render is passed through
+    as one of the arguments that the "render_done" signal provides.
+    """
+    root_doc.render(invalidate_cdn_cache=invalidate_cdn_cache)
+    mock_render_done.send.assert_called_once_with(
+        sender=root_doc.__class__,
+        instance=root_doc,
+        invalidate_cdn_cache=invalidate_cdn_cache
+    )
+
+
 class UserDocumentTests(UserTestCase):
     """Document tests which need the users fixture"""
 

--- a/kuma/wiki/tests/test_signal_handlers.py
+++ b/kuma/wiki/tests/test_signal_handlers.py
@@ -26,7 +26,8 @@ def test_on_document_save_signal_invalidated_tags_cache(root_doc, wiki_user):
 @mock.patch('kuma.wiki.signal_handlers.build_json_data_for_document')
 def test_render_signal(build_json_task, root_doc):
     """The JSON is rebuilt when a Document is done rendering."""
-    render_done.send(sender=Document, instance=root_doc)
+    render_done.send(
+        sender=Document, instance=root_doc, invalidate_cdn_cache=False)
     assert build_json_task.delay.called
 
 
@@ -34,5 +35,6 @@ def test_render_signal(build_json_task, root_doc):
 def test_render_signal_doc_deleted(build_json_task, root_doc):
     """The JSON is not rebuilt when a deleted Document is done rendering."""
     root_doc.deleted = True
-    render_done.send(sender=Document, instance=root_doc)
+    render_done.send(
+        sender=Document, instance=root_doc, invalidate_cdn_cache=False)
     assert not build_json_task.delay.called


### PR DESCRIPTION
This PR replaces https://github.com/mozilla/kuma/pull/5384 by building on top of it, adding the ability to skip the CDN cache invalidation when doing bulk document renders. Document renders don't have direct access to the `publish` command, only indirect access via the `render_done` signal.  So at its root, this PR changes the `render_done` signal such that it now provides/carries the additional information of whether or not to invalidate the CDN cache. It was important  to find a way to do that because we often run bulk re-renders (for example, all documents that use the `compat` macro).

I think this is complete (including tests), but I do still need to test this with the actual AWS keys, and I need to add the CloudFront distribution ID's for stage/production to the respective Kubernetes secrets as well as add the `MDN_CLOUDFRONT_API_DISTRIBUTIONID` to the stage/prod/standby environment configurations in mdn/infra (https://github.com/mdn/infra/tree/master/apps/mdn/mdn-aws/k8s/regions).