### PR TITLE
bug 1567482 - no tags in read-only site search results

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -258,13 +258,13 @@ def search(request, locale):
     if locale == 'en-US':
         search = (WikiDocumentType.search()
                   .filter('term', locale=locale)
-                  .source(['slug', 'title', 'summary', 'tags'])
+                  .source(['slug', 'title', 'summary'])
                   .query('multi_match', query=query_string,
                          fields=['title^7', 'summary^2', 'content']))
     else:
         search = (WikiDocumentType.search()
                   .filter('terms', locale=[locale, 'en-US'])
-                  .source(['slug', 'title', 'summary', 'tags', 'locale'])
+                  .source(['slug', 'title', 'summary', 'locale'])
                   .query(query.Bool(
                       must=Q('multi_match', query=query_string,
                              fields=['title^7', 'summary^2', 'content']),

--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -17,7 +17,6 @@ export type SearchResults = {
         slug: string,
         title: string,
         summary: string,
-        tags: Array<string>,
         score: number,
         excerpts: Array<string>
     }>,
@@ -64,21 +63,6 @@ const styles = {
     }),
     url: css({
         fontSize: 12
-    }),
-    tags: css({
-        flex: '1 0 250px',
-        paddingLeft: 30,
-        alignSelf: 'center'
-    }),
-    tag: css({
-        whiteSpace: 'nowrap',
-        fontSize: 12,
-        lineHeight: 1.2,
-        backgroundColor: '#f5f9fa',
-        border: 'solid 1px #dce3e5',
-        borderRadius: 5,
-        padding: '2px 4px',
-        marginRight: 8
     }),
     noresults: css({
         fontWeight: 'bold',
@@ -133,17 +117,6 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                                             }}
                                         />
                                     ))}
-                                </div>
-                                <div css={styles.tags}>
-                                    {hit.tags
-                                        .filter(tag => !tag.startsWith('Needs'))
-                                        .map(tag => (
-                                            <React.Fragment key={tag}>
-                                                <span css={styles.tag}>
-                                                    {tag}
-                                                </span>{' '}
-                                            </React.Fragment>
-                                        ))}
                                 </div>
                             </div>
                         );

--- a/kuma/javascript/src/search-results-page.test.js
+++ b/kuma/javascript/src/search-results-page.test.js
@@ -12,7 +12,6 @@ const fakeResults = [
         slug: 'slug1',
         title: 'title1',
         summary: 'summary1',
-        tags: ['tag1.1', 'tag1.2'],
         score: 10,
         excerpts: ['Test <mark>result</mark>', 'Excerpt <mark>2</mark>']
     },
@@ -20,7 +19,6 @@ const fakeResults = [
         slug: 'slug2',
         title: 'title2',
         summary: 'summary2',
-        tags: ['tag2.1', 'tag2.2'],
         score: 5,
         excerpts: []
     }
@@ -154,8 +152,7 @@ describe('SearchRoute', () => {
                                 _source: {
                                     slug: r.slug,
                                     title: r.title,
-                                    summary: r.summary,
-                                    tags: r.tags
+                                    summary: r.summary
                                 },
                                 _score: r.score,
                                 highlight: {


### PR DESCRIPTION
I first edited `search-results-page.jsx` and removed all mention of tags etc. Then I ran the jest tests and everything passed. Kinda sad. Clearly something there is overly mocking or we were just not testing tags in any way. 