### PR TITLE
Componentize SearchResultsPage

### DIFF
--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -47,7 +47,7 @@ function makePaginationPageURL(uri) {
 
 function ResultsMeta({
     locale,
-    results
+    results: { count, previous, next, query, start, end }
 }: {
     locale: string,
     results: SearchResults
@@ -59,29 +59,23 @@ function ResultsMeta({
                     ngettext(
                         '%(count)s document found for "%(query)s" in %(locale)s.',
                         '%(count)s documents found for "%(query)s" in %(locale)s.',
-                        results.count
+                        count
                     ),
                     {
-                        count: results.count.toLocaleString(),
+                        count: count.toLocaleString(),
                         // XXX this 'locale' is something like 'en-US'
                         // need to turn that into "English (US)".
-                        locale: locale,
-                        query: results.query
+                        locale,
+                        query
                     }
                 )}{' '}
-                {!!results.count &&
-                    !results.previous &&
-                    !results.next &&
-                    gettext('Showing all results.')}
-                {!!results.count &&
-                    (results.previous || results.next) &&
-                    interpolate(
-                        gettext('Showing results %(start)s to %(end)s.'),
-                        {
-                            start: results.start,
-                            end: results.end
-                        }
-                    )}
+                {count > 0 &&
+                    (previous || next
+                        ? interpolate(
+                              gettext('Showing results %(start)s to %(end)s.'),
+                              { start, end }
+                          )
+                        : gettext('Showing all '))}
             </p>
         </div>
     );

--- a/kuma/javascript/src/search-results-page.jsx
+++ b/kuma/javascript/src/search-results-page.jsx
@@ -52,6 +52,17 @@ function ResultsMeta({
     locale: string,
     results: SearchResults
 }) {
+    let resultsText;
+    if (count > 0) {
+        if (previous || next) {
+            resultsText = interpolate(
+                gettext('Showing results %(start)s to %(end)s.'),
+                { start, end }
+            );
+        } else {
+            resultsText = gettext('Showing all ');
+        }
+    }
     return (
         <div className="result-container">
             <p className="result-meta">
@@ -69,13 +80,7 @@ function ResultsMeta({
                         query
                     }
                 )}{' '}
-                {count > 0 &&
-                    (previous || next
-                        ? interpolate(
-                              gettext('Showing results %(start)s to %(end)s.'),
-                              { start, end }
-                          )
-                        : gettext('Showing all '))}
+                {resultsText}
             </p>
         </div>
     );


### PR DESCRIPTION
[As requested](https://github.com/mozilla/kuma/pull/5770#issuecomment-534527385)

This extracts a lot of the SearchResultsPage render code into separate components, making the control fow in it easier to follow.