### PR TITLE
use sentry for the ssr service

### DIFF
--- a/kuma/javascript/ssr-server.js
+++ b/kuma/javascript/ssr-server.js
@@ -13,6 +13,21 @@ if (process.env.NEW_RELIC_LICENSE_KEY && process.env.NEW_RELIC_APP_NAME) {
     require('newrelic');
 }
 
+if (process.env.SENTRY_DSN) {
+    console.log('Configuring Sentry for the SSR server.');
+    const Sentry = require('@sentry/node');
+    let options = {
+        dsn: process.env.SENTRY_DSN
+    };
+    if (process.env.REVISION_HASH) {
+        options.release = process.env.REVISION_HASH;
+    }
+    if (process.env.SENTRY_ENVIRONMENT) {
+        options.environment = process.env.SENTRY_ENVIRONMENT;
+    }
+    Sentry.init(options);
+}
+
 const express = require('express'); // Express server framework
 const morgan = require('morgan');
 

--- a/kuma/javascript/ssr-server.js
+++ b/kuma/javascript/ssr-server.js
@@ -13,9 +13,15 @@ if (process.env.NEW_RELIC_LICENSE_KEY && process.env.NEW_RELIC_APP_NAME) {
     require('newrelic');
 }
 
+const express = require('express'); // Express server framework
+const morgan = require('morgan');
+const sentry = require('@sentry/node');
+
+const ssr = require('./dist/ssr.js'); // Function to do server-side rendering
+
+// Configure and initialize Sentry if a DSN has been provided.
 if (process.env.SENTRY_DSN) {
     console.log('Configuring Sentry for the SSR server.');
-    const Sentry = require('@sentry/node');
     let options = {
         dsn: process.env.SENTRY_DSN
     };
@@ -25,13 +31,8 @@ if (process.env.SENTRY_DSN) {
     if (process.env.SENTRY_ENVIRONMENT) {
         options.environment = process.env.SENTRY_ENVIRONMENT;
     }
-    Sentry.init(options);
+    sentry.init(options);
 }
-
-const express = require('express'); // Express server framework
-const morgan = require('morgan');
-
-const ssr = require('./dist/ssr.js'); // Function to do server-side rendering
 
 // Configuration
 const PID = process.pid;

--- a/package-lock.json
+++ b/package-lock.json
@@ -6087,6 +6087,67 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
         },
+        "@sentry/core": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.2.tgz",
+            "integrity": "sha512-grbjvNmyxP5WSPR6UobN2q+Nss7Hvz+BClBT8QTr7VTEG5q89TwNddn6Ej3bGkaUVbct/GpVlI3XflWYDsnU6Q==",
+            "requires": {
+                "@sentry/hub": "5.6.1",
+                "@sentry/minimal": "5.6.1",
+                "@sentry/types": "5.6.1",
+                "@sentry/utils": "5.6.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@sentry/hub": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.6.1.tgz",
+            "integrity": "sha512-m+OhkIV5yTAL3R1+XfCwzUQka0UF/xG4py8sEfPXyYIcoOJ2ZTX+1kQJLy8QQJ4RzOBwZA+DzRKP0cgzPJ3+oQ==",
+            "requires": {
+                "@sentry/types": "5.6.1",
+                "@sentry/utils": "5.6.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@sentry/minimal": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.6.1.tgz",
+            "integrity": "sha512-ercCKuBWHog6aS6SsJRuKhJwNdJ2oRQVWT2UAx1zqvsbHT9mSa8ZRjdPHYOtqY3DoXKk/pLUFW/fkmAnpdMqRw==",
+            "requires": {
+                "@sentry/hub": "5.6.1",
+                "@sentry/types": "5.6.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@sentry/node": {
+            "version": "5.6.2",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.6.2.tgz",
+            "integrity": "sha512-A9CELco6SjF4zt8iS1pO3KdUVI2WVhtTGhSH6X04OVf2en1fimPR+Vs8YVY/04udwd7o+3mI6byT+rS9+/Qzow==",
+            "requires": {
+                "@sentry/core": "5.6.2",
+                "@sentry/hub": "5.6.1",
+                "@sentry/types": "5.6.1",
+                "@sentry/utils": "5.6.1",
+                "cookie": "0.3.1",
+                "https-proxy-agent": "2.2.1",
+                "lru_map": "0.3.3",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@sentry/types": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.6.1.tgz",
+            "integrity": "sha512-Kub8TETefHpdhvtnDj3kKfhCj0u/xn3Zi2zIC7PB11NJHvvPXENx97tciz4roJGp7cLRCJsFqCg4tHXniqDSnQ=="
+        },
+        "@sentry/utils": {
+            "version": "5.6.1",
+            "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.6.1.tgz",
+            "integrity": "sha512-rfgha+UsHW816GqlSRPlniKqAZylOmQWML2JsujoUP03nPu80zdN43DK9Poy/d9OxBxv0gd5K2n+bFdM2kqLQQ==",
+            "requires": {
+                "@sentry/types": "5.6.1",
+                "tslib": "^1.9.3"
+            }
+        },
         "@types/babel__core": {
             "version": "7.1.1",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.1.tgz",
@@ -15323,6 +15384,11 @@
                 }
             }
         },
+        "lru_map": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+            "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+        },
         "make-dir": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
@@ -19715,8 +19781,7 @@
         "tslib": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-            "dev": true
+            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
         },
         "tty-browserify": {
             "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "pretty": "prettier --check **/*{.js,.jsx,.scss}"
     },
     "dependencies": {
+        "@sentry/node": "^5.6.2",
         "express": "^4.16.4",
         "jsesc": "2.5.2",
         "morgan": "^1.9.1",


### PR DESCRIPTION
Fixes #5783 

This PR enables Sentry for the `ssr` service, so uncaught exceptions are now captured by Sentry.

The `package.json` and `package-lock.json` files were auto-generated from doing `npm install @sentry/node`.