### PR TITLE
bug 1558255 - xrange is dead

### DIFF
--- a/kuma/dashboards/utils.py
+++ b/kuma/dashboards/utils.py
@@ -5,7 +5,6 @@ from collections import Counter, defaultdict
 
 from dateutil import parser
 from django.core.exceptions import ImproperlyConfigured
-from six.moves import xrange
 
 from kuma.wiki.models import (DocumentDeletionLog, DocumentSpamAttempt,
                               Revision, RevisionAkismetSubmission)
@@ -29,11 +28,11 @@ def date_range(start, end):
     if getattr(end, 'date', None) is not None:
         end = end.date()
     days = (end - start).days + 1
-    return (start + datetime.timedelta(days=d) for d in xrange(days))
+    return (start + datetime.timedelta(days=d) for d in range(days))
 
 
 def chunker(seq, size):
-    for i in xrange(0, len(seq), size):
+    for i in range(0, len(seq), size):
         yield seq[i:i + size]
 
 


### PR DESCRIPTION
Oops. When I first did a search on the code I didn't see that we're already using xrange from `six`. Turns out, the existing use of `xrange` wasn't blocking Python 3. 

Anyway, I removed it now anyway. I've seen `xrange()` be vastly overused in Python 2. It only makes sense to "upgrade to the iterator version" if you're dealing with VAST lists. Which we don't. Less weird == better. 