### PR TITLE
bug 1561055 - /api/v1/search/en-US?q=stuff includes too much

### DIFF
--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -370,7 +370,7 @@ class APISearchIntegration(ElasticTestCase):
         hits = response.json()['hits']
         assert hits
         expected_keys = set(
-            ['score', 'excerpts', 'summary', 'title', 'slug', 'tags'])
+            ['excerpts', 'summary', 'title', 'slug'])
         for hit in hits:
             assert set(hit.keys()) == expected_keys
 

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -290,12 +290,8 @@ def search(request, locale):
         # Be explicit about what to return.
         # Only include things the React component might and will use.
         hit_dict = hit.to_dict()
-        # Not every document has 'tags' so set this default.
-        hit_dict.setdefault('tags', [])
         # 'locale' might get returned from hit.to_dict(). Remove it if there.
         hit_dict.pop('locale', None)
-        # This one comes from the meta
-        hit_dict['score'] = hit.meta.score,
         try:
             # Turn it into a plain list instead of an <type AbstractList>
             excerpts = list(hit.meta.highlight.content)

--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -190,29 +190,12 @@ export class SearchRoute extends Route<SearchRouteParams, SearchResults> {
                     if (
                         !results ||
                         !results.hits ||
-                        !Array.isArray(results.hits.hits)
+                        !Array.isArray(results.hits)
                     ) {
                         throw new Error('Search API returned unexpected data');
                     }
                     return {
-                        results: results.hits.hits.map(hit => {
-                            let score = hit._score;
-                            let excerpts =
-                                (hit.highlight && hit.highlight.content) || [];
-
-                            // Sometimes ElasticSearch returns excerpts that
-                            // are thousands of bytes long without any spaces
-                            // and we don't want to display those
-                            if (excerpts) {
-                                excerpts = excerpts.filter(e => e.length < 256);
-                            }
-
-                            // And we only want to display the top 3 excerpts
-                            if (excerpts && excerpts.length > 3) {
-                                excerpts = excerpts.slice(0, 3);
-                            }
-                            return { ...hit._source, score, excerpts };
-                        }),
+                        results: results.hits,
                         error: null
                     };
                 })

--- a/kuma/javascript/src/search-results-page.test.js
+++ b/kuma/javascript/src/search-results-page.test.js
@@ -145,21 +145,13 @@ describe('SearchRoute', () => {
                 ok: true,
                 json: () =>
                     Promise.resolve({
-                        // ElasticSearch buries the results in layers of
-                        // other stuff that we fake out here
-                        hits: {
-                            hits: fakeResults.map(r => ({
-                                _source: {
-                                    slug: r.slug,
-                                    title: r.title,
-                                    summary: r.summary
-                                },
-                                _score: r.score,
-                                highlight: {
-                                    content: r.excerpts
-                                }
-                            }))
-                        }
+                        hits: fakeResults.map(r => ({
+                            slug: r.slug,
+                            title: r.title,
+                            summary: r.summary,
+                            score: r.score,
+                            excerpts: r.excerpts
+                        }))
                     })
             });
         });


### PR DESCRIPTION
http://beta.mdn.localhost:8000/en-US/search?q=stuff still seems to work at least. 

It started with that I just wanted to see how the `.to_dict()` stuff worked then I realized it would be easy to change and it would give me a chance to be challenged by jest and flow and just generally working on the post-David code. 
Then I noticed that there was no Python test coverage at all on the new API search so I spent some time on that. It's not perfect and it's a big fat test but it's a lot better than nothing. 