### PR TITLE
5833 client side sentry for react front end

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - PYTHONWARNINGS=${PYTHONWARNINGS:-default}
       - MAINTENANCE_MODE=${MAINTENANCE_MODE:-False}
       - REVISION_HASH=${KUMA_REVISION_HASH:-undefined}
+      - SENTRY_DSN=${SENTRY_DSN:-}
       # For the server side rendering server and the code that connects to it.
       - SSR_PORT=8000
       - SSR_URL=http://ssr:8000/ssr

--- a/package-lock.json
+++ b/package-lock.json
@@ -6087,6 +6087,17 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
             "dev": true
         },
+        "@sentry/browser": {
+            "version": "5.6.3",
+            "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.6.3.tgz",
+            "integrity": "sha512-bP1LTbcKPOkkmfJOAM6c7WZ0Ov0ZEW6B9keVZ9wH9fw/lBPd9UyDMDCwJ+FAYKz9M9S5pxQeJ4Ebd7WUUrGVAQ==",
+            "requires": {
+                "@sentry/core": "5.6.2",
+                "@sentry/types": "5.6.1",
+                "@sentry/utils": "5.6.1",
+                "tslib": "^1.9.3"
+            }
+        },
         "@sentry/core": {
             "version": "5.6.2",
             "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.6.2.tgz",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
         "debug:development:web": "npm run debug -- --env.presets web --env.presets svg --env.mode development",
         "webpack:web": "npm run webpack -- --env.presets web --env.presets svg",
         "webpack:node": "npm run webpack -- --env.presets node --env.presets svg",
-        "webpack:production:web": "npm run webpack:web -- --env.mode production",
+        "webpack:production:web": "npm run webpack:web -- --env.mode production --env.SENTRY_DSN=$SENTRY_DSN",
         "webpack:production:node": "npm run webpack:node -- --env.mode production",
-        "webpack:development:web": "npm run webpack:web -- --env.mode development --env.presets hardsource",
+        "webpack:development:web": "npm run webpack:web -- --env.mode development --env.presets hardsource --env.SENTRY_DSN=$SENTRY_DSN",
         "webpack:development:node": "npm run webpack:node -- --env.mode development --env.presets hardsource",
         "webpack:prod": "npm-run-all webpack:production:*",
         "webpack:analyze": "npm run webpack:production:web -- --env.presets analyze",
@@ -36,6 +36,7 @@
         "pretty": "prettier --check **/*{.js,.jsx,.scss}"
     },
     "dependencies": {
+        "@sentry/browser": "^5.6.3",
         "@sentry/node": "^5.6.2",
         "express": "^4.16.4",
         "jsesc": "2.5.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,9 @@ const nodePath = process.env.NODE_PATH || path.join(__dirname, 'node_modules');
 const modeConfig = env => require(`./webpack-build-utils/webpack.${env}`)(env);
 const presetsConfig = require('./webpack-build-utils/loadPresets');
 
-module.exports = ({ mode, presets } = { mode: 'production', presets: [] }) => {
+module.exports = (
+    { mode, presets, SENTRY_DSN } = { mode: 'production', presets: [] }
+) => {
     const merged = webpackMerge(
         {
             mode,
@@ -45,7 +47,12 @@ module.exports = ({ mode, presets } = { mode: 'production', presets: [] }) => {
             output: {
                 filename: 'react.js'
             },
-            plugins: [new webpack.ProgressPlugin()]
+            plugins: [
+                new webpack.ProgressPlugin(),
+                new webpack.DefinePlugin({
+                    'process.env.SENTRY_DSN': JSON.stringify(SENTRY_DSN)
+                })
+            ]
         },
         modeConfig(mode),
         presetsConfig({ mode, presets })


### PR DESCRIPTION
Annoyingly, this increases the size of the main `react.js` bundle by 59K (from 187K to 246K) which kinda matches what my bundle size tooltip thing in VSCode shows:
<img width="612" alt="Screen Shot 2019-10-04 at 10 10 52 AM" src="https://user-images.githubusercontent.com/26739/66214236-57d80f00-e68f-11e9-90ee-2f149ff700ae.png">

And this is nuts because we're not a web APP. We're a web site and I just don't know how common these errors are going to be. 

It might be an idea to just use GA's `trackError` which won't give us fancy stack traces with sourcemaps or whatever Sentry might be able to offer but it'd give us some indications about troubled URLs.
