### PR TITLE
Fixes issue #5668, segment breadcrumb CSS

### DIFF
--- a/kuma/javascript/src/breadcrumbs.jsx
+++ b/kuma/javascript/src/breadcrumbs.jsx
@@ -1,0 +1,25 @@
+// @flow
+import * as React from 'react';
+
+import type { DocumentData } from './document.jsx';
+
+type DocumentProps = {
+    document: DocumentData
+};
+
+export default function Breadcrumbs({ document }: DocumentProps) {
+    return (
+        <nav className="breadcrumbs" role="navigation">
+            <ol>
+                {document.parents.map(p => (
+                    <li key={p.url}>
+                        <a href={p.url} className="breadcrumb-chevron">
+                            {p.title}
+                        </a>
+                    </li>
+                ))}
+                <li>{document.title}</li>
+            </ol>
+        </nav>
+    );
+}

--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -5,6 +5,7 @@ import { css } from '@emotion/core';
 import A11yNav from './a11y/a11y-nav.jsx';
 import Article from './article.jsx';
 import Banners from './banners.jsx';
+import Breadcrumbs from './breadcrumbs.jsx';
 import { gettext } from './l10n.js';
 import LanguageMenu from './header/language-menu.jsx';
 import Header from './header/header.jsx';
@@ -51,46 +52,8 @@ export type DocumentProps = {
 // A media query that identifies screens narrower than a tablet
 const NARROW = '@media (max-width: 749px)';
 
+// Content styles: the sidebar and main article content
 const styles = {
-    // Breadcrumbs styles
-    breadcrumbsContainer: css({
-        boxSizing: 'border-box',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        width: '100%',
-        minHeight: 40,
-        padding: '4px 16px 4px 24px',
-        borderBottom: 'solid 1px #dce3e5',
-        backgroundColor: '#fff'
-    }),
-    breadcrumbsRow: css({
-        display: 'flex',
-        flexDirection: 'row',
-        alignItems: 'center',
-        width: '100%',
-        maxWidth: 1360
-    }),
-    breadcrumbs: css({
-        flex: '1 1'
-    }),
-    crumb: css({
-        display: 'inline',
-        fontSize: 14,
-        hyphens: 'auto',
-        '&a': {
-            color: '#3d7e9a'
-        }
-    }),
-    chevron: css({
-        fontFamily: 'zillaslab,serif',
-        fontWeight: 'bold',
-        fontSize: 18,
-        margin: '0 8px'
-    }),
-
-    // Content styles: the sidebar and main article content
     contentLayout: css({
         display: 'grid',
         boxSizing: 'border-box',
@@ -150,37 +113,6 @@ export function Sidebar({ document }: DocumentProps) {
     );
 }
 
-function Chevron() {
-    return <span css={styles.chevron}>›</span>;
-}
-
-export function Breadcrumbs({ document }: DocumentProps) {
-    // The <span> elements below aren't needed except that the stylesheets
-    // are set up to expect them.
-    return (
-        <div css={styles.breadcrumbsContainer}>
-            <div css={styles.breadcrumbsRow}>
-                <nav css={styles.breadcrumbs} role="navigation">
-                    <ol>
-                        {document.parents.map(p => (
-                            <li css={styles.crumb} key={p.url}>
-                                <a href={p.url}>
-                                    <span>{p.title}</span>
-                                </a>
-                                <Chevron />
-                            </li>
-                        ))}
-                        <li css={styles.crumb}>
-                            <span>{document.title}</span>
-                        </li>
-                    </ol>
-                </nav>
-                <LanguageMenu document={document} />
-            </div>
-        </div>
-    );
-}
-
 function Content({ document }: DocumentProps) {
     // The wiki-left-present class below is needed for correct BCD layout
     // See kuma/static/styles/components/compat-tables/bc-table.scss
@@ -207,7 +139,12 @@ function DocumentPage({ document }: DocumentProps) {
             <Header document={document} />
             <main role="main">
                 <Titlebar title={document.title} document={document} />
-                <Breadcrumbs document={document} />
+                <div className="full-width-row-container">
+                    <div className="max-content-width-container">
+                        <Breadcrumbs document={document} />
+                        <LanguageMenu document={document} />
+                    </div>
+                </div>
                 <Content document={document} />
             </main>
             <TaskCompletionSurvey document={document} />

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -3,7 +3,8 @@ import React from 'react';
 import { create } from 'react-test-renderer';
 
 import Article from './article.jsx';
-import Document, { Breadcrumbs, DocumentRoute, Sidebar } from './document.jsx';
+import Breadcrumbs from './breadcrumbs.jsx';
+import Document, { DocumentRoute, Sidebar } from './document.jsx';
 import Header from './header/header.jsx';
 import TaskCompletionSurvey from './task-completion-survey.jsx';
 import Titlebar from './titlebar.jsx';
@@ -83,7 +84,7 @@ describe('Document component renders all of its parts', () => {
             let parent = fakeDocumentData.parents[i];
             let link = links[i];
             expect(link.props.href).toBe(parent.url);
-            expect(link.children[0].children[0]).toBe(parent.title);
+            expect(link.children[0]).toBe(parent.title);
         }
     });
 

--- a/kuma/javascript/src/titlebar.jsx
+++ b/kuma/javascript/src/titlebar.jsx
@@ -38,7 +38,7 @@ const styles = {
         flexDirection: 'row',
         alignItems: 'center',
         width: '100%',
-        maxWidth: 1400
+        maxWidth: 1352
     }),
     title: css({
         flex: '1 1',

--- a/kuma/javascript/src/titlebar.jsx
+++ b/kuma/javascript/src/titlebar.jsx
@@ -38,7 +38,7 @@ const styles = {
         flexDirection: 'row',
         alignItems: 'center',
         width: '100%',
-        maxWidth: 1352
+        maxWidth: 1400
     }),
     title: css({
         flex: '1 1',
@@ -56,7 +56,7 @@ const styles = {
 
 function EditButton({ document }: DocumentProps) {
     /* we want to omit the trailing `$edit` from the URL
-       to ensure users are not sent into edit mode immediately 
+       to ensure users are not sent into edit mode immediately
        https://bugzilla.mozilla.org/show_bug.cgi?id=1567720#c1 */
     let editURL = document.editURL.split('$')[0];
     return (

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -1,0 +1,22 @@
+.breadcrumbs {
+    flex: 1 1;
+
+    ol {
+        flex: 1 1;
+        font-size: 0.9rem;
+    }
+
+    li {
+        display: inline;
+        hyphens: auto;
+    }
+
+    .breadcrumb-chevron:after {
+        display: inline-block;
+        content: '›';
+        color: $grey-vdark;
+        margin: 0 5px;
+        font-size: 1rem;
+        font-weight: bold;
+    }
+}

--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -18,6 +18,7 @@ Utitlity classes (reused in a variety of contexts)
 ====================================================================== */
 @import '../components/wiki/document-list';
 @import '../components/wiki/external-icon';
+@import 'structure/containers';
 
 /*
 Components that may appear on most wiki pages
@@ -47,7 +48,7 @@ Article meta
 - contains breadcrumbs and page buttons.
 -------------------------------------------------------------- */
 @import '../components/wiki/article-head';
-@import '../components/wiki/crumbs';
+@import 'components/breadcrumbs';
 @import '../components/wiki/page-buttons';
 
 /*

--- a/kuma/static/styles/minimalist/structure/_containers.scss
+++ b/kuma/static/styles/minimalist/structure/_containers.scss
@@ -8,7 +8,7 @@
     flex-direction: row;
     align-items: center;
     margin: 0 auto;
-    padding: 12px 24px;
+    padding: 0 24px;
     max-width: 1352px;
     min-height: 40px;
 }

--- a/kuma/static/styles/minimalist/structure/_containers.scss
+++ b/kuma/static/styles/minimalist/structure/_containers.scss
@@ -9,6 +9,6 @@
     align-items: center;
     margin: 0 auto;
     padding: 12px 24px;
-    max-width: 1400px;
+    max-width: 1352px;
     min-height: 40px;
 }

--- a/kuma/static/styles/minimalist/structure/_containers.scss
+++ b/kuma/static/styles/minimalist/structure/_containers.scss
@@ -1,0 +1,14 @@
+.full-width-row-container {
+    border-bottom: solid 1px $grey-light;
+    width: 100%;
+}
+
+.max-content-width-container {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    margin: 0 auto;
+    padding: 12px 24px;
+    max-width: 1400px;
+    min-height: 40px;
+}


### PR DESCRIPTION
This segments the CSS for breadcrumbs between the two different front-ends. I also cleaned up the HTML significantly and moved the CSS out of Emotion and into Sass. Visually, nothing should really have changed.

@callahad r?