### PR TITLE
Bug 1573928: Fix double top <h2> border on mobile regression

### DIFF
--- a/kuma/static/styles/components/wiki/content/collapsible.scss
+++ b/kuma/static/styles/components/wiki/content/collapsible.scss
@@ -1,8 +1,8 @@
 h2 > .collapse-trigger {
     /* over-ride button styles */
     @include set-font-size($collapse-trigger-mobile-font-size);
-    background-color: inherit;
-    border: inherit;
+    background-color: transparent;
+    border: none;
     color: inherit;
     display: inline-block;
     font-family: inherit;


### PR DESCRIPTION
Fixes [bug 1573928](https://bugzilla.mozilla.org/show_bug.cgi?id=1573928) and fixes #5643.