### PR TITLE
Bug 1568305, add specific styling for active state on in content links

### DIFF
--- a/kuma/static/styles/components/wiki/elements.scss
+++ b/kuma/static/styles/components/wiki/elements.scss
@@ -11,8 +11,8 @@ article {
         }
 
         &:active {
-            color: $blue-dark;
-            font-weight: bold;
+            background-color: $blue-dark;
+            color: #fff;
         }
 
         &[name] {

--- a/kuma/static/styles/components/wiki/elements.scss
+++ b/kuma/static/styles/components/wiki/elements.scss
@@ -10,6 +10,11 @@ article {
             text-decoration: underline;
         }
 
+        &:active {
+            color: $blue-dark;
+            font-weight: bold;
+        }
+
         &[name] {
             &:hover,
             &:focus,


### PR DESCRIPTION
@callahad This adds a specific style for the active state of in-content

![active-style](https://user-images.githubusercontent.com/10350960/62011760-56d7ae00-b131-11e9-8e46-8e6c90c3dc6f.gif)

r?

