### PR TITLE
Load BCD table CSS after content

### DIFF
--- a/kuma/settings/common.py
+++ b/kuma/settings/common.py
@@ -690,9 +690,6 @@ PIPELINE_CSS = {
             'styles/libs/prism/prism-line-numbers.css',
 
             'styles/wiki-syntax.scss',
-
-            # Styles for BCD tables
-            'styles/wiki-compat-tables.scss',
         ),
         'output_filename': 'build/styles/react-mdn.css',
     },
@@ -701,6 +698,12 @@ PIPELINE_CSS = {
             'styles/minimalist/search-page.scss',
         ),
         'output_filename': 'build/styles/react-search.css',
+    },
+    'react-bcd': {
+        'source_filenames': (
+            'styles/wiki-compat-tables.scss',
+        ),
+        'output_filename': 'build/styles/react-bcd.css'
     },
     'mdn': {
         'source_filenames': (

--- a/kuma/wiki/jinja2/wiki/react_document.html
+++ b/kuma/wiki/jinja2/wiki/react_document.html
@@ -118,7 +118,7 @@
   {{ render_react("SPA", request.LANGUAGE_CODE, request.get_full_path(),
                   document_data)|safe }}
 
-  <!-- site js -->
+  {% stylesheet 'react-bcd' %}
   {% javascript 'react-main' %}
   <script>
     if (window.mdn && mdn.analytics) mdn.analytics.trackOutboundLinks();


### PR DESCRIPTION
Fixes #5669 

Wasn't sure if there's a preferred way of deferring this load, so I just moved it into its own style bundle that'll be included after content (but before the JS bundle).