### PR TITLE
inefficient queries in DocumentContributorsJob

### DIFF
--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -41,6 +41,17 @@ class DocumentContributorsJob(KumaJob):
         if not recent_creator_ids:
             return self.empty()
 
+        # If a document has repeated revisions by the same user, the *list*
+        # of IDs is not distinct.
+        # We can't use `recent_creator_ids = list(set(recent_creator_ids))`
+        # since that would break the order.
+        # The fastest way to "uniqify" a list, whilst preserving the order,
+        # in Python 2 is this way:
+        # (See https://www.peterbe.com/plog/uniqifiers-benchmark)
+        seen = set()
+        recent_creator_ids = [
+            x for x in recent_creator_ids if x not in seen and not seen.add(x)]
+
         # then return the ordered results given the ID list, MySQL only syntax
         select = collections.OrderedDict([
             ('ordered_ids',


### PR DESCRIPTION
This PR isn't particularly important. I just didn't want to throw it away. 

What I noticed was the [this `if` statement](https://github.com/mozilla/kuma/blob/bd7581053f3840f5fa22b28e6372c729b0c3468f/kuma/wiki/jobs.py#L42) which would always be true because at that point `recent_creator_ids` isn't a list but a QuerySet object.
It's only later that it gets turned in a python list type. 

Turns out, I can't find any documents in *my* mysql that has no creators and that if statement was never covered with tests anyway. 

Then when I poked I noticed the unnecessary extra SQL query which can be heavy. 

Now in hindsight I realize how RARE this whole block of code is because it's Redis cached for 12 hours. A well. If you just find this annoying and distracting, please close the PR. 
