### PR TITLE
Bug 1558308: Always pass full HTML strings in document data

### DIFF
--- a/kuma/wiki/tests/test_ssr.py
+++ b/kuma/wiki/tests/test_ssr.py
@@ -57,10 +57,6 @@ def test_server_side_render(mock_get_l10n_data, mock_dumps, locale,
     output = ssr.render_react('document', locale, document_data)
 
     # Make sure the output is as expected
-    # The HTML attributes in the data should not be repeated in the output
-    # But note that this is a special case that depends on the first argument
-    # to render_react() being "document"
-    document_data.update(bodyHTML='', tocHTML='', quickLinksHTML='')
     data = {
         'locale': locale,
         'stringCatalog': localization_data['catalog'],


### PR DESCRIPTION
Typically when a React page is server-side rendered, the data associated
with that page ends up in the HTML page twice: once as HTML and once
as a JSON object. For MDN document pages I implemented an optimization
where I avoided passing the long strings of HTML content in the JSON
blob.

But then I modified the Sidebar component so that it would render the
TOC only if document.tocHTML was defined and by making the render
dependent on this variable that I had not sent in the JSON blob I
caused Bug 1558308 where hydration failed and the sidebar ended up
missing (it worked for client-side navigation, but the SSR'ed version
of the page would not work correctly.)

I'm reluctant to remove this optimization, but it seems likely to cause
confusing bugs later on, so I'm commenting it out for now. This is
something we can revisit later.

I suspect this won't have a noticable impact on page load time but
will track the stats on speedcurve to see.