### PR TITLE
bug 1557666: remove locale-populate-react Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,37 +89,10 @@ localeextract:
 	python manage.py extract
 	python manage.py merge
 
-# The "react" domain contains all the strings from the "javascript" domain,
-# plus some strings duplicated from the "django" domain. While the React
-# pages are in beta, borrow translations from the other two domains.
-# This works by combining (msgcat) the django and javascript domains into a
-# temporary compendium, and then using that as a source of translations
-# (msgmerge). These react.po files are generated but not committed or
-# sent to Pontoon, so new strings are not yet translated.
-#
-# When we're ready to move the new pages out of beta, the copied strings can
-# be committed:
-#
-# 1. Run "make locale-populate-react" one last time
-# 2. Check in /{locale}/react.po files into mdn-l10n, remove from .gitignore
-# 3. Remove this command locale-populate-react
-#
-# We can then treat the "react" domain like others, and translate strings
-# (including new ones) in Pontoon.
-locale-populate-react:
-	@ mkdir -p locale/compendia
-	for localename in `find locale -mindepth 1 -maxdepth 1 -type d | cut -d/ -f2 | grep -v templates | grep -v compendia | grep -v .git`; do \
-		rm -f locale/compendia/$$localename.compendium; \
-		msgcat --use-first -o locale/compendia/$$localename.compendium locale/$$localename/LC_MESSAGES/django.po locale/$$localename/LC_MESSAGES/javascript.po; \
-		rm -f locale/$$localename/LC_MESSAGES/react.po; \
-		msgmerge --compendium locale/compendia/$$localename.compendium -o locale/$$localename/LC_MESSAGES/react.po /dev/null locale/templates/LC_MESSAGES/react.pot; \
-	done
-	rm -rf locale/compendia
-
 localecompile:
 	cd locale; ../scripts/compile-mo.sh .
 
-localerefresh: localeextract locale-populate-react localetest localecompile build-static
+localerefresh: localeextract localetest localecompile build-static
 
 pull-base:
 	docker pull ${BASE_IMAGE}
@@ -198,4 +171,4 @@ npmrefresh:
 	npm install
 
 # Those tasks don't have file targets
-.PHONY: test coveragetest locust clean locale install compilejsi18n collectstatic localetest localeextract localecompile localerefresh npmrefresh webpack compile-react-i18n locale-populate-react
+.PHONY: test coveragetest locust clean locale install compilejsi18n collectstatic localetest localeextract localecompile localerefresh npmrefresh webpack compile-react-i18n

--- a/docker/images/kuma/Dockerfile
+++ b/docker/images/kuma/Dockerfile
@@ -11,4 +11,4 @@ COPY --chown=kuma:kuma . /app
 # environments, but still defaults to disabled in production.
 # Also generate react.po translation files for beta.
 RUN ENABLE_CANDIDATE_LANGUAGES=True \
-    make locale-populate-react localecompile build-static
+    make localecompile build-static

--- a/scripts/ci-localerefresh
+++ b/scripts/ci-localerefresh
@@ -6,7 +6,6 @@ set -u  # Treat unset variables as an error
 # each and every one of these. Otherwise it causes to build-static again.
 ## docker-compose exec -T web make localerefresh
 docker-compose exec -T web make localeextract
-docker-compose exec -T web make locale-populate-react
 docker-compose exec -T web make localetest
 docker-compose exec -T web make localecompile
 


### PR DESCRIPTION
This PR removes the `locale-populate-react` Makefile target per @jwhitlock's [instructions](https://github.com/mozilla/kuma/blob/8515a75dbe19613b1480ba88faa725301a71aa24/Makefile#L105). I've already updated https://github.com/mozilla-l10n/mdn-l10n per steps 1 and 2 in @jwhitlock's instructions (see https://github.com/mozilla-l10n/mdn-l10n/commit/4eb53eb84bd21b2582a3c9a79a32187049b90eec).

Thanks to @jwhitlock for not only the original work on this, but the clear instructions on how to take the next step.