### PR TITLE
Bug 1566429, prevent search input from expanding beyond viewport on iOS 10

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -194,6 +194,7 @@ exports[`Header snapshot 1`] = `
 .emotion-36 {
   grid-area: S;
   justify-self: stretch;
+  overflow: hidden;
 }
 
 .emotion-35 {
@@ -234,6 +235,7 @@ exports[`Header snapshot 1`] = `
   -ms-flex: 1 1 100px;
   flex: 1 1 100px;
   min-width: 60px;
+  max-width: 320px;
   color: #000;
   background-color: #fafafa !important;
 }

--- a/kuma/javascript/src/header/__snapshots__/search.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/search.test.js.snap
@@ -39,6 +39,7 @@ exports[`Search snapshot 1`] = `
   -ms-flex: 1 1 100px;
   flex: 1 1 100px;
   min-width: 60px;
+  max-width: 320px;
   color: #000;
   background-color: #fafafa !important;
 }

--- a/kuma/javascript/src/header/header.jsx
+++ b/kuma/javascript/src/header/header.jsx
@@ -76,7 +76,8 @@ const styles = {
     }),
     search: css({
         gridArea: 'S',
-        justifySelf: 'stretch'
+        justifySelf: 'stretch',
+        overflow: 'hidden'
     }),
     login: css({
         gridArea: 'L',

--- a/kuma/javascript/src/header/search.jsx
+++ b/kuma/javascript/src/header/search.jsx
@@ -32,6 +32,7 @@ const styles = {
         fontSize: 14,
         flex: '1 1 100px',
         minWidth: 60,
+        maxWidth: 320,
         color: '#000',
         backgroundColor: '#fafafa !important'
     })


### PR DESCRIPTION
This fixes the problem of the search input in the header expanding beyond the visible viewport in Safari on iOS 10. Tested on Firefox, Chrome using responsive mode, as well as on iPhone 7 using Safari running iOS 10.

![Screenshot 2019-07-18 at 11 30 39](https://user-images.githubusercontent.com/10350960/61446800-110c3000-a950-11e9-8887-798bb354f305.png)
