### PR TITLE
bug 1566456 - don't need diff.scss in beta site

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -720,7 +720,6 @@ PIPELINE_CSS = {
         'source_filenames': (
             'styles/main.scss',
             'styles/wiki.scss',
-            'styles/diff.scss',
 
             # Custom build of our Prism theme
             'styles/libs/prism/prism.css',


### PR DESCRIPTION
I suspect there'll be more PRs like that until we can close [the bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1566456).

I noticed that `diff.scss` gets included in the `react-mdn` bundle but it's very hard to check that because, you know, globals. 
