### PR TITLE
Add command to help with GitHub setup

### DIFF
--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -36,3 +36,5 @@
 # Developer CKEditor plugins
 # See https://kuma.readthedocs.io/en/latest/ckeditor.html
 #CKEDITOR_DEV=True
+
+#DOMAIN=mdn.localhost

--- a/.env-dist.dev
+++ b/.env-dist.dev
@@ -37,4 +37,4 @@
 # See https://kuma.readthedocs.io/en/latest/ckeditor.html
 #CKEDITOR_DEV=True
 
-#DOMAIN=mdn.localhost
+DOMAIN=mdn.localhost

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -242,13 +242,24 @@ To enable GitHub authentication, you'll need to
 * Application description: My own GitHub app for MDN!
 * Authorization callback URL: http://localhost:8000/users/github/login/callback/.
 
-As an admin user, `add a django-allauth social app`_ for GitHub:
+To automate setting Django up for Github auth you can run
+``docker-compose exec web ./manage.py configure_github_social`` and follow its steps.
+
+If you want to do it manually, as an admin user, `add a django-allauth social app`_ for GitHub:
 
 * Provider: GitHub.
 * Name: MDN Development.
 * Client id: <*your GitHub App Client ID*>.
 * Secret key: <*your GitHub App Client Secret*>.
 * Sites: Move ``locahost:8000`` from "Available sites" to "Chosen sites".
+
+``locahost:8000`` needs to either have ID 1 or ``SITE_ID=1`` has to be set in ``.env``
+to its actual ID. You'll also need to set ``DOMAIN=mdn.localhost`` there.
+
+Your hosts file should contain the following lines::
+
+    127.0.0.1 kubernetes.docker.internal localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
+    ::1             mdn.localhost beta.mdn.localhost wiki.mdn.localhost
 
 Now you can sign in with GitHub.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -258,7 +258,7 @@ to its actual ID. You'll also need to set ``DOMAIN=mdn.localhost`` there.
 
 Your hosts file should contain the following lines::
 
-    127.0.0.1 kubernetes.docker.internal localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
+    127.0.0.1 localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
     ::1             mdn.localhost beta.mdn.localhost wiki.mdn.localhost
 
 Now you can sign in with GitHub.

--- a/kuma/attachments/management/commands/configure_github_social.py
+++ b/kuma/attachments/management/commands/configure_github_social.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
 
             print(GITHUB_INFO)
             client_id = raw_input('Client ID: ').strip()
