### PR TITLE
Fixes #5692, remove collapsible.scss from new front-end

### DIFF
--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -59,7 +59,6 @@ Styling for article content
 @import '../components/wiki/content/alllinks';
 @import '../components/wiki/content/bug';
 @import '../components/wiki/content/callout-box';
-@import '../components/wiki/content/collapsible';
 @import '../components/wiki/content/card-grid';
 @import '../components/wiki/content/columnList';
 @import '../components/wiki/content/columns';


### PR DESCRIPTION
Removes `collapsible.scss` from the new frontend saving us some 🏋 