### PR TITLE
avoid excess wiki_document get queries on /docs/Web

### DIFF
--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -124,8 +124,7 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
     else:
         en_slug = ''
 
-    other_translations = doc.get_other_translations(
-        fields=('locale', 'slug', 'title'))
+    other_translations = doc.get_other_translations()
     available_locales = (
         set([doc.locale]) | set(t.locale for t in other_translations))
 

--- a/kuma/api/v1/views.py
+++ b/kuma/api/v1/views.py
@@ -124,7 +124,8 @@ def document_api_data(doc=None, ensure_contributors=False, redirect_url=None):
     else:
         en_slug = ''
 
-    other_translations = doc.get_other_translations()
+    other_translations = doc.get_other_translations(
+        fields=('locale', 'slug', 'title', 'parent'))
     available_locales = (
         set([doc.locale]) | set(t.locale for t in other_translations))
 


### PR DESCRIPTION
Fixes #5637

That `other_translations` QuerySet is used in two places. When the QuerySet was used in the second place, it noticed it had filtered too much so for every locale it had to go back to the database and fetch more complimentary stuff. 