### PR TITLE
Fixes #5753, beta site shows empty sidebar

### DIFF
--- a/kuma/javascript/src/document.jsx
+++ b/kuma/javascript/src/document.jsx
@@ -50,8 +50,8 @@ export type DocumentProps = {
 
 export function Sidebar({ document }: DocumentProps) {
     return (
-        <div className="sidebar">
-            {document.quickLinksHTML && (
+        document.quickLinksHTML && (
+            <div className="sidebar">
                 <div className="quick-links">
                     <div className="quick-links-head sidebar-heading">
                         {gettext('Related Topics')}
@@ -62,8 +62,8 @@ export function Sidebar({ document }: DocumentProps) {
                         }}
                     />
                 </div>
-            )}
-        </div>
+            </div>
+        )
     );
 }
 
@@ -71,12 +71,18 @@ function Content({ document }: DocumentProps) {
     // The wiki-left-present class below is needed for correct BCD layout
     // See kuma/static/styles/components/compat-tables/bc-table.scss
     return (
-        /* adding aria-live here to mark this as a live region to
-          ensure a screen reader will read the new content after navigation */
+        /* If we have either `tocHTML` or `quicklinksHTML`, add the
+           `wiki-left-present` class */
         <div
-            className="wiki-left-present content-layout"
-            // See https://bugzilla.mozilla.org/show_bug.cgi?id=1570043
-            // aria-live="assertive"
+            className={
+                document.tocHTML || document.quickLinksHTML
+                    ? 'wiki-left-present content-layout'
+                    : 'content-layout'
+            }
+            /* adding aria-live here to mark this as a live region to
+               ensure a screen reader will read the new content after navigation 
+               See https://bugzilla.mozilla.org/show_bug.cgi?id=1570043
+               aria-live="assertive" */
         >
             {!!document.tocHTML && <TOC html={document.tocHTML} />}
             <Article document={document} />

--- a/kuma/static/styles/minimalist/structure/_containers.scss
+++ b/kuma/static/styles/minimalist/structure/_containers.scss
@@ -9,9 +9,15 @@
     grid-template-areas: 'main' 'document-toc-container' 'side';
 
     @media #{$mq-tablet-and-up} {
-        grid-template-columns: 25% 75%;
-        grid-template-rows: max-content 1fr;
-        grid-template-areas: 'document-toc-container main' 'side main';
+        grid-template-columns: 100%;
+        grid-template-rows: 1fr;
+        grid-template-areas: 'main';
+
+        &.wiki-left-present {
+            grid-template-columns: 25% 75%;
+            grid-template-rows: max-content 1fr;
+            grid-template-areas: 'document-toc-container main' 'side main';
+        }
     }
 }
 


### PR DESCRIPTION
This resolves the problem where pages displayed an empty sidebar.

## Testing

1. Open up http://beta.mdn.localhost:8000/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array and ensure that the layout is as expected.

1. Next open http://beta.mdn.localhost:8000/en-US/docs/Web/Guide
This only has a TOC in the sidebar, but we should still have the two-column layout with the TOC on the left.

1. Next, go to http://wiki.mdn.localhost:8000/en-US/docs/Web/Guide
2. Click on Edit
3. Click on Edit Page Title and Properties and change TOC to `No table of contents`
4. Click publish
5. Go to http://beta.mdn.localhost:8000/en-US/docs/Web/Guide
6. There is nothing to display in the sidebar so, the main content should fill up the entire available space

## Before

![Screenshot 2019-09-16 at 14 23 04](https://user-images.githubusercontent.com/10350960/64957632-b3cc2680-d88d-11e9-89bc-e01287b7d78c.png)

## After

![Screenshot 2019-09-16 at 14 23 26](https://user-images.githubusercontent.com/10350960/64957645-b9297100-d88d-11e9-98fb-011f7524b32b.png)
