### PR TITLE
bug 1568265 - better error handling in perf.js

### DIFF
--- a/kuma/javascript/src/perf.js
+++ b/kuma/javascript/src/perf.js
@@ -45,7 +45,12 @@ export function navigateFetchComplete() {
             // client-side navigation
             performance.measure(FETCH, START);
         } catch (e) {
-            console.error(e);
+            console.error(
+                `Error in performance.measure(${JSON.stringify({
+                    FETCH,
+                    START
+                })}) (error: ${e.toString()})`
+            );
         }
     }
 }
@@ -58,23 +63,44 @@ export function navigateRenderComplete(ga: GAFunction) {
             // Record the time it takes to fetch page data and re-render
             // the page during client-side navigation
             performance.measure(RENDER, START);
+        } catch (e) {
+            console.error(
+                `Error in performance.measure(${JSON.stringify({
+                    FETCH,
+                    START
+                })}) (error: ${e.toString()})`
+            );
+        }
 
-            // Send LUX data to Speedcurve to record the client-side navigation
-            try {
-                if (
-                    typeof window === 'object' &&
-                    window.LUX &&
-                    typeof window.LUX.send === 'function'
-                ) {
-                    window.LUX.send();
-                }
-            } catch (e) {
-                console.error('LUX.send() error:', e);
+        // Send LUX data to Speedcurve to record the client-side navigation
+        try {
+            if (
+                typeof window === 'object' &&
+                window.LUX &&
+                typeof window.LUX.send === 'function'
+            ) {
+                window.LUX.send();
             }
+        } catch (e) {
+            console.error('LUX.send() error:', e);
+        }
 
-            let fetchTime = performance.getEntriesByName(FETCH)[0].duration;
-            let renderTime = performance.getEntriesByName(RENDER)[0].duration;
+        let fetchTime;
+        let renderTime;
+        try {
+            fetchTime = performance.getEntriesByName(FETCH)[0].duration;
+            renderTime = performance.getEntriesByName(RENDER)[0].duration;
+        } catch (e) {
+            console.error(
+                `Error in performance.getEntriesByName() (${JSON.stringify({
+                    FETCH,
+                    RENDER
+                })}) (error: ${e.toString()})`
+            );
+            return;
+        }
 
+        try {
             ga('send', {
                 hitType: 'timing',
                 timingCategory: 'Client side navigation',
@@ -89,7 +115,12 @@ export function navigateRenderComplete(ga: GAFunction) {
                 timingValue: Math.round(renderTime)
             });
         } catch (e) {
-            console.error(e);
+            console.error(
+                `Error sending to ga (${JSON.stringify({
+                    fetchTime,
+                    renderTime
+                })}) (error: ${e.toString()})`
+            );
         }
     }
 }


### PR DESCRIPTION
This is what an error can look like now:
<img width="948" alt="Screen Shot 2019-07-25 at 8 16 04 AM" src="https://user-images.githubusercontent.com/26739/61873665-7f06a900-aeb4-11e9-91d8-83b41bb4bf3a.png">

I forced that to happen by putting in a `throw new Error('Peter testing')` inside the `try` block. 

The other changes are just rearranging it a little so that the error handling has one try block per block of relevant code. 

For the record, I didn't change *any code* other than the `catch` blocks. 