### PR TITLE
Bug 1557013: don't use zero width spaces for hyphenation

### DIFF
--- a/kuma/javascript/src/__snapshots__/page.test.js.snap
+++ b/kuma/javascript/src/__snapshots__/page.test.js.snap
@@ -648,6 +648,10 @@ Array [
   font-family: x-locale-heading-primary,zillaslab,"Palatino","Palatino Linotype",x-locale-heading-secondary,serif;
   font-size: 45px;
   font-weight: bold;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
 }
 
 @media (max-width:749px) {
@@ -810,6 +814,10 @@ Array [
 .emotion-1 {
   display: inline;
   font-size: 14px;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
 }
 
 .emotion-1a {

--- a/kuma/javascript/src/page.jsx
+++ b/kuma/javascript/src/page.jsx
@@ -57,6 +57,7 @@ const styles = {
             'x-locale-heading-primary, zillaslab, "Palatino", "Palatino Linotype", x-locale-heading-secondary, serif',
         fontSize: 45,
         fontWeight: 'bold',
+        hyphens: 'auto',
         [NARROW]: {
             // Reduce the H1 size on narrow screens
             fontSize: 28
@@ -114,6 +115,7 @@ const styles = {
     crumb: css({
         display: 'inline',
         fontSize: 14,
+        hyphens: 'auto',
         '&a': {
             color: '#3d7e9a'
         }

--- a/kuma/static/js/wiki.js
+++ b/kuma/static/js/wiki.js
@@ -60,33 +60,6 @@
     });
 
     /*
-        Add intelligent break points to:
-        - long article titles in document head
-        - left nav
-        - breadcrumbs
-        Don't use this on anything that might have child elements
-    */
-    $('.document .document-head h1, .quick-links a code, .crumbs span[property=name]').each(function() {
-        var $wrapper = $(this);
-        // don't do anything if there are any child elements, they would be removed
-        if ($wrapper.children().length > 0) {
-            return;
-        }
-
-        /*
-         * split on 3 lowercase characters in a row (try to avoid breaking acronyms)
-         *     - splitting here is a bit of a hack to get around lack of look behind in jS
-         * IF followed by [ . : ( OR capital letter
-         * IF followed by 3 letters or [ @ . : (
-         */
-        $wrapper.text(
-            $wrapper.text().replace(
-                /([a-z]{3})(?=[[.:(A-Z][@.:(A-Z]{0,}[a-zA-Z]{3})/g,'$1\u200b'
-            )
-        );
-    });
-
-    /*
         Syntax highlighting scripts
     */
     if ($('article pre').length && ('querySelectorAll' in doc)) {

--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -9,8 +9,8 @@
 .document-title {
     h1 {
         @include set-font-size($mobile-document-title-font-size);
-        /* Needed to make Chrome honor the zero-width spaces */
-        word-break: break-word;
+        /* Hyphenate long titles like CanvasRenderingContext2D if needed*/
+        hyphens: auto;
 
         @media #{$mq-mobile-and-up} {
             @include set-font-size($h1-font-size);

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -43,8 +43,9 @@ $crumb-vertical-spacing-desktop: $grid-spacing / 4;
         border-top: 15px solid transparent;
         border-bottom: 15px solid transparent;
         line-height: 1.5;
-        /* Needed to make Chrome honor the zero-width spaces */
-        word-break: break-word;
+
+        /* Hyphenate long titles like CanvasRenderingContext2D if needed*/
+        hyphens: auto;
 
         @media #{$mq-tablet-and-up} {
             border-top: none;

--- a/kuma/static/styles/components/wiki/quick-links.scss
+++ b/kuma/static/styles/components/wiki/quick-links.scss
@@ -20,6 +20,7 @@
         position: relative;
         overflow: hidden;
         text-overflow: ellipsis;
+        hyphens: auto;
     }
 
     /* 404 link */


### PR DESCRIPTION
Some of our documents have really long one-word titles, like:

  CanvasRenderingContext2D.globalCompositeOperation

We want MDN to be able to break long strings like these reasonably.
In the past, we find the lower-to-upper case transitions and
inserted HTML <wbr> tags at those points to tell the browser that
they could break the word there. That was good user-facing UX, but
in bug 1523662 we discovered that for some reason Google was
sometimes showing the literal string "<wbr/>" in its search
results for our site.

So to fix that, we switched from <wbr> to zero width spaces
at the internal word transitions. This resulted in the same word
wrapping behavior, and google has been happy with it, I think.
But it caused this bug: that copy and paste is broken, especially
when trying to paste the title of a page into a code editor.

So in this iteration, we instead just using the CSS 'hyphens:auto'
property to tell browsers that they can break the long word. They
don't always break the word where we would like them to at the
internal word boundaries, but do seem to at least get syllable
boundaries (in English anyway). And, the benefit of this approach
is that browsers insert a hypen, so that users can more easily
tell that the line has been broken.

So we're running less code and we're getting a result that is
arguable better by just relying on the web platform to to the
right thing (or at least a reasonable thing).

Note that this PR adds the hyphens:auto change for both the new
React-based frontend and the old non-React frontend