### PR TITLE
Bug 1566726, Web Docs logo lacks focus style

### DIFF
--- a/kuma/static/styles/components/structure/page-header/main-header.scss
+++ b/kuma/static/styles/components/structure/page-header/main-header.scss
@@ -31,17 +31,6 @@ Main header, wraps all components of logo, main, and secondary navigation
     }
 }
 
-a[class*='logoContainer'] {
-    outline: none;
-
-    /* do not remove the outline for keyboard users */
-    /* stylelint-disable selector-pseudo-class-no-unknown */
-    &:focus-visible {
-        outline: unset;
-    }
-    /* stylelint-enable */
-}
-
 .logo {
     position: relative;
     z-index: $logo-z;


### PR DESCRIPTION
Ensures the logo shows a focus ring when focused.

![logo-focus](https://user-images.githubusercontent.com/10350960/61942638-185bbb00-af9a-11e9-8b6e-3ff72ea6d27b.gif)

@callahad r?