### PR TITLE
Long lines in search results

### DIFF
--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -40,7 +40,8 @@ const styles = {
         fontWeight: 'bold'
     }),
     summary: css({
-        marginBottom: 8
+        marginBottom: 8,
+        maxWidth: '42rem'
     }),
     excerpt: css({
         padding: '2px 24px',


### PR DESCRIPTION
Fixes #5658

Improve readability by adding a max-width to search result summaries.
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1569169

__Before:__

![Screenshot of search results for WebRTC](https://user-images.githubusercontent.com/24193/63331227-1ed91a80-c32d-11e9-8e9a-35a6c15cc332.png)

__After:__

![Screenshot of search results for WebRTC, with max-width enabled](https://user-images.githubusercontent.com/24193/63331246-2e586380-c32d-11e9-802e-cc1871695a4d.png)
