### PR TITLE
Bug 1525719: make signin and signout work on the beta domain

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -585,7 +585,7 @@ Array [
       <a
         className="emotion-37"
         data-service="GitHub"
-        href="/users/github/login/?next=http://localhost/"
+        href="/users/github/login/?next=/"
         rel="nofollow"
       >
         Sign in

--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -585,7 +585,7 @@ Array [
       <a
         className="emotion-37"
         data-service="GitHub"
-        href="/users/github/login/?next=http://localhost/"
+        href="/users/github/login/?next=/"
         rel="nofollow"
       >
         Sign in

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -166,7 +166,7 @@ exports[`Login component when user is logged in 1`] = `
           <input
             name="next"
             type="hidden"
-            value="http://localhost/"
+            value="/"
           />
           <button
             className="emotion-3"
@@ -212,7 +212,7 @@ exports[`Login component when user is not logged in 1`] = `
 <a
   className="emotion-0"
   data-service="GitHub"
-  href="/users/github/login/?next=http://localhost/"
+  href="/users/github/login/?next=/"
   rel="nofollow"
 >
   Sign in

--- a/kuma/javascript/src/header/login.jsx
+++ b/kuma/javascript/src/header/login.jsx
@@ -64,8 +64,8 @@ export default function Login(): React.Node {
     // available during server side rendering, but this code will
     // never run during server side rendering because we won't have
     // user data then.
-    const LOCATION = window.location.href;
-    const WIKI_URL = window.mdn ? window.mdn.wikiSiteUrl : '';
+    const LOCATION = window.location.pathname;
+    const WIKI = window.mdn ? window.mdn.wikiSiteUrl : '';
 
     if (userData.isAuthenticated && userData.username) {
         // If we have user data and the user is logged in, show their
@@ -80,9 +80,7 @@ export default function Login(): React.Node {
                 alt={userData.username}
             />
         );
-        let viewProfileLink = `${WIKI_URL}/${locale}/profiles/${
-            userData.username
-        }`;
+        let viewProfileLink = `${WIKI}/${locale}/profiles/${userData.username}`;
         let editProfileLink = `${viewProfileLink}/edit`;
 
         return (
@@ -95,10 +93,7 @@ export default function Login(): React.Node {
                         <a href={editProfileLink}>{gettext('Edit profile')}</a>
                     </li>
                     <li>
-                        <form
-                            action={`${WIKI_URL}/${locale}/users/signout`}
-                            method="post"
-                        >
+                        <form action={`/${locale}/users/signout`} method="post">
                             <input name="next" type="hidden" value={LOCATION} />
                             <button css={styles.signOutButton} type="submit">
                                 {gettext('Sign out')}
@@ -112,7 +107,7 @@ export default function Login(): React.Node {
         // Otherwise, show a login prompt
         return (
             <a
-                href={`${WIKI_URL}/users/github/login/?next=${LOCATION}`}
+                href={`/users/github/login/?next=${LOCATION}`}
                 data-service="GitHub"
                 rel="nofollow"
                 css={styles.signInLink}

--- a/kuma/urls_beta.py
+++ b/kuma/urls_beta.py
@@ -1,5 +1,7 @@
+from decorator_include import decorator_include
 from django.conf import settings
 from django.conf.urls import include, url
+from django.views.decorators.cache import never_cache
 from django.views.generic import RedirectView
 from django.views.static import serve
 
@@ -7,6 +9,7 @@ from kuma.core import views as core_views
 from kuma.core.decorators import beta_shared_cache_control, shared_cache_control
 from kuma.core.urlresolvers import i18n_patterns
 from kuma.landing.urls_beta import lang_urlpatterns as landing_lang_urlpatterns
+from kuma.users.urls_beta import lang_urlpatterns as users_lang_urlpatterns
 from kuma.views import serve_from_media_root
 
 
@@ -49,6 +52,13 @@ urlpatterns += [
     url(r'^(?P<path>@api/deki/files/.+)$', redirect_to_attachments_domain,
         name='attachments.mindtouch_file_redirect'),
 ]
+
+# Add the signin and signout urls
+urlpatterns += [url('users/', include('kuma.users.urls_beta'))]
+urlpatterns += i18n_patterns(url('',
+                                 decorator_include(never_cache,
+                                                   users_lang_urlpatterns)))
+
 
 if getattr(settings, 'DEBUG_TOOLBAR_INSTALLED', False):
     import debug_toolbar

--- a/kuma/users/urls_beta.py
+++ b/kuma/users/urls_beta.py
@@ -19,9 +19,6 @@ for provider in providers.registry.get_list():
         urlpatterns += prov_urlpatterns
 
 users_patterns = [
-    url(r'^signup/?$',
-        redirect_in_maintenance_mode(account_views.signup),
-        name='account_signup'),
     url(r'^signin/?$',
         redirect_in_maintenance_mode(account_views.login),
         name='account_login'),

--- a/kuma/users/urls_beta.py
+++ b/kuma/users/urls_beta.py
@@ -1,0 +1,35 @@
+import importlib
+
+from allauth.account import views as account_views
+from allauth.socialaccount import providers
+from django.conf.urls import include, url
+from django.views.decorators.csrf import csrf_exempt
+
+from kuma.core.decorators import redirect_in_maintenance_mode
+
+
+urlpatterns = []
+for provider in providers.registry.get_list():
+    try:
+        prov_mod = importlib.import_module(provider.package + '.urls')
+    except ImportError:
+        continue
+    prov_urlpatterns = getattr(prov_mod, 'urlpatterns', None)
+    if prov_urlpatterns:
+        urlpatterns += prov_urlpatterns
+
+users_patterns = [
+    url(r'^signup/?$',
+        redirect_in_maintenance_mode(account_views.signup),
+        name='account_signup'),
+    url(r'^signin/?$',
+        redirect_in_maintenance_mode(account_views.login),
+        name='account_login'),
+    url(r'^signout/?$',
+        redirect_in_maintenance_mode(csrf_exempt(account_views.logout)),
+        name='account_logout')
+]
+
+lang_urlpatterns = [
+    url(r'^users/', include(users_patterns)),
+]


### PR DESCRIPTION
Our login and logout endpoints require the ?next= redirect URL to
have the same origin as the endpoint. We were trying to use endpoints
on the wiki domain so that we didn't have to support them on the beta
domain. But that meant that when a user logged in or out, they were
taken away from the beta domain.

This PR fixes that by adding the auth endpoints (and also profile
viewing and editing) endpoints to the beta domain. It makes
corresponding frontend changes in the login.jsx component and
also tweaks the Jinja template for profile view so that we don't
show document editing activity on the beta domain--doing that
requires URLs that are not supported on the beta domain and were
causing 500 server errors due to reverse lookup failures.