### PR TITLE
bug 1569168 - make urls in search results clickable

### DIFF
--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -104,7 +104,9 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                                             {hit.title}
                                         </a>
                                     </div>
-                                    <div css={styles.url}>{url}</div>
+                                    <div css={styles.url}>
+                                        <a href={path}>{url}</a>
+                                    </div>
                                     <div css={styles.summary}>
                                         {hit.summary}
                                     </div>


### PR DESCRIPTION
<img width="863" alt="Screen Shot 2019-07-26 at 9 29 11 AM" src="https://user-images.githubusercontent.com/26739/61954948-01ac6880-af88-11e9-80f5-f3eb46cca6ad.png">
