### PR TITLE
include 'ga' in effect that alerts google analytics

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -61,7 +61,7 @@ export default function Article({ document }: DocumentProps) {
                 eventLabel: ''
             });
         }
-    }, [document, locale]);
+    }, [document, locale, ga]);
 
     return (
         /*


### PR DESCRIPTION
Fixes #5880

Tested with `docker-compose exec web npm run eslint` and no more warning now. 