### PR TITLE
Don't show the loading bar for fast client-side navigation.

### DIFF
--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -33,10 +33,17 @@ import {
 } from './perf.js';
 
 // These are CSS animations for the loading bar
+// The slidein animation runs for 500ms, but doesn't do anything
+// for the first 100ms, so when client-side navigation is really fast
+// the user won't even see a flash of the progress bar starting.
 const slidein = keyframes`
-  from { transform: translate(-90%, 0); }
-  to { transform: translate(0, 0); }
+  0% { transform: translate(-100%, 0); }
+  20% { transform: translate(-100%, 0); }
+  100% { transform: translate(0, 0); }
 `;
+// When client side navigation takes an unexpectedly long time
+// this color throbbing animation takes over once the progress par
+// has slid in.
 const throb = keyframes`
   from { opacity: 1.0; }
   to { opacity: 0.5; }
@@ -539,11 +546,6 @@ export default function Router({
             return;
         }
 
-        // Client side navigation is typically so fast that the loading
-        // animation might not even be noticed, so we artificially prolong
-        // the effect with setTimeout()
-        setTimeout(() => {
-            setLoading(false);
-        }, 200);
+        setLoading(false);
     }
 }


### PR DESCRIPTION
Currently in our single-page app, we make a point of showing the
loading bar animation on every page transition, and even prolong
the length of the animation so that the user has postitive feedback
that something has happened.

We've gotten feedback that the loading bar makes client-side navigation
feel slower than it actually is, however. So this PR changes the
progress bar animation in two ways.

- first, it no longer artificially prolongs the animation
- second, it changes the animation so that nothing happens
  for the first 100ms.

The upshot is that when the page transition takes less than 100ms
the user will not see the progress bar at all. For navigations that
are under 200ms the user will just see a flash of blue, and for
navigations that take longer than that, they'll probably see something
that they recognize as a progress bar.

This is a trivial patch. We should try it out and see if we like
the site better with or without it.