### PR TITLE
bug 1552159: fix code sample when no rendered HTML

### DIFF
--- a/kuma/wiki/models.py
+++ b/kuma/wiki/models.py
@@ -1267,14 +1267,16 @@ Full traceback:
     def language(self):
         return get_language_mapping()[self.locale.lower()]
 
-    def get_absolute_url(self, endpoint='wiki.document', **kwargs):
+    def get_absolute_url(self, endpoint='wiki.document', urlconf='kuma.urls',
+                         **kwargs):
         """
         Build the absolute URL to this document from its full path
         """
-        return reverse(endpoint, locale=self.locale, args=[self.slug], **kwargs)
+        return reverse(endpoint, locale=self.locale, args=[self.slug],
+                       urlconf=urlconf, **kwargs)
 
     def get_edit_url(self):
-        return self.get_absolute_url(endpoint='wiki.edit', urlconf='kuma.urls')
+        return self.get_absolute_url(endpoint='wiki.edit')
 
     def get_redirect_url(self):
         """

--- a/kuma/wiki/tests/test_views_code.py
+++ b/kuma/wiki/tests/test_views_code.py
@@ -87,18 +87,19 @@ def test_code_sample_host_allowed(code_sample_doc, settings, client):
 
 # The pytest-django urls marker also resets urlconf caches after the test
 @pytest.mark.urls(settings.ROOT_URLCONF)
-def test_code_sample_host_restricted_host(code_sample_doc, settings, client):
+def test_code_sample_host_restricted_host(code_sample_doc, constance_config,
+                                          settings, client):
     """Users are allowed to view samples on the attachment domain."""
-    # Render the document, which will be a sync operation, before applying
-    # host restrictions.
-    code_sample_doc.get_rendered()
-
     url = reverse('wiki.code_sample',
                   args=[code_sample_doc.slug, 'sample1'])
     host = 'sampleserver'
     settings.ALLOWED_HOSTS.append(host)
     settings.ATTACHMENT_HOST = host
     settings.ENABLE_RESTRICTIONS_BY_HOST = True
+    # Setting the KUMASCRIPT_TIMEOUT to a non-zero value forces kumascript
+    # rendering so we ensure that path is tested for these requests that use
+    # a restricted urlconf environment.
+    constance_config.KUMASCRIPT_TIMEOUT = 1
     response = client.get(url, HTTP_HOST=host)
     assert response.status_code == 200
     assert 'public' in response['Cache-Control']


### PR DESCRIPTION
This fixes the bug described in https://bugzilla.mozilla.org/show_bug.cgi?id=1552159. The conditions for the bug are the following:
- `ENABLE_RESTRICTIONS_BY_HOST` is True (this is always true for stage and production, but false by default for local development)
- a request is made for a document's code sample using one of the attachment domains -- for production, these are either `mdn.mozillademos.org` or `demos-origin.mdn.mozit.cloud` 
- the document does not yet have any rendered HTML (its `rendered_html` attribute is falsy)

Under these conditions, an attempt is made to render the document, but fails when `document.get_absolute_url()` is called within `kuma.wiki.kumascript.get`, since the `wiki.document` endpoint is not defined for the attachments domains (for those domains, the root urlconf is set to `kuma.urls_untrusted`, which does not include that endpoint).

The fix is to explicitly specify the `urlconf` as `kuma.urls` when calling `reverse` within the `get_absolute_url` method.

I also modified an existing test so that it exposes the bug, preventing regressions.