### PR TITLE
Bug 1525719: implement a React component for call-to-action banners

### DIFF
--- a/kuma/javascript/src/banners.jsx
+++ b/kuma/javascript/src/banners.jsx
@@ -1,0 +1,192 @@
+/**
+ * This file defines a React Banner component that renders a
+ * call-to-action banner fixed to the bottom of the screen. The props
+ * of the Banner component allow customization of the title,
+ * description and button call-to-action text of the banner, as well
+ * as the URL of the page that clicking on the call-to-action button
+ * takes the user to. The Banner component is not exported,
+ * however. Instead, we export a Banners component that takes an array
+ * of BannerProps objects describing one or more banners. The Banners
+ * component finds the first banner that is enabled by Waffle and has
+ * not been dismissed by the user and displays that banner. Or, if
+ * none of the specified banners is enabled, or if all enabled banners
+ * have been recently dismissed, then it displays nothing.
+ *
+ * This file is a React port of the code in the following files:
+ *
+ *   kuma/banners/jinja2/banners/cta-banners.html
+ *   kuma/banners/jinja2/banners/developer-needs.html
+ *   kuma/static/js/components/banners/banners.js
+ *   kuma/static/js/components/banners/utils/banners-event-util.js
+ *   kuma/static/js/components/banners/utils/banners-state-util.js
+ *
+ * If you make changes in this file and also want those changes to be
+ * reflected on the wiki site, you will need to edit those older files
+ * as well.
+ *
+ * The reason that this React-based version of the banner feature is needed
+ * is that in order to cache our pages in the CDN, we can't use waffle
+ * flags in our HTML templates and instead have to modify all waffle-related
+ * logic to query waffle flags obtained from the <UserProvider> context.
+ *
+ * This port removes the minimize feature from banners since it is
+ * not used by the developer needs survey and seems unlikely to be
+ * needed for future banners (it was part of the experimental payments
+ * banner.)
+ *
+ * This ported component does not use CSS-in-JS, and depends on the
+ * original banners stylesheet built from:
+ *
+ *    kuma/static/styles/components/banners/base.scss
+ *
+ * TODO: copy the styles from that stylesheet directly into this
+ * component so that we only need to emit them (and the browser only
+ * needs to parse them) when a banner will actually be rendered.
+ *
+ * @flow
+ */
+import * as React from 'react';
+import { useContext, useState } from 'react';
+
+import CloseIcon from './icons/close.svg';
+import { gettext } from './l10n.js';
+import UserProvider from './user-provider.jsx';
+
+// Set a localStorage key with a timestamp the specified number of
+// days into the future. When the user dismisses a banner we use this
+// to prevent the redisplay of the banner for a while.
+function setEmbargoed(id, days) {
+    try {
+        let key = `banner.${id}.embargoed_until`;
+        localStorage.setItem(
+            key,
+            String(Date.now() + Math.round(days * 24 * 60 * 60 * 1000))
+        );
+    } catch (e) {
+        // If localStorage is not supported, then embargos are not supported.
+    }
+}
+
+// See whether the specified id was passed to setEmbargoed() fewer than the
+// specified number of days ago. We check this before displaying a banner
+// so a user does not see a banner they recently dismissed.
+function isEmbargoed(id) {
+    try {
+        let key = `banner.${id}.embargoed_until`;
+        let value = localStorage.getItem(key);
+        // If it is not set, then the banner has never been dismissed
+        if (!value) {
+            return false;
+        }
+        // The value from localStorage is a timestamp that we compare to
+        // the current time
+        if (parseInt(value) > Date.now()) {
+            // If the timestamp is in the future then the banner has been
+            // dismissed and the embargo has not yet expired.
+            return true;
+        } else {
+            // Otherwise, the banner was dismissed, but the embargo has
+            // expired and we can show it again.
+            localStorage.removeItem(key);
+            return false;
+        }
+    } catch (e) {
+        // If localStorage is not supported, then the embargo feature
+        // just won't work
+        return false;
+    }
+}
+
+// The <Banner> component displays a simple call-to-action banner at
+// the bottom of the window. The following props allow it to be customized.
+//
+// TODO: we should probably make the image and maybe the background of
+// the banner configurable through props like these. For now, however,
+// that is hardcoded into the stylesheet.
+export type BannerProps = {
+    // A unique string associated with this banner. It must match the
+    // name of the waffle flag that controls the banner, and is also
+    // used as part of a localStorage key.
+    id: string,
+    // The banner title. e.g. "MDN Survey"
+    title: string,
+    // The banner description. e.g. "Help us understand the top 10 needs..."
+    copy: string,
+    // The call to action button text. e.g. "Take the survey"
+    cta: string,
+    // The URL of the page to open when the button is clicked
+    url: string,
+    // An optional property. If present, it specifies the number of days
+    // for which a dismissed banner will not be shown. If omitted, the
+    // default is 5 days.
+    embargoDays?: number
+};
+
+function Banner(props: BannerProps) {
+    const [isDismissed, setDismissed] = useState(false);
+
+    if (isDismissed) {
+        return null;
+    }
+
+    return (
+        <div className="mdn-cta-container">
+            <div
+                id="mdn-cta-content"
+                className="mdn-cta-content cta-background-linear"
+            >
+                <div id="developer-needs" className="mdn-cta-content-container">
+                    <h2 className="mdn-cta-title slab-text">{props.title}</h2>
+                    <p className="mdn-cta-copy">{props.copy}</p>
+                </div>
+                <p className="mdn-cta-button-container">
+                    <a
+                        href={props.url}
+                        className="mdn-cta-button"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        {props.cta}
+                    </a>
+                </p>
+            </div>
+            <div className="mdn-cta-controls">
+                <button
+                    type="button"
+                    id="mdn-cta-close"
+                    className="mdn-cta-close"
+                    aria-label={gettext('Close banner')}
+                    onClick={() => {
+                        setDismissed(true);
+                        setEmbargoed(props.id, props.embargoDays || 5);
+                    }}
+                >
+                    <CloseIcon className="icon icon-close" />
+                </button>
+            </div>
+        </div>
+    );
+}
+
+type BannersProps = {
+    banners: Array<BannerProps>
+};
+
+export default function Banners(props: BannersProps) {
+    const userData = useContext(UserProvider.context);
+
+    // If we have user data the loop through the specified banners
+    // to see if we can find one that is enabled by waffle
+    // and has not been recently dismissed by the user. We render
+    // the first such banner that we find, or render nothing.
+    if (userData) {
+        for (const banner of props.banners) {
+            if (userData.waffle.flags[banner.id]) {
+                if (!isEmbargoed(banner.id)) {
+                    return <Banner {...banner} />;
+                }
+            }
+        }
+    }
+    return null;
+}

