### PR TITLE
bug 1542817 - `ReferenceError: ga is not defined` on some pages

### DIFF
--- a/kuma/static/js/utils/perf-post-message-handler.js
+++ b/kuma/static/js/utils/perf-post-message-handler.js
@@ -15,10 +15,12 @@ function handlePerfMarks(perfData) {
         });
 
         /* If Analytics has loaded, go ahead with tracking
-           Checking for ".create" due to Ghostery mocking of ga */
-        if (ga && ga.create) {
+           Checking for ".create" due to Ghostery mocking of ga.
+           Use "window.ga" otherwise you'd get a
+           "ReferenceError: ga is not defined" error. */
+        if (window.ga && window.ga.create) {
             // Send event to GA
-            ga('send', {
+            window.ga('send', {
                 hitType: 'timing',
                 timingCategory: 'RUM - Interactive Examples',
                 timingVar: perfData.measureName,


### PR DESCRIPTION
When I was hacking on https://github.com/mozilla/kuma/pull/5544/files as I was poking around and reloading the page with different console debugging. I got the error every time. Then I applied this fix and it went away. Yay! 