### PR TITLE
whitespace after 'Last modified'

### DIFF
--- a/kuma/javascript/src/last-modified.jsx
+++ b/kuma/javascript/src/last-modified.jsx
@@ -32,7 +32,7 @@ export default function LastModified({
             <ClockIcon />
             <header>
                 <h4>{gettext('Last modified:')}</h4>
-            </header>
+            </header>{' '}
             <time dateTime={lastModified}>
                 {lastModifiedDate.toLocaleString(
                     documentLocale,


### PR DESCRIPTION
Fixes #5973

Before:
<img width="406" alt="Screen Shot 2019-10-11 at 10 48 34 AM" src="https://user-images.githubusercontent.com/26739/66661271-b6176b80-ec14-11e9-83f1-ed7abceaf0be.png">

After:
<img width="424" alt="Screen Shot 2019-10-11 at 10 49 00 AM" src="https://user-images.githubusercontent.com/26739/66661305-c4fe1e00-ec14-11e9-9735-c5b0952d0b87.png">
