### PR TITLE
For client render don't serialize what only needs to be rendered on the server

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -77,7 +77,9 @@ function Content({ document }: DocumentProps) {
             // See https://bugzilla.mozilla.org/show_bug.cgi?id=1570043
             // aria-live="assertive"
         >
-            {!!document.tocHTML && <TOC html={document.tocHTML} />}
+            {typeof document.tocHTML == 'string' && (
+                <TOC html={document.tocHTML} />
+            )}
             <Article document={document} />
             <Sidebar document={document} />
         </div>

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -15,10 +15,6 @@ if (container) {
     // with all the data needed to hydrate or render the UI.
     let data = window._react_data;
 
-    // Remove the global reference to this data object so that it can
-    // be garbage collected once it is no longer in use.
-    window._react_data = null; // eslint-disable-line camelcase
-
     // Store the string catalog so that l10n.gettext() can do translations
     localize(data.locale, data.stringCatalog, data.pluralFunction);
 
@@ -35,7 +31,7 @@ if (container) {
                 /* StrictMode is a tool for highlighting potential problems
                    in an application. Like Fragment, StrictMode does not
                    render any visible UI. It activates additional checks and
-                   warnings for its descendants. 
+                   warnings for its descendants.
                    @see https://reactjs.org/docs/strict-mode.html */
                 <React.StrictMode>
                     <SinglePageApp

--- a/kuma/wiki/templatetags/ssr.py
+++ b/kuma/wiki/templatetags/ssr.py
@@ -72,9 +72,13 @@ def _render(component_name, html, script, needs_serialization=False):
 
 def client_side_render(component_name, data):
     """
-    Output an empty <div> and a script with complete state so that
+    Output an empty <div> and a script with most of the  state so that
     the UI can be rendered on the client-side.
+    The HTML fields are omitted, as they increase the payload by a lot
+    and are not needed on the client-side
     """
+    for key in ('quickLinksHTML', 'bodyHTML', 'tocHTML'):
+        data['documentData'][key] = ''
     return _render(component_name, '', data, needs_serialization=True)
 
 


### PR DESCRIPTION
Fixes #5613

Based on #5757 but minus the client-side state re-building of the HTML fields, as an empty string seems to suffice for hydrating dangerouslySetInnerHTML. I'd still like to hear back from the React team whether this should officially be considered part of the API (https://github.com/facebook/react/issues/10923#issuecomment-528793579)