### PR TITLE
chore(editorconfig): Fix `.jsx` indentation configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,6 +8,6 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 
 # Indentiation
-[*.{css,html,js,json,py,styl}]
+[*.{css,html,js,jsx,json,py,styl}]
 indent_style = space
 indent_size = 4


### PR DESCRIPTION
**Q:** Should I set `indent_style` and `indent_size` for all files? And if so, what should I set it to?