### PR TITLE
Fix a JS exception that was breaking client-side navigation.

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -352,6 +352,19 @@ export class DocumentRoute extends Route<DocumentRouteParams, DocumentData> {
                         history.replaceState(url, '', url);
                     }
 
+                    // The tags property was added to the doc API recently
+                    // and the cached JSON blobs may not be updated yet.
+                    // So if we receive data with no tags property, we
+                    // have to add one set to an empty array for backward
+                    // compatibility.
+                    //
+                    // NOTE: as a general matter, because of our S3
+                    // cache we need to do this every time we update
+                    // the doc API to ensure backward compatibility.
+                    if (!documentData.tags) {
+                        documentData.tags = [];
+                    }
+
                     return documentData;
                 } else {
                     throw new Error('Invalid response from document API');

--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -327,6 +327,16 @@ export default function Router({
                     // probably a hard load in the first place and we
                     // don't want to try again because we'll just get
                     // into a loop.
+                    //
+                    // NOTE: when something does go wrong and we fall
+                    // back on loading the page, it means that any
+                    // error message printed to the console is
+                    // immediately erased, which makes debugging these
+                    // situations difficult, especially in
+                    // production. The Firefox dev tools debugger
+                    // allows you to set a breakpoint on beforeunload
+                    // events which allows us to examine the stack and
+                    // find out what the caught exception is.
                     if (url !== initialURL) {
                         window.location = url;
                     } else {


### PR DESCRIPTION
In a recent PR I landed code that displayed document tags on
each page. In order to do this, I had to extend the doc API to
include a tags property in the JSON blob. It worked fine locally
but I forgot about our S3 cache of JSON blobs used in staging
and in production. The pre-rendered JSON blobs do not have the
new tags property, but the code for displaying the tags assumes
that it will always see tags or at least an empty array.

This was causing an exception during rendering and the router
fell back on doing a hard reload. This PR fixes the problem
by adding backwards compatibility code in the DocumentRoute class:
after fetching a JSON blob, we check for the tags property and
add one (an empty array) if the property does not exist.

With that fix in place, the frontend code can continue to
assume that the API always returns a tags array and the exception
goes away. Because of the way we do caching we will need to remember
to always add code like this whenever we evolve the doc schema in
the future.