### PR TITLE
Add Constance flag for disabling attachment upload

### DIFF
--- a/kuma/attachments/tests/test_models.py
+++ b/kuma/attachments/tests/test_models.py
@@ -1,5 +1,6 @@
 import datetime
 
+from constance.test import override_config
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
@@ -184,3 +185,9 @@ class AttachmentModelTests(UserTestCase):
         u7.user_permissions.add(p2)
         u7.save()
         self.assertTrue(allow_add_attachment_by(u7))
+
+    @override_config(WIKI_ATTACHMENTS_DISABLE_UPLOAD=True)
+    def test_permissions_when_disabled(self):
+        # All users, including superusers, are denied
+        admin = self.user_model.objects.get(username='admin')
+        self.assertFalse(allow_add_attachment_by(admin))

--- a/kuma/attachments/tests/test_views.py
+++ b/kuma/attachments/tests/test_views.py
@@ -57,6 +57,14 @@ class AttachmentViewTests(UserTestCase, WikiTestCase):
         assert rev.comment == 'Initial upload'
         assert rev.is_approved
 
+    @override_config(WIKI_ATTACHMENTS_DISABLE_UPLOAD=True)
+    def test_disabled_edit_attachment(self):
+        response = self._post_attachment()
+        assert_no_cache_header(response)
+        self.assertEqual(response.status_code, 403)  # HTTP 403 Forbidden
+        with self.assertRaises(Attachment.DoesNotExist):
+            Attachment.objects.get(title='Test uploaded file')
+
     def test_get_previous(self):
         """
         AttachmentRevision.get_previous() should return this revisions's

--- a/kuma/attachments/utils.py
+++ b/kuma/attachments/utils.py
@@ -2,6 +2,7 @@ import calendar
 import hashlib
 from datetime import datetime
 
+from constance import config
 from django.conf import settings
 from django.utils import timezone
 from django.utils.http import http_date
@@ -16,6 +17,9 @@ def allow_add_attachment_by(user):
     When the user has this permission, upload is disallowed unless it's
     a superuser or staff.
     """
+    if config.WIKI_ATTACHMENTS_DISABLE_UPLOAD:
+        # Uploading via the Wiki is disabled
+        return False
     if user.is_superuser or user.is_staff:
         # Superusers and staff always allowed
         return True

--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -1571,6 +1571,11 @@ CONSTANCE_CONFIG = dict(
         'image/gif image/jpeg image/png image/svg+xml text/html image/vnd.adobe.photoshop',
         'Allowed file types for wiki file attachments',
     ),
+    WIKI_ATTACHMENTS_DISABLE_UPLOAD=(
+        False,
+        'Disable uploading of new or revised attachments via the Wiki. '
+        'Attachments may still be modified via the Django Admin.'
+    ),
     WIKI_ATTACHMENTS_KEEP_TRASHED_DAYS=(
         14,
         "Number of days to keep the trashed attachments files before they "


### PR DESCRIPTION
This defines a new Constance flag (`WIKI_ATTACHMENTS_DISABLE_UPLOAD`)
which disables adding or editing attachments via the Wiki. Changes may
still be made via the Django Admin.

We need this capability for the EFS-to-S3 migration (#5798).