### PR TITLE
bug 1568239 - Don't include tags in Document JSON API

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -173,7 +173,6 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
                     'title': t.title
                 } for t in other_translations
             ],
-            'tags': doc.all_tags_name,
             'contributors': contributors,
             'lastModified': (doc.current_revision and
                              doc.current_revision.created.isoformat()),


### PR DESCRIPTION
It's a bit cheeky to mutate the versioned API but given the circumstances and situation, I think it's justifiable. 

However, soon this Document API is going to be used fully on developer.m.o so then it's going to be much more disappointing, to integrators, if we change the API. 
With that in mind, *now* is the right time to REMOVE things from the API. I'm not sure how but we should evaluate all the things in that [JSON](https://gist.github.com/peterbe/578e5a291972700f3a9d047693d743af). 