### PR TITLE
Fixes #5735, remove document editing and management styling from new frontend

### DIFF
--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -77,13 +77,3 @@ Styling for article content
 
 @import 'structure/article';
 @import 'structure/sidebar';
-
-/*
-Delete, move or revert pages.
-====================================================================== */
-
-@import '../components/wiki/parent-suggest';
-@import '../components/wiki/move-decendants';
-@import '../components/wiki/doc-source';
-@import '../components/wiki/delete-document';
-@import '../components/wiki/delete-revision';


### PR DESCRIPTION
Removes a couple of pieces of CSS from the `document.scss` file. Saves us a couple of kb ~ @peterbe r?