### PR TITLE
Remove wiki/article-head from new frontend (#5924)

### DIFF
--- a/kuma/static/styles/minimalist/document.scss
+++ b/kuma/static/styles/minimalist/document.scss
@@ -44,7 +44,6 @@ Components that may appear on most wiki pages
 Article meta
 - contains breadcrumbs and page buttons.
 -------------------------------------------------------------- */
-@import '../components/wiki/article-head';
 @import './components/breadcrumbs';
 
 /*


### PR DESCRIPTION
Remove `wiki/article-head.scss` from `kuma/static/styles/minimalist/document.scss`

Fixes #5924