### PR TITLE
Bug 1560573: Don't send two pageview events on the first page load

### DIFF
--- a/kuma/javascript/src/perf.js
+++ b/kuma/javascript/src/perf.js
@@ -11,11 +11,8 @@ let navigating = false;
 export function navigateStart() {
     navigating = true;
     try {
-        performance.clearMarks(START);
-        performance.clearMeasures(FETCH);
-        performance.clearMeasures(RENDER);
-        performance.mark(START);
-
+        // If we're using Speedcurve's LUX analytics, tell it that we're
+        // starting a new client-side navigation
         if (
             typeof window === 'object' &&
             window.LUX &&
@@ -23,6 +20,16 @@ export function navigateStart() {
         ) {
             window.LUX.init();
         }
+
+        // The LUX init call above also appears to clear everthing
+        // But just to be sure we will explicitly clear the custom
+        // marks and measures that we care about.
+        performance.clearMarks(START);
+        performance.clearMeasures(FETCH);
+        performance.clearMeasures(RENDER);
+
+        // Record the start time for a client-side navigation
+        performance.mark(START);
     } catch (e) {
         console.error(e);
     }
@@ -31,6 +38,8 @@ export function navigateStart() {
 export function navigateFetchComplete() {
     if (navigating) {
         try {
+            // Record the time it takes to fetch page data during a
+            // client-side navigation
             performance.measure(FETCH, START);
         } catch (e) {
             console.error(e);
@@ -43,8 +52,11 @@ export function navigateRenderComplete(ga: GAFunction) {
         navigating = false;
 
         try {
+            // Record the time it takes to fetch page data and re-render
+            // the page during client-side navigation
             performance.measure(RENDER, START);
 
+            // Send LUX data to Speedcurve to record the client-side navigation
             if (
                 typeof window === 'object' &&
                 window.LUX &&

--- a/kuma/javascript/src/user-provider.jsx
+++ b/kuma/javascript/src/user-provider.jsx
@@ -90,10 +90,6 @@ export default function UserProvider(props: {
                 // it is time to send the initial 'pageview' event for
                 // the initial load. See router.jsx for code that
                 // sends 'pageview' events for client-side navigation.
-                //
-                // TODO: the Router component might be sending pageview
-                // for the initial load as well, and we need to work
-                // that out.
                 ga('send', {
                     hitType: 'pageview',
                     hitCallback: () => {


### PR DESCRIPTION
There is code in router.jsx that sends GA events for client-side
navigation. But it was also running on the initial page load as well.
This PR fixes that.

Also, this PR fixes a related bug in perf.js that I discovered while
working on the initial bug. When I added the LUX.init() call in
perf.js, I broke the custom performance measures I was collecting
because apparently LUX.init() clears all existing marks. I've fixed
that bug by calling LUX.init() first before I mark the start time for
the client-side navigation.