### PR TITLE
add message when falling-back to English

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -66,7 +66,7 @@ export default function Article({ document }: DocumentProps) {
             }
         >
             {document.locale !== locale && (
-                <div id="doc-pending-fallback" class="warning">
+                <div id="doc-pending-fallback" className="warning">
                     <p>
                         <bdi>
                             {gettext(

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -4,6 +4,7 @@ import { useContext, useEffect, useRef } from 'react';
 
 import { activateBCDSignals, activateBCDTables } from './bcd.js';
 import { addLiveExampleButtons } from './live-examples.js';
+import { getLocale, gettext } from './l10n.js';
 import { highlightSyntax } from './prism.js';
 import * as InteractiveExamples from './interactive-examples.js';
 import UserProvider from './user-provider.jsx';
@@ -47,6 +48,7 @@ export default function Article({ document }: DocumentProps) {
 
     const isArchive =
         document.slug === 'Archive' || document.slug.startsWith('Archive/');
+    const locale = getLocale();
 
     return (
         /*
@@ -63,6 +65,21 @@ export default function Article({ document }: DocumentProps) {
                     : 'article text-content'
             }
         >
+            {document.locale !== locale && (
+                <div id="doc-pending-fallback" class="warning">
+                    <p>
+                        <bdi>
+                            {gettext(
+                                "You're reading the English version of this content, since no translation exists yet for this locale."
+                            )}
+                            &nbsp;
+                            <a href={document.translateURL} rel="nofollow">
+                                {gettext('Help us translate this article!')}
+                            </a>
+                        </bdi>
+                    </p>
+                </div>
+            )}
             <article
                 id="wikiArticle"
                 dangerouslySetInnerHTML={{ __html: document.bodyHTML }}

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -66,7 +66,7 @@ export default function Article({ document }: DocumentProps) {
             }
         >
             {document.locale !== locale && (
-                <div id="doc-pending-fallback" className="warning">
+                <div className="warning">
                     <p>
                         <bdi>
                             {gettext(

--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -70,7 +70,7 @@ export default function Article({ document }: DocumentProps) {
                     <p>
                         <bdi>
                             {gettext(
-                                "You're reading the English version of this content, since no translation exists yet for this locale."
+                                'You’re reading the English version of this content since no translation exists yet for this locale.'
                             )}
                             &nbsp;
                             <a href={document.translateURL} rel="nofollow">


### PR DESCRIPTION
Fixes #5806 

This PR adds a simplified `beta` domain version of the translation message that is displayed within the `wiki` domain when falling-back to the English version of a document that has been requested in a non-English locale. The goal here was to show a clear message that was simple to implement in the React world (e.g., no changes would be required to the `document_api_data` function in the back-end). cc @SphinxKnight 

For example, this is the **`wiki`** version of the message (http://wiki.mdn.localhost:8000/ca/docs/Web/HTTP):

<img width="1436" alt="image" src="https://user-images.githubusercontent.com/3743693/65192348-97fe8700-da2b-11e9-8541-103cda0fb195.png">


This is the `beta` version **before** this PR (http://beta.mdn.localhost:8000/ca/docs/Web/HTTP):

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/3743693/65192566-54584d00-da2c-11e9-90f2-51ba348fe87f.png">


This is the `beta` version **after** this PR (http://beta.mdn.localhost:8000/ca/docs/Web/HTTP):

![image](https://user-images.githubusercontent.com/3743693/65192412-e01da980-da2b-11e9-9f7c-7ebd9d626026.png)

For local testing, I used these settings in my `.env` file (my usual settings):
```
DEBUG=True
DOMAIN=mdn.localhost
BETA_HOST=beta.mdn.localhost:8000
WIKI_HOST=wiki.mdn.localhost:800
SITE_URL=http://mdn.localhost:8000
STATIC_URL=http://mdn.localhost:8000/static/
```
and this content for my `/etc/hosts` file:
```
##
# Host Database
#
# localhost is used to configure the loopback interface
# when the system is booting.  Do not change this entry.
##
127.0.0.1	localhost demos mdn.localhost beta.mdn.localhost wiki.mdn.localhost
255.255.255.255	broadcasthost
::1             localhost
```
and did something like this:
```
docker-compose pull
docker-compose up -d
docker-compose exec web make build-static
docker-compose restart
```

Then try:
- http://beta.mdn.localhost:8000/en-US/docs/Web/HTTP (no fallback, so no message)
- http://beta.mdn.localhost:8000/es/docs/Web/HTTP (no fallback, so no message)
- http://beta.mdn.localhost:8000/ca/docs/Web/HTTP (fallback, so show message)
- http://wiki.mdn.localhost:8000/ca/docs/Web/HTTP (for comparison)

The `Help us translate this article!` link should go to `http://wiki.mdn.localhost:8000/en-US/docs/Web/HTTP$locales`.