### PR TITLE
Bug 1557787: Fix inline indicator without icon padding regression

### DIFF
--- a/kuma/static/styles/includes/_mixins_indicators.scss
+++ b/kuma/static/styles/includes/_mixins_indicators.scss
@@ -67,11 +67,15 @@ inline indicators aka badges
     line-height: normal;
 }
 
-/* icon styling for indicators needs to be seperate because .spec
-   extend %indicator-inline into some :before content */
+/*
+ * icon styling for indicator icons needs to be separate because
+ * .spec-* extends `%indicator-inline` into some :before content
+ *
+ * This also can't extend `%indicator-with-icon`, as `%indicator-inline-icon`
+ * is applied to all inline indicators to ensure consistent inline icon spacing,
+ * whereas `%indicator-with-icon` is used to add inline padding.
+ */
 %indicator-inline-icon {
-    @extend %indicator-with-icon;
-
     &:before {
         display: inline-block;
         @include bidi((


### PR DESCRIPTION
Caused by https://github.com/mozilla/kuma/commit/ff8b3efec11748d5d083368b78d905f473dcf03e#diff-60e8b0bdf8dc8d343884f0096dc6c8eeR73 (#5482), as I didn’t quite realise what the difference between `%indicator‑inline‑icon` and `%indicator‑with‑icon` was back then.

---

review?(@schalkneethling)