--- a/kuma/javascript/src/banners.test.js
+++ b/kuma/javascript/src/banners.test.js
@@ -1,0 +1,253 @@
+//@flow
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import Banners from './banners.jsx';
+import UserProvider from './user-provider.jsx';
+
+import type { BannerProps } from './banners.jsx';
+
+const mockUserData = { ...UserProvider.defaultUserData };
+
+const banners: Array<BannerProps> = [
+    {
+        id: 'flag1',
+        title: 'title1',
+        copy: 'copy1',
+        cta: 'cta1',
+        url: 'link1',
+        embargoDays: 1
+    },
+    {
+        id: 'flag2',
+        title: 'title2',
+        copy: 'copy2',
+        cta: 'cta2',
+        url: 'link2',
+        embargoDays: 2
+    }
+];
+
+describe('Banners', () => {
+    test('renders nothing if no waffle flags set', () => {
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        expect(banner.toJSON()).toBe(null);
+    });
+
+    test('renders banners when their waffle flags are set', () => {
+        for (let b of banners) {
+            mockUserData.waffle.flags = { [b.id]: true };
+            let banner = create(
+                <UserProvider.context.Provider value={mockUserData}>
+                    <Banners banners={banners} />
+                </UserProvider.context.Provider>
+            );
+
+            let snapshot = JSON.stringify(banner.toJSON());
+            expect(snapshot).toContain(b.title);
+            expect(snapshot).toContain(b.copy);
+            expect(snapshot).toContain(b.cta);
+            expect(snapshot).toContain(b.url);
+        }
+    });
+
+    test('renders first banner and not second when both flags are set', () => {
+        mockUserData.waffle.flags = {
+            [banners[0].id]: true,
+            [banners[1].id]: true
+        };
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        let snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[0].title);
+        expect(snapshot).toContain(banners[0].copy);
+        expect(snapshot).toContain(banners[0].cta);
+        expect(snapshot).toContain(banners[0].url);
+
+        expect(snapshot).not.toContain(banners[1].title);
+        expect(snapshot).not.toContain(banners[1].copy);
+        expect(snapshot).not.toContain(banners[1].cta);
+        expect(snapshot).not.toContain(banners[1].url);
+    });
+
+    test('renders second active banner if first is embargoed', () => {
+        mockUserData.waffle.flags = {
+            [banners[0].id]: true,
+            [banners[1].id]: true
+        };
+
+        localStorage.setItem(
+            `banner.${banners[0].id}.embargoed_until`,
+            String(Date.now() + 10000)
+        );
+
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        let snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[1].title);
+        expect(snapshot).toContain(banners[1].copy);
+        expect(snapshot).toContain(banners[1].cta);
+        expect(snapshot).toContain(banners[1].url);
+
+        expect(snapshot).not.toContain(banners[0].title);
+        expect(snapshot).not.toContain(banners[0].copy);
+        expect(snapshot).not.toContain(banners[0].cta);
+        expect(snapshot).not.toContain(banners[0].url);
+    });
+
+    test('renders nothing if all active banners are embargoed', () => {
+        mockUserData.waffle.flags = {
+            [banners[0].id]: true,
+            [banners[1].id]: true
+        };
+
+        localStorage.setItem(
+            `banner.${banners[0].id}.embargoed_until`,
+            String(Date.now() + 10000)
+        );
+        localStorage.setItem(
+            `banner.${banners[1].id}.embargoed_until`,
+            String(Date.now() + 10000)
+        );
+
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        expect(banner.toJSON()).toBe(null);
+    });
+
+    test('embargos expire', () => {
+        mockUserData.waffle.flags = {
+            [banners[0].id]: true,
+            [banners[1].id]: true
+        };
+
+        localStorage.setItem(
+            `banner.${banners[0].id}.embargoed_until`,
+            String(Date.now() + 10000)
+        );
+        localStorage.setItem(
+            `banner.${banners[1].id}.embargoed_until`,
+            String(Date.now() - 1)
+        );
+
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        let snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[1].title);
+
+        localStorage.setItem(
+            `banner.${banners[0].id}.embargoed_until`,
+            String(Date.now() - 1)
+        );
+
+        banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[0].title);
+    });
+
+    test('banners can be dismissed', () => {
+        mockUserData.waffle.flags = {
+            [banners[0].id]: true,
+            [banners[1].id]: true
+        };
+        let banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        let snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[0].title);
+        expect(snapshot).toContain(banners[0].copy);
+        expect(snapshot).toContain(banners[0].cta);
+        expect(snapshot).toContain(banners[0].url);
+
+        let button = banner.root.findByType('button');
+        expect(button).toBeDefined();
+
+        act(() => {
+            // Simulate a click on the dismiss button
+            button.props.onClick();
+        });
+
+        // Now that it is dismissed expect to render null
+        expect(banner.toJSON()).toBe(null);
+
+        // The banner should be embargoed now
+        let value = localStorage.getItem(
+            `banner.${banners[0].id}.embargoed_until`
+        );
+        let actualEmbargo = parseInt(value);
+        let approximateEmbargo =
+            (banners[0].embargoDays || 5) * 24 * 60 * 60 * 1000 + Date.now();
+        let difference = approximateEmbargo - actualEmbargo;
+        expect(difference).toBeGreaterThanOrEqual(0);
+        expect(difference).toBeLessThan(100);
+
+        // Re-render and expect the second banner
+        banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        snapshot = JSON.stringify(banner.toJSON());
+        expect(snapshot).toContain(banners[1].title);
+        expect(snapshot).toContain(banners[1].copy);
+        expect(snapshot).toContain(banners[1].cta);
+        expect(snapshot).toContain(banners[1].url);
+
+        // Dismiss the second banner
+        button = banner.root.findByType('button');
+        act(() => {
+            // Simulate a click on the dismiss button
+            button.props.onClick();
+        });
+
+        // Now that it is dismissed expect to render null
+        expect(banner.toJSON()).toBe(null);
+
+        // The banner should be embargoed now
+        value = localStorage.getItem(`banner.${banners[1].id}.embargoed_until`);
+        actualEmbargo = parseInt(value);
+        approximateEmbargo =
+            (banners[1].embargoDays || 5) * 24 * 60 * 60 * 1000 + Date.now();
+        difference = approximateEmbargo - actualEmbargo;
+        expect(difference).toBeGreaterThanOrEqual(0);
+        expect(difference).toBeLessThan(100);
+
+        // Do one final re-render and expect null since both are embargoed
+        banner = create(
+            <UserProvider.context.Provider value={mockUserData}>
+                <Banners banners={banners} />
+            </UserProvider.context.Provider>
+        );
+
+        expect(banner.toJSON()).toBe(null);
+    });
+});

