### PR TITLE
make breadcrumb schema validate

### DIFF
--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -35,6 +35,13 @@ $crumb-vertical-spacing-desktop: $grid-spacing / 4;
         }
     }
 
+    a.crumb-current-page {
+        &:link,
+        &:visited {
+            color: $text-color;
+        }
+    }
+
     span {
         display: inline-block;
         position: relative;
@@ -66,10 +73,5 @@ $crumb-vertical-spacing-desktop: $grid-spacing / 4;
 
     li:last-child span:after {
         display: none;
-    }
-
-    li:last-child a {
-        // Make the last-child <a> appear like regular text
-        color: #333;
     }
 }

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -67,4 +67,9 @@ $crumb-vertical-spacing-desktop: $grid-spacing / 4;
     li:last-child span:after {
         display: none;
     }
+
+    li:last-child a {
+        // Make the last-child <a> appear like regular text
+        color: #333;
+    }
 }

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -11,7 +11,7 @@
           </li>
         {% endfor %}
         <li property="itemListElement" typeof="ListItem" class="crumb">
-          <a href="{{ document.get_absolute_url() }}" property="item" typeof="WebPage">
+          <a href="{{ document.get_absolute_url() }}" class="crumb-current-page" property="item" typeof="WebPage">
             <span property="name" aria-current="page">{{ document.title }}</span>
           </a>
           <meta property="position" content="{{ document.parents|length_plus_one }}">

--- a/kuma/wiki/jinja2/wiki/includes/document_macros.html
+++ b/kuma/wiki/jinja2/wiki/includes/document_macros.html
@@ -11,7 +11,10 @@
           </li>
         {% endfor %}
         <li property="itemListElement" typeof="ListItem" class="crumb">
-          <span property="name" aria-current="page">{{ document.title }}</span>
+          <a href="{{ document.get_absolute_url() }}" property="item" typeof="WebPage">
+            <span property="name" aria-current="page">{{ document.title }}</span>
+          </a>
+          <meta property="position" content="{{ document.parents|length_plus_one }}">
         </li>
       </ol>
     </nav>

--- a/kuma/wiki/templatetags/jinja_helpers.py
+++ b/kuma/wiki/templatetags/jinja_helpers.py
@@ -262,3 +262,12 @@ def include_svg(path, title=None, title_id=None):
     else:
         svg_out = svg
     return jinja2.Markup(svg_out)
+
+
+@library.filter
+def length_plus_one(lengthy):
+    """Useful when you want to do something like
+    `{{ somelist|length_plus_one }}` and you want it to output the
+    Python equivalent of `len(somelist) + 1`.
+    """
+    return len(lengthy) + 1


### PR DESCRIPTION
Fixes #5853

This one was tricky. I know the issue is a handful but ponder what this PR results in...:

This is what it looks like:
<img width="449" alt="Screen Shot 2019-09-20 at 3 12 58 PM" src="https://user-images.githubusercontent.com/26739/65353073-37ea1b00-dbba-11e9-9fdc-e15f27155495.png">

And if I open view-source:http://wiki.mdn.localhost:8000/en-US/docs/Web/CSS/animation-delay and paste in the relevant `<ol>` tag it validates:
<img width="1494" alt="Screen Shot 2019-09-20 at 3 17 55 PM" src="https://user-images.githubusercontent.com/26739/65353111-4fc19f00-dbba-11e9-8ba0-101de2fd1540.png">

