### PR TITLE
Bug 1563511, ensure new page content is read on navigation complete

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -227,7 +227,13 @@ function Content({ document }: DocumentProps) {
     // The wiki-left-present class below is needed for correct BCD layout
     // See kuma/static/styles/components/compat-tables/bc-table.scss
     return (
-        <div css={styles.contentLayout} className="wiki-left-present">
+        /* adding aria-live here to mark this as a live region to
+          ensure a screen reader will read the new content after navigation */
+        <div
+            css={styles.contentLayout}
+            className="wiki-left-present"
+            aria-live="assertive"
+        >
             <Article document={document} />
             <Sidebar document={document} />
         </div>

--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -146,6 +146,7 @@ export default function Router({
     // analytics and the other stops the loading animation. Both
     // functions are defined at the bottom of the component.
     useEffect(recordAndReportAnalytics, [pageState.data]);
+    useEffect(resetFocus, [pageState.data]);
     useEffect(stopLoading, [pageState.data]);
 
     // When the page is first loaded, and this function is called for
@@ -512,6 +513,16 @@ export default function Router({
         // browser to be able to go back to it by client-side navigation
         // we need to set its state.
         history.replaceState(initialURL, '', initialURL);
+    }
+
+    /**
+     * Reset focus to the window after navigation
+     */
+    function resetFocus() {
+        let documentTitle = document.querySelector('a[class*="logoContainer"]');
+        if (documentTitle) {
+            documentTitle.focus();
+        }
     }
 
     // This is an effect function that runs after a new page (with new

--- a/kuma/static/styles/components/structure/document-head.scss
+++ b/kuma/static/styles/components/structure/document-head.scss
@@ -6,6 +6,7 @@
     padding: $first-content-top-padding 0 $last-content-bottom-padding 0;
 }
 
+div[class*='titlebar'],
 .document-title {
     h1 {
         @include set-font-size($mobile-document-title-font-size);

--- a/kuma/static/styles/components/structure/page-header/main-header.scss
+++ b/kuma/static/styles/components/structure/page-header/main-header.scss
@@ -31,6 +31,17 @@ Main header, wraps all components of logo, main, and secondary navigation
     }
 }
 
+a[class*='logoContainer'] {
+    outline: none;
+
+    /* do not remove the outline for keyboard users */
+    /* stylelint-disable selector-pseudo-class-no-unknown */
+    &:focus-visible {
+        outline: unset;
+    }
+    /* stylelint-enable */
+}
+
 .logo {
     position: relative;
     z-index: $logo-z;


### PR DESCRIPTION
This improves the accessibility of our client-side navigation by setting a `live-region` and also moving focus to the logo. In a follow on PR I am going to reintroduce the skip links for documentation pages. When I do that, I will also move focus to the container for these links as opposed to the logo. For now, this is a noticeable improvement.

### Here is the before

https://send.firefox.com/download/56f9e4901abcc514/#rnmfD8S5RpLXmbiPtC7Nwg

### Here is the after

https://send.firefox.com/download/2f2b7d36ef9b99cc/#c0M47TqnXzSoQJDt4f3P1Q

@callahad-mozilla-owner r?