### PR TITLE
Fixes #5690, remove page-button CSS from new front-end

### DIFF
--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -50,7 +50,6 @@ Article meta
 -------------------------------------------------------------- */
 @import '../components/wiki/article-head';
 @import './components/breadcrumbs';
-@import '../components/wiki/page-buttons';
 
 /*
 Styling for article content


### PR DESCRIPTION
This removes the `page-buttons` styling from the new frontend.