### PR TITLE
Fixes #5859, improve accessibility of custom lang dropdown

### DIFF
--- a/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/dropdown.test.js.snap
@@ -5,11 +5,13 @@ exports[`Dropdown closed and open snapshots 1`] = `
   className="dropdown-container"
 >
   <button
+    aria-haspopup="true"
     className="dropdown-menu-label"
     type="button"
   >
     Test
     <span
+      aria-hidden="true"
       className="dropdown-arrow-down"
     >
       ▼
@@ -17,6 +19,7 @@ exports[`Dropdown closed and open snapshots 1`] = `
   </button>
   <ul
     className="dropdown-menu-items"
+    role="menu"
   >
     <li>
       foo

--- a/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/language-menu.test.js.snap
@@ -5,11 +5,15 @@ exports[`LanguageMenu snapshot 1`] = `
   className="dropdown-container"
 >
   <button
+    aria-haspopup="true"
+    aria-label="Current language is English. Choose your preferred language."
+    aria-owns="language-menu"
     className="dropdown-menu-label"
     type="button"
   >
     English
     <span
+      aria-hidden="true"
       className="dropdown-arrow-down"
     >
       ▼
@@ -17,6 +21,8 @@ exports[`LanguageMenu snapshot 1`] = `
   </button>
   <ul
     className="dropdown-menu-items"
+    id="language-menu"
+    role="menu"
     style={
       Object {
         "right": 0,
@@ -25,6 +31,7 @@ exports[`LanguageMenu snapshot 1`] = `
   >
     <li
       lang="es"
+      role="menuitem"
     >
       <a
         href="[fake spanish url]"

--- a/kuma/javascript/src/header/__snapshots__/login.test.js.snap
+++ b/kuma/javascript/src/header/__snapshots__/login.test.js.snap
@@ -8,6 +8,7 @@ exports[`Login component when user is logged in 1`] = `
     className="dropdown-container"
   >
     <button
+      aria-haspopup="true"
       className="dropdown-menu-label"
       type="button"
     >
@@ -20,6 +21,7 @@ exports[`Login component when user is logged in 1`] = `
     </button>
     <ul
       className="dropdown-menu-items"
+      role="menu"
       style={
         Object {
           "right": 0,

--- a/kuma/javascript/src/header/dropdown.jsx
+++ b/kuma/javascript/src/header/dropdown.jsx
@@ -5,6 +5,13 @@ type DropdownProps = {|
     // The string or component to display. Hovering over this will
     // display the menu
     label: string | React.Node,
+    // An optional string that, when specified, is set as the `id` attribute
+    // of the `ul` menu element. This is then also used as the value of the
+    // `aria-owns` property on the menu trigger button
+    ariaOwns?: string,
+    // An optional string that, when spcecified, is used to set a custom
+    // label for the menu trigger button using `aria-label`
+    ariaLabel?: string,
     // If set to true, the menu will be anchored to the right edge of
     // the label and may extend beyond the left edge. If this is
     // false or unset, the default behavior is to attach the menu to
@@ -19,15 +26,25 @@ type DropdownProps = {|
 export default function Dropdown(props: DropdownProps) {
     return (
         <div className="dropdown-container">
-            <button type="button" className="dropdown-menu-label">
+            <button
+                type="button"
+                className="dropdown-menu-label"
+                aria-haspopup="true"
+                aria-owns={props.ariaOwns}
+                aria-label={props.ariaLabel}
+            >
                 {props.label}
                 {!props.hideArrow && (
-                    <span className="dropdown-arrow-down">▼</span>
+                    <span className="dropdown-arrow-down" aria-hidden="true">
+                        ▼
+                    </span>
                 )}
             </button>
             <ul
+                id={props.ariaOwns}
                 className="dropdown-menu-items"
                 style={props.right && { right: 0 }}
+                role="menu"
             >
                 {props.children}
             </ul>

--- a/kuma/javascript/src/header/language-menu.jsx
+++ b/kuma/javascript/src/header/language-menu.jsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 
 import Dropdown from './dropdown.jsx';
-import { gettext } from '../l10n.js';
+import { gettext, interpolate } from '../l10n.js';
 
 import type { DocumentData } from '../document.jsx';
 
@@ -28,11 +28,20 @@ export default function LanguageMenu({ document }: Props): React.Node {
     // and we can just use the document language string without translation.
     let label =
         document.locale === 'en-US' ? gettext('English') : document.language;
+    let chooseLanguageString = interpolate(
+        gettext('Current language is %s. Choose your preferred language.'),
+        [label]
+    );
 
     return (
-        <Dropdown label={label} right={true}>
+        <Dropdown
+            label={label}
+            right={true}
+            ariaOwns="language-menu"
+            ariaLabel={chooseLanguageString}
+        >
             {document.translations.map(t => (
-                <li key={t.locale} lang={t.locale}>
+                <li key={t.locale} lang={t.locale} role="menuitem">
                     <a href={t.url} title={t.localizedLanguage}>
                         <bdi>{t.language}</bdi>
                     </a>

--- a/kuma/static/styles/minimalist/components/_dropdown.scss
+++ b/kuma/static/styles/minimalist/components/_dropdown.scss
@@ -1,5 +1,3 @@
-@import '../vars/vars-nav';
-
 .dropdown-container {
     /* We use relative here not because we need to tweak positioning
        but because we need to position the menu itself relative to the
@@ -9,15 +7,16 @@
     /* This adjusts for the 5px left padding */
     margin-left: -5px;
 
-    &:hover {
-        &.dropdown-menu-label,
-        &.dropdown-menu-label a {
-            color: $dropdown-item-background-color;
-        }
-
-        &.dropdown-menu-items {
-            display: flex;
-        }
+    .dropdown-menu-label {
+        display: flex;
+        flex-direction: row;
+        align-items: center;
+        color: $text-color;
+        padding: 0 5px 5px;
+        border: none;
+        white-space: nowrap;
+        font-size: $tiny-font-size;
+        font-weight: bold;
     }
 
     .dropdown-menu-items {
@@ -54,24 +53,20 @@
         }
     }
 
-    &:hover .dropdown-menu-items {
-        display: flex;
+    &:hover,
+    &:focus {
+        .dropdown-menu-label,
+        .dropdown-menu-label a {
+            color: $dropdown-item-background-color;
+        }
     }
 
-    .dropdown-menu-label {
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        color: $text-color;
-        padding: 0 5px 5px;
-        border: none;
-        white-space: nowrap;
-        font-size: $tiny-font-size;
-        font-weight: bold;
-
-        &:focus {
-            /* The default focus outline doesn't look right in Chrome without this */
-            outline-offset: -3px;
+    &:hover,
+    &:focus,
+    &:focus-within {
+        .dropdown-menu-items,
+        .dropdown-menu-items {
+            display: flex;
         }
     }
 


### PR DESCRIPTION
This does not entirely resolve issue #5859 but, it is now on par with the rest of our menus on the new frontend. The next steps would be to add the additional required JavaScript to ensure that:

1. the menu is navigable via the arrow keys
2. When the menu is opened and closed toggle `aria-hidden` (current `aria-hidden` is not set at all)
3. Ensure focus moves to the first item in the list
4. Pressing the escape key closes the menu

All of this is relevant to this custom menu as well as the main navigation of the site. I will create separate issues for these so that it can be triaged, prioritized, and moved into our sprint work.

In this pull request, I do set a custom label for the `button` element that triggers the menu so that instead of the assistive technology simply reading `English pop-up button`, it will now read `Choose your preferred language pop-up button`

@MarcoZehe let me know your thoughts on this pull request as well as my comments above. Thank you.