### PR TITLE
Fixes issue #5676, load banners CSS conditionally

### DIFF
--- a/kuma/landing/jinja2/landing/react_homepage.html
+++ b/kuma/landing/jinja2/landing/react_homepage.html
@@ -8,6 +8,10 @@
   {{ super() }}
 
   {% stylesheet 'home' %}
+
+  {% if waffle.flag('developer_needs') %}
+    {% stylesheet 'banners' %}
+  {% endif %}
 {% endblock %}
 
 {% block extrahead %}

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -730,10 +730,6 @@ PIPELINE_CSS = {
 
             # Styles for BCD tables
             'styles/wiki-compat-tables.scss',
-
-            # Styles for call-to-action banners
-            # See kuma/javascript/src/banners.jsx
-            'styles/components/banners/base.scss'
         ),
         'output_filename': 'build/styles/react-mdn.css',
     },

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -81,6 +81,10 @@
   {% javascript 'html5shiv' %}
   <![endif]-->
 
+  {% if waffle.flag('developer_needs') %}
+    {% stylesheet 'banners' %}
+  {% endif %}
+
   <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
   <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
 


### PR DESCRIPTION
Conditionally loads the `banners.css` file on the React side as well. If the waffle flag `developer_needs` is enabled, you will notice the banners file being loaded:

![Screenshot 2019-08-22 at 12 15 45](https://user-images.githubusercontent.com/10350960/63507402-f0e40980-c4d7-11e9-97ee-9a9538682203.png)

if the flag is disabled, the `link rel` will no longer be present:

![Screenshot 2019-08-22 at 12 18 00](https://user-images.githubusercontent.com/10350960/63507426-fe998f00-c4d7-11e9-8264-a610ba76909b.png)

@peterbe r?