### PR TITLE
JSONDecodeError in ssr.py

### DIFF
--- a/kuma/javascript/ssr-server.js
+++ b/kuma/javascript/ssr-server.js
@@ -21,7 +21,13 @@ const ssr = require('./dist/ssr.js'); // Function to do server-side rendering
 // Configuration
 const PID = process.pid;
 const PORT = parseInt(process.env.SSR_PORT) || 8000;
-const MAX_BODY_SIZE = 1024 * 1024; // 1 megabyte max JSON payload
+
+// Some documents, with lots of Unicode, get very large when Python
+// serializes it to a binary string. For example,
+// https://developer.mozilla.org/ja/docs/Web/API/Window when turned into
+// a JSON string, by Python, becomes a string of length ~1.1MB.
+// Add a little extra just to be on the safe side.
+const MAX_BODY_SIZE = 1024 * 1024 * 5; // 5 megabyte max JSON payload
 
 // We're using the Express server framework
 const app = express();

--- a/kuma/wiki/templatetags/ssr.py
+++ b/kuma/wiki/templatetags/ssr.py
@@ -130,6 +130,7 @@ def server_side_render(component_name, data):
         #     data['documentData'].update(bodyHTML='',
         #                                 tocHTML='',
         #                                 quickLinksHTML='')
+        response.raise_for_status()
         result = response.json()
         return _render(component_name, result['html'], result['script'])
 


### PR DESCRIPTION
Fixes #5777

Our ssr-server.js has a max on the body size of 1MB. 
I opened a django shell and looked at the data:

```
>>> doc = Document.objects.get(locale='ja', slug='Web/API/Window')
>>> from kuma.api.v1.views import document_api_data
>>> data = document_api_data(doc)
>>> import json
>>> dumped = json.dumps(data).encode('utf8')
>>> len(dumped)
1202902
>>> len(dumped) / 1024.  / 1024.0
1.147176742553711
```

I.e. **larger than 1MB**. 

I still wasn't able to reproduce it locally. 