### PR TITLE
live-examples trusts section IDs too much

### DIFF
--- a/kuma/javascript/src/article.jsx
+++ b/kuma/javascript/src/article.jsx
@@ -35,11 +35,21 @@ export default function Article({ document }: DocumentProps) {
             InteractiveExamples.setLayout(rootElement);
             // Keep addLiveExampleButtons() before addAnchors() so the
             // example title doesn't end up with a link in it on codepen.
-            addLiveExampleButtons(rootElement);
+            try {
+                addLiveExampleButtons(rootElement);
+            } catch (error) {
+                console.error(error);
+                ga('send', {
+                    hitType: 'event',
+                    eventCategory: 'article-effect-error',
+                    eventAction: 'addLiveExampleButtons',
+                    eventLabel: error.toString()
+                });
+            }
             highlightSyntax(rootElement);
             activateBCDTables(rootElement);
         }
-    }, [document]);
+    }, [document, ga]);
 
     useEffect(() => {
         let rootElement = article.current;


### PR DESCRIPTION
Fixes #5959

<img width="1500" alt="Screen Shot 2019-10-14 at 3 56 10 PM" src="https://user-images.githubusercontent.com/26739/66779016-41a22e00-ee9b-11e9-803c-8b1772b1dcea.png">

Note that there are *no* "Open in Codepen" buttons. At *first*, I did this:

```javascript
// in article.jsx
addLiveExampleButtons(rootElement);

// in live-examples.js
for (let frame of iframes) {
  ...
  try {
      let html = rootElement.querySelector(
            `#${sectid} ~ pre[class*=html], #${sectid} ~ * pre[class*=html]`
        );
   } catch(error) {
     ...
   }
```

But then I realized that in that context, we don't have the GAProvider context because `addLiveExampleButtons` isn't a React component. It's just a function. 
So then I changed it to:

```javascript
// in article.jsx
try { 
    addLiveExampleButtons(rootElement);
} catch(error) {
    console.error(error);
   ga('send', ...)
}

// in live-examples.js
for (let frame of iframes) {
  ...
  let html = rootElement.querySelector(
        `#${sectid} ~ pre[class*=html], #${sectid} ~ * pre[class*=html]`
    );
```

Yes, it means that it bails on the first `iframe` failing in the loop. But this feels still cleaner and it's also a bit more defensive in that it captures anything that can go wrong anywhere inside `live-examples.js`. 