### PR TITLE
bug 1562858: 'add a translation' link for beta

### DIFF
--- a/kuma/api/v1/tests/test_views.py
+++ b/kuma/api/v1/tests/test_views.py
@@ -103,6 +103,7 @@ def test_doc_api(client, api_settings, trans_doc, cleared_cacheback_cache,
     assert doc_data['absoluteURL'] == trans_doc.get_absolute_url()
     assert doc_data['editURL'] == absolutify(trans_doc.get_edit_url(),
                                              for_wiki_site=True)
+    assert doc_data['translateURL'] is None
     assert doc_data['bodyHTML'] == trans_doc.get_body_html()
     assert doc_data['quickLinksHTML'] == trans_doc.get_quick_links_html()
     assert doc_data['tocHTML'] == trans_doc.get_toc_html()
@@ -159,6 +160,15 @@ def test_doc_api_for_redirect_to_doc(client, api_settings, root_doc,
     assert doc_data['absoluteURL'] == root_doc.get_absolute_url()
     assert doc_data['editURL'] == absolutify(root_doc.get_edit_url(),
                                              for_wiki_site=True)
+    assert doc_data['translateURL'] == absolutify(
+        reverse(
+            'wiki.select_locale',
+            args=(root_doc.slug,),
+            locale=root_doc.locale,
+            urlconf='kuma.urls'
+        ),
+        for_wiki_site=True
+    )
     assert doc_data['bodyHTML'] == root_doc.get_body_html()
     assert doc_data['quickLinksHTML'] == root_doc.get_quick_links_html()
     assert doc_data['tocHTML'] == root_doc.get_toc_html()

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -141,6 +141,19 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
             'hrefLang': doc.get_hreflang(available_locales),
             'absoluteURL': doc.get_absolute_url(),
             'editURL': absolutify(doc.get_edit_url(), for_wiki_site=True),
+            'translateURL': (
+                absolutify(
+                    reverse(
+                        'wiki.select_locale',
+                        args=(doc.slug,),
+                        locale=doc.locale,
+                        urlconf='kuma.urls'
+                    ),
+                    for_wiki_site=True
+                )
+                if doc.is_localizable else
+                None
+            ),
             'bodyHTML': doc.get_body_html(),
             'quickLinksHTML': doc.get_quick_links_html(),
             'tocHTML': doc.get_toc_html(),

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -24,6 +24,7 @@ export type DocumentData = {
     hrefLang: string,
     absoluteURL: string,
     editURL: string,
+    translateURL: string,
     bodyHTML: string,
     quickLinksHTML: string,
     tocHTML: string,

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -19,6 +19,7 @@ export const fakeDocumentData = {
     hrefLang: 'en',
     absoluteURL: '[fake absolute url]',
     editURL: '[fake edit url]',
+    translateURL: '[fake translate url]',
     bodyHTML: '[fake body HTML]',
     quickLinksHTML: '[fake quicklinks HTML]',
     tocHTML: '[fake TOC HTML]',

--- a/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
@@ -127,6 +127,15 @@ exports[`LanguageMenu snapshot 1`] = `
         </bdi>
       </a>
     </li>
+    <li>
+      <a
+        href="[fake translate url]"
+        id="translations-add"
+        rel="nofollow"
+      >
+        Add a translation
+      </a>
+    </li>
   </ul>
 </div>
 `;

--- a/kuma/javascript/src/header/language-menu.jsx
+++ b/kuma/javascript/src/header/language-menu.jsx
@@ -11,8 +11,12 @@ type Props = {
 };
 
 export default function LanguageMenu({ document }: Props): React.Node {
-    // If there aren't any translations available, don't display anyhing
-    if (!document || document.translations.length === 0) {
+    // If there are no translations available and there is no translateURL,
+    // don't display anything.
+    if (
+        !document ||
+        !(document.translations.length > 0 || document.translateURL)
+    ) {
         return null;
     }
 
@@ -34,6 +38,17 @@ export default function LanguageMenu({ document }: Props): React.Node {
                     </a>
                 </li>
             ))}
+            {document.translateURL && (
+                <li>
+                    <a
+                        href={document.translateURL}
+                        rel="nofollow"
+                        id="translations-add"
+                    >
+                        {gettext('Add a translation')}
+                    </a>
+                </li>
+            )}
         </Dropdown>
     );
 }


### PR DESCRIPTION
This PR adds the `Add a translation` link to the language menu on document pages in the `beta` domain. As part of that effort, it adds a new `translateURL` attribute to the JSON structure provided by the document API. That attribute may be either `null` (e.g., when the document is not localizable, which is the case for all non-English documents as well as any documents explicitly marked as such) or an absolute URL to the `wiki` domain. That attribute will be missing from the currently published JSON objects, but since an `undefined` attribute is falsy, that case is handled by the React-based code the same as if the document page was not localizable. In other words, no `Add a translation` link will be seen on stage/prod until all of the stage/prod documents are re-published. So, if and when this PR is deployed, that final step is required. Of course, that isn't an issue when testing this locally.

For local testing, I used these settings in my `.env` file (my usual settings):
```
DEBUG=True
DOMAIN=mdn.localhost
ENABLE_RESTRICTIONS_BY_HOST=True
BETA_HOST=beta.mdn.localhost:8000
WIKI_HOST=wiki.mdn.localhost:8000
ATTACHMENT_HOST=demos:8000
SITE_URL=http://mdn.localhost:8000
STATIC_URL=http://mdn.localhost:8000/static/
```
and this content for my `/etc/hosts` file:
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
255.255.255.255	broadcasthost
::1             localhost
```
and did something like this:
```
docker-compose pull
docker-compose up -d
docker-compose exec web make build-static
docker-compose restart
```

You should then be able to see the new link within the language menu on these pages:
- http://beta.mdn.localhost:8000/en-US/docs/Web/CSS
- http://beta.mdn.localhost:8000/en-US/docs/Web/HTML

as well as the absence of the new link within the language menu on these pages:
- http://beta.mdn.localhost:8000/es/docs/Web/CSS
- http://beta.mdn.localhost:8000/fr/docs/Web/HTML

Also make sure you check that the link is added correctly when using client-side navigation. So for example, first go to http://beta.mdn.localhost:8000/en-US/docs/Web, click on one of the `HTML`, `CSS`, or other document links on that page, and then check the language menu.