### PR TITLE
Better footer article metadata display

### DIFF
--- a/kuma/javascript/src/last-modified.jsx
+++ b/kuma/javascript/src/last-modified.jsx
@@ -30,7 +30,9 @@ export default function LastModified({
     return (
         <section className="contributors-sub">
             <ClockIcon />
-            <strong>{gettext('Last modified: ')}</strong>
+            <span className="contributors-sub-label">
+                {gettext('Last modified:')}
+            </span>
             <time dateTime={lastModified}>
                 {lastModifiedDate.toLocaleString(
                     documentLocale,

--- a/kuma/javascript/src/last-modified.jsx
+++ b/kuma/javascript/src/last-modified.jsx
@@ -30,9 +30,7 @@ export default function LastModified({
     return (
         <section className="contributors-sub">
             <ClockIcon />
-            <header>
-                <h4>{gettext('Last modified:')}</h4>
-            </header>
+            <strong>{gettext('Last modified: ')}</strong>
             <time dateTime={lastModified}>
                 {lastModifiedDate.toLocaleString(
                     documentLocale,

--- a/kuma/javascript/src/last-modified.jsx
+++ b/kuma/javascript/src/last-modified.jsx
@@ -30,9 +30,9 @@ export default function LastModified({
     return (
         <section className="contributors-sub">
             <ClockIcon />
-            <span className="contributors-sub-label">
-                {gettext('Last modified:')}
-            </span>
+            <header>
+                <h4>{gettext('Last modified:')}</h4>
+            </header>
             <time dateTime={lastModified}>
                 {lastModifiedDate.toLocaleString(
                     documentLocale,

--- a/kuma/static/styles/minimalist/structure/_article.scss
+++ b/kuma/static/styles/minimalist/structure/_article.scss
@@ -20,5 +20,10 @@ Main wiki article content
         margin-top: 32px;
         font-size: 0.88889rem;
         color: $grey;
+
+        .contributors-sub-label {
+            margin: 5px;
+            font-weight: bold;
+        }
     }
 }

--- a/kuma/static/styles/minimalist/structure/_article.scss
+++ b/kuma/static/styles/minimalist/structure/_article.scss
@@ -21,9 +21,13 @@ Main wiki article content
         font-size: 0.88889rem;
         color: $grey;
 
-        .contributors-sub-label {
-            margin: 5px;
-            font-weight: bold;
+        .icon-clock {
+            vertical-align: unset;
+        }
+
+        header {
+            display: inline-block;
+            padding: 4px 0;
         }
     }
 }


### PR DESCRIPTION
Fix #5954

![Screen Shot 2019-10-09 at 5 59 43 PM](https://user-images.githubusercontent.com/1201062/66524157-9cb0db00-eabf-11e9-9fa4-7885d91bff2c.png)
