### PR TITLE
Add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug report
+about: Help us fix things that are broken
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Summary**
+_What is the problem?_
+
+
+**Steps To Reproduce (STR)**
+_How can we reproduce the problem?_
+
+1. 
+2. 
+3. 
+
+
+**Actual behavior**
+_What actually happened?_
+
+
+**Expected behavior**
+_What did you expect to happen?_
+
+
+**Additional context**
+_Is there anything else we should know?_

--- a/.github/ISSUE_TEMPLATE/change-request.md
+++ b/.github/ISSUE_TEMPLATE/change-request.md
@@ -1,0 +1,27 @@
+---
+name: Change request
+about: Suggest a change to how MDN currently works
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Summary**
+_What should be changed? (Please provide a URL if applicable)_
+
+
+**Rationale**
+_What problems would this solve?_
+
+
+**Audience**
+_Who would use this changed feature?_
+
+
+**Proposal**
+_What would users see and do? What would happen as a result?_
+
+
+**Additional context**
+_Is there anything else we should know?_

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest a new idea for MDN
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Summary**
+_What problem would this solve?_
+
+
+**Audience**
+_Who has this problem? Everyone? Article authors? Etc._
+
+
+**Rationale**
+_How do you know that people identified above actually have this problem?_
+
+
+**Workaround**
+_How are the people identified above currently handling this problem?_
+
+
+**Proposal**
+_Do you have suggestions for solving this problem?_
+
+
+**Additional context**
+_Is there anything else we should know?_


### PR DESCRIPTION
Ports an approximation of our Bugzilla templates from https://bugzilla.mozilla.org/form.mdn to GitHub

Unblocks #5683