### PR TITLE
bug 1566944 - going back scrolls to the top

### DIFF
--- a/kuma/javascript/src/router.jsx
+++ b/kuma/javascript/src/router.jsx
@@ -146,7 +146,6 @@ export default function Router({
     // analytics and the other stops the loading animation. Both
     // functions are defined at the bottom of the component.
     useEffect(recordAndReportAnalytics, [pageState.data]);
-    useEffect(resetFocus, [pageState.data]);
     useEffect(stopLoading, [pageState.data]);
 
     // When the page is first loaded, and this function is called for
@@ -513,16 +512,6 @@ export default function Router({
         // browser to be able to go back to it by client-side navigation
         // we need to set its state.
         history.replaceState(initialURL, '', initialURL);
-    }
-
-    /**
-     * Reset focus to the window after navigation
-     */
-    function resetFocus() {
-        let documentTitle = document.querySelector('a[class*="logoContainer"]');
-        if (documentTitle) {
-            documentTitle.focus();
-        }
     }
 
     // This is an effect function that runs after a new page (with new


### PR DESCRIPTION
See the comment about how to reproduce: https://bugzilla.mozilla.org/show_bug.cgi?id=1566944#c4

Removing this code solves the problem. And it makes sense. Forcing focus on that title DOM element will force the browser to scroll into view. 

That begs the question: What did that code really do? I.e. what was it for? Why was it necessary?
It was added in this commit: https://github.com/mozilla/kuma/commit/345687b46fb98d782c9256d78eb967acb21fbd4c#diff-17a8d9db184a0bff5b4b3e2054788150R518
I think it's related to a11y but I don't really get it. 