### PR TITLE
Allow cdn.speedcurve.com in our CSP so the LUX script is not blocked

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1375,6 +1375,7 @@ if ATTACHMENT_SITE_URL not in (_PROD_ATTACHMENT_SITE_URL, SITE_URL):
 CSP_SCRIPT_SRC = [
     SITE_URL,
     "www.google-analytics.com",
+    "cdn.speedcurve.com",
     "static.codepen.io",
     # TODO fix things so that we don't need this
     "'unsafe-inline'",


### PR DESCRIPTION
The LUX script is blocked by CSP on developer.allizom.org. This PR
allows that domain in our CSP configuration.