### PR TITLE
bug 1566971 - set DEBUG_PROPAGATE_EXCEPTIONS free

### DIFF
--- a/kuma/settings/local.py
+++ b/kuma/settings/local.py
@@ -8,7 +8,8 @@ INTERNAL_IPS = ('127.0.0.1', '192.168.10.1', '172.18.0.1')
 # Default DEBUG to True, and recompute derived settings
 DEBUG = config('DEBUG', default=True, cast=bool)
 DEBUG_TOOLBAR = config('DEBUG_TOOLBAR', default=False, cast=bool)
-DEBUG_PROPAGATE_EXCEPTIONS = DEBUG
+DEBUG_PROPAGATE_EXCEPTIONS = config(
+    'DEBUG_PROPAGATE_EXCEPTIONS', default=DEBUG, cast=bool)
 PIPELINE['PIPELINE_ENABLED'] = config('PIPELINE_ENABLED', not DEBUG, cast=bool)
 PIPELINE['PIPELINE_COLLECTOR_ENABLED'] = config('PIPELINE_COLLECTOR_ENABLED',
                                                 not DEBUG, cast=bool)


### PR DESCRIPTION
I made this PR entirely in the GitHub UI whilst waiting for slow docker-compose things in my current messy branch. 
By the way, in that messy branch I needed to make this change and it solved the problem. Now I get tracebacks on stdout. 