### PR TITLE
bug 1564277: use default USE_X_FORWARDED_HOST setting (False)

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1786,8 +1786,6 @@ ABSOLUTE_URL_OVERRIDES = {
     'users.user': get_user_url
 }
 
-USE_X_FORWARDED_HOST = True
-
 # Set header X-XSS-Protection: 1; mode=block
 SECURE_BROWSER_XSS_FILTER = True
 


### PR DESCRIPTION
Currently, we're setting the Django `USE_X_FORWARDED_HOST` setting to `True`. This is a relic of the past. This PR changes that Django setting to simply use the default value, which is `False`.