### PR TITLE
Bug 1562853, scrollbars at bottom of article, sidebar on windows

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -25,7 +25,6 @@ const styles = {
         gridArea: 'main',
         boxSizing: 'border-box',
         width: '100%',
-        overflowX: 'scroll',
         // Less padding on the left because the sidebar also has
         // padding on the right
         padding: '30px 24px 30px 12px',

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -107,7 +107,6 @@ const styles = {
         gridArea: 'side',
         boxSizing: 'border-box',
         width: '100%',
-        overflowX: 'scroll',
         // Less padding on the right because the article area
         // has padding on the left, too.
         padding: '30px 12px 30px 24px',


### PR DESCRIPTION
Fixes scrollbars at the bottom of doc pages.

## Before

<img width="1416" alt="Screenshot 2019-07-09 at 08 46 43" src="https://user-images.githubusercontent.com/10350960/60865499-73fe1880-a226-11e9-82bc-0cd0a7ec9993.png">

## After

<img width="1424" alt="Screenshot 2019-07-09 at 08 47 29" src="https://user-images.githubusercontent.com/10350960/60865523-7e201700-a226-11e9-9387-406074cf4166.png">

NOTE: This only happens on Windows - @callahad r?