### PR TITLE
bug 1570076 - Move GOOGLE_ANALYTICS_ACCOUNT from constance to env vars

### DIFF
--- a/jinja2/includes/google_analytics.html
+++ b/jinja2/includes/google_analytics.html
@@ -1,7 +1,7 @@
 <script>
     // Mozilla DNT Helper
     {% include "js/libs/mozilla.dnthelper.min.js" %}
-    {%- if config.GOOGLE_ANALYTICS_ACCOUNT != '0' %}
+    {%- if settings.GOOGLE_ANALYTICS_ACCOUNT %}
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
@@ -10,7 +10,7 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
 
-        ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
+        ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
 
         {% if request.user and request.user.is_authenticated %}

--- a/kuma/core/context_processors.py
+++ b/kuma/core/context_processors.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from constance import config
 from django.conf import settings
 from django.utils import translation
 from six.moves.urllib.parse import urlparse
@@ -20,6 +21,19 @@ def global_settings(request):
                 netloc='username:secret@' + parsed.netloc.split('@')[-1]
             )
         return parsed.geturl()
+
+    # TODO: Ideally, GOOGLE_ANALYTICS_ACCOUNT is only set in settings (from
+    # an environment variable) but for safe transition, we rely on
+    # constance if it hasn't been put into settings yet.
+    # Once we know with confidence, that GOOGLE_ANALYTICS_ACCOUNT is set
+    # and a valid value in the environment (for production!) then we
+    # can delete these lines of code.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1570076
+    google_analytics_account = getattr(
+        settings, 'GOOGLE_ANALYTICS_ACCOUNT', None)
+    if google_analytics_account is None:
+        if config.GOOGLE_ANALYTICS_ACCOUNT != '0':
+            settings.GOOGLE_ANALYTICS_ACCOUNT = config.GOOGLE_ANALYTICS_ACCOUNT
 
     return {
         'settings': settings,

--- a/kuma/core/tests/test_views.py
+++ b/kuma/core/tests/test_views.py
@@ -236,10 +236,10 @@ def test_ratelimit_429(client, db):
     assert_no_cache_header(response)
 
 
-def test_error_handler_minimal_request(rf, db, constance_config):
+def test_error_handler_minimal_request(rf, db, settings):
     '''Error page renders if middleware hasn't added request members.'''
     # Setup conditions for adding analytics with a flag check
-    constance_config.GOOGLE_ANALYTICS_ACCOUNT = 'UA-00000000-0'
+    settings.GOOGLE_ANALYTICS_ACCOUNT = 'UA-00000000-0'
     Flag.objects.create(name='section_edit', authenticated=True)
 
     # Create minimal request

--- a/kuma/landing/tests/test_templates.py
+++ b/kuma/landing/tests/test_templates.py
@@ -6,15 +6,15 @@ from kuma.core.urlresolvers import reverse
 from kuma.search.models import Filter, FilterGroup
 
 
-def test_google_analytics_disabled(constance_config, client):
-    constance_config.GOOGLE_ANALYTICS_ACCOUNT = '0'
+def test_google_analytics_disabled(db, settings, client):
+    settings.GOOGLE_ANALYTICS_ACCOUNT = None
     response = client.get(reverse('home'), follow=True)
     assert 200 == response.status_code
     assert b"ga('create" not in response.content
 
 
-def test_google_analytics_enabled(constance_config, client):
-    constance_config.GOOGLE_ANALYTICS_ACCOUNT = 'UA-99999999-9'
+def test_google_analytics_enabled(db, settings, client):
+    settings.GOOGLE_ANALYTICS_ACCOUNT = 'UA-99999999-9'
     response = client.get(reverse('home'), follow=True)
     assert 200 == response.status_code
     assert b"ga('create" in response.content

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1631,9 +1631,12 @@ CONSTANCE_CONFIG = dict(
          r')'),
         'Regex comprised of domain names that are allowed for IFRAME SRCs'
     ),
