### PR TITLE
ignore npm-debug.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ node_modules/
 /static/
 kuma/javascript/dist/
 /tmp/emails/*.log
+npm-debug.log
 
 # Selenium
 geckodriver.log


### PR DESCRIPTION
Useful when you get sporadic errors from `npm install` which happens from time to time. 