### PR TITLE
bug 1525719: remove history button on beta doc pages

### DIFF
--- a/kuma/javascript/src/titlebar.jsx
+++ b/kuma/javascript/src/titlebar.jsx
@@ -5,7 +5,6 @@ import { css } from '@emotion/core';
 
 import { gettext } from './l10n.js';
 import EditIcon from './icons/pencil.svg';
-import HistoryIcon from './icons/clock.svg';
 import UserProvider from './user-provider.jsx';
 
 import type { DocumentData, DocumentProps } from './document.jsx';
@@ -55,13 +54,7 @@ const styles = {
         }
     }),
 
-    editAndHistoryButtons: css({
-        display: 'flex',
-        flexDirection: 'row',
-        flex: '0 0'
-    }),
     editButton: css({
-        flex: '1 0 auto',
         height: 32,
         border: 'solid 2px #3d7e9a',
         color: '#3d7e9a', // for the text
@@ -71,37 +64,20 @@ const styles = {
         fontSize: 15,
         fontWeight: 'bold',
         padding: '0 18px'
-    }),
-    historyButton: css({
-        border: 'solid 2px #333',
-        backgroundColor: '#fff',
-        padding: 5,
-        marginLeft: 8
     })
 };
 
-function EditAndHistoryButtons({ document }: DocumentProps) {
+function EditButton({ document }: DocumentProps) {
     let editURL = document.editURL;
     return (
-        <div css={styles.editAndHistoryButtons}>
-            <button
-                css={styles.editButton}
-                onClick={() => {
-                    window.location = editURL;
-                }}
-            >
-                <EditIcon width={13} height={13} /> {gettext('Edit')}
-            </button>
-            <button
-                css={styles.historyButton}
-                aria-label={gettext('History')}
-                onClick={() => {
-                    window.location = editURL.replace('$edit', '$history');
-                }}
-            >
-                <HistoryIcon width={18} height={18} />
-            </button>
-        </div>
+        <button
+            css={styles.editButton}
+            onClick={() => {
+                window.location = editURL;
+            }}
+        >
+            <EditIcon width={13} height={13} /> {gettext('Edit')}
+        </button>
     );
 }
 
@@ -115,11 +91,10 @@ export default function Titlebar({
     const userData = useContext(UserProvider.context);
 
     // If we have user data, and the user is logged in, and they
-    // are a contributor (or, if we don't know whether they are
-    // a contributor because the backend does not support that yet)
-    // then we want to show Edit and History buttons on the
-    // right side of the titlebar.
-    let showEditAndHistory =
+    // are a contributor (or, if we don't know whether they are a
+    // contributor because the backend does not support that yet) then
+    // we want to show the Edit button on the right side of the titlebar.
+    let showEdit =
         userData &&
         userData.isAuthenticated &&
         (userData.isContributor === undefined || userData.isContributor);
@@ -128,9 +103,7 @@ export default function Titlebar({
         <div css={styles.titlebarContainer}>
             <div css={styles.titlebar}>
                 <h1 css={styles.title}>{title}</h1>
-                {document && showEditAndHistory && (
-                    <EditAndHistoryButtons document={document} />
-                )}
+                {document && showEdit && <EditButton document={document} />}
             </div>
         </div>
     );

--- a/kuma/javascript/src/titlebar.test.js
+++ b/kuma/javascript/src/titlebar.test.js
@@ -16,7 +16,7 @@ describe('Titlebar', () => {
         expect(heading.props.children).toBe('test_title!');
     });
 
-    test('Titlebar shows edit and history buttons', () => {
+    test('Titlebar shows edit button', () => {
         let titlebar;
         let buttons;
 
@@ -38,7 +38,7 @@ describe('Titlebar', () => {
         buttons = titlebar.root.findAll(instance => instance.type === 'button');
         expect(buttons.length).toBe(0);
 
-        // User logged in and contributor, expect two buttons
+        // User logged in and contributor, expect one button
         titlebar = create(
             <UserProvider.context.Provider
                 value={{
@@ -57,7 +57,7 @@ describe('Titlebar', () => {
             </UserProvider.context.Provider>
         );
         buttons = titlebar.root.findAll(instance => instance.type === 'button');
-        expect(buttons.length).toBe(2);
+        expect(buttons.length).toBe(1);
 
         // Make the mock window.location property writeable
         // NOTE: This is a little brittle since it assumes that titlebar.jsx
@@ -67,11 +67,8 @@ describe('Titlebar', () => {
             value: null
         });
 
-        // Clicking first button sets window.location.href to editURL
-        // Clicking the second button sets it to the history URL instead
+        // Clicking the button sets window.location.href to editURL
         buttons[0].props.onClick();
         expect(window.location).toBe('foobar$edit');
-        buttons[1].props.onClick();
-        expect(window.location).toBe('foobar$history');
     });
 });

--- a/kuma/static/styles/base/icons.scss
+++ b/kuma/static/styles/base/icons.scss
@@ -267,15 +267,6 @@ button[type='submit'] .icon-check-mark {
     vertical-align: text-bottom;
 }
 
-/* TODO: Need to remove the need for this be removing the
-   styling added from the React side */
-div[class*='editAndHistoryButtons'] {
-    div[class*='historyButton'] {
-        padding-top: 2px;
-        padding-bottom: 0;
-    }
-}
-
 /* specific styling for icons on mobile */
 @media #{$mq-mobile-and-down} {
     .column-hacks .icon-star,


### PR DESCRIPTION
This PR removes the "History" button (clock icon) from the document pages on the beta domain.

Before:
<img width="425" alt="image" src="https://user-images.githubusercontent.com/3743693/61103410-b55d1680-a426-11e9-9561-b1aeb5f82947.png">

After:
<img width="423" alt="image" src="https://user-images.githubusercontent.com/3743693/61103415-bc842480-a426-11e9-956f-94b0ed5f2175.png">

Note: This PR made me think that perhaps, within https://github.com/mozilla/kuma/pull/5548, I should have only added the `Add a translation` link within the language menu dropdown if the user was logged in and a contributor (the same logic used here for deciding whether or not to display the `Edit` button). I suppose so. What do you guys and @atopal and @nickbrandt think?