### PR TITLE
bug 1525719: fix templates

### DIFF
--- a/jinja2/403.html
+++ b/jinja2/403.html
@@ -43,7 +43,7 @@
       {% endtrans %}
     {% endif %}
 
-    {%- if wiki %}
+    {%- if not untrusted %}
       <ul class="prose">
       {% if user.username %}
         {% trans logout_url=url('account_logout') %}
@@ -55,7 +55,7 @@
         {% endtrans %}
       {% endif %}
       </ul>
-    {%- endif %} {# if wiki #}
+    {%- endif %} {# if not untrusted #}
     {% endblock %}
 
     {% block tumbeast_attribution -%}

--- a/jinja2/404.html
+++ b/jinja2/404.html
@@ -21,7 +21,7 @@
           We're sorry, we couldn't find what you were looking for.
           {% endtrans %}</p>
 
-        {%- if not untrusted %}
+        {%- if wiki and not untrusted %}
         <p>{% trans homepage_url=url('home') %}
           You can try a search or start over on the <a href="{{ homepage_url }}">home page</a>.
           {% endtrans %}</p>
@@ -37,7 +37,7 @@
         <p class="notice">{{ _("This user's profile has been banned.") }}</p>
       {% endif %}
 
-      {% if wiki and not user.is_authenticated %}
+      {% if wiki and not untrusted and not user.is_authenticated %}
       {% include "socialaccount/snippets/provider_list.html" %}
       {% endif %}
 

--- a/jinja2/includes/config.html
+++ b/jinja2/includes/config.html
@@ -6,7 +6,7 @@
         'use strict';
 
         {#- This stuff is not needed by the React-based site #}
-        {%- if wiki %}
+        {%- if wiki or untrusted %}
             {#- With React, waffle flags are returned by the /whoami API. #}
             {{ waffle.wafflejs() }}
 
@@ -27,13 +27,13 @@
         win.mdn.wikiSiteUrl = '{{ settings.WIKI_SITE_URL }}';
         win.mdn.staticPath = '{{ settings.STATIC_URL }}';
         win.mdn.wiki = {
-            {%- if wiki %}
+            {%- if not untrusted %}
             autosuggestTitleUrl: '{{ url('wiki.autosuggest_documents') }}'
             {%- endif %}
         };
 
         {#- This is stuff not needed by the React-based site #}
-        {%- if wiki %}
+        {%- if wiki or untrusted %}
         win.mdn.assets = {
             css: {
                 'editor-content': [


### PR DESCRIPTION
With #5614, I broke the logic in the following templates for attachment domain requests. This PR corrects that.

- jinja2/includes/config.html
- jinja2/403.html
- jinja2/404.html