### PR TITLE
Fix broken search tests from SSR

### DIFF
--- a/kuma/search/views.py
+++ b/kuma/search/views.py
@@ -24,9 +24,10 @@ def search(request, *args, **kwargs):
     if is_wiki(request):
         return wiki_search(request, *args, **kwargs)
 
+    results = search_api(request, *args, **kwargs).data
     context = {
         'results': {
-            'results': search_api(request, *args, **kwargs).data
+            'results': None if results.get('error') else results
         }
     }
 


### PR DESCRIPTION
Reproduced error locally by going to search page with no actual search. After this adjustment tests passed and page works regardless if something is actually searched.