### PR TITLE
bug 1565618 - 'last updated by' date localized

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -191,6 +191,7 @@ function ArticleMetadata({ document }: DocumentProps) {
                 lastModifiedBy={document.lastModifiedBy}
                 lastModified={document.lastModified}
                 profileBaseURL={profileBaseURL}
+                documentLocale={document.locale}
             />
         </div>
     );

--- a/kuma/javascript/src/last-modified-by.jsx
+++ b/kuma/javascript/src/last-modified-by.jsx
@@ -6,16 +6,30 @@ import { gettext } from './l10n.js';
 import ClockIcon from './icons/clock.svg';
 
 type LastModifiedByProps = {
+    documentLocale: String,
     lastModifiedBy: String,
     lastModified: String,
     profileBaseURL: String
 };
 
 export default function LastModifiedBy({
+    documentLocale,
     lastModifiedBy,
     lastModified,
     profileBaseURL
 }: LastModifiedByProps) {
+
+    // This fortunately works because the 'lastModified' date string is
+    // predictable and always of the same format. It's not a proper ISO
+    // string but it's close.
+    const lastModifiedDate = new Date(lastModified);
+    // Justification for these is to match the Wiki.
+    const dateStringOptions = {
+        year: 'numeric',
+        month: 'short',
+        day: 'numeric'
+    };
+
     return (
         <section className="contributors-sub">
             <ClockIcon />
@@ -25,7 +39,12 @@ export default function LastModifiedBy({
             <a href={`${profileBaseURL}${lastModifiedBy}`} rel="nofollow">
                 {`${lastModifiedBy}, `}
             </a>
-            <time dateTime={lastModified}>{lastModified}</time>
+            <time dateTime={lastModified}>
+                {lastModifiedDate.toLocaleString(
+                    documentLocale,
+                    dateStringOptions
+                )}
+            </time>
         </section>
     );
 }

--- a/kuma/javascript/src/last-modified-by.jsx
+++ b/kuma/javascript/src/last-modified-by.jsx
@@ -18,7 +18,6 @@ export default function LastModifiedBy({
     lastModified,
     profileBaseURL
 }: LastModifiedByProps) {
-
     // This fortunately works because the 'lastModified' date string is
     // predictable and always of the same format. It's not a proper ISO
     // string but it's close.


### PR DESCRIPTION
On a `en-US` document: 
<img width="424" alt="Screen Shot 2019-07-12 at 1 44 12 PM" src="https://user-images.githubusercontent.com/26739/61148113-111db300-a4ac-11e9-987e-24c6a7c5844e.png">

On a `sv-SE` document:
<img width="448" alt="Screen Shot 2019-07-12 at 1 44 27 PM" src="https://user-images.githubusercontent.com/26739/61148143-1e3aa200-a4ac-11e9-84f9-05ad2fdb200d.png">


