### PR TITLE
bug 1563210 - visually distinguish between current and obsolete

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -117,20 +117,19 @@ export default function Article({ document }: DocumentProps) {
         }
     }, [document, userData]);
 
+    const isArchive =
+        document.slug === 'Archive' || document.slug.startsWith('Archive/');
+
     return (
         /*
          * The "text-content" class and "wikiArticle" id are required
          * because our stylesheets expect them and formatting isn't quite
          * right without them.
          */
-        <div
-            id="content"
-            ref={article}
-            className="text-content"
-            css={styles.article}
-        >
+        <div id="content" ref={article} css={styles.article}>
             <article
                 id="wikiArticle"
+                className={isArchive ? 'archive-content' : null}
                 dangerouslySetInnerHTML={{ __html: document.bodyHTML }}
             />
             <ArticleMetadata document={document} />

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -126,10 +126,16 @@ export default function Article({ document }: DocumentProps) {
          * because our stylesheets expect them and formatting isn't quite
          * right without them.
          */
-        <div id="content" ref={article} css={styles.article}>
+        <div
+            id="content"
+            ref={article}
+            className={
+                isArchive ? 'text-content archive-content' : 'text-content'
+            }
+            css={styles.article}
+        >
             <article
                 id="wikiArticle"
-                className={isArchive ? 'archive-content' : null}
                 dangerouslySetInnerHTML={{ __html: document.bodyHTML }}
             />
             <ArticleMetadata document={document} />

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -892,13 +892,6 @@ PIPELINE_CSS = {
         ),
         'output_filename': 'build/styles/samples.css',
     },
-    # special styling for archived pages
-    'archive': {
-        'source_filenames': (
-            'styles/archive.scss',
-        ),
-        'output_filename': 'build/styles/archive.css',
-    },
 }
 
 # Locales with locale-specific fonts

--- a/kuma/static/styles/components/structure.scss
+++ b/kuma/static/styles/components/structure.scss
@@ -79,6 +79,7 @@ Footer
 Misc - needs sorting
 ====================================================================== */
 
+@import 'structure/archive';
 @import 'structure/socialaccount-providers';
 @import 'structure/feature-test-element';
 @import 'structure/pagination';

--- a/kuma/static/styles/components/structure/archive.scss
+++ b/kuma/static/styles/components/structure/archive.scss
@@ -1,15 +1,9 @@
-@import 'includes/vars';
-
 /*
-Archived pages
+For articles that are archive content. Makes them stand out more.
 ********************************************************************** */
 
-/*
-Red background & stripped border for archived pages
-- intentionally odd
-********************************************************************** */
 
-.wiki-main-content {
+.archive-content {
     background-color: $red-light;
     border: 10px solid $red;
     border-image: repeating-linear-gradient(-45deg, $red 0, $red 5px, $yellow 5px, $yellow 10px, $red 10px) 10 10 repeat;
@@ -19,7 +13,7 @@ Red background & stripped border for archived pages
 }
 
 @media #{$mq-tablet-and-up} {
-    .wiki-main-content {
+    .archive-content {
         border-width: 20px;
         border-image: repeating-linear-gradient(-45deg, $red 0, $red 10px, $yellow 10px, $yellow 20px, $red 20px) 20 20 repeat;
         // negative margins to make border flush to outside

--- a/kuma/static/styles/components/structure/archive.scss
+++ b/kuma/static/styles/components/structure/archive.scss
@@ -7,8 +7,6 @@ For articles that are archive content. Makes them stand out more.
     background-color: $red-light;
     border: 10px solid $red;
     border-image: repeating-linear-gradient(-45deg, $red 0, $red 5px, $yellow 5px, $yellow 10px, $red 10px) 10 10 repeat;
-    // negative margins to make border flush to outside
-    margin: ($first-content-top-padding * -1) ($mobile-center-spacing * -1);
     padding: $mobile-center-spacing;
 }
 
@@ -16,8 +14,6 @@ For articles that are archive content. Makes them stand out more.
     .archive-content {
         border-width: 20px;
         border-image: repeating-linear-gradient(-45deg, $red 0, $red 10px, $yellow 10px, $yellow 20px, $red 20px) 20 20 repeat;
-        // negative margins to make border flush to outside
-        margin: ($first-content-top-padding * -1) ($gutter-width * -1);
         padding: $gutter-width;
     }
 }

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -53,10 +53,6 @@
 
 {% block site_css %}
     {{ super() }}
-    {% if is_archive %}
-      {% stylesheet 'archive' %}
-    {% endif %}
-
     {% if waffle.flag('developer_needs') %}
       {% stylesheet 'banners' %}
     {% endif %}
@@ -219,7 +215,7 @@
               {% endif %}
 
               <!-- just the article content -->
-              <article id="wikiArticle">
+              <article id="wikiArticle"{%- if is_archive %} class="archive-content"{% endif -%}>
                 {% if not fallback_reason %}
                   {% if not document_html %}
                     {{ _("This article doesn't have any content yet.") }}


### PR DESCRIPTION
I'm clearly out of my depth here on the scss and stuff...

Basically, the wiki site relies on the fact that the `<head>` is only rendered once per page. That's why it conditionally inserts (or omits) a `<link rel=stylesheet href=archive.css>` into the DOM. That archive.css then overrides `.wiki-main-content`. 

This approach is not going to work with the React site because this kinda of business logic needs to depend not only on the initial server HTML rendering (aka. SSR) but also when you jump between pages. E.g. you might be on a non-archive page and click into an archive page and then click out to another non-archive page. 

So I changed approach. The `<article id="wikiArticle">` tag now becomes `<article id="wikiArticle" class="archive-content">` dynamically. *And*, now the CSS selector `.archive-content { ... }` is included on every page but used or not used dynamically. Yes, this bloats the total CSS even more but I can't think of a more convenient way. 

However, we COULD use emotion instead! The reason I didn't want to do that was because I didn't want to have to manually port that snippet of SCSS to emotion. Partially because I don't know how and partially because it's a form of DRY since you'd *have* to define that gradient color thing in two different places. 

The reason this PR isn't ready is because it doesn't work right. Here's what it looks like:
<img width="1501" alt="Screen Shot 2019-07-12 at 3 10 19 PM" src="https://user-images.githubusercontent.com/26739/61153136-51832e00-a4b8-11e9-8b70-c31ff440d210.png">
For some reason, that thing has a negative margin which hides the color striped (red and orange) border. 

 