### PR TITLE
bug 1567572 - gravatar_34 is inefficient and never used

### DIFF
--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -57,17 +57,11 @@ class DocumentContributorsJob(KumaJob):
             ('ordered_ids',
              'FIELD(id,%s)' % ','.join(map(str, recent_creator_ids))),
         ])
-        contributors = (User.objects.filter(id__in=recent_creator_ids,
-                                            is_active=True)
-                                    .extra(select=select,
-                                           order_by=['ordered_ids'])
-                                    .values('id', 'username', 'email'))
-        result = []
-        for contributor in contributors:
-            contributor['gravatar_34'] = gravatar_url(contributor['email'],
-                                                      size=34)
-            result.append(contributor)
-        return result
+        return list(User.objects.filter(id__in=recent_creator_ids,
+                                        is_active=True)
+                                .extra(select=select,
+                                       order_by=['ordered_ids'])
+                                .values('id', 'username', 'email'))
 
     def empty(self):
         # the empty result needs to be an empty list instead of None

--- a/kuma/wiki/jobs.py
+++ b/kuma/wiki/jobs.py
@@ -5,7 +5,6 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 
 from kuma.core.jobs import GenerationJob, KumaJob
-from kuma.users.templatetags.jinja_helpers import gravatar_url
 
 
 class DocumentContributorsJob(KumaJob):


### PR DESCRIPTION
I don't think this will conflict with https://github.com/mozilla/kuma/pull/5546 

Thing is, the `DocumentContributorsJob`cacheback job has a TTL of 12h and the `UserGravatarURLJob` job has a TTL of 24h. But basically, every 12h for every single document, we're calling `UserGravatarURLJob.get()` mostly as a waste of time. 