### PR TITLE
Update bug reporting link to Git Issues. Bug #5647 

### DIFF
--- a/contribute.json
+++ b/contribute.json
@@ -21,7 +21,7 @@
     },
     "bugs": {
         "list": "https://mzl.la/2onLvZ8",
-        "report": "https://bugzilla.mozilla.org/form.mdn",
+        "report": "https://github.com/mozilla/kuma/issues/new",
         "mentored": "https://mzl.la/2BFx4Ie",
         "goodfirstbug": "https://mzl.la/2ojEGaW"
     },

--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -32,7 +32,7 @@
       {%- endif %}
     {% endif %}
     <p>If you have additional information how to reproduce this problem, please
-    <a href="https://bugzilla.mozilla.org/form.mdn" rel="nofollow">file a bug.</a>
+    <a href="https://github.com/mozilla/kuma/issues/new" rel="nofollow">file a bug.</a>
     Thanks!</p>
 
     <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>

--- a/jinja2/500.html
+++ b/jinja2/500.html
@@ -32,7 +32,7 @@
       {%- endif %}
     {% endif %}
     <p>If you have additional information how to reproduce this problem, please
-    <a href="https://github.com/mozilla/kuma/issues/new" rel="nofollow">file a bug.</a>
+    <a href="https://github.com/mozilla/kuma/issues/new" rel="nofollow">file an issue.</a>
     Thanks!</p>
 
     <p class="attrib"><small><a href="http://theoatmeal.com/comics/state_web_summer#tumblr" rel="nofollow">Tumbeasts</a> by Matthew Inman of <a href="http://theoatmeal.com" rel="nofollow">The Oatmeal</a></small></p>

--- a/jinja2/includes/header-main-nav.html
+++ b/jinja2/includes/header-main-nav.html
@@ -65,7 +65,7 @@
                       </a>
                   </li>
                   <li>
-                      <a target="_blank" rel="noopener" href="https://bugzilla.mozilla.org/form.mdn">{{ _('Report a bug') }}
+                      <a target="_blank" rel="noopener" href="https://github.com/mozilla/kuma/issues/new">{{ _('Report an issue') }}
                           {% include 'includes/icons/general/external-link.svg' %}
                       </a>
                   </li>

--- a/kuma/javascript/src/header/__snapshots__/header.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/header.test.js.snap
@@ -405,11 +405,11 @@ exports[`Header snapshot 1`] = `
             role="menuitem"
           >
             <a
-              href="https://bugzilla.mozilla.org/form.mdn"
+              href="https://github.com/mozilla/kuma/issues/new"
               rel="noopener noreferrer"
               target="_blank"
             >
-              Report a bug
+              Report an issue
                🌐
             </a>
           </li>

--- a/kuma/javascript/src/header/main-menu.jsx
+++ b/kuma/javascript/src/header/main-menu.jsx
@@ -129,9 +129,9 @@ const _MainMenu = ({ document, locale }: Props) => {
                             'https://github.com/mdn/sprints/issues/new?template=issue-template.md&projects=mdn/sprints/2&labels=user-report&title={{PATH}}'
                     },
                     {
-                        label: gettext('Report a bug'),
+                        label: gettext('Report an issue'),
                         external: true,
-                        url: 'https://bugzilla.mozilla.org/form.mdn'
+                        url: 'https://github.com/mozilla/kuma/issues/new'
                     }
                 ]
             }

--- a/tests/pages/base.py
+++ b/tests/pages/base.py
@@ -88,7 +88,7 @@ class BasePage(Page):
             'https://github.com/mdn/sprints/issues/new?template='
             'issue-template.md&projects=mdn/sprints/2&labels=user-report'
             '&title=')
-        report_bug_form_url = 'https://bugzilla.mozilla.org/form.mdn'
+        report_bug_form_url = 'https://github.com/mozilla/kuma/issues/new'
         # locators
         SIGNIN_SELECTOR = '#toolbox .login-link'
 


### PR DESCRIPTION
Changes made to the links of reporting a bug from "https://bugzilla.mozilla.org/form.mdn" to "https://github.com/mozilla/kuma/issues/new" .
Changes made to the text Label from "Report a bug" to "Report an issue".