### PR TITLE
remove old stray print

### DIFF
--- a/tests/utils/urls.py
+++ b/tests/utils/urls.py
@@ -125,7 +125,6 @@ def assert_valid_url(url, location=None, status_code=requests.codes.moved_perman
 
     if resp_headers and not follow_redirects:
         for name, value in resp_headers.items():
-            print name, value
             assert name in resp.headers
             assert resp.headers[name].lower() == value.lower()
 


### PR DESCRIPTION
This was accidentally [added 3 years ago](https://github.com/mozilla/kuma/commit/6fc1528f39b408074d471d4644bad037e489ffcd#diff-6db1517f37de7d319af9950d4ad2b891R146).
Would cause a `SyntaxError` with Python 3. 