+    # TODO: Delete this line once we know that the production environment
+    # definitely has 'GOOGLE_ANALYTICS_ACCOUNT' set.
+    # See https://bugzilla.mozilla.org/show_bug.cgi?id=1570076
     GOOGLE_ANALYTICS_ACCOUNT=(
         '0',
-        'Google Analytics Tracking Account Number (0 to disable)',
+        '(This is deprecated and will disappear)',
     ),
     GOOGLE_ANALYTICS_CREDENTIALS=(
         '{}',
@@ -1689,6 +1692,9 @@ CONSTANCE_CONFIG = dict(
         'Email address to request admin intervention'
     ),
 )
+
+# Google Analytics Tracking Account Number (0 to disable)
+GOOGLE_ANALYTICS_ACCOUNT = config('GOOGLE_ANALYTICS_ACCOUNT', default=None)
 
 KUMASCRIPT_URL_TEMPLATE = config('KUMASCRIPT_URL_TEMPLATE',
                                  default='http://localhost:9080/docs/{path}')

--- a/kuma/settings/testing.py
+++ b/kuma/settings/testing.py
@@ -75,3 +75,6 @@ WHITENOISE_USE_FINDERS = True
 # This makes sure we our tests never actually use the real settings for
 # this.
 MDN_CLOUDFRONT_DISTRIBUTIONS = {}
+
+# Never rely on the .env
+GOOGLE_ANALYTICS_ACCOUNT = None

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -34,7 +34,7 @@
 <script>
     // Mozilla DNT Helper
     {% include "js/libs/mozilla.dnthelper.min.js" %}
-    {%- if config.GOOGLE_ANALYTICS_ACCOUNT != '0' %}
+    {%- if settings.GOOGLE_ANALYTICS_ACCOUNT %}
     {%- set GA_FILE = 'analytics_debug' if settings.DEBUG else 'analytics' %}
     // only load GA if DNT is not enabled
     if (Mozilla && !Mozilla.dntEnabled()) {
@@ -42,7 +42,7 @@
         (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
         })(window,document,'script','https://www.google-analytics.com/{{ GA_FILE }}.js','ga');
-        ga('create', '{{ config.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
+        ga('create', '{{ settings.GOOGLE_ANALYTICS_ACCOUNT }}', 'mozilla.org');
         ga('set', 'anonymizeIp', true);
     }
     {%- endif %}

--- a/kuma/wiki/tests/test_templates.py
+++ b/kuma/wiki/tests/test_templates.py
@@ -5,7 +5,6 @@ import urllib
 import mock
 import pytest
 from constance import config
-from constance.test import override_config
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Group
 from django.contrib.sites.models import Site
@@ -320,8 +319,8 @@ _PIPELINE['JAVASCRIPT']['experiment-test'] = {
 
 
 @override_settings(CONTENT_EXPERIMENTS=_TEST_CONTENT_EXPERIMENTS,
-                   PIPELINE=_PIPELINE)
-@override_config(GOOGLE_ANALYTICS_ACCOUNT='fake')
+                   PIPELINE=_PIPELINE,
+                   GOOGLE_ANALYTICS_ACCOUNT='fake')
 class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
 
     # src attribute of the content experiment <script> tag
@@ -389,7 +388,7 @@ class DocumentContentExperimentTests(UserTestCase, WikiTestCase):
         assert not doc('#edit-button')
 
 
-@override_config(GOOGLE_ANALYTICS_ACCOUNT='fake')
+@override_settings(GOOGLE_ANALYTICS_ACCOUNT='fake')
 class GoogleAnalyticsTests(UserTestCase, WikiTestCase):
 
     ga_create = "ga('create', 'fake', 'mozilla.org');"


### PR DESCRIPTION
By landing this, and shipping it to prod, nothing will or should change. If the environment variable isn't even set, it falls back on constance. 