### PR TITLE
Bug 1561034: fix BCD table layout for small-desktop widths

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -217,8 +217,10 @@ export function Breadcrumbs({ document }: DocumentProps) {
 }
 
 function Content({ document }: DocumentProps) {
+    // The wiki-left-present class below is needed for correct BCD layout
+    // See kuma/static/styles/components/compat-tables/bc-table.scss
     return (
-        <div css={styles.contentLayout}>
+        <div css={styles.contentLayout} className="wiki-left-present">
             <Article document={document} />
             <Sidebar document={document} />
         </div>


### PR DESCRIPTION
The CSS for BCD table layout is complicated and depends on the
presence of an element with class wiki-left-present to indicate that
there is a sidbar. That element had been removed on the beta pages,
breaking BCD table layout for widths 1023-1199. This PR adds
the class back to the element that contains the sidebar and
article, fixing BCD table layout.