### PR TITLE
correct schema on breadcrumb component

### DIFF
--- a/kuma/javascript/src/breadcrumbs.jsx
+++ b/kuma/javascript/src/breadcrumbs.jsx
@@ -10,15 +10,44 @@ type DocumentProps = {
 export default function Breadcrumbs({ document }: DocumentProps) {
     return (
         <nav className="breadcrumbs" role="navigation">
-            <ol>
-                {document.parents.map(p => (
-                    <li key={p.url}>
-                        <a href={p.url} className="breadcrumb-chevron">
-                            {p.title}
+            <ol
+                typeof="BreadcrumbList"
+                vocab="https://schema.org/"
+                aria-label="breadcrumbs"
+            >
+                {document.parents.map((p, i) => (
+                    <li
+                        key={p.url}
+                        property="itemListElement"
+                        typeof="ListItem"
+                    >
+                        <a
+                            href={p.url}
+                            className="breadcrumb-chevron"
+                            property="item"
+                            typeof="WebPage"
+                        >
+                            <span property="name">{p.title}</span>
                         </a>
+                        <meta property="position" content={i + 1} />
                     </li>
                 ))}
-                <li>{document.title}</li>
+                <li property="itemListElement" typeof="ListItem">
+                    <a
+                        href={document.absoluteURL}
+                        className="crumb-current-page"
+                        property="item"
+                        typeof="WebPage"
+                    >
+                        <span property="name" aria-current="page">
+                            {document.title}
+                        </span>
+                    </a>
+                    <meta
+                        property="position"
+                        content={document.parents.length + 1}
+                    />
+                </li>
             </ol>
         </nav>
     );

--- a/kuma/javascript/src/document.test.js
+++ b/kuma/javascript/src/document.test.js
@@ -84,7 +84,7 @@ describe('Document component renders all of its parts', () => {
             let parent = fakeDocumentData.parents[i];
             let link = links[i];
             expect(link.props.href).toBe(parent.url);
-            expect(link.children[0]).toBe(parent.title);
+            expect(link.children[0].children[0]).toBe(parent.title);
         }
     });
 

--- a/kuma/static/styles/components/wiki/crumbs.scss
+++ b/kuma/static/styles/components/wiki/crumbs.scss
@@ -42,6 +42,13 @@ $crumb-vertical-spacing-desktop: $grid-spacing / 4;
         }
     }
 
+    a.crumb-current-page {
+        &:link,
+        &:visited {
+            color: $text-color;
+        }
+    }
+
     span {
         display: inline-block;
         position: relative;

--- a/kuma/static/styles/minimalist/components/_breadcrumbs.scss
+++ b/kuma/static/styles/minimalist/components/_breadcrumbs.scss
@@ -9,14 +9,25 @@
     li {
         display: inline;
         hyphens: auto;
-    }
 
-    .breadcrumb-chevron:after {
-        display: inline-block;
-        content: '›';
-        color: $grey-vdark;
-        margin: 0 5px;
-        font-size: 1rem;
-        font-weight: bold;
+        a.crumb-current-page {
+            &:link,
+            &:visited {
+                color: $text-color;
+            }
+        }
+
+        .breadcrumb-chevron:after {
+            display: inline-block;
+            content: '›';
+            color: $grey-vdark;
+            margin: 0 5px;
+            font-size: 1rem;
+            font-weight: bold;
+        }
+
+        :last-child .breadcrumb-chevron:after {
+            display: none;
+        }
     }
 }


### PR DESCRIPTION
Fixes #5856

<img width="1090" alt="Screen Shot 2019-09-24 at 9 51 34 AM" src="https://user-images.githubusercontent.com/26739/65518138-cf4cb800-deb1-11e9-8d00-dc7004e4f0b1.png">

I also copied the rendered DOM HTML into here:
<img width="1497" alt="Screen Shot 2019-09-24 at 9 58 14 AM" src="https://user-images.githubusercontent.com/26739/65518193-e1c6f180-deb1-11e9-9e16-0398ede4da2f.png">
(the use of relative URLs is fine. It's just that tool not possible knowing which domain this came from)