### PR TITLE
Bug 1567409, separate metadata tags styling to wiki

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -719,7 +719,7 @@ PIPELINE_CSS = {
     'react-mdn': {
         'source_filenames': (
             'styles/main.scss',
-            'styles/wiki.scss',
+            'styles/wiki-shared.scss',
 
             # Custom build of our Prism theme
             'styles/libs/prism/prism.css',

--- a/kuma/static/styles/base/icons.scss
+++ b/kuma/static/styles/base/icons.scss
@@ -12,10 +12,9 @@
 }
 
 label #{$selector-icon}:first-child {
-    @include bidi((
-        (margin-left, 0, $icon-margin),
-        (margin-right, $icon-margin, 0),
-    ));
+    @include bidi(
+        ((margin-left, 0, $icon-margin), (margin-right, $icon-margin, 0))
+    );
 }
 
 .icon {
@@ -88,7 +87,9 @@ i.icon-beaker {
 
 /* icon used by NonStandardBadge macro */
 i.icon-warning-sign {
-    @include set-icon($path-to-svg-notification-icons + 'exclamation-triangle.svg');
+    @include set-icon(
+        $path-to-svg-notification-icons + 'exclamation-triangle.svg'
+    );
     vertical-align: bottom;
 }
 
@@ -100,7 +101,11 @@ i.icon-trash {
 
 /* used with .notification-img */
 i.icon-info-sign {
-    @include set-icon($path-to-svg-notification-icons + 'info-circle.svg', 24px, 30px);
+    @include set-icon(
+        $path-to-svg-notification-icons + 'info-circle.svg',
+        24px,
+        30px
+    );
 }
 
 .icon-only-inline {
@@ -151,11 +156,6 @@ i.icon-info-sign {
 .page-attachments .icon-question-mark,
 .page-attachments .icon-paperclip {
     vertical-align: bottom;
-}
-
-/* tags icon on the bottom of wiki pages */
-.tag-attach-list .icon-tags {
-    vertical-align: middle;
 }
 
 /* community and clock icon size for contributors section */
@@ -256,7 +256,7 @@ button[type='submit'] .icon-check-mark {
     .icon-undo,
     .icon-play,
     .icon-pencil,
-    .icon-book, {
+    .icon-book {
         float: left;
         margin-right: 5px;
     }

--- a/kuma/static/styles/components/tags.scss
+++ b/kuma/static/styles/components/tags.scss
@@ -40,6 +40,11 @@ ul.tags li {
     }
 }
 
+/* tags icon on the bottom of wiki pages */
+.tag-attach-list .icon-tags {
+    vertical-align: middle;
+}
+
 /*
 small
 ====================================================================== */

--- a/kuma/static/styles/main.scss
+++ b/kuma/static/styles/main.scss
@@ -16,7 +16,6 @@ Main stylesheet for the site, standalone
 @import 'components/structure';
 @import 'components/form';
 @import 'components/highlight';
-@import 'components/tags';
 @import 'components/errorlist';
 @import 'components/compact';
 @import 'components/newsletter';

--- a/kuma/static/styles/wiki-shared.scss
+++ b/kuma/static/styles/wiki-shared.scss
@@ -1,3 +1,6 @@
+/*
+Styling that is shared across the wiki and read-only sites
+====================================================================== */
 @import 'includes/vars';
 @import 'includes/mixins';
 @import 'includes/mixins_indicators';
@@ -9,13 +12,11 @@ General element over-rides
 ====================================================================== */
 @import 'components/wiki/elements';
 
-
 /*
 Utitlity classes (reused in a variety of contexts)
 ====================================================================== */
 @import 'components/wiki/document-list';
 @import 'components/wiki/external-icon';
-
 
 /*
 Components that may appear on most wiki pages
@@ -25,7 +26,6 @@ Components that may appear on most wiki pages
 @import 'components/wiki/quick-links';
 @import 'components/wiki/reviews';
 @import 'components/wiki/contributors';
-@import 'components/tags';
 @import 'components/wiki/toc';
 @import 'components/wiki/topicpage-table';
 @import 'components/wiki/kserrors';
@@ -41,7 +41,6 @@ Components that may appear on most wiki pages
 @import 'components/wiki/mega';
 @import 'components/wiki/interactive';
 
-
 /*
 Article meta
 - contains breadcrumbs and page buttons.
@@ -49,7 +48,6 @@ Article meta
 @import 'components/wiki/article-head';
 @import 'components/wiki/crumbs';
 @import 'components/wiki/page-buttons';
-
 
 /*
 Styling for article content
@@ -74,7 +72,6 @@ Styling for article content
 @import 'components/wiki/sample-code';
 @import 'components/wiki/section-edit';
 
-
 /*
 Delete, move or revert pages.
 ====================================================================== */
@@ -84,7 +81,6 @@ Delete, move or revert pages.
 @import 'components/wiki/doc-source';
 @import 'components/wiki/delete-document';
 @import 'components/wiki/delete-revision';
-
 
 /*
 Promos


### PR DESCRIPTION
This is the first small step in cleaning up our CSS and separating the CSS we serve to the read-only vs. the wiki versions of MDN Web Docs.

@peterbe r?