--- a/kuma/javascript/src/landing-page.jsx
+++ b/kuma/javascript/src/landing-page.jsx
@@ -1,9 +1,31 @@
 // @flow
 import * as React from 'react';
 
+import Banners from './banners.jsx';
 import GAProvider from './ga-provider.jsx';
+import { gettext } from './l10n.js';
 import Header from './header/header.jsx';
 import UserProvider from './user-provider.jsx';
+
+import type BannerProps from './banners.jsx';
+
+// The landing page will display the first of the banners listed here that:
+//
+// 1) is enabled by its waffle flag
+// 2) has not been recently dismissed by the user
+//
+// To add a new banner, simply add a new element to the array.
+const banners: Array<BannerProps> = [
+    {
+        id: 'developer_needs',
+        title: gettext('MDN Survey'),
+        copy: gettext(
+            'Help us understand the top 10 needs of Web developers and designers.'
+        ),
+        cta: gettext('Take the survey'),
+        url: 'https://qsurvey.mozilla.com/s3/Developer-Needs-Assessment-2019'
+    }
+];
 
 /**
  * This is the React component that we use for the React homepage.
@@ -16,6 +38,7 @@ export default function LandingPage() {
         <GAProvider>
             <UserProvider>
                 <Header />
+                <Banners banners={banners} />
             </UserProvider>
         </GAProvider>
     );

--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -8,10 +8,6 @@
   {{ super() }}
 
   {% stylesheet 'home' %}
-
-  {% if waffle.flag('developer_needs') %}
-    {% stylesheet 'banners' %}
-  {% endif %}
 {% endblock %}
 
 {% block extrahead %}
@@ -121,17 +117,9 @@
 </div>
 {% endblock %}
 
-{% if waffle.flag('developer_needs') %}
-    {%- block banners %}
-        {% include "banners/cta-banners.html" %}
-    {% endblock %}
-{% endif %}
-
 {% block js %}
   {{ super() }}
   {% if settings.NEWSLETTER %}
     {% javascript 'newsletter' %}
   {% endif %}
-
-  {% javascript 'banners' %}
 {% endblock %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -730,7 +730,12 @@ PIPELINE_CSS = {
             'js/prism-mdn/components/prism-json.css',
             'styles/wiki-syntax.scss',
 
+            # Styles for BCD tables
             'styles/wiki-compat-tables.scss',
+
+            # Styles for call-to-action banners
+            # See kuma/javascript/src/banners.jsx
+            'styles/components/banners/base.scss'
         ),
         'output_filename': 'build/styles/react-mdn.css',
         'variant': 'datauri',


### PR DESCRIPTION
Our current system for call-to-action banners relies on the use of
waffle flags in our Jinja templates, which means that the rendered
html cannot be cached on a CDN. This PR introduces a <Banners>
component that can be used in place of the existing banners
javascript bundle and that gets waffle data from the user API
instead of relying on it in the Jinja template. The PR also set
up the react_homepage.html template and the landing_page.jsx
component to display the developer needs survey banner when the
waffle flag is turned on.