### PR TITLE
GA track errors from error boundaries

### DIFF
--- a/kuma/javascript/src/error-boundaries.jsx
+++ b/kuma/javascript/src/error-boundaries.jsx
@@ -1,24 +1,31 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
 
+import GAProvider from './ga-provider.jsx';
 import { gettext } from './l10n.js';
 
 export class AppErrorBoundary extends React.Component {
     state = { error: null };
 
+    static contextType = GAProvider.context;
+
     static getDerivedStateFromError(error) {
         return { error };
     }
 
-    logError() {
-        // https://github.com/mozilla/kuma/issues/5833
-        // When we start to use Sentry, change the method signature to
-        // logError(error, errorInfo) {
+    logError(boundaryName) {
+        // https://developers.google.com/analytics/devguides/collection/analyticsjs/events#event_fields
+        this.context('send', {
+            hitType: 'event',
+            eventCategory: 'errorboundary',
+            eventAction: boundaryName,
+            eventLabel: document.location.href
+        });
     }
 
-    componentDidCatch(error, errorInfo) {
+    componentDidCatch() {
         document.title = 'Application rendering Error';
-        this.logError(error, errorInfo);
+        this.logError('application');
     }
 
     render() {
@@ -39,9 +46,9 @@ AppErrorBoundary.propTypes = {
 };
 
 export class ContentErrorBoundary extends AppErrorBoundary {
-    componentDidCatch(error, errorInfo) {
+    componentDidCatch() {
         document.title = 'Content rendering error';
-        this.logError(error, errorInfo);
+        this.logError('content');
     }
     render() {
         if (this.state.error) {
@@ -65,7 +72,7 @@ function ErrorMessage({ title, children }) {
                         <h1 className="page-title">{title}</h1>
                         <p>
                             {gettext(
-                                'An unhandled error occurred in the application. The error has been logged and an administrator was notified. We apologize for the inconvenience!'
+                                'An unhandled error occurred in the application. We apologize for the inconvenience!'
                             )}
                         </p>
                         {children}

--- a/kuma/javascript/src/index.jsx
+++ b/kuma/javascript/src/index.jsx
@@ -6,6 +6,7 @@ import SinglePageApp from './single-page-app.jsx';
 import LandingPage from './landing-page.jsx';
 import SignupFlow from './signup-flow.jsx';
 import { AppErrorBoundary } from './error-boundaries.jsx';
+import GAProvider from './ga-provider.jsx';
 import { localize } from './l10n.js';
 
 let container = document.getElementById('react-container');
@@ -67,10 +68,13 @@ if (container) {
        render any visible UI. It activates additional checks and
        warnings for its descendants.
        @see https://reactjs.org/docs/strict-mode.html */
-    app = <React.StrictMode>{app}</React.StrictMode>;
-
-    /* Need docstring*/
-    app = <AppErrorBoundary>{app}</AppErrorBoundary>;
+    app = (
+        <GAProvider>
+            <AppErrorBoundary>
+                <React.StrictMode>{app}</React.StrictMode>
+            </AppErrorBoundary>
+        </GAProvider>
+    );
 
     // NOTE: `document.all` is only available in lte IE10
     // $FlowFixMe

--- a/kuma/javascript/src/landing-page.jsx
+++ b/kuma/javascript/src/landing-page.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 import A11yNav from './a11y/a11y-nav.jsx';
 import Banners from './banners.jsx';
-import GAProvider from './ga-provider.jsx';
 import Header from './header/header.jsx';
 import UserProvider from './user-provider.jsx';
 
@@ -15,12 +14,10 @@ import UserProvider from './user-provider.jsx';
  */
 export default function LandingPage() {
     return (
-        <GAProvider>
-            <UserProvider>
-                <A11yNav />
-                <Header />
-                <Banners />
-            </UserProvider>
-        </GAProvider>
+        <UserProvider>
+            <A11yNav />
+            <Header />
+            <Banners />
+        </UserProvider>
     );
 }

--- a/kuma/javascript/src/signup-flow.jsx
+++ b/kuma/javascript/src/signup-flow.jsx
@@ -3,7 +3,6 @@ import * as React from 'react';
 
 import A11yNav from './a11y/a11y-nav.jsx';
 import Banners from './banners.jsx';
-import GAProvider from './ga-provider.jsx';
 import Header from './header/header.jsx';
 import UserProvider from './user-provider.jsx';
 
@@ -15,12 +14,10 @@ import UserProvider from './user-provider.jsx';
  */
 export default function SignupFlow() {
     return (
-        <GAProvider>
-            <UserProvider>
-                <A11yNav />
-                <Header />
-                <Banners />
-            </UserProvider>
-        </GAProvider>
+        <UserProvider>
+            <A11yNav />
+            <Header />
+            <Banners />
+        </UserProvider>
     );
 }

--- a/kuma/javascript/src/single-page-app.jsx
+++ b/kuma/javascript/src/single-page-app.jsx
@@ -2,7 +2,6 @@
 import * as React from 'react';
 
 import { DocumentRoute } from './document.jsx';
-import GAProvider from './ga-provider.jsx';
 import { getLocale } from './l10n.js';
 import Router from './router.jsx';
 import { SearchRoute } from './search-results-page.jsx';
@@ -21,14 +20,12 @@ export default function SinglePageApp({
     const routes = [new DocumentRoute(locale), new SearchRoute(locale)];
 
     return (
-        <GAProvider>
-            <UserProvider>
-                <Router
-                    routes={routes}
-                    initialURL={initialURL}
-                    initialData={initialData}
-                />
-            </UserProvider>
-        </GAProvider>
+        <UserProvider>
+            <Router
+                routes={routes}
+                initialURL={initialURL}
+                initialData={initialData}
+            />
+        </UserProvider>
     );
 }


### PR DESCRIPTION
Fixes #5929

Truth be told, I don't know if this works. I'm not even sure how to test it. If I fake it by manually making sure [these lines](https://github.com/mozilla/kuma/blob/6df857e40c19011fe41b00347d3e7f3de51349cb/kuma/wiki/jinja2/wiki/react_document.html#L41-L46) really do render then `window.ga` *is* defined by when the call to it happens, I see no XHR requests in my browser. 
I don't know if it's because my fake UA is `12345`. Or perhaps there's a race condition. The way we set up GA is that sometime during the `window.onload` it injects a script tag with src `'https://www.google-analytics.com/{{ GA_FILE }}.js'`. What if, milliseconds before that, our React hydration code happens and comes across this `logError` method.

All in all, I'm just nervous about all of this working. Would love some extra review and perhaps a slow rollout. 