-            client_secret = raw_input('Client Secret: ')
+            client_secret = raw_input('Client Secret: ').strip()
 
             social_app, created = SocialApp.objects.update_or_create(
                 provider='github',

--- a/kuma/attachments/management/commands/configure_github_social.py
+++ b/kuma/attachments/management/commands/configure_github_social.py
@@ -1,24 +1,34 @@
-import fileinput, os, sys, urllib2
+import fileinput
+import os
+import sys
 
-from django.core.management.base import BaseCommand, CommandError
-from django.contrib.sites.models import Site
 from allauth.socialaccount.models import SocialApp
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.core.management.base import BaseCommand
+
+try:
+    input = raw_input
+except NameError:
+    # Python3's input behaves like raw_input
+    # TODO: Delete this block when we've migrated
+    pass
 
 LOCALHOST = 'localhost:8000'
 MDN_LOCALHOST = 'mdn.localhost'
 
 OVERWRITE_PROMPT = 'There\'s already a SocialApp for GitHub, if you want to overwrite it type "yes":'
-GITHUB_INFO = '\n'.join([
-    'Visit https://github.com/settings/developers and click "New OAuth App"',
+GITHUB_INFO = (
+    'Visit https://github.com/settings/developers and click "New OAuth App"\n'
     'Set "Homepage URL" to "http://mdn.localhost:8000/" and Authorization callback URL to ' +
     '"http://mdn.localhost:8000/users/github/login/callback/" respectively'
-])
+)
 ENV_INFO = 'Putting SITE_ID and DOMAIN into .env'
-HOSTS_INFO = '\n'.join([
-    'Make sure your hosts file contains these lines:'
-    '127.0.0.1 kubernetes.docker.internal localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost',
+HOSTS_INFO = (
+    'Make sure your hosts file contains these lines:\n'
+    '127.0.0.1 localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost\n'
     '::1             mdn.localhost beta.mdn.localhost wiki.mdn.localhost'
-])
+)
 
 
 def overwrite_or_create_env_vars(env_vars):
@@ -30,8 +40,9 @@ def overwrite_or_create_env_vars(env_vars):
             sys.stdout.write(line)
 
     with open(file_path, 'a') as file:
-        for key, value in env_vars.iteritems():
-            file.write('\n' + key + '=' + str(value))
+        file.write('\n')
+        for key, value in env_vars.items():
+            file.write(key + '=' + str(value) + '\n')
 
 
 class Command(BaseCommand):
@@ -41,12 +52,12 @@ class Command(BaseCommand):
         print('\n')
 
         social_app = SocialApp.objects.filter(provider='github').first()
-        if social_app is not None and raw_input(OVERWRITE_PROMPT) == 'yes':
+        if social_app is not None and input(OVERWRITE_PROMPT) == 'yes':
             print('\n')
 
             print(GITHUB_INFO)
-            client_id = raw_input('Client ID: ').strip()
-            client_secret = raw_input('Client Secret: ').strip()
+            client_id = input('Client ID: ').strip()
+            client_secret = input('Client Secret: ').strip()
 
             social_app, created = SocialApp.objects.update_or_create(
                 provider='github',
@@ -66,6 +77,8 @@ class Command(BaseCommand):
         print('\n')
 
         print(ENV_INFO)
-        overwrite_or_create_env_vars({'SITE_ID': site.id, 'DOMAIN': MDN_LOCALHOST})
+        overwrite_or_create_env_vars(
+            {'SITE_ID': site.id, 'DOMAIN': MDN_LOCALHOST} if site.id != settings.SITE_ID else
+            {'DOMAIN': MDN_LOCALHOST})
 
         print(HOSTS_INFO)

--- a/kuma/attachments/management/commands/configure_github_social.py
+++ b/kuma/attachments/management/commands/configure_github_social.py
@@ -45,7 +45,7 @@ class Command(BaseCommand):
             print('\n')
 
             print(GITHUB_INFO)
-            client_id = raw_input('Client ID: ')
+            client_id = raw_input('Client ID: ').strip()
             client_secret = raw_input('Client Secret: ')
 
             social_app, created = SocialApp.objects.update_or_create(

--- a/kuma/attachments/management/commands/configure_github_social.py
+++ b/kuma/attachments/management/commands/configure_github_social.py
@@ -37,7 +37,7 @@ def overwrite_or_create_env_vars(env_vars):
 class Command(BaseCommand):
     help = 'Configure Kuma for Sign-In with GitHub'
 
-    def handle(self, *args, **options):
+    def handle(self, **options):
         print('\n')
 
         social_app = SocialApp.objects.filter(provider='github').first()

--- a/kuma/attachments/management/commands/configure_github_social.py
+++ b/kuma/attachments/management/commands/configure_github_social.py
@@ -1,0 +1,71 @@
+import fileinput, os, sys, urllib2
+
+from django.core.management.base import BaseCommand, CommandError
+from django.contrib.sites.models import Site
+from allauth.socialaccount.models import SocialApp
+
+LOCALHOST = 'localhost:8000'
+MDN_LOCALHOST = 'mdn.localhost'
+
+OVERWRITE_PROMPT = 'There\'s already a SocialApp for GitHub, if you want to overwrite it type "yes":'
+GITHUB_INFO = '\n'.join([
+    'Visit https://github.com/settings/developers and click "New OAuth App"',
+    'Set "Homepage URL" to "http://mdn.localhost:8000/" and Authorization callback URL to ' +
+    '"http://mdn.localhost:8000/users/github/login/callback/" respectively'
+])
+ENV_INFO = 'Putting SITE_ID and DOMAIN into .env'
+HOSTS_INFO = '\n'.join([
+    'Make sure your hosts file contains these lines:'
+    '127.0.0.1 kubernetes.docker.internal localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost',
+    '::1             mdn.localhost beta.mdn.localhost wiki.mdn.localhost'
+])
+
+
+def overwrite_or_create_env_vars(env_vars):
+    file_path = os.path.join(os.getcwd(), '.env')
+
+    for line in fileinput.input(file_path, inplace=True):
+        key = line.strip().split('=')[0]
+        if key not in env_vars:
+            sys.stdout.write(line)
+
+    with open(file_path, 'a') as file:
+        for key, value in env_vars.iteritems():
+            file.write('\n' + key + '=' + str(value))
+
+
+class Command(BaseCommand):
+    help = 'Configure Kuma for Sign-In with GitHub'
+
+    def handle(self, *args, **options):
+        print('\n')
+
+        social_app = SocialApp.objects.filter(provider='github').first()
+        if social_app is not None and raw_input(OVERWRITE_PROMPT) == 'yes':
+            print('\n')
+
+            print(GITHUB_INFO)
+            client_id = raw_input('Client ID: ')
+            client_secret = raw_input('Client Secret: ')
+
+            social_app, created = SocialApp.objects.update_or_create(
+                provider='github',
+                defaults={
+                    'name': 'MDN Development',
+                    'client_id': client_id,
+                    'secret': client_secret
+                }
+            )
+
+        site, created = Site.objects.update_or_create(
+            domain=LOCALHOST,
+            defaults={'name': LOCALHOST}
+        )
+        social_app.sites.add(site)
+
+        print('\n')
+
+        print(ENV_INFO)
+        overwrite_or_create_env_vars({'SITE_ID': site.id, 'DOMAIN': MDN_LOCALHOST})
+
+        print(HOSTS_INFO)


### PR DESCRIPTION
Fixes #5822 

In addition to documenting the fields, this also includes a command (and documentation for it) that sets the fields and also creates (or updates) the SocialApp model for GitHub.

To test it run the command as described in the docs (maybe back up your `.env` file). Different scenarios you can test are permutations of pre-existing SocialApp and localhost-Site models, as well as with/without `SITE_ID` and `DOMAIN` fields in your `.env`.

Missing feature: it doesn't ping mdn.localhost to check if hosts are correctly set up. Why? Because our docker instances don't ship with ping 🙈 