### PR TITLE
Port various JS modules to work with React and to remove jQuery.

### DIFF
--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -31,6 +31,9 @@
             autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
             {%- endif %}
         };
+
+        {#- This is stuff not needed by the React-based site #}
+        {%- if not beta %}
         win.mdn.assets = {
             css: {
                 'editor-content': [
@@ -45,6 +48,7 @@
                 'wiki-compat-tables': [{% javascript 'wiki-compat-tables' %}]
             }
         };
+        {%- endif %}
 
         win.mdn.notifications = [];
 

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -28,11 +28,7 @@
 
   {% block site_css %}
 
-    {% stylesheet 'mdn' %}
-
-    {% for style in styles %}
-      {% stylesheet style %}
-    {% endfor %}
+    {% stylesheet 'react-mdn' %}
   {% endblock %}
 
   {%- if settings.MAINTENANCE_MODE %}
@@ -153,8 +149,6 @@
     <!--[if lte IE 8]>{% javascript 'selectivizr' %}<![endif]-->
 
     {{ providers_media_js() }}
-    {# Strings used by javascript modules. Hopefully we can remove soon. #}
-    <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
     {% javascript 'react-main' %}
     <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();

--- a/kuma/javascript/src/bcd.js
+++ b/kuma/javascript/src/bcd.js
@@ -1,0 +1,264 @@
+// @flow
+import { gettext } from './l10n.js';
+
+/**
+ * This file contains functions for working with the BCD tables
+ * contained in the HTML of an Article component. The tables are not
+ * React elements, so have to add interactivity the old fashioned way
+ * and hook it up via useEffect().
+ */
+
+// Used by makeRevealButton() below
+let revealButtonTemplate = null;
+
+/**
+ * Raw BCD tables don't include the UX for showing and hiding
+ * implementation notes, so we have to add a button manually. This
+ * function creates and returns an HTMLButton element that can be
+ * added to table cells.
+ */
+function makeRevealButton() {
+    if (!revealButtonTemplate) {
+        revealButtonTemplate = window.document.createElement('div');
+        revealButtonTemplate.innerHTML = `<button title="${gettext(
+            'Open implementation notes'
+        )}" class="bc-history-link only-icon" tabindex="0"><span>${gettext(
+            'Open'
+        )}</span><i class="ic-history" aria-hidden="true"></i></button>`;
+    }
+    return revealButtonTemplate.children[0].cloneNode(true);
+}
+
+/**
+ * When we open or close an implementation note, we animate the bottom
+ * border width of the cells above it to make room for it. But there
+ * is a different set of cells that need to be animated depending on
+ * the screen width. For unknown historical reasons, the screen width
+ * is encoded into the zindex of a hidden td element in the thead of
+ * the table. This utility function takes a cell as input and returns
+ * the set of cells that need to be enlarged to make room for the
+ * implementation note. The return value will be an iterable object.
+ */
+function cellsToEnlarge(cell: HTMLElement) {
+    let row = cell.closest('tr');
+    if (row) {
+        let table = row.closest('table');
+        if (table) {
+            let td = table.querySelector('thead td');
+            if (td) {
+                let zindex = window.getComputedStyle(td).zIndex;
+                switch (zindex) {
+                    case '1':
+                        return row.querySelectorAll('td');
+                    case '2':
+                        return [cell];
+                    default:
+                        return row.querySelectorAll('th,td');
+                }
+            }
+        }
+    }
+    return [];
+}
+
+/**
+ * Open up the implementation note for a BCD table cell
+ */
+function open(cell: HTMLElement) {
+    let row = cell.closest('tr');
+    if (!row) {
+        return;
+    }
+    let table = row.closest('table');
+    let details = cell.querySelector('.bc-history');
+    let button = cell.querySelector('.bc-history-link');
+
+    if (!(table instanceof HTMLElement) || !details || !button) {
+        return;
+    }
+    // Set the new display parameters for the details
+    details.style.display = 'block';
+    details.style.width = `${table.clientWidth}px`;
+    details.style.left = `${table.offsetLeft - cell.offsetLeft}px`;
+    details.style.top = `${cell.clientHeight}px`;
+    details.setAttribute('aria-hidden', 'false');
+
+    // Measure the height of the details at this new width and position
+    let detailsHeight = `${details.clientHeight}px`;
+
+    // But now set the height to 0, so that we can animate it open.
+    details.style.height = '0px';
+
+    // In order for the height to actually get set before the animation
+    // starts, we need to force a layout by querying the height
+    details.clientHeight; // Forces relayout
+
+    // Start animating the height of the details element.
+    // TODO: it is never very efficient to animate the height of an element.
+    // There ought to be a more efficient way to acheive this effect.
+    details.style.transition = 'height 150ms';
+    details.style.height = detailsHeight;
+
+    // And make room for the details element by animating the
+    // bottom border width of all the cells in the row.
+    for (let c of cellsToEnlarge(cell)) {
+        c.style.transition = 'border-bottom-width 150ms';
+        c.style.borderBottomWidth = detailsHeight;
+    }
+
+    // Finlly, mark the cell as active
+    cell.classList.add('active');
+    cell.setAttribute('aria-expanded', 'true');
+
+    // And flip the icon in the reveal button to indicate that
+    // another click will conceal the note
+    button.style.transform = 'scale(1, -1)';
+}
+
+/**
+ * Hide the implementation note for a BCD table cell, optionally
+ * animating the close.
+ */
+function close(cell, animate) {
+    let details = cell.querySelector('.bc-history');
+    let button = cell.querySelector('.bc-history-link');
+
+    if (!details || !button) {
+        return;
+    }
+
+    // Animate the border widths back to their default value
+    if (animate) {
+        for (let c of cellsToEnlarge(cell)) {
+            c.style.borderBottomWidth = '';
+        }
+    }
+
+    function transitionEndHandler() {
+        details.removeEventListener('transitionend', transitionEndHandler);
+        details.style.display = 'none';
+        details.style.height = 'auto';
+        details.style.transition = '';
+    }
+
+    if (animate) {
+        details.style.height = '0px';
+        details.addEventListener('transitionend', transitionEndHandler);
+    } else {
+        // If we're not animating, just do these things from the
+        // transition end handler.
+        details.style.display = 'none';
+        details.style.height = 'auto';
+    }
+
+    // Make the cell inactive
+    button.style.transform = '';
+    details.setAttribute('aria-hidden', 'true');
+    cell.classList.remove('active');
+    cell.setAttribute('aria-expanded', 'false');
+}
+
+/**
+ * When a BCD table includes implementation notes, we want to display
+ * a little down arrow to reveal the notes. This will be invoked via
+ * useEffect() in article.jsx. The implementation here is based on the
+ * code in static/js/wiki-compat-tables.js (but has been substantially
+ * modified to remove the jQuery dependency). If you fix a bug here
+ * you may also want to fix it in that other file.
+ */
+export function activateBCDTables(root: HTMLElement) {
+    // All cells in all tables that have implementation notes need
+    // a unique id. This variable lets us generate them.
+    let cellNumber = 0;
+
+    // Loop through all BCD tables under the specified element
+    const tables = root.querySelectorAll('.bc-table');
+    for (const table of tables) {
+        // Find the cells in the table that have implementation notes.
+        // For historical reasons we call these notes "history"
+        const cells = table.querySelectorAll('.bc-has-history');
+
+        // Keep track of which one of these (if any) is open and visible
+        let currentlyOpenCell = null;
+
+        // Activate each of these cells
+        for (const cell of cells) {
+            // Find the element that contains the implementation note
+            const details = cell.querySelector('.bc-history');
+
+            if (!details) {
+                continue;
+            }
+
+            // Set an id on the details for aria purposes
+            let cellId = `bc-history-${++cellNumber}`;
+            details.id = cellId;
+
+            // Set cell ARIA attributes, including a reference to
+            // the details element
+            cell.setAttribute('aria-expanded', 'false');
+            cell.setAttribute('aria-controls', cellId);
+
+            // Add the open button right before that element
+            let button = makeRevealButton();
+            let parent = details.parentElement;
+            parent && parent.insertBefore(button, details);
+
+            // Keep track of last open or close so we don't allow rapid clicks.
+            let lastClick = 0;
+
+            // Add a click event listener on the cell (not just the open
+            // button) to open and close the implementation note
+            cell.addEventListener('click', (event: MouseEvent) => {
+                // But don't open or close this cell more often than
+                // twice a second. Otherwise bugs can occur if we try
+                // to transition states when animations are still going on.
+                let now = Date.now();
+                if (lastClick && now - lastClick < 500) {
+                    return;
+                }
+                lastClick = now;
+
+                // Also, if the click was inside an open note, we don't
+                // want to close it for that.
+                let target = event.target;
+                if (
+                    !target ||
+                    !(target instanceof HTMLElement) ||
+                    target.closest('.bc-history')
+                ) {
+                    event.stopPropagation();
+                    return;
+                }
+
+                // Give the button the keyboard focus if it doesn't
+                // already have it.
+                button.focus();
+
+                // If there is already an open implementation note for this
+                // table we want to close it.
+                if (currentlyOpenCell) {
+                    // If we're going to be opening a different cell
+                    // on the same row then we don't want a full closing
+                    // animation.
+                    let animate =
+                        currentlyOpenCell === cell ||
+                        currentlyOpenCell.closest('tr') !== cell.closest('tr');
+
+                    close(currentlyOpenCell, animate);
+                }
+
+                if (cell !== currentlyOpenCell) {
+                    // If the click was on something other than the currently
+                    // open cell then we want to open the new cell.
+                    currentlyOpenCell = cell;
+                    open(cell);
+                } else {
+                    // Otherwise, the user was just closing an open cell
+                    // and there is nothing more to do.
+                    currentlyOpenCell = null;
+                }
+            });
+        }
+    }
+}

--- a/kuma/javascript/src/interactive-examples.js
+++ b/kuma/javascript/src/interactive-examples.js
@@ -12,13 +12,17 @@ const ieSelector = 'iframe.interactive';
 
 // This is the origin we expect for the iframes.
 const ieOrigin =
-    (window && window.mdn && window.mdn.interactiveEditor.editorUrl) ||
+    (typeof window !== 'undefined' &&
+        window.mdn &&
+        window.mdn.interactiveEditor.editorUrl) ||
     'https://interactive-examples.mdn.mozilla.net';
 
 // This is our media query breakpoint. If this media query does not
 // match, then we want interactive examples to use "small viewport" layout.
 const mediaQuery =
-    window.matchMedia && window.matchMedia('(min-width: 63.9385em)');
+    typeof window !== 'undefined' &&
+    window.matchMedia &&
+    window.matchMedia('(min-width: 63.9385em)');
 
 // This function is intended to be used as a one-time useEffect() hook
 // It sets up a listener for the media query so that when we switch

--- a/kuma/javascript/src/interactive-examples.js
+++ b/kuma/javascript/src/interactive-examples.js
@@ -1,0 +1,74 @@
+/**
+ * This file defines functions that are used to set the size of
+ * interactive examples after a new page has been displayed.
+ * It is based on the code in kuma/static/js/interactive.js. If
+ * you make changes here, you should probably also make changes
+ * in that file.
+ * @flow
+ */
+
+// We use this selector to find interactive example iframes on the page.
+const ieSelector = 'iframe.interactive';
+
+// This is the origin we expect for the iframes.
+const ieOrigin =
+    (window && window.mdn && window.mdn.interactiveEditor.editorUrl) ||
+    'https://interactive-examples.mdn.mozilla.net';
+
+// This is our media query breakpoint. If this media query does not
+// match, then we want interactive examples to use "small viewport" layout.
+const mediaQuery =
+    window.matchMedia && window.matchMedia('(min-width: 63.9385em)');
+
+// This function is intended to be used as a one-time useEffect() hook
+// It sets up a listener for the media query so that when we switch
+// from narrow to wide or vice versa we send a signal to any
+// interactive example iframes to make them change their layout.
+// Because this is a useEffect() function, we could modify it to return
+// a function that calls removeListener() if we decide we want to
+// implement that kind of cleanup.
+export function makeResponsive() {
+    mediaQuery &&
+        mediaQuery.addListener(function(event) {
+            for (let iframe of document.querySelectorAll(ieSelector)) {
+                if (iframe instanceof HTMLIFrameElement) {
+                    iframe.contentWindow.postMessage(
+                        { smallViewport: !event.matches },
+                        ieOrigin
+                    );
+                }
+            }
+        });
+}
+
+// This function is intended as a useEffect() hook to be called
+// whenever we display a new article page. If the browser width is
+// narrow, it finds all interactive example iframes in the article
+// and registers an onload event on them. When the load event is
+// received, it uses postMessage to tell them to use a narrow layout.
+export function setLayout(root: HTMLElement) {
+    if (mediaQuery && !mediaQuery.matches) {
+        for (let iframe of root.querySelectorAll(ieSelector)) {
+            if (iframe instanceof HTMLIFrameElement) {
+                // NOTE: if we just do the postMessage() right away the
+                // message probably won't get through because the iframe
+                // won't have loaded enough to be listening for messages.
+                // So instead we wait until the iframe is ready.  It is
+                // possible (though it seems unlikely) that the iframe
+                // could finish loading before this effect function gets
+                // called. If that happens we would miss the load event
+                // and never send the message. This doesn't seem like a
+                // problem in local testing, but if we don't reliably get
+                // the right layout in production then we might want to
+                // combine this load event handler with a setTimeout() call
+                // so that we post the message on load or after 1 second.
+                iframe.addEventListener('load', () => {
+                    iframe.contentWindow.postMessage(
+                        { smallViewport: true },
+                        ieOrigin
+                    );
+                });
+            }
+        }
+    }
+}

--- a/kuma/javascript/src/live-examples.js
+++ b/kuma/javascript/src/live-examples.js
@@ -1,0 +1,158 @@
+/**
+ * This file exports an addLiveExampleButtons() function that is
+ * intended to be run via the useEffect() hook each time we display a
+ * new document in article.jsx. It looks to see if there is a "Live
+ * Example" on the page, and if so, it adds the "Open in CodePen" and
+ * "Open in JSFiddle" buttons to the page.
+ *
+ * The code in this file is a port of kuma/static/js/wiki-samples.js
+ *
+ * NOTE: flow is not enabled for this file because it does not work
+ * well with the kind of raw HTML manipulation we're doing here.
+ */
+import { gettext } from './l10n.js';
+
+const iframeSelector = '.sample-code-frame';
+const tableSelector = '.sample-code-table';
+const idPrefix = /^frame_/;
+
+export function addLiveExampleButtons(rootElement) {
+    let iframes = rootElement.querySelectorAll(iframeSelector);
+
+    for (let frame of iframes) {
+        // We expect the iframe to be in a section with an id related
+        // to the frame id.
+        let sectid = frame.id.replace(idPrefix, '');
+        let section = document.getElementById(sectid);
+        if (!section) {
+            // If the section doesn't exist, then none of the selectors below
+            // will work, so we can bail out early
+            continue;
+        }
+        let sectionTitle = section.textContent;
+
+        // Find the elements that hold the HTML, CSS and JS source code
+        // We're looking for a <pre> element with a language-specific
+        // class that comes after the section header. We look for both
+        // direct siblings and also descendants of direct siblings
+        // (because sometimes some of the source code is tucked inside
+        // a hidden div).
+        let html = rootElement.querySelector(
+            `#${sectid} ~ pre[class*=html], #${sectid} ~ * pre[class*=html]`
+        );
+        let css = rootElement.querySelector(
+            `#${sectid} ~ pre[class*=css], #${sectid} ~ * pre[class*=css]`
+        );
+        let js = rootElement.querySelector(
+            `#${sectid} ~ pre[class*=js], #${sectid} ~ * pre[class*=js]`
+        );
+
+        // Now get the source code out of those pre elements
+        let htmlCode = html ? html.textContent : '';
+        let jsCode = js ? js.textContent : '';
+        let cssCode = css ? css.textContent : '';
+
+        // If we found any source code, then add buttons
+        if (htmlCode || cssCode || jsCode) {
+            // Add a link back to the original code as part of the HTML
+            let canonical = document.querySelector('link[rel=canonical]');
+            let sourceURL =
+                (canonical &&
+                    canonical instanceof HTMLLinkElement &&
+                    canonical.href) ||
+                window.location.href.split('#')[0];
+            htmlCode = `<!-- Learn about this code on MDN: ${sourceURL} -->\n\n${htmlCode}`;
+
+            // Tweak the CSS code also
+            cssCode = cssCode.replace(/\xA0/g, ' '); // fixes bug 1284781
+
+            // Create buttons
+            let codepen = document.createElement('button');
+            codepen.className = 'open-in-host button neutral';
+            codepen.textContent = gettext('Open in CodePen');
+
+            let jsfiddle = document.createElement('button');
+            jsfiddle.className = 'open-in-host button neutral';
+            jsfiddle.textContent = gettext('Open in JSFiddle');
+
+            // And a container for the buttons
+            let buttonBox = document.createElement('div');
+            buttonBox.classList.add('open-in-host-container');
+            buttonBox.appendChild(codepen);
+            buttonBox.appendChild(jsfiddle);
+
+            // Insert the container after the iframe or its enclosing table
+            let insertButtonsAfter = frame.closest(tableSelector) || frame;
+            insertButtonsAfter.insertAdjacentElement('afterend', buttonBox);
+
+            // Finally, assign event handlers to the buttons
+            codepen.onclick = function openInCodePen() {
+                let div = document.createElement('div');
+                div.innerHTML = `
+<form method="post" action="https://codepen.io/pen/define" class="hidden" target="_blank" rel="noopener">
+  <input type="hidden" name="data">
+  <input type="hidden" name="utm_source" value="mdn" />
+  <input type="hidden" name="utm_medium" value="code-sample" />
+  <input type="hidden" name="utm_campaign" value="external-samples" />
+  <input type="submit" />
+</form>
+`;
+                let form = div.firstElementChild;
+                form.data.value = JSON.stringify({
+                    title: sectionTitle,
+                    html: htmlCode,
+                    css: cssCode,
+                    js: jsCode
+                });
+                document.body.appendChild(form);
+                form.submit();
+
+                // TODO: the old code in wiki-samples.js also sets GA
+                // dimension8 to Yes at this point, but never actually
+                // sends the data to Google, so I have not ported that.
+                if (window && window.mdn && window.mdn.analytics) {
+                    window.mdn.analytics.trackEvent({
+                        category: 'Samples',
+                        action: 'open-codepen',
+                        label: sectid
+                    });
+                }
+            };
+
+            jsfiddle.onclick = function openInJSFiddle() {
+                let div = document.createElement('div');
+                div.innerHTML = `
+<form method="post" action="https://jsfiddle.net/api/mdn/" class="hidden" target="_blank" rel="noopener">
+  <input type="hidden" name="html" />
+  <input type="hidden" name="css" />
+  <input type="hidden" name="js" />
+  <input type="hidden" name="title" />
+  <input type="hidden" name="wrap" value="b" />
+  <input type="hidden" name="utm_source" value="mdn" />
+  <input type="hidden" name="utm_medium" value="code-sample" />
+  <input type="hidden" name="utm_campaign" value="external-samples" />
+  <input type="submit" />
+</form>
+`;
+                let form = div.firstElementChild;
+                form.html.value = htmlCode;
+                form.css.value = cssCode;
+                form.js.value = jsCode;
+                form.title.value = sectionTitle;
+                document.body.appendChild(form);
+                form.submit();
+
+                // TODO: the old code in wiki-samples.js also sets GA
+                // dimension8 to Yes at this point, but never actually
+                // sends the data to Google, so I have not ported that.
+                if (window && window.mdn && window.mdn.analytics) {
+                    window.mdn.analytics.trackEvent({
+                        category: 'Samples',
+                        action: 'open-jsfiddle',
+                        label: sectid
+                    });
+                }
+            };
+        }
+    }
+}

--- a/kuma/javascript/src/prism.js
+++ b/kuma/javascript/src/prism.js
@@ -1,0 +1,105 @@
+/**
+ * This file defines a highlightSyntax() function that article.jsx
+ * uses as an effect hook to highlight code samples each time we
+ * display a new article. The code in this file does not do any code
+ * formatting itself. It simply finds the <pre> elements in the
+ * article and puts them in the format expected by the Prism code
+ * formatter. We assume that window.Prism is defined.
+ *
+ * TODO: we should dynamically load the Prism code when it is first used.
+ *
+ * This code is based on the code in static/js/syntax-prism.js
+ * This version is a port that removes jQuery calls. If you change
+ * this file, you should probably also change that original one.
+ *
+ * @flow
+ */
+
+let initialized = false;
+
+export function highlightSyntax(root: HTMLElement) {
+    // If the Prism module is not here, there is nothing we can do
+    if (typeof window === 'undefined' || !window.Prism) {
+        return;
+    }
+
+    // Flow is not comfortable with undeclared global symbols
+    const Prism = window.Prism;
+
+    // Set up Prism the first time we're called.
+    if (!initialized) {
+        initialized = true;
+
+        // Define some language aliases
+        let languages = Prism.languages;
+        languages.xml = languages.xul = languages.html = languages.markup;
+        languages.js = languages.javascript;
+        languages.cpp = languages.clike;
+    }
+
+    // Loop through all <pre> blocks within the root (article) element
+    // tweaking them so that they use proper Prism classes and attributes.
+    for (let block of root.querySelectorAll('pre')) {
+        // Exclude syntax boxes from this pre-processing
+        if (
+            block.classList.contains('syntaxbox') ||
+            block.classList.contains('twopartsyntaxbox')
+        ) {
+            continue;
+        }
+
+        // Expect each block to have a single text node child which
+        // holds the code to be highlighted. If there is is more than
+        // one child or if it is not a text node, then assume that the
+        // block is already formatted and does not need to be tweaked.
+        if (
+            block.childNodes.length !== 1 ||
+            block.childNodes[0].nodeType !== 3
+        ) {
+            continue;
+        }
+
+        // If a block does not specify a language, assume HTML highlighting.
+        let language = 'html';
+
+        // MDN documents refer to the syntax highlight language as
+        // a "brush", and encode it for a <pre> element with
+        // "brush:<lang>" or "brush: <lang>" in the class attribute.
+        // We can extract the desired language from the attribute.
+        let match = block.className.match(/brush: ?(\w+)/);
+        if (match && match[1]) {
+            language = match[1].toLowerCase();
+            // Don't ask for languages that our Prism build does not support.
+            if (!(language in Prism.languages)) {
+                language = '';
+            }
+        }
+
+        // If the author did not explicitly turn off line numbers
+        // then ask Prism to add line numbers for us
+        if (!block.classList.contains('no-line-numbers')) {
+            block.classList.add('line-numbers');
+        }
+
+        // Do we need to highlight any lines?
+        // Legacy format: highlight:[8,9,10,11,17,18,19,20]
+        let lines = block.className.match(/highlight:? ?\[(.*)\]/);
+        if (lines && lines[1]) {
+            block.setAttribute('data-line', lines[1]);
+        }
+
+        // Finally, add a <code> element to the block and specify the
+        // highlight language on that element. Then reparent the code text
+        // into that code element. We know from the check above that
+        // the code is a single text node at block.childNodes[0])
+        let code = document.createElement('code');
+        if (language) {
+            code.classList.add(`language-${language}`);
+        }
+        block.appendChild(code);
+        code.appendChild(block.childNodes[0]);
+    }
+
+    // Now that we've fixed up the code blocks, ask Prism to highlight them
+    Prism.highlightAll();
+}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -713,6 +713,29 @@ def pipeline_one_scss(slug, **kwargs):
 
 
 PIPELINE_CSS = {
+    # Combines the mdn, wiki and wiki-compat-tables styles into
+    # one bundle for use by pages that are part of the new
+    # single page app.
+    'react-mdn': {
+        'source_filenames': (
+            'styles/main.scss',
+            'styles/wiki.scss',
+            'styles/diff.scss',
+
+            # Custom build of our Prism theme
+            'styles/libs/prism/prism.css',
+            'styles/libs/prism/prism-line-highlight.css',
+            'styles/libs/prism/prism-line-numbers.css',
+
+            'js/prism-mdn/components/prism-json.css',
+            'styles/wiki-syntax.scss',
+
+            'styles/wiki-compat-tables.scss',
+        ),
+        'output_filename': 'build/styles/react-mdn.css',
+        'variant': 'datauri',
+    },
+
     'mdn': {
         'source_filenames': (
             'styles/main.scss',
@@ -952,17 +975,30 @@ PIPELINE_JS = {
     },
     'react-main': {
         'source_filenames': (
-            'js/libs/jquery/jquery.js',
-            'js/libs/jquery-ajax-prefilter.js',
+            # TODO: these are the last legacy files from the wiki site
+            # that we're still using on the React-based pages. Ideally
+            # we should just move these to the React code so webpack
+            # can deal with them.
             'js/utils/post-message-handler.js',
-            # 'js/libs/icons.js',
-            # 'js/components.js',
             'js/analytics.js',
-            # 'js/main.js',
-            'js/auth.js',
-            # 'js/highlight.js',
-            'js/wiki-compat-trigger.js',
-            # 'js/lang-switcher.js',
+
+            # Custom Prism build
+            # TODO: the prism.js file should be imported dynamcally
+            # when we need it instead of being hardcoded in here.
+            "js/libs/prism/prism-core.js",
+            "js/libs/prism/prism-bash.js",
+            "js/libs/prism/prism-markup.js",
+            "js/libs/prism/prism-css.js",
+            "js/libs/prism/prism-clike.js",
+            "js/libs/prism/prism-javascript.js",
+            "js/libs/prism/prism-json.js",
+            "js/libs/prism/prism-jsonp.js",
+            "js/libs/prism/prism-css-extras.js",
+            "js/libs/prism/prism-rust.js",
+            "js/libs/prism/prism-wasm.js",
+            "js/libs/prism/prism-line-highlight.js",
+            "js/libs/prism/prism-line-numbers.js",
+
             # The react.js file is created by webpack and
             # placed in the kuma/javascript/dist/ directory.
             'react.js'

--- a/kuma/static/js/newsletter.js
+++ b/kuma/static/js/newsletter.js
@@ -5,23 +5,18 @@
 
     var newsletterForm = doc.getElementById('newsletterForm');
     var isHidden = false;
-    var isArticle = false;
+    var isArticle = window.location.pathname.indexOf('/docs/') !== -1;
 
     if(!newsletterForm) {
         return;
     } else {
         // check for local storage
-        if(mdn.features.localStorage) {
+        if(mdn.features.localStorage !== false) {
             // if hidden by local storage
             isHidden = localStorage.getItem('newsletterHide') === 'true' ? true : false;
         }
 
-        // check for article
-        if(doc.querySelector('#wikiArticle')) {
-            isArticle = true;
-        }
-
-        if(!mdn.features.localStorage || !isArticle) {
+        if(mdn.features.localStorage === false || !isArticle) {
             newsletter();
         } else if(isArticle && !isHidden) {
             newsletter();
@@ -59,7 +54,7 @@
                 errorList.appendChild(item);
             }
             newsletterErrors.appendChild(errorList);
-            $(newsletterErrors).removeClass('hidden');
+            newsletterErrors.classList.remove('hidden');
             // track an error happened
             mdn.analytics.trackEvent({
                 'category': 'newsletter',
@@ -71,11 +66,11 @@
         // show success message
         function newsletterThanks() {
             // hide form
-            $(newsletterForm).addClass('hidden');
+            newsletterForm.classList.add('hidden');
             // show thanks message
-            $('#newsletterThanks').removeClass('hidden');
+            doc.querySelector('#newsletterThanks').classList.remove('hidden');
             // hide close button, analytics get confusing if it stays
-            $('#newsletterHide').addClass('hidden');
+            doc.querySelector('#newsletterHide').classList.add('hidden');
             // track success
             mdn.analytics.trackEvent({
                 'category': 'newsletter',
@@ -111,7 +106,7 @@
 
             // new submission, clear old errors
             errorArray = [];
-            $(newsletterErrors).addClass('hidden');
+            newsletterErrors.classList.add('hidden');
             while (newsletterErrors.firstChild) {
                 newsletterErrors.removeChild(newsletterErrors.firstChild);
             }
@@ -172,7 +167,7 @@
         newsletterForm.addEventListener('submit', newsletterSubscribe, false);
 
         newsletterEmailInput.addEventListener('focus', function() {
-            $(newsletterPrivacy).removeClass('hidden');
+            newsletterPrivacy.classList.remove('hidden');
             mdn.analytics.trackEvent({
                 'category': 'newsletter',
                 'action': 'prompt',
@@ -182,16 +177,14 @@
     }
 
     function newsletterAddHideButton() {
-        var $hideButton = $('#newsletterHide');
-        // show button
-        $hideButton.removeClass('hidden');
-        // add listener
-        $hideButton.on('click', newsletterHandleHideClick);
+        var hideButton = doc.querySelector('#newsletterHide');
+        hideButton.classList.remove('hidden');
+        hideButton.addEventListener('click', newsletterHandleHideClick);
     }
 
     function newsletterHide() {
-        var $newsletterBox = $('.newsletter-box');
-        $newsletterBox.addClass('hidden');
+        var newsletterBox = doc.querySelector('.newsletter-box');
+        newsletterBox.classList.add('hidden');
     }
 
     function newsletterSaveHide() {

--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -227,9 +227,12 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     typography
     ====================================================================== */
 
-    /* don't allow empty paragraphs by CKEditor */
+    /*
+     * Don't allow empty paragraphs by CKEditor.
+     * But do allow empty divs created by the Prism syntax highlighter.
+     */
     p:empty,
-    div:empty {
+    div:not(.line-highlight):empty {
         display: none;
     }
 

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -24,8 +24,7 @@
   <link rel="home" href="{{ url('home') }}">
   <link rel="license" href="#license">
 
-  {% stylesheet 'mdn' %}
-  {% stylesheet 'wiki' %}
+  {% stylesheet 'react-mdn' %}
 
   {#- If the stylesheet exists, include it. Otherwise, does nothing. #}
   {% stylesheet 'locale-%s' % LANG %}
@@ -147,8 +146,6 @@
     </div>
   </footer>
 
-  {# strings used by javascript modules. Hopefully we can remove soon #}
-  <script src="{{ statici18n(request.LANGUAGE_CODE) }}"></script>
   <!-- site js -->
   {% javascript 'react-main' %}
   <script>


### PR DESCRIPTION
This large PR creates React-compatible versions of a number of
jQuery-based modules, and removes jQuery entirely from our beta pages.

This patch resolves bugs 1559480, 1560161, 1560135 and 1561037.

1) Bug 1559480: make BCD tables appear and behave correctly on beta site.

BCD table formatting and behavior depends on code in
wiki-compat-trigger.js running on page load, so the tables don't work
correctly with client-side navigation. This PR fixes that.

It makes the BCD stylesheet part of the main bundle that is loaded
into every React-based page, so the styles are always there and don't
have to be loaded when we find a page with a BCD table.

It also defines a new bcd.js file that defines an activateBCDTables()
function. We call this function with useEffect() from the Article
component so that it runs every time we display a new article that
might have a new BCD table in it.

activateBCDTables() is essentially a port of the jQuery code in
static/js/wiki-compat-table.js

2) Bug 1560161: syntax highlighting

In addition to patching up the BCD tables each time we display
a new article, we also need to perform syntax highlighting on
code blocks for each new article, so this commit adds a prism.js
file with a highlightSyntax() function that we can call from the
useEffect() hook of the Article component.

In addition it fixes what seems to be a regression in our SCSS files
where line highlighting was no longer happening on the beta site
or on the wiki site.

3) Bug 1560135: Open buttons for live examples

This PR ports the code from wiki-samples.js to live-examples.js so
that we can use an effect hook to add "Open in CodePen" and "Open in
JSFiddle" buttons to any documents that have live examples in them.

4) Bug 1561037: Narrow layouts for interactive examples

This PR ports the interactive example mediaQuery/narrowLayout code in
kuma/static/js/interactive.js to
kuma/javascript/src/interactive-examples.js and uses effect hooks in
article.jsx to get the code to run at the right time. This is so that
on narrow screens the interactive examples use their narrow layout
instead of their default wide layout.

5) Removing jQuery

This commit removes the last jQuery dependencies for our React-based pages.
It modifies two static/js/*.js files to convert simple jQuery calls
to the now widely-implemented standard alternatives. With those two
files modified (on both the wiki and beta domains) we no longer need
to include jQuery into the javascript bundle on the beta domain.

6) Other cleanup

Now that BCD and Prism JS is handled differently for the beta site
we no longer need window.mdn.assets output in our HTML, so that has
been removed for beta sites.

And, finally now that so much of the existing JS code has been ported
to the React codebase, there are no more gettext() calls in the
remaining legacy code used on the beta site, and so we can stop
outputting the javascript.js localization file.