### PR TITLE
Bug 1569816, switch highlight section to CSS only

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -63,23 +63,27 @@ const styles = {
     })
 };
 
-// This is an effect function that runs every time the article is rendered.
-// This is the React version of the code in kuma/static/js/highlight.js
-// which is used on the wiki domain
-function highlightSections(article) {
-    let sections = article.querySelectorAll('#wikiArticle h3, #wikiArticle h5');
-    for (let section of sections) {
-        section.classList.add('highlight-spanned');
-        section.innerHTML = `<span class="highlight-span">${section.innerHTML}</span>`;
-    }
-}
-
-// This is an effect function that runs every time the article is rendered.
-// This is the React version of the pre-React code in
-// kuma/static/js/components/local-anchor.js
+/* This is an effect function that runs every time the article is rendered.
+   This is the React version of the pre-React code in
+   kuma/static/js/components/local-anchor.js */
 function addAnchors(article) {
     for (let heading of article.querySelectorAll('h2[id], h3[id]')) {
-        heading.insertAdjacentElement('beforeend', sectionAnchor(heading));
+        // do not add the widget to headings that are hidden
+        if (!heading.classList.contains('offscreen')) {
+            /* we add the widget to a different place in the DOM
+               for H2 elements than for H3 elements */
+            if (heading.tagName === 'H2') {
+                heading.insertAdjacentElement(
+                    'beforeend',
+                    sectionAnchor(heading)
+                );
+            } else {
+                heading.insertAdjacentElement(
+                    'afterend',
+                    sectionAnchor(heading)
+                );
+            }
+        }
     }
 }
 
@@ -101,7 +105,6 @@ export default function Article({ document }: DocumentProps) {
             // Keep addLiveExampleButtons() before addAnchors() so the
             // example title doesn't end up with a link in it on codepen.
             addLiveExampleButtons(rootElement);
-            highlightSections(rootElement);
             addAnchors(rootElement);
             highlightSyntax(rootElement);
             activateBCDTables(rootElement);

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -718,7 +718,7 @@ PIPELINE_CSS = {
     # single page app.
     'react-mdn': {
         'source_filenames': (
-            'styles/main.scss',
+            'styles/main-shared.scss',
             'styles/wiki-shared.scss',
 
             # Custom build of our Prism theme

--- a/kuma/static/styles/components/highlight.scss
+++ b/kuma/static/styles/components/highlight.scss
@@ -1,29 +1,3 @@
 .highlight {
     @extend %highlight;
 }
-
-article {
-    h3,
-    h5 {
-        background-color: $text-color;
-        color: #fff;
-        font-weight: normal;
-        line-height: 1.25;
-        padding: 0 4px;
-        @include vendorize(box-decoration-break, clone);
-
-        a {
-            color: $accent-light;
-
-            &[name] {
-                color: inherit;
-                text-decoration: none;
-            }
-        }
-
-        code {
-            background-color: rgba(255, 255, 255, .4) !important; /* stylelint-disable-line declaration-no-important */
-            color: #fff !important; /* stylelint-disable-line declaration-no-important */
-        }
-    }
-}

--- a/kuma/static/styles/components/home/home-masthead.scss
+++ b/kuma/static/styles/components/home/home-masthead.scss
@@ -27,6 +27,12 @@ homepage masthead (search, feature callouts)
     }
 }
 
+.home-masthead-no-search {
+    h1 {
+        @extend %highlight;
+    }
+}
+
 
 @media #{$mq-tablet-and-up} {
     .home-masthead {

--- a/kuma/static/styles/components/wiki/content/static/_highlighted-headings.scss
+++ b/kuma/static/styles/components/wiki/content/static/_highlighted-headings.scss
@@ -1,8 +1,9 @@
-.highlight {
-    @extend %highlight;
-}
-
 article {
+    h3[id],
+    h5[id] {
+        display: inline-block;
+    }
+
     h3,
     h5 {
         background-color: $text-color;

--- a/kuma/static/styles/includes/_mixins.scss
+++ b/kuma/static/styles/includes/_mixins.scss
@@ -475,17 +475,9 @@ These are not dynamic but serve as mixins
 
 @mixin heading-2-section() {
     position: relative;
-    margin-top: $grid-spacing * 5 + $section-border-width;
-
-    &:before {
-        @include bidi(((left, 0, right, auto),));
-        border-top: $section-border;
-        content: '';
-        display: block;
-        position: absolute;
-        top: $grid-spacing * 2.5 * -1;
-        width: 100%;
-    }
+    margin-top: $grid-spacing * 3;
+    padding-top: $grid-spacing * 2;
+    border-top: $section-border;
 }
 
 @mixin callout() {

--- a/kuma/static/styles/main-shared.scss
+++ b/kuma/static/styles/main-shared.scss
@@ -1,0 +1,22 @@
+@import 'includes/vars';
+@import 'includes/mixins';
+
+/*
+Main stylesheet for the site, standalone
+********************************************************************** */
+
+/* stylesheets used only in main  */
+@import 'base/elements';
+@import 'base/icons';
+
+/* components also used elsewhere */
+@import 'components/components';
+@import 'components/content';
+@import 'components/cta';
+@import 'components/structure';
+@import 'components/form';
+@import 'components/wiki/content/static/highlighted-headings';
+@import 'components/errorlist';
+@import 'components/compact';
+@import 'components/newsletter';
+@import 'components/payments';


### PR DESCRIPTION
This removes the need for the `highlightSections` JavaScript function that ensures that some of the document headings use the slab style dark backgrounds. It also adds a couple of small updates to the `addAnchors` function to:

1. Not add it to hidden headings
2. To add the link to a different location on the DOM based on whether the heading is an `h2` or `h3`

I tested this on all the top-level pages liked form the main menu, as well as the `Array` page.

@peterbe r?