### PR TITLE
update sub-modules

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -656,7 +656,7 @@ TEMPLATES = [
 ]
 
 PUENTE = {
-    'VERSION': '2019.11',
+    'VERSION': '2019.12',
     'BASE_DIR': BASE_DIR,
     'TEXT_DOMAIN': 'django',
     # Tells the extract script what files to look for l10n in and what function


### PR DESCRIPTION
Update the `locale` sub-module. There are no changes to the `kumascript` sub-module. I also pushed a commit to https://github.com/mozilla-l10n/mdn-l10n containing a new string for the `beta` header.