### PR TITLE
Bug 1534911, page headings often loads with different font

### DIFF
--- a/kuma/static/styles/base/fonts/opensans.scss
+++ b/kuma/static/styles/base/fonts/opensans.scss
@@ -1,6 +1,6 @@
 @font-face {
     font-family: 'Open Sans';
-    font-display: 'fallback';
+    font-display: 'swap';
     src: url('#{$path-to-fonts}#{"OpenSans-Regular-webfont.woff2"}') format('woff2'),
          url('#{$path-to-fonts}#{"OpenSans-Regular-webfont.woff"}') format('woff');
     font-weight: normal;
@@ -9,7 +9,7 @@
 
 @font-face {
     font-family: 'Open Sans';
-    font-display: 'optional';
+    font-display: 'swap';
     src: url('#{$path-to-fonts}#{"OpenSans-Semibold-webfont.woff2"}') format('woff2'),
          url('#{$path-to-fonts}#{"OpenSans-Semibold-webfont.woff"}') format('woff');
     font-weight: bold;
@@ -18,7 +18,7 @@
 
 @font-face {
     font-family: 'Open Sans';
-    font-display: 'fallback';
+    font-display: 'swap';
     src: url('#{$path-to-fonts}#{"OpenSans-Italic-webfont.woff2"}') format('woff2'),
          url('#{$path-to-fonts}#{"OpenSans-Italic-webfont.woff"}') format('woff');
     font-weight: normal;

--- a/kuma/static/styles/locales/_zilla.scss
+++ b/kuma/static/styles/locales/_zilla.scss
@@ -2,7 +2,7 @@
 
 @font-face {
     font-family: zillaslab;
-    font-display: 'fallback';
+    font-display: 'swap';
     src: url('#{$path-to-locale-fonts}#{"ZillaSlab-Regular.subset.woff2"}') format('woff2'),
          url('#{$path-to-locale-fonts}#{"ZillaSlab-Regular.subset.woff"}') format('woff');
     font-weight: normal;
@@ -11,7 +11,7 @@
 
 @font-face {
     font-family: zillaslab;
-    font-display: 'optional';
+    font-display: 'swap';
     src: url('#{$path-to-locale-fonts}#{"ZillaSlab-Bold.subset.woff2"}') format('woff2'),
          url('#{$path-to-locale-fonts}#{"ZillaSlab-Bold.subset.woff"}') format('woff');
     font-weight: bold;

--- a/kuma/static/styles/locales/ar.scss
+++ b/kuma/static/styles/locales/ar.scss
@@ -5,28 +5,28 @@ Styles for Arabic
 
 @font-face {
     font-family: x-locale-heading-primary;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Regular.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-heading-primary;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Bold.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Regular.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Bold.woff"}') format('woff');
 }

--- a/kuma/static/styles/locales/az.scss
+++ b/kuma/static/styles/locales/az.scss
@@ -10,14 +10,14 @@ Styles for Azerbaijani
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"az/mplus-2c-regular-az-subset.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     src: url('#{$path-to-locale-fonts}#{"az/mplus-2c-bold-az-subset.woff"}') format('woff');
 }

--- a/kuma/static/styles/locales/fa.scss
+++ b/kuma/static/styles/locales/fa.scss
@@ -5,28 +5,28 @@ Styles for Farsi
 
 @font-face {
     font-family: x-locale-heading-primary;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Regular.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-heading-primary;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Bold.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Regular.woff"}') format('woff');
 }
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     src: url('#{$path-to-locale-fonts}#{"ar/DroidNaskh-Bold.woff"}') format('woff');
 }

--- a/kuma/static/styles/locales/ff.scss
+++ b/kuma/static/styles/locales/ff.scss
@@ -7,7 +7,7 @@ Styles for Fulah
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     src: url('#{$path-to-locale-fonts}#{"ff/mplus-2c-regular-fulah-subset.woff"}') format('woff');
 }

--- a/kuma/static/styles/locales/ro.scss
+++ b/kuma/static/styles/locales/ro.scss
@@ -10,7 +10,7 @@ Styles for Romaniaian
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     font-style: normal;
     src: url('#{$path-to-locale-fonts}#{"ro/opensans-regular-ro-subset.woff2"}') format('woff2'),
@@ -19,7 +19,7 @@ Styles for Romaniaian
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     font-style: normal;
     src: url('#{$path-to-locale-fonts}#{"ro/opensans-bold-ro-subset.woff2"}') format('woff2'),
@@ -28,7 +28,7 @@ Styles for Romaniaian
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'fallback';
+    font-display: 'swap';
     font-weight: normal;
     font-style: italic;
     src: url('#{$path-to-locale-fonts}#{"ro/opensans-italic-ro-subset.woff2"}') format('woff2'),
@@ -37,7 +37,7 @@ Styles for Romaniaian
 
 @font-face {
     font-family: x-locale-body;
-    font-display: 'optional';
+    font-display: 'swap';
     font-weight: bold;
     font-style: italic;
     src: url('#{$path-to-locale-fonts}#{"ro/opensans-bolditalic-ro-subset.woff2"}') format('woff2'),


### PR DESCRIPTION
@peterbe Finally got around to this one. While `swap` does seem like the property we want, and while it does solve the problem, it introduces a new one. As you can see from the Gif below when on a slow connection there is a period of time when the headings are invisible.

They are then rendered using a fallback, and finally the "correct" font swaps in.

![swap](https://user-images.githubusercontent.com/10350960/61955999-84e7b180-afbc-11e9-917b-68e6d35e359f.gif)

So we are swapping ;p one tradeoff for another in essence. I guess the period where the headings are not shown at all is the short block period, followed by fallback and then finally swap.

Thoughts? r?