### PR TITLE
make ngettext safer

### DIFF
--- a/kuma/javascript/src/l10n.js
+++ b/kuma/javascript/src/l10n.js
@@ -101,16 +101,30 @@ export function ngettext(
     if (Array.isArray(translation)) {
         // If we got an array of translations, figure out which one
         // to use for this specific count
-        return translation[currentPluralFunction(count)];
+        if (translation.length === 1) {
+            // If there's only one option, use it. This is not strictly
+            // necessary, but is a bit safer for localizations whose plural
+            // forms are the same as their singular form (Chinese, Japanese,
+            // Korean, Vietnamese, etc.) since there's no need to call the
+            // "currentPluralFunction" which could be incorrect and return
+            // an index outside the range of the array.
+            return translation[0];
+        }
+        const selectedTranslation = translation[currentPluralFunction(count)];
+        // Protect against a "currentPluralFunction" that returns an bad index,
+        // by falling back to the default English singular or plural selection
+        // below when the "selectedTranslation" is undefined.
+        if (selectedTranslation !== undefined) {
+            return selectedTranslation;
+        }
     } else if (typeof translation === 'string') {
         // If we only got one string, just return it, regardless
         // of the count
         return translation;
-    } else {
-        // If there is no data, or no translation found, then return
-        // the english singular or plural.
-        return count === 1 ? singular : plural;
     }
+    // If there is no data, or no translation found, then return
+    // the english singular or plural.
+    return count === 1 ? singular : plural;
 }
 
 /**

--- a/kuma/javascript/src/l10n.test.js
+++ b/kuma/javascript/src/l10n.test.js
@@ -125,6 +125,20 @@ describe('ngettext', () => {
         expect(ngtext('s', 'p', 2)).toBe('t');
         expect(ngtext('s', 'p', 3)).toBe('t');
     });
+
+    it('Returns sole plural form regardless of count', () => {
+        localize('test', { s: ['t'] }, n => (n === 1 ? 0 : 1));
+        expect(ngtext('s', 'p', 0)).toBe('t');
+        expect(ngtext('s', 'p', 1)).toBe('t');
+        expect(ngtext('s', 'p', 2)).toBe('t');
+    });
+
+    it('Returns untranslated text if plural function returns bad index', () => {
+        localize('test', { s: ['t1', 't2'] }, n => n);
+        expect(ngtext('s', 'p', 0)).toBe('t1');
+        expect(ngtext('s', 'p', 1)).toBe('t2');
+        expect(ngtext('s', 'p', 2)).toBe('p');
+    });
 });
 
 describe('interpolate()', () => {


### PR DESCRIPTION
Fixes #5958 

Although this PR fixes #5958 by making the `ngettext` call safer, the root cause of #5958 runs deeper, and its fix seemed to call for more thought and scrutiny (so I'll open a separate PR that partially addresses that). The root cause of #5958 is that we're not sending the `pluralFunction` as part of the `data` that we encode into `window._react_data`, so the default plural function is always used, which causes problems for locales like `zh-CN`, `ko`, and `ja` whose proper plural function is very different (it always returns `0`). The reason this bug only affected the Chinese locales, is that they had translations for the search page while locales like `ko` and `ja` did not yet.
