### PR TITLE
DOMException on some pages due to invalid selectors

### DIFF
--- a/kuma/javascript/src/live-examples.js
+++ b/kuma/javascript/src/live-examples.js
@@ -23,7 +23,6 @@ export function addLiveExampleButtons(rootElement) {
         // We expect the iframe to be in a section with an id related
         // to the frame id.
         let sectid = frame.id.replace(idPrefix, '');
-
         // It *used* to be that the ' character was allowed as a safe
         // character in IDs. We've since changed the Wiki post-processing
         // code to replace those with an empty string.
@@ -34,7 +33,16 @@ export function addLiveExampleButtons(rootElement) {
         // For context, see https://github.com/mozilla/kuma/issues/5810
         sectid = sectid.replace("'", '');
 
+        if (/^\d/.test(sectid)) {
+            // The iframe's ID didn't necessary start with a number but
+            // if you remove the iframes IDs' prefix what's left might
+            // start with a number. But that won't find a section because
+            // no section in the DOM has an ID that starts with a number.
+            sectid = `id${sectid}`;
+        }
+
         let section = document.getElementById(sectid);
+
         if (!section) {
             // If the section doesn't exist, then none of the selectors below
             // will work, so we can bail out early
@@ -62,7 +70,10 @@ export function addLiveExampleButtons(rootElement) {
                 `#${sectid} ~ pre[class*=js], #${sectid} ~ * pre[class*=js]`
             );
         } catch (err) {
-            console.error('Error trying to find html, css, js DOM nodes:', err);
+            console.error(
+                `Error trying to find html, css, js DOM nodes (section id ${sectid})`,
+                err
+            );
         }
 
         // Now get the source code out of those pre elements

--- a/kuma/javascript/src/live-examples.js
+++ b/kuma/javascript/src/live-examples.js
@@ -48,15 +48,22 @@ export function addLiveExampleButtons(rootElement) {
         // direct siblings and also descendants of direct siblings
         // (because sometimes some of the source code is tucked inside
         // a hidden div).
-        let html = rootElement.querySelector(
-            `#${sectid} ~ pre[class*=html], #${sectid} ~ * pre[class*=html]`
-        );
-        let css = rootElement.querySelector(
-            `#${sectid} ~ pre[class*=css], #${sectid} ~ * pre[class*=css]`
-        );
-        let js = rootElement.querySelector(
-            `#${sectid} ~ pre[class*=js], #${sectid} ~ * pre[class*=js]`
-        );
+        let html = null;
+        let css = null;
+        let js = null;
+        try {
+            html = rootElement.querySelector(
+                `#${sectid} ~ pre[class*=html], #${sectid} ~ * pre[class*=html]`
+            );
+            css = rootElement.querySelector(
+                `#${sectid} ~ pre[class*=css], #${sectid} ~ * pre[class*=css]`
+            );
+            js = rootElement.querySelector(
+                `#${sectid} ~ pre[class*=js], #${sectid} ~ * pre[class*=js]`
+            );
+        } catch (err) {
+            console.error('Error trying to find html, css, js DOM nodes:', err);
+        }
 
         // Now get the source code out of those pre elements
         let htmlCode = html ? html.textContent : '';

--- a/kuma/wiki/content.py
+++ b/kuma/wiki/content.py
@@ -614,6 +614,18 @@ class SectionIDFilter(html5lib_Filter):
         # Slugify the text we found inside the header, generate an ID
         # as a last resort.
         slug = self.slugify(u''.join(text))
+
+        # If the slug starts with a digit we need to pad it because the ID
+        # won't work as a DOM attribute ID. E.g.
+        # >> document.querySelector('#123_foo')
+        # SyntaxError: '#123_foo' is not a valid selector
+        #
+        # So, to prevent that replace any leading digits.
+        if slug and slug[0].isdigit():
+            # If the ID starts with a number put in an extra string at
+            # the start so it at least becomes a perfectly valid ID.
+            slug = 'id' + slug
+
         if not slug:
             slug = self.gen_id()
         else:


### PR DESCRIPTION
Part of #5959

This is a band-aid solution to get certain pages to not throw. Some pages have stuff like:
```html
<h3 id="45도_기울어진_그레이디언트">45도 기울어진 그레이디언트</h3>
```

The flaw here isn't the non-ascii as an ID but the fact that it starts with a number which makes it an **invalid** ID. 

What this PR does it swallows those exceptions and just moves on and thus you don't get the "Open in Codepen" buttons. 

<img width="1504" alt="Screen Shot 2019-10-10 at 11 07 55 AM" src="https://user-images.githubusercontent.com/26739/66581873-d7ae1f80-eb4e-11e9-81ff-8aae3d94be02.png">

