### PR TITLE
Make the DNA banner appear on React-based document pages

### DIFF
--- a/kuma/javascript/src/banners.jsx
+++ b/kuma/javascript/src/banners.jsx
@@ -185,18 +185,21 @@ export default function Banners(props: BannersProps) {
     // gettext() calls are made after our string catalog is ready. But
     // we do it inside a useMemo() function so that the localization
     // only happens once.
-    const defaultBanners = useMemo(() => [
-        {
-            id: 'developer_needs',
-            title: gettext('MDN Survey'),
-            copy: gettext(
-                'Help us understand the top 10 needs of Web developers and designers.'
-            ),
-            cta: gettext('Take the survey'),
-            url:
-                'https://qsurvey.mozilla.com/s3/Developer-Needs-Assessment-2019'
-        }
-    ]);
+    const defaultBanners = useMemo(
+        () => [
+            {
+                id: 'developer_needs',
+                title: gettext('MDN Survey'),
+                copy: gettext(
+                    'Help us understand the top 10 needs of Web developers and designers.'
+                ),
+                cta: gettext('Take the survey'),
+                url:
+                    'https://qsurvey.mozilla.com/s3/Developer-Needs-Assessment-2019'
+            }
+        ],
+        [] // This tells useMemo() to only compute this once.
+    );
 
     const userData = useContext(UserProvider.context);
 

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { css } from '@emotion/core';
 
 import Article from './article.jsx';
+import Banners from './banners.jsx';
 import { gettext } from './l10n.js';
 import LanguageMenu from './header/language-menu.jsx';
 import Header from './header/header.jsx';
@@ -237,10 +238,11 @@ function DocumentPage({ document }: DocumentProps) {
     return (
         <>
             <Header document={document} />
-            <TaskCompletionSurvey document={document} />
             <Titlebar title={document.title} document={document} />
             <Breadcrumbs document={document} />
             <Content document={document} />
+            <TaskCompletionSurvey document={document} />
+            <Banners />
         </>
     );
 }

--- a/kuma/javascript/src/landing-page.jsx
+++ b/kuma/javascript/src/landing-page.jsx
@@ -3,29 +3,8 @@ import * as React from 'react';
 
 import Banners from './banners.jsx';
 import GAProvider from './ga-provider.jsx';
-import { gettext } from './l10n.js';
 import Header from './header/header.jsx';
 import UserProvider from './user-provider.jsx';
-
-import type BannerProps from './banners.jsx';
-
-// The landing page will display the first of the banners listed here that:
-//
-// 1) is enabled by its waffle flag
-// 2) has not been recently dismissed by the user
-//
-// To add a new banner, simply add a new element to the array.
-const banners: Array<BannerProps> = [
-    {
-        id: 'developer_needs',
-        title: gettext('MDN Survey'),
-        copy: gettext(
-            'Help us understand the top 10 needs of Web developers and designers.'
-        ),
-        cta: gettext('Take the survey'),
-        url: 'https://qsurvey.mozilla.com/s3/Developer-Needs-Assessment-2019'
-    }
-];
 
 /**
  * This is the React component that we use for the React homepage.
@@ -38,7 +17,7 @@ export default function LandingPage() {
         <GAProvider>
             <UserProvider>
                 <Header />
-                <Banners banners={banners} />
+                <Banners />
             </UserProvider>
         </GAProvider>
     );


### PR DESCRIPTION
Previously the banner was only on the home page, this adds it to
document pages (but not search results pages) for the beta site.