### PR TITLE
Bug 1525719: add highlighted excerpts to search results

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -246,7 +246,7 @@ def search(request, locale):
                       ])))
 
     # Add excerpts with search results highlighted
-    search = search.highlight(*WikiDocumentType.excerpt_fields)
+    search = search.highlight('content')
     search = search.highlight_options(order='score',
                                       pre_tags=['<mark>'],
                                       post_tags=['</mark>'])

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -245,6 +245,12 @@ def search(request, locale):
                           Q('term', locale={'value': locale, 'boost': 8}),
                       ])))
 
+    # Add excerpts with search results highlighted
+    search = search.highlight(*WikiDocumentType.excerpt_fields)
+    search = search.highlight_options(order='score',
+                                      pre_tags=['<mark>'],
+                                      post_tags=['</mark>'])
+
     # Return as many as 40 matches, since we're not implementing pagination yet
     response = search[0:40].execute()
     return JsonResponse(response.to_dict())

--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -317,13 +317,21 @@ export default function Router({
                     //    effect functions below will be invoked to
                     //    finish up the client-side navigation process.
                 })
-                .catch(() => {
+                .catch(e => {
                     // If anything went wrong (such as a 404 when
                     // fetching data), we give up on client-side nav
                     // and just try loading the page. This may allow
                     // error recovery or will at least show the user
-                    // a real 404 page.
-                    window.location = url;
+                    // a real 404 page. Note, however that if this url
+                    // is the same as the initial URL, then this was
+                    // probably a hard load in the first place and we
+                    // don't want to try again because we'll just get
+                    // into a loop.
+                    if (url !== initialURL) {
+                        window.location = url;
+                    } else {
+                        console.error('Error while routing', e);
+                    }
                 });
 
             // Finally, return true to indicate that we found a

--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -19,7 +19,7 @@ export type SearchResults = {
         summary: string,
         tags: Array<string>,
         score: number,
-        excerpt: string
+        excerpts: Array<string>
     }>,
     error: ?any
 };
@@ -40,11 +40,24 @@ const styles = {
     link: css({
         fontWeight: 'bold'
     }),
-    summary: css({}),
+    summary: css({
+        marginBottom: 8
+    }),
     excerpt: css({
-        padding: 8,
+        padding: '2px 24px',
         fontStyle: 'italic',
-        fontSize: 12
+        fontSize: 12,
+
+        '& mark': {
+            fontWeight: 'bold',
+            backgroundColor: 'inherit'
+        },
+        ':before': {
+            content: '"..."'
+        },
+        ':after': {
+            content: '"..."'
+        }
     }),
     url: css({
         fontSize: 12
@@ -103,12 +116,15 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                                     <div css={styles.summary}>
                                         {hit.summary}
                                     </div>
-                                    <div
-                                        css={styles.excerpt}
-                                        dangerouslySetInnerHTML={{
-                                            __html: hit.excerpt
-                                        }}
-                                    />
+                                    {hit.excerpts.map((excerpt, i) => (
+                                        <div
+                                            css={styles.excerpt}
+                                            key={i}
+                                            dangerouslySetInnerHTML={{
+                                                __html: excerpt
+                                            }}
+                                        />
+                                    ))}
                                 </div>
                                 <div css={styles.tags}>
                                     {hit.tags
@@ -195,12 +211,13 @@ export class SearchRoute extends Route<SearchRouteParams, SearchResults> {
                     return {
                         results: results.hits.hits.map(hit => {
                             let score = hit._score;
-                            let excerpt =
-                                hit.highlight &&
-                                hit.highlight.content &&
-                                hit.highlight.content[0];
+                            let excerpts =
+                                (hit.highlight && hit.highlight.content) || [];
+                            if (excerpts && excerpts.length > 3) {
+                                excerpts = excerpts.slice(0, 3);
+                            }
 
-                            return { ...hit._source, score, excerpt };
+                            return { ...hit._source, score, excerpts };
                         }),
                         error: null
                     };

--- a/kuma/javascript/src/search-results-page.test.js
+++ b/kuma/javascript/src/search-results-page.test.js
@@ -14,7 +14,7 @@ const fakeResults = [
         summary: 'summary1',
         tags: ['tag1.1', 'tag1.2'],
         score: 10,
-        excerpt: 'Test <mark>result</mark>'
+        excerpts: ['Test <mark>result</mark>', 'Excerpt <mark>2</mark>']
     },
     {
         slug: 'slug2',
@@ -22,7 +22,7 @@ const fakeResults = [
         summary: 'summary2',
         tags: ['tag2.1', 'tag2.2'],
         score: 5,
-        excerpt: 'Test <mark>results</mark>'
+        excerpts: []
     }
 ];
 
@@ -59,7 +59,9 @@ describe('SearchResultsPage component', () => {
             expect(snapshot).toContain(hit.title);
             expect(snapshot).toContain(hit.summary);
             expect(snapshot).toContain(hit.slug);
-            expect(snapshot).toContain(hit.excerpt);
+            for (const excerpt of hit.excerpts) {
+                expect(snapshot).toContain(excerpt);
+            }
         }
     });
 });
@@ -142,7 +144,7 @@ describe('SearchRoute', () => {
                                 },
                                 _score: r.score,
                                 highlight: {
-                                    content: [r.excerpt]
+                                    content: r.excerpts
                                 }
                             }))
                         }

--- a/kuma/javascript/src/search-results-page.test.js
+++ b/kuma/javascript/src/search-results-page.test.js
@@ -12,13 +12,17 @@ const fakeResults = [
         slug: 'slug1',
         title: 'title1',
         summary: 'summary1',
-        tags: ['tag1.1', 'tag1.2']
+        tags: ['tag1.1', 'tag1.2'],
+        score: 10,
+        excerpt: 'Test <mark>result</mark>'
     },
     {
         slug: 'slug2',
         title: 'title2',
         summary: 'summary2',
-        tags: ['tag2.1', 'tag2.2']
+        tags: ['tag2.1', 'tag2.2'],
+        score: 5,
+        excerpt: 'Test <mark>results</mark>'
     }
 ];
 
@@ -55,6 +59,7 @@ describe('SearchResultsPage component', () => {
             expect(snapshot).toContain(hit.title);
             expect(snapshot).toContain(hit.summary);
             expect(snapshot).toContain(hit.slug);
+            expect(snapshot).toContain(hit.excerpt);
         }
     });
 });
@@ -129,7 +134,16 @@ describe('SearchRoute', () => {
                         // other stuff that we fake out here
                         hits: {
                             hits: fakeResults.map(r => ({
-                                _source: r
+                                _source: {
+                                    slug: r.slug,
+                                    title: r.title,
+                                    summary: r.summary,
+                                    tags: r.tags
+                                },
+                                _score: r.score,
+                                highlight: {
+                                    content: [r.excerpt]
+                                }
                             }))
                         }
                     })


### PR DESCRIPTION
Our current search results include highlighted excerpts of
matching documents to provide more context about where the
search terms appear. This PR adds a similar feature to the
beta search results page.