### PR TITLE
use npm ci within the docker image builds

### DIFF
--- a/docker/images/kuma_base/Dockerfile
+++ b/docker/images/kuma_base/Dockerfile
@@ -116,7 +116,7 @@ WORKDIR /tools
 USER kuma
 RUN ln -s /app/package.json /tools \
     && ln -s /app/package-lock.json /tools \
-    && npm install
+    && npm ci
 USER root
 RUN find /tools/node_modules/.bin/ -executable -type f -o -type l -exec ln -s {} /usr/local/bin/ \;
 ENV NODE_PATH=/tools/node_modules

--- a/docker/images/kuma_base/Dockerfile-py3
+++ b/docker/images/kuma_base/Dockerfile-py3
@@ -108,7 +108,7 @@ WORKDIR /tools
 USER kuma
 RUN ln -s /app/package.json /tools \
     && ln -s /app/package-lock.json /tools \
-    && npm install
+    && npm ci
 USER root
 RUN find /tools/node_modules/.bin/ -executable -type f -o -type l -exec ln -s {} /usr/local/bin/ \;
 

--- a/docker/images/kumascript/Dockerfile
+++ b/docker/images/kumascript/Dockerfile
@@ -24,7 +24,7 @@ COPY kumascript/package.json kumascript/npm-shrinkwrap.json /
 RUN npm config set python /usr/bin/python2.7 && \
     # install the Node.js dependencies,
     # with versions specified in npm-shrinkwrap.json
-    npm install && \
+    npm ci && \
     # update any top-level npm packages listed in package.json,
     # such as mdn-browser-compat-data,
     # as allowed by each package's given "semver".


### PR DESCRIPTION
Fixes #5762 

Tested as follows:
```
cd  <kuma repo root dir>
VERSION=latest make build-base
KS_VERSION=latest make build-kumascript
docker-compose up -d
docker-compose exec web make build-static
docker-compose restart
docker-compose exec web make test
docker-compose exec web make lint
cd <kumascript repo root dir>
VERSION=latest make test
VERSION=latest make lint
```