### PR TITLE
Bug 1557787: Fix inline indicator with icon padding regression

### DIFF
--- a/kuma/static/styles/components/wiki/indicators.scss
+++ b/kuma/static/styles/components/wiki/indicators.scss
@@ -212,10 +212,6 @@ inline indicators aka badges
 - inline-block, smaller font
 ====================================================================== */
 
-.inlineIndicator {
-    padding: .25rem;
-}
-
 .inlineIndicator,
 .indicatorInHeadline {
     @extend %indicator-inline;

--- a/kuma/static/styles/includes/_mixins_indicators.scss
+++ b/kuma/static/styles/includes/_mixins_indicators.scss
@@ -59,7 +59,7 @@ inline indicators aka badges
         (border-left, 4px solid, border-right, none),
     ));
     border-radius: 2px;
-    padding: .45em $inline-horizontal-padding .3em;
+    padding: .45em $inline-horizontal-padding;
     background-color: $light-background-color;
     font-family: $tiny-font-family;
     font-size: $tiny-font-size;
@@ -70,6 +70,8 @@ inline indicators aka badges
 /* icon styling for indicators needs to be seperate because .spec
    extend %indicator-inline into some :before content */
 %indicator-inline-icon {
+    @extend %indicator-with-icon;
+
     &:before {
         display: inline-block;
         @include bidi((


### PR DESCRIPTION
Fixes [bug 1557787](https://bugzilla.mozilla.org/show_bug.cgi?id=1557787)

See also #5477, which introduced the regression.

---

review?(@schalkneethling)