### PR TITLE
update sub-modules

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -656,7 +656,7 @@ TEMPLATES = [
 ]
 
 PUENTE = {
-    'VERSION': '2019.13',
+    'VERSION': '2019.14',
     'BASE_DIR': BASE_DIR,
     'TEXT_DOMAIN': 'django',
     # Tells the extract script what files to look for l10n in and what function


### PR DESCRIPTION
Update the `locale` sub-module. There are no `kumascript` updates. I also pushed a new string (`'Edit in wiki'`) to https://github.com/mozilla-l10n/mdn-l10n so it can be translated via Pontoon.