### PR TITLE
use JSON.parse for hydration data

### DIFF
--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -13,14 +13,12 @@ if (container) {
     // The HTML page that loads this code is expected to have an inline
     // script that sets this window._document_data property to an object
     // with all the data needed to hydrate or render the UI.
-    let data = window._react_data;
-
-    // Remove the global reference to this data object so that it can
-    // be garbage collected once it is no longer in use.
-    window._react_data = null; // eslint-disable-line camelcase
+    // let data = window._react_data;
+    let data = JSON.parse(document.getElementById('react-data').textContent);
+    let pluralFunction = window._pluralFunction;
 
     // Store the string catalog so that l10n.gettext() can do translations
-    localize(data.locale, data.stringCatalog, data.pluralFunction);
+    localize(data.locale, data.stringCatalog, pluralFunction);
 
     let app = null;
     // This switch statement is duplicated in ssr.jsx. Anything changed

--- a/kuma/wiki/tests/test_ssr.py
+++ b/kuma/wiki/tests/test_ssr.py
@@ -66,7 +66,7 @@ def test_server_side_render(mock_get_l10n_data, mock_dumps, locale,
     }
     assert output == (
         u'<div id="react-container" data-component-name="{}">{}</div>\n'
-        u'<script>window._react_data = {};</script>\n'
+        u'<script id="react-data" type="application/json">{}</script>\n'
     ).format('document', mock_html, json.dumps(data))
 
 
@@ -95,7 +95,7 @@ def test_plural_function(mock_get_l10n_data, mock_dumps,
     path = '/en-US/docs/foo'
     output = ssr.render_react('page', 'es', path, document_data)
 
-    expected = '<script>window._react_data = {pluralFunction:function(n){'
+    expected = '<script>window._pluralFunction = function(n){'
 
     # Make sure the output is as expected
     assert expected in output
@@ -121,7 +121,7 @@ def test_client_side_render(mock_get_l10n_data, mock_dumps):
     output = ssr.render_react('page', 'en-US', path, document_data, ssr=False)
     assert output == (
         u'<div id="react-container" data-component-name="{}"></div>\n'
-        u'<script>window._react_data = {};</script>\n'
+        u'<script id="react-data" type="application/json">{}</script>\n'
     ).format('page', json.dumps(data))
 
 


### PR DESCRIPTION
Fixes #5619

It used to render out this:
```
<script>window._react_data = {"locale": "en-US", "stri
```
now it renders out this:
```
<script id="react-data" type="application/json">{"locale": "en-U
```
To get to the same variable value, inside the client-side code instead of just accessing `window._react_data` it now does `JSON.parse(document.getElementById('react-data').textContent)`.

Same functionality, just packaing things (very) differently. 

This means, that when the browser parses the HTML document, as soon as it gets to that `<scrit` tag, instead of pausing the HTML/CSSOM parsing, to go into JavaScript parsing mode, it just moves on and ignores this as a piece of other-data. Then, whence the JavaScript code has been downloaded, parsed and started executing, it *now* turns that blob of data into real data. 

So I think it's got 3 big advantages:

1. `var stateData = JSON.parse(<state data as string>)` is faster than `var stateData = <state data>`
2. This way, the HTML parsing isn't blocked by the main thread having to switch over to JS parsing. Remember, inline script tags are blocking because it could be that there's a `document.write()` in there that would make the CSSOM different!
3. One less inline JS script that would block us from enabling CSP. (We still need to solve the `pluralFunction` stuff some day)

To test; please try some non-trivial documents that in in non-en-US. 