### PR TITLE
Remove interpolate's named indexed params capabilities

### DIFF
--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -129,6 +129,7 @@ export function interpolate(s: string, args: Array<any> | { [string]: any }) {
     if (Array.isArray(args)) {
         return s.replace(/%s/g, () => String(args.shift()));
     } else {
+        // for flow's type refinement, which otherwise breaks inside of closures
         const typedArgs = args;
         return s.replace(/%\(\w+\)s/g, match =>
             String(typedArgs[match.slice(2, -2)])

--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -118,25 +118,20 @@ export function ngettext(
  * ngettext()) that interpolates values from an array or properties from
  * an object into a template string and then returns the resulting string.
  *
- * If the third argument is omitted or is false, then args should be
- * an array, and the values from that array will be interpolated into
- * the string s replacing each occurrance of the string `%s`.
+ * If the second argument is an array, the values from that array will be
+ * interpolated into the string s replacing each occurrance of the string `%s`.
  *
- * If the third argument is true, then args should be an object and s
- * should contain substrings of the form `%(name)s`. Each substring of
- * this form will be replaced with the value of the named property of args.
+ * If the second argument is object then s should contain substrings of
+ * the form `%(name)s`. Each substring of this form will be replaced with the
+ * value of the named property of args.
  */
-export function interpolate(
-    s: string,
-    args: Array<any> | { [string]: any },
-    named: boolean = false
-) {
-    if (named) {
-        let props = ((args: any): { [string]: any }); // A cast for flow
-        return s.replace(/%\(\w+\)s/g, match =>
-            String(props[match.slice(2, -2)])
-        );
-    } else {
+export function interpolate(s: string, args: Array<any> | { [string]: any }) {
+    if (Array.isArray(args)) {
         return s.replace(/%s/g, () => String(args.shift()));
+    } else {
+        const typedArgs = args;
+        return s.replace(/%\(\w+\)s/g, match =>
+            String(typedArgs[match.slice(2, -2)])
+        );
     }
 }

--- a/kuma/javascript/src/l10n.test.js
+++ b/kuma/javascript/src/l10n.test.js
@@ -138,32 +138,16 @@ describe('interpolate()', () => {
         expect(interpolate('A%sfoo%sZ', ['a', 'z'])).toBe('AafoozZ');
     });
 
-    it('three argument form, with an array', () => {
-        expect(interpolate('foo', [], true)).toBe('foo');
-        expect(interpolate('%(0)s', [1], true)).toBe('1');
-        expect(interpolate('%(1)s foo %(0)s', [1, true], true)).toBe(
-            'true foo 1'
-        );
-        expect(interpolate('A%(1)sfoo%(0)sZ', ['a', 'z'], true)).toBe(
-            'AzfooaZ'
-        );
-        expect(interpolate('%(0)s%(1)s%(2)s', [1, 2, 3], true)).toBe('123');
-        expect(interpolate('%(2)s%(2)s', [1, 2, 3], true)).toBe('33');
-        expect(interpolate('%(0)s%(1)s%(5)s', [1, 2, 3], true)).toBe(
-            '12undefined'
-        );
-    });
-
     it('three argument form, with object', () => {
-        expect(interpolate('foo', {}, true)).toBe('foo');
-        expect(interpolate('%(a)s', { a: 1 }, true)).toBe('1');
-        expect(interpolate('%(b)s foo %(a)s', { a: 1, b: true }, true)).toBe(
+        expect(interpolate('foo', {})).toBe('foo');
+        expect(interpolate('%(a)s', { a: 1 })).toBe('1');
+        expect(interpolate('%(b)s foo %(a)s', { a: 1, b: true })).toBe(
             'true foo 1'
         );
-        expect(interpolate('A%(z)sfoo%(a)sZ', { a: 'a', z: 'z' }, true)).toBe(
+        expect(interpolate('A%(z)sfoo%(a)sZ', { a: 'a', z: 'z' })).toBe(
             'AzfooaZ'
         );
-        expect(interpolate('%(a)s%(b)s%(d)s', { a: 1, b: 2, c: 3 }, true)).toBe(
+        expect(interpolate('%(a)s%(b)s%(d)s', { a: 1, b: 2, c: 3 })).toBe(
             '12undefined'
         );
     });

--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -139,8 +139,7 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                                 // need to turn that into "English (US)".
                                 locale: locale,
                                 query: results.query
-                            },
-                            true
+                            }
                         )}{' '}
                         {!!results.count &&
                             !results.previous &&
@@ -155,8 +154,7 @@ export default function SearchResultsPage({ locale, query, data }: Props) {
                                 {
                                     start: results.start,
                                     end: results.end
-                                },
-                                true
+                                }
                             )}
                     </p>
                 </div>
@@ -305,12 +303,8 @@ export class SearchRoute extends Route<
     }
 
     getTitle({ query }: SearchRouteParams): string {
-        return `${interpolate(
-            gettext('Search results for "%(query)s"'),
-            {
-                query
-            },
-            true
-        )} | MDN`;
+        return `${interpolate(gettext('Search results for "%(query)s"'), {
+            query
+        })} | MDN`;
     }
 }


### PR DESCRIPTION
Fixes #5869 

This removes the indexed params capability of interpolate, since it wasn't used. It also makes the interpolate function a bit simpler.