### PR TITLE
Fix Bug 1553512: blank paragraphs when pasting

### DIFF
--- a/kuma/static/styles/components/content.scss
+++ b/kuma/static/styles/components/content.scss
@@ -228,10 +228,8 @@ We cannot put these styles in the base/elements/ files because they don't apply 
     ====================================================================== */
 
     /*
-     * Don't allow empty paragraphs by CKEditor.
-     * But do allow empty divs created by the Prism syntax highlighter.
+     * Allow empty divs created by the Prism syntax highlighter.
      */
-    p:empty,
     div:not(.line-highlight):empty {
         display: none;
     }


### PR DESCRIPTION
See https://bugzilla.mozilla.org/show_bug.cgi?id=1553512

If `p:empty { display: none; }` is defined in the CKEditor stylesheet,
then pasting multiple lines of text also inserts an empty `<p></p>`
before the pasted content.

The "Source" button must be clicked twice to re-render the editor and
display the extraneous paragraphs.

I do not entirely understand why this resolves the issue, but it does.