### PR TITLE
Bug 1560958: display a message when there are no search results

### DIFF
--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -57,6 +57,11 @@ const styles = {
         padding: '2px 4px',
         marginRight: 8
     }),
+    noresults: css({
+        fontWeight: 'bold',
+        maxWidth: 1200,
+        margin: '20px auto'
+    }),
     error: css({
         margin: 16,
         padding: 16,
@@ -111,6 +116,11 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                             </div>
                         );
                     })}
+                {data && data.results && data.results.length === 0 && (
+                    <div css={styles.noresults}>
+                        {gettext('No matching documents found.')}
+                    </div>
+                )}
                 {data && data.error && (
                     <div css={styles.error}>
                         <h2>{data.error.toString()}</h2>

--- a/kuma/javascript/src/search-results-page.test.js
+++ b/kuma/javascript/src/search-results-page.test.js
@@ -77,6 +77,21 @@ describe('SearchResultsPage with error', () => {
     });
 });
 
+describe('SearchResultsPage with no results found', () => {
+    const page = create(
+        <SearchResultsPage
+            locale="en-US"
+            query="qq"
+            data={{ error: null, results: [] }}
+        />
+    );
+    const snapshot = JSON.stringify(page.toJSON());
+
+    test('Page displays no results message', () => {
+        expect(snapshot).toContain('No matching documents found.');
+    });
+});
+
 describe('SearchRoute', () => {
     const route = new SearchRoute('en-US');
     test('getComponent()', () => {


### PR DESCRIPTION
The beta search results page does not currently display a
"no matches found" message for searches with no results. This PR
adds that message.