### PR TITLE
Notify Slack as well as IRC from Jenkins

### DIFF
--- a/Jenkinsfiles/utils.groovy
+++ b/Jenkinsfiles/utils.groovy
@@ -110,10 +110,18 @@ def sh_with_notify(cmd, display, notify_on_success=false) {
                 stage: display,
                 status: 'success'
             ])
+            notify_slack([
+                stage: display,
+                status: 'success'
+            ])
         }
     } catch(err) {
         notify_irc([
             irc_nick: nick,
+            stage: display,
+            status: 'failure'
+        ])
+        notify_slack([
             stage: display,
             status: 'failure'
         ])
@@ -218,6 +226,10 @@ def announce_push() {
     def tag = get_commit_tag()
     notify_irc([
         irc_nick: "mdn-${env.BRANCH_NAME}",
+        status: "Pushing to ${target}",
+        message: "${repo} image ${tag}"
+    ])
+    notify_slack([
         status: "Pushing to ${target}",
         message: "${repo} image ${tag}"
     ])

--- a/scripts/slack-notify.sh
+++ b/scripts/slack-notify.sh
@@ -17,7 +17,7 @@ return_status() {
         STATUS=$(echo "$STATUS" | tr '[:lower:]' '[:upper:]')
         case "$STATUS" in
         'SUCCESS')
-        	STATUS_PREFIX=":tada:"
+            STATUS_PREFIX=":tada:"
             COLOR="good"
         ;;
         'SHIPPED')
@@ -75,8 +75,7 @@ while [ "$1" != "" ]; do
 done
 
 if [[ -n "$STAGE" ]]; then
-    MESSAGE="${STATUS}${STAGE}:"
-    MESSAGE="$MESSAGE Branch ${BOLD}${BRANCH_NAME}${NORMAL} build #${BUILD_NUMBER}: ${RUN_DISPLAY_URL}"
+    MESSAGE="${STATUS}${STAGE}"
 elif [[ -n "$MESSAGE" ]]; then
     MESSAGE="${STATUS}${MESSAGE}"
 else
@@ -97,13 +96,6 @@ read -r -d '' payload <<EOF
             "title": "${JOB_NAME} Build #${BUILD_NUMBER}",
             "title_link": "${RUN_DISPLAY_URL}",
             "text": "${MESSAGE}",
-            "fields": [
-                {
-                    "title": "Status",
-                    "value": "${STATUS}",
-                    "short": false,
-                }
-            ],
             "footer": "Slack incoming webhook",
             "footer_icon": "https://platform.slack-edge.com/img/default_application_icon.png",
             "ts": $(date +%s)


### PR DESCRIPTION
Fixes #5730 

Add notification to Slack `mdn-infra` (for now) on Kuma and Kumascript deployments.