### PR TITLE
add Slack notification to integration tests

### DIFF
--- a/Jenkinsfiles/integration-tests.groovy
+++ b/Jenkinsfiles/integration-tests.groovy
@@ -73,8 +73,10 @@ stage('Test') {
         parallel allTests
         // Notify on success
         utils.notify_irc([irc_nick: nick, stage: 'Test', status: 'success'])
+        utils.notify_slack([stage: 'Test', status: 'success'])
     } catch(err) {
         utils.notify_irc([irc_nick: nick, stage: 'Test', status: 'failure'])
+        utils.notify_slack([stage: 'Test', status: 'failure'])
         throw err
     }
 }


### PR DESCRIPTION
Fixes #5749 

Add Slack notification on success or failure of the integration tests when run within Jenkins.