### PR TITLE
drop preconnect to interactive examples

### DIFF
--- a/kuma/wiki/jinja2/wiki/document.html
+++ b/kuma/wiki/jinja2/wiki/document.html
@@ -59,7 +59,6 @@
 {% endblock %}
 
 {% block extrahead %}
-  <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
   <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
 
   <link rel="alternate" type="application/json" href="{{ url('wiki.json_slug', document.slug) | absolutify }}">

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -85,7 +85,6 @@
     {% stylesheet 'banners' %}
   {% endif %}
 
-  <link rel="dns-prefetch" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
   <link rel="preconnect" href="https://interactive-examples.mdn.mozilla.net" pr="0.75" />
 
   <link rel="canonical" href="{{ canonical }}" >
@@ -106,7 +105,7 @@
   <meta name="description" content="{{ seo_summary }}">
   <meta name="twitter:description" content="{{ seo_summary }}">
   {% endif %}
-  
+
   {% block printstyle %}
     {% stylesheet 'print' %}
   {% endblock %}


### PR DESCRIPTION
Fixes #5680

It's pointless to do `dns-prefetch` *and* `preconnect` because one is a subset of the other. 
What I don't like is that so many pages don't have a iframe whose source is `https://interactive-examples.mdn.mozilla.net/...`. These for example:

* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/head
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/title
* https://developer.mozilla.org/en-US/docs/Web/HTML/Element/body
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array 
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON
* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math

For all those, the user's browser is doing HTTP stuff all in vain. 

I started a deeper rabbit hole where it would analyze the HTML about to be rendered and only for the pages with an iframe (whose domain is in a whitelist) bother. Maybe I should finish that. 

Thoughts @atopal ?