### PR TITLE
preload ZillaSlab-RBold.subset.woff2

### DIFF
--- a/jinja2/includes/preload.html
+++ b/jinja2/includes/preload.html
@@ -1,2 +1,2 @@
 {# because this is non-blocking, preload as early as possible #}
-<link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Regular.subset.woff2') }}" as="font" type="font/woff2" crossorigin />
+<link rel="preload" href="{{ static('fonts/locales/ZillaSlab-Bold.subset.woff2') }}" as="font" type="font/woff2" crossorigin />


### PR DESCRIPTION
We use the Bold for all headings so it's good to preload it. 