### PR TITLE
Bug 1567218, add banner to wiki to distinguish it from devmo

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -107,6 +107,9 @@
   {%- if not untrusted %}
     {% include "includes/a11y-nav.html" %}
 
+    {# Banner shown on wiki.d.m.o to clearly distinguish it from pages on d.m.o #}
+    {% block wiki_notice %}{% endblock %}
+
     <!-- Header -->
     {%- if beta %}
     <header id="react-header"></header>

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -773,6 +773,7 @@ PIPELINE_CSS = {
     },
     'wiki': {
         'source_filenames': (
+            'styles/components/banners/wiki-notice.scss',
             'styles/wiki.scss',
             'styles/diff.scss',
 

--- a/kuma/static/styles/components/banners/wiki-notice.scss
+++ b/kuma/static/styles/components/banners/wiki-notice.scss
@@ -1,0 +1,25 @@
+@import '../../includes/vars';
+
+.mdn-wiki-notice {
+    display: flex;
+    flex-flow: column;
+    background-color: $blue-vdark;
+    color: #fff;
+    padding: 10px 10px 10px 20px;
+
+    h3 {
+        margin: 0;
+        line-height: 1.3;
+        font-weight: normal;
+    }
+
+    p {
+        margin-bottom: 0;
+    }
+
+    a:link,
+    a:visited {
+        color: #fff;
+        text-decoration: underline;
+    }
+}

--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -85,6 +85,12 @@
   {% endif %}
 {% endblock %}
 
+{% block wiki_notice %}
+    {% if request.get_host().startswith('wiki.') %}
+        {% include "wiki/includes/wiki-notice.html" %}
+    {% endif %}
+{% endblock %}
+
 {% block lang_switcher %}
   {% if (document.is_localizable or document.parent) and other_translations %}
     <form class="languages go" method="get" action="{{ wiki_url('Web') }}">

--- a/kuma/wiki/jinja2/wiki/includes/wiki-notice.html
+++ b/kuma/wiki/jinja2/wiki/includes/wiki-notice.html
@@ -1,4 +1,4 @@
-{% set url = 'https://developer.mozilla.org/' + request.path %}
+{% set url = settings.SITE_URL + request.path %}
 <div class="mdn-wiki-notice">
     <h3>{{ _('You are on the <strong>editable</strong> version of MDN Web Docs') }}</h3>
     <p>{{ _('View as an MDN Web Docs user:') }}

--- a/kuma/wiki/jinja2/wiki/includes/wiki-notice.html
+++ b/kuma/wiki/jinja2/wiki/includes/wiki-notice.html
@@ -1,0 +1,7 @@
+{% set url = 'https://developer.mozilla.org/' + request.path %}
+<div class="mdn-wiki-notice">
+    <h3>{{ _('You are on the <strong>editable</strong> version of MDN Web Docs') }}</h3>
+    <p>{{ _('View as an MDN Web Docs user:') }}
+        <a href="{{ url }}">{{ url }}</a>
+    </p>
+</div>


### PR DESCRIPTION
Adds banner to `wiki.` with a link through to `d.m.o`

![Screenshot 2019-07-25 at 19 03 35](https://user-images.githubusercontent.com/10350960/61893782-303a2d00-af0f-11e9-921a-b3640921c64e.png)

@peterbe r?