### PR TITLE
Remove prism-json.css from PIPELINE_CSS

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -726,7 +726,6 @@ PIPELINE_CSS = {
             'styles/libs/prism/prism-line-highlight.css',
             'styles/libs/prism/prism-line-numbers.css',
 
-            'js/prism-mdn/components/prism-json.css',
             'styles/wiki-syntax.scss',
 
             # Styles for BCD tables


### PR DESCRIPTION
There is no `js/prism-mdn/components/prism-json.css` file anywhere. 
There is a `prism-json.js` though. 
It's sad that django-pipeline doesn't complain louder about that. I should fix that.


<img width="682" alt="Screen Shot 2019-08-21 at 11 07 41 AM" src="https://user-images.githubusercontent.com/26739/63444180-1b649280-c404-11e9-80cb-3b8af039b298.png">