### PR TITLE
Issue #5782, move setShowNewsletterLang into useEffect

### DIFF
--- a/kuma/javascript/src/newsletter.jsx
+++ b/kuma/javascript/src/newsletter.jsx
@@ -153,19 +153,17 @@ export default function Newsletter() {
         }
     };
 
-    /* If this is not en-US, show message informing the user
-       that newsletter is only acailable in English */
-    if (locale !== 'en-US') {
-        setShowNewsletterLang(true);
-    }
-
     useEffect(() => {
         // if `newsletterHide` is set
         if (localStorage.getItem('newsletterHide') === 'true') {
             // do not show the newsletter
             setShowNewsletter(false);
+        } else if (locale !== 'en-US') {
+            /* If this is not en-US, show message informing the user
+               that newsletter is only acailable in English */
+            setShowNewsletterLang(true);
         }
-    }, []);
+    }, [locale]);
 
     return (
         <section className="newsletter-container">


### PR DESCRIPTION
@Gregoor, https://github.com/mozilla/kuma/issues/5782#issue-491326603 explains what was happening on staging. Essentially, if you load a docs page with a locale other than `en-US`, the code below causes multiple rerenders and React prevented an infinite loop.

```
if (locale !== 'en-US') {
  setShowNewsletterLang(true);
}
```

I moved this into `useEffect` so this only happens post mount, and only once per page load, or if the `locale` changes.

## Testing

1. Open up for example http://beta.mdn.localhost:8000/de/docs/Web/CSS
2. You should get a server error
3. Run the following in terminal

```
docker-compose logs --tail=300 -f ssr
```

You will see:

```
ssr_1            | Invariant Violation: Too many re-renders. React limits the number of renders to prevent an infinite loop.
ssr_1            |     at invariant (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:58:15)
ssr_1            |     at dispatchAction (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:1203:44)
ssr_1            |     at Newsletter (webpack:///./kuma/javascript/src/newsletter.jsx?:181:5)
ssr_1            |     at finishHooks (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:1032:16)
ssr_1            |     at processChild (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:2872:14)
ssr_1            |     at resolve (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:2795:5)
ssr_1            |     at ReactDOMServerRenderer.render (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:3185:22)
ssr_1            |     at ReactDOMServerRenderer.read (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:3144:29)
ssr_1            |     at renderToString (webpack:///./node_modules/react-dom/cjs/react-dom-server.node.development.js?:3629:27)
ssr_1            |     at ssr (webpack:///./kuma/javascript/src/ssr.jsx?:60:85)
```

4. Grab this branch
5. Restart all the things
6. Load up http://beta.mdn.localhost:8000/de/docs/Web/CSS
7. It renders as expected
8. Load up http://beta.mdn.localhost:8000/en-US/docs/Web/CSS
9. It renders as expected