### PR TITLE
Bug 1562293: don't crash in Google Translate

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -56,7 +56,15 @@ if (container) {
         if (container.firstElementChild) {
             // If the container element is not empty, then it was presumably
             // rendered on the server, and we just need to hydrate it now.
-            ReactDOM.hydrate(app, container);
+            //
+            // If we're running under google translate, however, we skip
+            // the hydration step because the mismatched origins cause
+            // errors and cause all the content to disappear when React
+            // unmounts the components. It is better for the end user in
+            // this case to just get a static HTML page. See Bug 1562293.
+            if (window.origin !== 'https://translate.googleusercontent.com') {
+                ReactDOM.hydrate(app, container);
+            }
         } else {
             // Otherwise, if the container is empty, then we need to do a full
             // client-side render. The goal is that pages should always be


### PR DESCRIPTION
When our React-based pages are loaded in translate.google.com
various JS errors caused by Google make React unmount the components
that display the (now-translated) content. This patch works around
the problem by simply never calling ReactDOM.hydrate() when we're
loaded into Google Translate