### PR TITLE
bug 1566302: sanitize name attr when override for id

### DIFF
--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -681,7 +681,11 @@ class SectionIDFilter(html5lib_Filter):
                 # treat it as a manual override by the author and make
                 # that value be the ID.
                 if (None, 'name') in attrs:
-                    attrs[(None, u'id')] = attrs[(None, 'name')]
+                    # Sanitize the "name" attribute with self.slugify to
+                    # prevent the injection of spaces (which are illegal
+                    # for the "id" attribute) or any of the non-URL-safe
+                    # characters listed above.
+                    attrs[(None, u'id')] = self.slugify(attrs[(None, 'name')])
                     token['data'] = attrs
                     yield token
                     continue

--- a/kuma/wiki/tests/test_content.py
+++ b/kuma/wiki/tests/test_content.py
@@ -114,9 +114,10 @@ class InjectSectionIDsTests(TestCase):
             <p>test</p>
             <section>
                 <h1 class="header2">Header Two</h1>
+                <h1 name="Header: X" class="header3">Header Three</h1>
                 <p>test</p>
             </section>
-            <h2 name="Constants" class="hasname">This title does not match the name</h2>
+            <h2 name="C~o:n;s/t%a$n=t@s" class="hasname">This is ignored</h2>
             <p>test</p>
 
             <h1 id="i-already-have-an-id" class="hasid">This text clobbers the ID</h1>
@@ -140,6 +141,7 @@ class InjectSectionIDsTests(TestCase):
         expected = (
             ('header1', 'Header_One'),
             ('header2', 'Header_Two'),
+            ('header3', 'Header_X'),
             ('hasname', 'Constants'),
             ('hasid', 'This_text_clobbers_the_ID'),
             ('Quick_Links', 'Quick_Links'),


### PR DESCRIPTION
This PR addresses a loophole in the code that's used to inject section `id`'s as part of the `clean_content` function,  which is run after every render as well as when revisions are saved. Currently, any HTML elements which qualify as "section" tags (see https://github.com/mozilla/kuma/blob/c30762afdebfdf9bfe50077f526188073ffdefd5/kuma/wiki/content.py#L44) are automatically assigned an `id`. For example, this:
```html
<h1>the header text</h1>
```
will become this:
```html
<h1 id="the_header_text">the header text</h1>
```

This automatic selection of an `id` can be manually overridden by providing a `name` attribute, whose value will then be used in place of what would have been automatically assigned. For example, this:
```html
<h1 name="use_me_as_the_id">the header text</h1>
```
will become this:
```html
<h1 id="use_me_as_the_id" name="use_me_as_the_id">the header text</h1>
```

The problem is that when a name attribute is provided, its value is used without considering whether it contains troublesome characters (like spaces for example) that could cause problems when used as an `id` attribute intended for use in URL fragments (to jump to the section via the URL). So, for example, this:
```html
<h3 name="clear:_left">clear: left</h3>
```
currently becomes this:
```html
<h3 id="clear:_left" name="clear:_left">clear: left</h3>
```
and the colon in the `id` can lead to problems down the road like an invalid CSS selector (see https://bugzilla.mozilla.org/show_bug.cgi?id=1566302#c2).

This PR closes that loophole by sanitizing the value of the `name` attribute before assigning it as the value of the `id` attribute. So, taking the case immediately above, the new result would be:
```html
<h3 id="clear_left" name="clear:_left">clear: left</h3>
```

For local testing, I used these settings in my `.env` file (my usual settings):
```
DEBUG=True
DOMAIN=mdn.localhost
ENABLE_RESTRICTIONS_BY_HOST=True
BETA_HOST=beta.mdn.localhost:8000
WIKI_HOST=wiki.mdn.localhost:8000
ATTACHMENT_HOST=demos:8000
SITE_URL=http://mdn.localhost:8000
STATIC_URL=http://mdn.localhost:8000/static/
```
and this content for my `/etc/hosts` file:
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
255.255.255.255	broadcasthost
::1             localhost
```
and did something like this:
```
docker-compose pull
docker-compose up -d
docker-compose exec web make build-static
docker-compose restart
docker-compose exec web ./manage.py scrape_document --revisions 5 https://developer.mozilla.org/en-US/docs/Web/CSS/clear
```

Then revert the document to one of the problematic revisions (one of the revisions before the most recent two revisions by `schalkneethling`), visit http://beta.mdn.localhost:8000/en-US/docs/Web/CSS/clear to see that React fails (most of the document is missing), log in, visit http://mdn.localhost:8000/en-US/docs/Web/CSS/clear, shift-reload to re-render, and then go back to http://beta.mdn.localhost:8000/en-US/docs/Web/CSS/clear and see that it loads fine this time.