### PR TITLE
Bug 1561081: Don't display "Related Topics" heading if there are none

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -171,16 +171,21 @@ export function Sidebar({ document }: DocumentProps) {
                     </div>
                 </>
             )}
-            <div className="quick-links">
-                <div css={styles.sidebarHeading} className="quick-links-head">
-                    {gettext('Related Topics')}
+            {document.quickLinksHTML && (
+                <div className="quick-links">
+                    <div
+                        css={styles.sidebarHeading}
+                        className="quick-links-head"
+                    >
+                        {gettext('Related Topics')}
+                    </div>
+                    <div
+                        dangerouslySetInnerHTML={{
+                            __html: document.quickLinksHTML
+                        }}
+                    />
                 </div>
-                <div
-                    dangerouslySetInnerHTML={{
-                        __html: document.quickLinksHTML
-                    }}
-                />
-            </div>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Some pages don't have any related topics, and we shouldn't display
the "Related Topics" heading in the sidebar for those pages.

Note that this patch just removes the unnecessary heading from the
sidebar, but does not remove the sidebar itself. There may still be
a few pages htat have not related topics and also have no
sections to link to in an "On this page" section. Those pages have
no need of a sidebar, but they are still going to get one.