### PR TITLE
Bug 1563481, toc component should be higher in source order

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -11,6 +11,7 @@ import Header from './header/header.jsx';
 import Route from './route.js';
 import TaskCompletionSurvey from './task-completion-survey.jsx';
 import Titlebar from './titlebar.jsx';
+import TOC from './toc.jsx';
 
 import type { GAFunction } from './ga-provider.jsx';
 
@@ -97,12 +98,13 @@ const styles = {
         maxWidth: 1400,
         margin: '0 auto',
         gridTemplateColumns: '25% 75%',
-        gridTemplateAreas: '"side main"',
+        gridTemplateRows: 'max-content 1fr',
+        gridTemplateAreas: '"document-toc-container main" "side main"',
         [NARROW]: {
             // If we're narrower than a tablet, put the sidebar at the
             // bottom and drop the toc line.
             gridTemplateColumns: '100%',
-            gridTemplateAreas: '"main" "side"'
+            gridTemplateAreas: '"main" "document-toc-container" "side"'
         }
     }),
     sidebar: css({
@@ -118,26 +120,6 @@ const styles = {
             padding: '15px 12px'
         }
     }),
-    tocHeader: css({
-        height: 4,
-        margin: '0 12px 0 -1px',
-        backgroundImage: 'linear-gradient(-272deg, #206584, #83d0f2)'
-    }),
-    toc: css({
-        backgroundColor: '#fcfcfc',
-        border: 'solid 1px #dce3e5',
-        padding: '8px 8px 0px 13px',
-        margin: '0 12px 20px -1px',
-        '& ul': {
-            listStyle: 'none',
-            paddingLeft: 12
-        },
-        '& li': {
-            fontSize: 14,
-            lineHeight: '20px',
-            margin: '10px 0'
-        }
-    }),
     sidebarHeading: css({
         fontFamily:
             'x-locale-heading-primary, zillaslab, "Palatino", "Palatino Linotype", x-locale-heading-secondary, serif',
@@ -148,32 +130,8 @@ const styles = {
 };
 
 export function Sidebar({ document }: DocumentProps) {
-    // TODO(djf): We may want to omit the "On this Page" section from
-    // the sidebar for pages with slugs like /Web/*/*/*: those are
-    // mostly HTML and CSS reference pages with repetitive TOCs. The
-    // TOC would afford quick access to the BCD table, but might not
-    // be useful for much else. For Learn/ slugs, however, the TOC is
-    // likely to be much more informative. I think a decision is still
-    // needed here. For now, we show the TOC on all pages that have one.
-    let showTOC = !!document.tocHTML;
-
     return (
         <div css={styles.sidebar}>
-            {showTOC && (
-                <>
-                    <div css={styles.tocHeader} />
-                    <div css={styles.toc}>
-                        <div css={styles.sidebarHeading}>
-                            {gettext('On this Page')}
-                        </div>
-                        <ul
-                            dangerouslySetInnerHTML={{
-                                __html: document.tocHTML
-                            }}
-                        />
-                    </div>
-                </>
-            )}
             {document.quickLinksHTML && (
                 <div className="quick-links">
                     <div
@@ -225,6 +183,15 @@ export function Breadcrumbs({ document }: DocumentProps) {
 }
 
 function Content({ document }: DocumentProps) {
+    // TODO(djf): We may want to omit the "On this Page" section from
+    // the sidebar for pages with slugs like /Web/*/*/*: those are
+    // mostly HTML and CSS reference pages with repetitive TOCs. The
+    // TOC would afford quick access to the BCD table, but might not
+    // be useful for much else. For Learn/ slugs, however, the TOC is
+    // likely to be much more informative. I think a decision is still
+    // needed here. For now, we show the TOC on all pages that have one.
+    let showTOC = !!document.tocHTML;
+
     // The wiki-left-present class below is needed for correct BCD layout
     // See kuma/static/styles/components/compat-tables/bc-table.scss
     return (
@@ -235,6 +202,7 @@ function Content({ document }: DocumentProps) {
             className="wiki-left-present"
             aria-live="assertive"
         >
+            {showTOC && <TOC html={document.tocHTML} />}
             <Article document={document} />
             <Sidebar document={document} />
         </div>

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -183,15 +183,6 @@ export function Breadcrumbs({ document }: DocumentProps) {
 }
 
 function Content({ document }: DocumentProps) {
-    // TODO(djf): We may want to omit the "On this Page" section from
-    // the sidebar for pages with slugs like /Web/*/*/*: those are
-    // mostly HTML and CSS reference pages with repetitive TOCs. The
-    // TOC would afford quick access to the BCD table, but might not
-    // be useful for much else. For Learn/ slugs, however, the TOC is
-    // likely to be much more informative. I think a decision is still
-    // needed here. For now, we show the TOC on all pages that have one.
-    let showTOC = !!document.tocHTML;
-
     // The wiki-left-present class below is needed for correct BCD layout
     // See kuma/static/styles/components/compat-tables/bc-table.scss
     return (
@@ -202,7 +193,7 @@ function Content({ document }: DocumentProps) {
             className="wiki-left-present"
             aria-live="assertive"
         >
-            {showTOC && <TOC html={document.tocHTML} />}
+            {!!document.tocHTML && <TOC html={document.tocHTML} />}
             <Article document={document} />
             <Sidebar document={document} />
         </div>

--- a/kuma/javascript/src/toc.jsx
+++ b/kuma/javascript/src/toc.jsx
@@ -2,16 +2,16 @@
 import * as React from 'react';
 import { gettext } from './l10n.js';
 
-type TOCProps = {
+type Props = {
     html: string
 };
 
-export default function TOC({ html }: TOCProps) {
+export default function TOC({ html }: Props) {
     return (
         <aside className="document-toc-container">
             <section className="document-toc">
                 <header>
-                    <h2> {gettext('On this Page')}</h2>
+                    <h2>{gettext('On this Page')}</h2>
                 </header>
                 <ul
                     dangerouslySetInnerHTML={{

--- a/kuma/javascript/src/toc.jsx
+++ b/kuma/javascript/src/toc.jsx
@@ -1,0 +1,24 @@
+// @flow
+import * as React from 'react';
+import { gettext } from './l10n.js';
+
+type TOCProps = {
+    html: string
+};
+
+export default function TOC({ html }: TOCProps) {
+    return (
+        <aside className="document-toc-container">
+            <section className="document-toc">
+                <header>
+                    <h2> {gettext('On this Page')}</h2>
+                </header>
+                <ul
+                    dangerouslySetInnerHTML={{
+                        __html: html
+                    }}
+                />
+            </section>
+        </aside>
+    );
+}

--- a/kuma/static/styles/components/wiki/toc.scss
+++ b/kuma/static/styles/components/wiki/toc.scss
@@ -113,3 +113,49 @@ $emify-tablet-height: (680px / 16px) * 1em;
         }
     }
 }
+
+/*
+On This Page component
+====================================================================== */
+/* Because of the blanket styling of all aside elements
+ here[1], we need to override those here to get an unstyled
+ aside element. [1] kuma/static/styles/base/elements/sectioning.scss
+ TODO: Do not apply such broad style rules to all elements of a type */
+.document-toc-container {
+    float: none;
+    background-color: unset;
+    margin: 0;
+    padding-top: 0;
+    width: unset;
+}
+
+.document-toc {
+    background-color: $toc-background-color;
+    margin-top: 30px;
+    border: solid 1px $toc-border-color;
+
+    &:before {
+        display: block;
+        background-image: linear-gradient(-272deg, $toc-gradient-start-color, $toc-gradient-end-color);
+        content: '';
+        height: 4px;
+    }
+
+    h2 {
+        margin: 15px 0;
+        @include bidi(((padding-left, 10px, padding-right, 0),));
+        font-weight: 400;
+        @include set-font-size(24px);
+    }
+
+    ul {
+        @include bidi(((padding-left, 20px, padding-right, 0),));
+        list-style: none;
+        @include set-font-size(16px);
+
+        li {
+            margin: 10px 0;
+            line-height: 1.2;
+        }
+    }
+}

--- a/kuma/static/styles/includes/_vars.scss
+++ b/kuma/static/styles/includes/_vars.scss
@@ -105,6 +105,11 @@ $text-light: #fff;
 $bg-dark: #222;
 $error: #900;
 
+$toc-background-color: #fcfcfc;
+$toc-border-color: #dce3e5;
+$toc-gradient-start-color: #206584;
+$toc-gradient-end-color: #83d0f2;
+
 
 /*
 typography


### PR DESCRIPTION
This ensures that the TOC component is in a more appropriate place in the DOM source order. As a result some `grid` styles needed updating as well. @callahad r?