### PR TITLE
Bug 1571137, ensure documents use appropriate landmarks

### DIFF
--- a/jinja2/base.html
+++ b/jinja2/base.html
@@ -113,7 +113,6 @@
     {% block wiki_notice %}{% endblock %}
 
     <!-- Header -->
-    {%- if wiki %}
     <header id="main-header" class="header-main">
       <a href="{{ url('home') }}" class="logo">{{ _('MDN Web Docs') }}</a>
       <div class="nav-toolbox-wrapper">
@@ -122,9 +121,6 @@
       </div>
       {% include "includes/nav-main-search.html" %}
     </header>
-    {%- else %}
-    <header id="react-header"></header>
-    {%- endif %} {# if wiki #}
 
   {%- endif %} {# if not untrusted #}
 

--- a/jinja2/react_base.html
+++ b/jinja2/react_base.html
@@ -92,6 +92,9 @@
     {{ soapbox_messages(get_soapbox_messages(request.path)) }}
   {%- endif %}
 
+  <!-- Header -->
+  {% block pageheader %}{% endblock %}
+
   <!-- Content will go here -->
   <main id="content">
       {% block document_head %}{% endblock %}

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -205,9 +205,11 @@ function DocumentPage({ document }: DocumentProps) {
         <>
             <A11yNav />
             <Header document={document} />
-            <Titlebar title={document.title} document={document} />
-            <Breadcrumbs document={document} />
-            <Content document={document} />
+            <main role="main">
+                <Titlebar title={document.title} document={document} />
+                <Breadcrumbs document={document} />
+                <Content document={document} />
+            </main>
             <TaskCompletionSurvey document={document} />
             <Banners />
         </>

--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -24,10 +24,12 @@
 
 {% endblock %}
 
-{% block document_head %}
-
+{% block pageheader %}
 {{ render_react("landing", request.LANGUAGE_CODE, request.get_full_path(),
                 None)|safe }}
+{% endblock %}
+
+{% block document_head %}
 
 <!-- top search area -->
 <div id="content" class="home-masthead home-masthead-no-search">


### PR DESCRIPTION
@callahad This brings us in line with current production. There is more we should do with regards to the structure and semantics of our pages, but this gets us a bit closer.

## Homepage before

![Screenshot 2019-08-13 at 12 43 43](https://user-images.githubusercontent.com/10350960/62935881-9278a600-bdc8-11e9-8abc-f5ff90ac7578.png)

## Homepage after

![Screenshot 2019-08-13 at 12 43 55](https://user-images.githubusercontent.com/10350960/62935898-9d333b00-bdc8-11e9-8fd8-a5c50575954d.png)

## Wiki page before

![Screenshot 2019-08-13 at 12 43 13](https://user-images.githubusercontent.com/10350960/62935914-a8866680-bdc8-11e9-95c9-e1572c9ab9ba.png)

## Wiki page after

![Screenshot 2019-08-13 at 12 43 24](https://user-images.githubusercontent.com/10350960/62935933-b2a86500-bdc8-11e9-8bbc-7de10f9fd6d9.png)

r?